### PR TITLE
fix : Replace ForbiddenException with NotFoundException for wallet ac…

### DIFF
--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/web/controllers/AuthController.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/web/controllers/AuthController.kt
@@ -579,7 +579,7 @@ fun PipelineContext<Unit, ApplicationCall>.ensurePermissionsForWallet(
                         (AccountWalletMappings.wallet eq walletId)
             }
             .firstOrNull()
-            ?: throw ForbiddenException("This account does not have access to the specified wallet."))[
+            ?: throw NotFoundException("This account does not have access to the specified wallet."))[
             AccountWalletMappings.permissions]
     }
 


### PR DESCRIPTION


## Description

Updated the exception thrown when an account does not have access to a specified wallet from ForbiddenException to NotFoundException. This change ensures that the error message better reflects the situation where the wallet cannot be found for the given account.

Fixes #582

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
