### PR TITLE
Refactore maven publishing structure

### DIFF
--- a/waltid-libraries/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/Key.kt
+++ b/waltid-libraries/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/Key.kt
@@ -150,7 +150,7 @@ abstract class Key {
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override fun toString() = "[walt.id CoreCrypto ${if (hasPrivateKey) "private" else "public"} $keyType key]"
+    override fun toString() = "[walt.id crypto ${if (hasPrivateKey) "private" else "public"} $keyType key]"
 
     @JvmBlocking
     @JvmAsync

--- a/waltid-libraries/waltid-mdoc-credentials/README.md
+++ b/waltid-libraries/waltid-mdoc-credentials/README.md
@@ -66,7 +66,7 @@ repositories {
 val mdocVersion = "1.xxx.0"
 [...]
 dependencies {
-  implementation("id.walt:waltid-mdoc-jvm:$mdocVersion")
+  implementation("id.walt.mdoc-credentials:waltid-mdoc-jvm:$mdocVersion")
 }
 ```
 

--- a/waltid-libraries/waltid-mdoc-credentials/build.gradle.kts
+++ b/waltid-libraries/waltid-mdoc-credentials/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `maven-publish`
 }
 
-group = "id.walt"
+group = "id.walt.mdoc-credentials"
 
 repositories {
     mavenCentral()

--- a/waltid-libraries/waltid-openid4vc/README.md
+++ b/waltid-libraries/waltid-openid4vc/README.md
@@ -33,7 +33,7 @@ snapshot for your project. [Latest releases](https://github.com/walt-id/waltid-i
 
 ```kotlin
 dependencies {
-  implementation("id.walt:waltid-openid4vc:<version>")
+  implementation("id.walt.openid4vc:waltid-openid4vc:<version>")
 }
 ```
 

--- a/waltid-libraries/waltid-openid4vc/build.gradle.kts
+++ b/waltid-libraries/waltid-openid4vc/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("com.github.ben-manes.versions")
 }
 
-group = "id.walt"
+group = "id.walt.openid4vc"
 
 repositories {
     mavenCentral()

--- a/waltid-libraries/waltid-sdjwt/README.md
+++ b/waltid-libraries/waltid-sdjwt/README.md
@@ -70,7 +70,7 @@ specification:  [draft-ietf-oauth-selective-disclosure-jwt-04](https://datatrack
 </repositories>
         [...]
 <dependency>
-<groupId>id.walt</groupId>
+<groupId>id.walt.sdjwt</groupId>
 <artifactId>waltid-sdjwt-jvm</artifactId>
 <version>[ version ]</version>
 </dependency>

--- a/waltid-libraries/waltid-sdjwt/build.gradle.kts
+++ b/waltid-libraries/waltid-sdjwt/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("com.github.ben-manes.versions")
 }
 
-group = "id.walt"
+group = "id.walt.sdjwt"
 
 repositories {
     mavenCentral()

--- a/waltid-services/waltid-issuer-api/build.gradle.kts
+++ b/waltid-services/waltid-issuer-api/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
@@ -162,10 +161,10 @@ publishing {
     publications {
         create<MavenPublication>("mavenJava") {
             pom {
-                name.set("walt.id XYZ Kit")
+                name.set("walt.id issuer")
                 description.set(
                     """
-                    Kotlin/Java library for XYZ core services
+                    Kotlin/Java library for walt.id issuer
                     """.trimIndent()
                 )
                 url.set("https://walt.id")

--- a/waltid-services/waltid-service-commons/README.md
+++ b/waltid-services/waltid-service-commons/README.md
@@ -17,6 +17,33 @@
 - Service initialization & phase management
 - Debug endpoints & health checks
 
+
+# How to use it
+
+Add the waltid-service-commons library as a dependency to your Kotlin or Java project.
+
+### walt.id Repository
+
+Add the Maven repository which hosts the walt.id libraries to your build.gradle file.
+
+```kotlin
+repositories {
+    maven { url = uri("https://maven.waltid.dev/releases") }
+} 
+```
+
+### Library Dependency
+
+Adding the waltid-service-commons library as dependency. Specify the version that coincides with the latest or required
+snapshot for your project. [Latest releases](https://github.com/walt-id/waltid-identity/releases).
+
+```kotlin
+dependencies {
+  implementation("id.walt:waltid-service-commons:<version>")
+}
+```
+
+
 # Feature system
 
 Many users have encountered various issues with the old configuration system, including:

--- a/waltid-services/waltid-service-commons/build.gradle.kts
+++ b/waltid-services/waltid-service-commons/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
+    `maven-publish`
 }
 
 group = "id.walt"
-version = "1.0.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
@@ -57,4 +57,42 @@ tasks.test {
 }
 kotlin {
     jvmToolchain(17)
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            pom {
+                name.set("walt.id service-commons")
+                description.set(
+                    """
+                    Kotlin/Java library for the walt.id services-commons
+                    """.trimIndent()
+                )
+                url.set("https://walt.id")
+            }
+            from(components["java"])
+        }
+    }
+
+    repositories {
+        maven {
+            val releasesRepoUrl = uri("https://maven.waltid.dev/releases")
+            val snapshotsRepoUrl = uri("https://maven.waltid.dev/snapshots")
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+            val envUsername = System.getenv("MAVEN_USERNAME")
+            val envPassword = System.getenv("MAVEN_PASSWORD")
+
+            val usernameFile = File("secret_maven_username.txt")
+            val passwordFile = File("secret_maven_password.txt")
+
+            val secretMavenUsername = envUsername ?: usernameFile.let { if (it.isFile) it.readLines().first() else "" }
+            val secretMavenPassword = envPassword ?: passwordFile.let { if (it.isFile) it.readLines().first() else "" }
+
+            credentials {
+                username = secretMavenUsername
+                password = secretMavenPassword
+            }
+        }
+    }
 }

--- a/waltid-services/waltid-verifier-api/build.gradle.kts
+++ b/waltid-services/waltid-verifier-api/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties


### PR DESCRIPTION
## Description

- All artifacts for the packages for mdocs, openid4vc, sdjwt were grouped together in the maven repo.
- Package waltid-service-commons is not also published to maven and can be used as dependency.

