### PR TITLE
Fix HTTP compression issue (for DEFLATE)

### DIFF
--- a/waltid-issuer-api/src/main/kotlin/id/walt/issuer/base/web/plugins/HTTP.kt
+++ b/waltid-issuer-api/src/main/kotlin/id/walt/issuer/base/web/plugins/HTTP.kt
@@ -7,15 +7,7 @@ import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.forwardedheaders.*
 
 fun Application.configureHTTP() {
-    install(Compression) {
-        gzip {
-            priority = 1.0
-        }
-        deflate {
-            priority = 10.0
-            minimumSize(1024) // condition
-        }
-    }
+    install(Compression)
     install(CORS) {
         allowHeaders { true }
         allowMethod(HttpMethod.Options)

--- a/waltid-verifier-api/src/main/kotlin/id/walt/verifier/base/web/plugins/HTTP.kt
+++ b/waltid-verifier-api/src/main/kotlin/id/walt/verifier/base/web/plugins/HTTP.kt
@@ -7,15 +7,7 @@ import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.plugins.forwardedheaders.*
 
 fun Application.configureHTTP() {
-    install(Compression) {
-        gzip {
-            priority = 1.0
-        }
-        deflate {
-            priority = 10.0
-            minimumSize(1024) // condition
-        }
-    }
+    install(Compression)
     install(CORS) {
 
         // TODO: Restrict CORS settings in production.

--- a/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/web/plugins/HTTP.kt
+++ b/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/web/plugins/HTTP.kt
@@ -8,15 +8,7 @@ import io.ktor.server.plugins.forwardedheaders.*
 import io.ktor.server.plugins.methodoverride.*
 
 fun Application.configureHTTP() {
-    install(Compression) {
-        gzip {
-            priority = 1.0
-        }
-        deflate {
-            priority = 10.0
-            minimumSize(1024) // condition
-        }
-    }
+    install(Compression)
     install(CORS) {
         allowMethod(HttpMethod.Options)
         allowNonSimpleContentTypes = true


### PR DESCRIPTION
Fix deflate compression issue by using default priorities for compression algorithms (deflate 0.9, gzip 1), thus prioritizing gzip when a client does not specifically request deflate, which should fix node fetch.
Fixes #88