### PR TITLE
fix docker compose env comment

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -21,6 +21,7 @@ MSSQL_DB_USR=mssql
 MSSQL_DB_PWD=p@ssw0rd
 MSSQL_SA_PWD=p@ssw0rd
 
-DATABASE_ENGINE=sqlite #postgres #mssql
+#sqlite | postgres | mssql
+DATABASE_ENGINE=sqlite
 VERSION_TAG=0.3.1
 COMPOSE_PROFILES=$DATABASE_ENGINE


### PR DESCRIPTION
### The issue
In the docker compose .env file, the `DATABASE_ENGINE` variable is set to a value which includes the whitespace and the comment, on some systems.

### Solution
Move the comment above the variable.