### PR TITLE
Fix some modules for macOS

### DIFF
--- a/waltid-libraries/waltid-did/build.gradle.kts
+++ b/waltid-libraries/waltid-did/build.gradle.kts
@@ -44,8 +44,6 @@ val enableAndroidBuild = getSetting("enableAndroidBuild")
 val enableIosBuild = getSetting("enableIosBuild")
 
 kotlin {
-    val isMacOS = System.getProperty("os.name") == "Mac OS X"
-
     targets.configureEach {
         compilations.configureEach {
             compileTaskProvider.configure {
@@ -160,7 +158,7 @@ kotlin {
             }
         }
 
-        if (isMacOS) {
+        if (enableIosBuild) {
             val iosArm64Main by getting
             val iosSimulatorArm64Main by getting
 

--- a/waltid-libraries/waltid-mdoc-credentials/build.gradle.kts
+++ b/waltid-libraries/waltid-mdoc-credentials/build.gradle.kts
@@ -17,8 +17,6 @@ val enableAndroidBuild = getSetting("enableAndroidBuild")
 val enableIosBuild = getSetting("enableIosBuild")
 
 kotlin {
-    val isMacOS = System.getProperty("os.name") == "Mac OS X"
-
     targets.configureEach {
         compilations.configureEach {
             compileTaskProvider.configure {
@@ -92,7 +90,7 @@ kotlin {
         }
 
 
-        if (isMacOS) {
+        if (enableIosBuild) {
             val iosArm64Main by getting
             val iosSimulatorArm64Main by getting
 

--- a/waltid-libraries/waltid-openid4vc/build.gradle.kts
+++ b/waltid-libraries/waltid-openid4vc/build.gradle.kts
@@ -40,7 +40,6 @@ val enableAndroidBuild = getSetting("enableAndroidBuild")
 val enableIosBuild = getSetting("enableIosBuild")
 
 kotlin {
-    val isMacOS = System.getProperty("os.name") == "Mac OS X"
     targets.configureEach {
         compilations.configureEach {
             compileTaskProvider.configure {
@@ -176,7 +175,7 @@ kotlin {
 //        val nativeTest by getting
         // Add for native: implementation("io.ktor:ktor-client-cio:$ktor_version")
 
-        if (isMacOS) {
+        if (enableIosBuild) {
             val iosArm64Main by getting
             val iosSimulatorArm64Main by getting
 

--- a/waltid-libraries/waltid-verifiable-credentials/build.gradle.kts
+++ b/waltid-libraries/waltid-verifiable-credentials/build.gradle.kts
@@ -44,7 +44,6 @@ val enableAndroidBuild = getSetting("enableAndroidBuild")
 val enableIosBuild = getSetting("enableIosBuild")
 
 kotlin {
-    val isMacOS = System.getProperty("os.name") == "Mac OS X"
     targets.configureEach {
         compilations.configureEach {
             compileTaskProvider.configure {
@@ -147,7 +146,7 @@ kotlin {
             }
         }
 
-        if (isMacOS) {
+        if (enableIosBuild) {
             val iosArm64Main by getting
             val iosSimulatorArm64Main by getting
 


### PR DESCRIPTION
Previously, iOS builds were enabled if the build happens on a macOS host. However, this assumed that the macOS machine would be in an ARM64 environment (e.g. Apple M1), as the iOS builds are for ARM64. However, if the host would be macOS, but not ARM64 but x86_64 instead, this would still try to build the ARM64 iOS sources, but of course fail to do so. This PR will use the build flags to determine instead.