### PR TITLE
Fixing failing DID tests by FileNotFoundException

### DIFF
--- a/waltid-did/src/jvmTest/kotlin/TestServer.kt
+++ b/waltid-did/src/jvmTest/kotlin/TestServer.kt
@@ -9,18 +9,25 @@ import io.ktor.server.routing.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import java.io.File
+import java.net.URI
 import javax.security.auth.x500.X500Principal
 
 object TestServer {
     private val keyStoreFile = File(this.javaClass.classLoader.getResource("")!!.path.plus("keystore.jks"))
     private val ed25519DocumentResponse =
-        this.javaClass.classLoader.getResource("did-web/ed25519.json")!!.path.let { File(it).readText() }
+        URI(
+            this.javaClass.classLoader.getResource("did-web/ed25519.json")!!.toString()
+        ).path.let { File(it).readText() }
     private val secp256k1DocumentResponse =
-        this.javaClass.classLoader.getResource("did-web/secp256k1.json")!!.path.let { File(it).readText() }
+        URI(
+            this.javaClass.classLoader.getResource("did-web/secp256k1.json")!!.toString()
+        ).path.let { File(it).readText() }
     private val secp256r1DocumentResponse =
-        this.javaClass.classLoader.getResource("did-web/secp256r1.json")!!.path.let { File(it).readText() }
+        URI(
+            this.javaClass.classLoader.getResource("did-web/secp256r1.json")!!.toString()
+        ).path.let { File(it).readText() }
     private val rsaDocumentResponse =
-        this.javaClass.classLoader.getResource("did-web/rsa.json")!!.path.let { File(it).readText() }
+        URI(this.javaClass.classLoader.getResource("did-web/rsa.json")!!.toString()).path.let { File(it).readText() }
     private val keyStore = buildKeyStore {
         certificate("test") {
             password = "test123"

--- a/waltid-did/src/jvmTest/kotlin/resolvers/UniResolverTest.kt
+++ b/waltid-did/src/jvmTest/kotlin/resolvers/UniResolverTest.kt
@@ -1,9 +1,6 @@
 package resolvers
 
 import id.walt.did.dids.resolver.UniresolverResolver
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.condition.EnabledIf
@@ -12,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.io.File
+import java.net.URI
 import java.util.stream.Stream
 import kotlin.test.assertEquals
 
@@ -46,19 +44,29 @@ class UniResolverTest {
         fun `given a did String, when calling resolve, then the result is a valid did document`(): Stream<Arguments> =
             Stream.of(
                 arguments("did:key:z6MkfXgppgAzxNZNijP35wjPdQjThkr78S3WXpsXLN8UpPH5#z6MkfXgppgAzxNZNijP35wjPdQjThkr78S3WXpsXLN8UpPH5",
-                    Companion::class.java.classLoader.getResource("uniresolver/jwk/document.json")!!.path.let { File(it).readText() }
+                    // URI(this.javaClass.getClassLoader().getResource(filename)!!.toString()).path
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/jwk/document.json")!!.toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), "")),
                 arguments("did:v1:test:nym:z6MkoPnnkWaXsC94xPJHNLUi15TLyCBe68jrKPi7PenS3pi4",
-                    Companion::class.java.classLoader.getResource("uniresolver/base58/document.json")!!.path.let { File(it).readText() }
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/base58/document.json")!!.toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), "")),
                 arguments(
                     "did:cheqd:testnet:55dbc8bf-fba3-4117-855c-1e0dc1d3bb47",
-                    Companion::class.java.classLoader.getResource("uniresolver/multibase/document.json")!!.path.let { File(it).readText() }
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/multibase/document.json")!!
+                            .toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), ""),
                 ),
                 arguments(
                     "did:io:0x476c81C27036D05cB5ebfe30ae58C23351a61C4A",
-                    Companion::class.java.classLoader.getResource("uniresolver/hex/document.json")!!.path.let { File(it).readText() }
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/hex/document.json")!!.toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), ""),
                 ),
             )
@@ -68,22 +76,32 @@ class UniResolverTest {
             Stream.of(
                 arguments(
                     "did:key:z6MkfXgppgAzxNZNijP35wjPdQjThkr78S3WXpsXLN8UpPH5#z6MkfXgppgAzxNZNijP35wjPdQjThkr78S3WXpsXLN8UpPH5",
-                    Companion::class.java.classLoader.getResource("uniresolver/jwk/publicKeyJwk.json")!!.path.let { File(it).readText() }
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/jwk/publicKeyJwk.json")!!.toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), ""),
                 ),
                 arguments(
                     "did:v1:test:nym:z6MkoPnnkWaXsC94xPJHNLUi15TLyCBe68jrKPi7PenS3pi4",
-                    Companion::class.java.classLoader.getResource("uniresolver/base58/publicKeyJwk.json")!!.path.let { File(it).readText() }
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/base58/publicKeyJwk.json")!!
+                            .toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), ""),
                 ),
                 arguments(
                     "did:cheqd:testnet:55dbc8bf-fba3-4117-855c-1e0dc1d3bb47",
-                    Companion::class.java.classLoader.getResource("uniresolver/multibase/publicKeyJwk.json")!!.path.let { File(it).readText() }
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/multibase/publicKeyJwk.json")!!
+                            .toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), ""),
                 ),
                 arguments(
                     "did:io:0x476c81C27036D05cB5ebfe30ae58C23351a61C4A",
-                    Companion::class.java.classLoader.getResource("uniresolver/hex/publicKeyJwk.json")!!.path.let { File(it).readText() }
+                    URI(
+                        Companion::class.java.classLoader.getResource("uniresolver/hex/publicKeyJwk.json")!!.toString()
+                    ).path.let { File(it).readText() }
                         .replace("[\\s\\n\\r]".toRegex(), ""),
                 ),
             )


### PR DESCRIPTION
Files were not being found because of white spaces encoded in the file path.

`val encodedPath = Companion::class.java.classLoader.getResource("uniresolver/jwk/document.json").path`

results in

```
/dir%20with%20white%20spaces/coding/waltid-identity/waltid-did/build/processedResources/jvm/test/uniresolver/jwk/document.json
```

whereas 

```
URI(encodedPath).toString().path
```

returns 

```
/dir with white spaces/coding/waltid-identity/waltid-did/build/processedResources/jvm/test/uniresolver/jwk/document.json
```

Another possible solution could be

```
URLDecoder.decode(encodedPath, "UTF-8")
```
