### PR TITLE
Fix old context reference (typo)

### DIFF
--- a/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/vc/vcs/W3CV2DataModel.kt
+++ b/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/vc/vcs/W3CV2DataModel.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.jsonObject
 @Serializable
 data class W3CV2DataModel(
     @SerialName("@context")
-    val context: List<String> = W3CV11DataModel.defaultContext, // [https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/credentials/examples/v2]
+    val context: List<String> = defaultContext, // [https://www.w3.org/ns/credentials/v2, https://www.w3.org/ns/credentials/examples/v2]
     val type: List<String> = listOf("VerifiableCredential"), // [VerifiableCredential, ExampleAlumniCredential]
     val credentialSubject: JsonObject,
     val id: String? = null, // http://university.example/credentials/1872


### PR DESCRIPTION
W3CV2 referenced to W3CV11 instead of internal default context. Fixes #87