### PR TITLE
fix: resource loading with blank spaces in the path

### DIFF
--- a/waltid-crypto/src/jvmTest/kotlin/TestUtils.kt
+++ b/waltid-crypto/src/jvmTest/kotlin/TestUtils.kt
@@ -1,4 +1,5 @@
 import java.io.File
+import java.net.URLDecoder
 
 object TestUtils {
     fun loadJwkLocal(filename: String): String = loadResource("jwk/$filename")
@@ -6,7 +7,9 @@ object TestUtils {
     fun loadSerializedLocal(filename: String): String = loadResource("serialized/local/$filename")
     fun loadSerializedTse(filename: String): String = loadResource("serialized/tse/$filename")
     fun loadResource(relativePath: String): String =
-        this::class.java.classLoader.getResource(relativePath)!!.path.let { File(it).readText() }
+        URLDecoder.decode(this::class.java.classLoader.getResource(relativePath)!!.path, "UTF-8")
+            .let { File(it).readText() }
     fun loadResourceBytes(relativePath: String): ByteArray =
-        this::class.java.classLoader.getResource(relativePath)!!.path.let { File(it).readBytes() }
+        URLDecoder.decode(this::class.java.classLoader.getResource(relativePath)!!.path, "UTF-8")
+            .let { File(it).readBytes() }
 }


### PR DESCRIPTION
Fixed resource loading so that it works when there are blank spaces in the directory name hierarchy.