### PR TITLE
fix: Encode SD-JWT disclosure value without padding

### DIFF
--- a/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDPayload.kt
+++ b/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDPayload.kt
@@ -141,7 +141,7 @@ data class SDPayload internal constructor(
                 add(key)
                 add(value)
             }.toString().encodeToByteArray()).let { disclosure ->
-                SDisclosure(disclosure, salt, key, value)
+                SDisclosure(disclosure.trimEnd('='), salt, key, value)
             }
         }
 


### PR DESCRIPTION
The SD-JWT specification uses base64url to encode the disclosure. As per section 1.2 (Conventions and Terminology), this refers to URL-safe Base64 without padding. Kotlins Base64.UrlSafe encoder, however uses padding. Depending on the input, this leads to padding characters in output, which is against the specification and also fails in the SDJwt.parse method due to the regex check.