### PR TITLE
New fix #475 default key config

### DIFF
--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/RegistrationDefaultsConfig.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/RegistrationDefaultsConfig.kt
@@ -1,20 +1,36 @@
 package id.walt.webwallet.config
 
 import id.walt.crypto.keys.KeyGenerationRequest
+import id.walt.crypto.keys.KeyType
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.*
 
 @Serializable
 data class RegistrationDefaultsConfig(
-    val defaultKeyConfig: KeyGenerationRequest = KeyGenerationRequest(),
+    val defaultKeyConfig: DefaultKeyConfig = DefaultKeyConfig(),
 
     val defaultDidConfig: DidMethodConfig = DidMethodConfig(),
 ) : WalletConfig() {
+
+    @Serializable
+    data class DefaultKeyConfig(
+        val backend: String = "jwk",
+        val keyType: KeyType = KeyType.Ed25519,
+        val config: Map<String, String>? = null,
+    )
+
     @Serializable
     data class DidMethodConfig(
         val didMethod: String = "jwk",
         val didConfig: Map<String, JsonPrimitive> = emptyMap(),
+    )
+
+    val keyGenerationRequest: KeyGenerationRequest = KeyGenerationRequest(
+        backend = defaultKeyConfig.backend,
+        keyType = defaultKeyConfig.keyType,
+        config = Json.encodeToJsonElement(defaultKeyConfig.config).jsonObject
     )
 
     @Transient

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/AccountsService.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/AccountsService.kt
@@ -53,7 +53,7 @@ object AccountsService {
 
         // Add default data:
 
-        val createdKey = walletService.generateKey(defaultGenerationConfig.defaultKeyConfig)
+        val createdKey = walletService.generateKey(defaultGenerationConfig.keyGenerationRequest)
 
         val createdDid = walletService.createDid(
             method = defaultGenerationConfig.didMethod,


### PR DESCRIPTION
I've added a conversion of the RegistrationDefaultKeyConfig class as Hoplite fails to read the config file when it expects a [JSON but getting a Hocon file](https://github.com/walt-id/waltid-identity/issues/475).

A better solution is probably to update the config of the [KeyGenerationRequest](https://github.com/walt-id/waltid-identity/blob/8c86ff22f1cb9fafaded3d8b3f02e5168bb44b50/waltid-libraries/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyGenerationRequest.kt#L11) class. However, this has some cascading effects and my Kotlin skills are not quite up to the task