### PR TITLE
Allow policies to be implemented with Java code

### DIFF
--- a/waltid-applications/waltid-cli/src/jvmTest/kotlin/id/walt/cli/verifiers/ExpirationDatePolicyTest.kt
+++ b/waltid-applications/waltid-cli/src/jvmTest/kotlin/id/walt/cli/verifiers/ExpirationDatePolicyTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import java.io.File
 import kotlin.test.*
 
@@ -47,7 +48,7 @@ class ExpirationDatePolicyTest {
     @Test
     fun `should NOT fail with a valid signed VC and data = jws-payload('vc')`() {
 
-        val data = notExpiredJws.decodeJws().payload["vc"]!!
+        val data = notExpiredJws.decodeJws().payload["vc"]!!.jsonObject
 
         val policy = ExpirationDatePolicy()
         val result = runBlocking { policy.verify(data = data, context = emptyMap()) }
@@ -58,7 +59,7 @@ class ExpirationDatePolicyTest {
     @Test
     fun `should NOT fail with a valid NOT signed VC and data = jwt`() {
 
-        val data = Json.parseToJsonElement(notExpiredJwt)
+        val data = Json.parseToJsonElement(notExpiredJwt).jsonObject
 
         val policy = ExpirationDatePolicy()
         val result = runBlocking { policy.verify(data = data, context = emptyMap()) }
@@ -69,7 +70,7 @@ class ExpirationDatePolicyTest {
     @Test
     fun `should fail ExpirationDatePolicy + jws-payload('vc')`() {
 
-        val data = expiredJws.decodeJws().payload["vc"]!!
+        val data = expiredJws.decodeJws().payload["vc"]!!.jsonObject
 
         val policy = ExpirationDatePolicy()
         val result = runBlocking { policy.verify(data = data, context = emptyMap()) }
@@ -80,7 +81,7 @@ class ExpirationDatePolicyTest {
     @Test
     fun `should fail ExpirationDatePolicy + jwt`() {
 
-        val data = Json.parseToJsonElement(expiredJwt)
+        val data = Json.parseToJsonElement(expiredJwt).jsonObject
 
         val policy = ExpirationDatePolicy()
         val result = runBlocking { policy.verify(data = data, context = emptyMap()) }

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/CredentialDataValidatorPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/CredentialDataValidatorPolicy.kt
@@ -1,5 +1,6 @@
 package id.walt.credentials.verification
 
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import love.forte.plugin.suspendtrans.annotation.JsPromise
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
@@ -19,4 +20,15 @@ abstract class CredentialDataValidatorPolicy(
     @JsExport.Ignore
     abstract suspend fun verify(data: JsonObject, args: Any? = null, context: Map<String, Any>): Result<Any>
 
+}
+
+abstract class JavaCredentialDataValidatorPolicy(
+    override val name: String,
+    override val description: String? = null
+): CredentialDataValidatorPolicy(name, description) {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
+        return runCatching { javaVerify(data, args, context) }
+    }
+
+    abstract fun javaVerify(data: JsonObject, args: Any? = null, context: Map<String, Any>): Any
 }

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/CredentialWrapperValidatorPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/CredentialWrapperValidatorPolicy.kt
@@ -1,6 +1,6 @@
 package id.walt.credentials.verification
 
-import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import love.forte.plugin.suspendtrans.annotation.JsPromise
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
 import love.forte.plugin.suspendtrans.annotation.JvmBlocking
@@ -17,6 +17,16 @@ abstract class CredentialWrapperValidatorPolicy(
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    abstract suspend fun verify(data: JsonElement, args: Any? = null, context: Map<String, Any>): Result<Any>
+    abstract suspend fun verify(data: JsonObject, args: Any? = null, context: Map<String, Any>): Result<Any>
+}
 
+abstract class JavaCredentialWrapperValidatorPolicy(
+    override val name: String,
+    override val description: String? = null
+): CredentialWrapperValidatorPolicy(name, description) {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
+        return runCatching { javaVerify(data, args, context) }
+    }
+
+    abstract fun javaVerify(data: JsonObject, args: Any?, context: Map<String, Any>): Any
 }

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/JwtVerificationPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/JwtVerificationPolicy.kt
@@ -1,5 +1,6 @@
 package id.walt.credentials.verification
 
+import kotlinx.serialization.json.JsonElement
 import love.forte.plugin.suspendtrans.annotation.JsPromise
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
 import love.forte.plugin.suspendtrans.annotation.JvmBlocking
@@ -16,4 +17,15 @@ abstract class JwtVerificationPolicy(override val name: String, override val des
     @JsExport.Ignore
     abstract suspend fun verify(credential: String, args: Any? = null, context: Map<String, Any>): Result<Any>
 
+}
+
+abstract class JavaJwtVerificationPolicy(
+    override val name: String,
+    override val description: String? = null
+): JwtVerificationPolicy(name, description) {
+    override suspend fun verify(credential: String, args: Any?, context: Map<String, Any>): Result<Any> {
+        return runCatching { javaVerify(credential, args, context) }
+    }
+
+    abstract fun javaVerify(credential: String, args: Any? = null, context: Map<String, Any>): Any
 }

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/AllowedIssuerPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/AllowedIssuerPolicy.kt
@@ -20,7 +20,7 @@ class AllowedIssuerPolicy : CredentialWrapperValidatorPolicy(
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         val allowedIssuers = when (args) {
             is JsonPrimitive -> listOf(args.content)
             is JsonArray -> args.map { it.jsonPrimitive.content }
@@ -28,8 +28,8 @@ class AllowedIssuerPolicy : CredentialWrapperValidatorPolicy(
         }
 
         val issuer =
-            data.jsonObject[JwsOption.ISSUER]?.jsonPrimitive?.content
-                ?: data.jsonObject["issuer"]?.jsonPrimitive?.content
+            data[JwsOption.ISSUER]?.jsonPrimitive?.content
+                ?: data["issuer"]?.jsonPrimitive?.content
                 ?: throw IllegalArgumentException("No issuer found in credential: $data")
 
         return when (issuer) {

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/ExpirationDatePolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/ExpirationDatePolicy.kt
@@ -22,7 +22,7 @@ class ExpirationDatePolicy : CredentialWrapperValidatorPolicy(
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         val (key, exp) = getExpirationKeyValuePair(data) ?: return buildPolicyUnavailableResult()
 
         val now = Clock.System.now()
@@ -34,18 +34,18 @@ class ExpirationDatePolicy : CredentialWrapperValidatorPolicy(
         }
     }
 
-    private fun getExpirationKeyValuePair(data: JsonElement): Pair<String, Instant>? =
-        checkVc(data.jsonObject["vc"]) ?: checkVc(data) ?: checkJwt(data)
+    private fun getExpirationKeyValuePair(data: JsonObject): Pair<String, Instant>? =
+        checkVc(data["vc"]?.jsonObject) ?: checkVc(data) ?: checkJwt(data)
 
-    private fun checkJwt(data: JsonElement?) =
+    private fun checkJwt(data: JsonObject?) =
         data?.jsonObject?.get(JwtClaims.NotAfter.getValue())?.jsonPrimitive?.longOrNull?.let {
             Pair("jwt:${JwtClaims.NotAfter.getValue()}", Instant.fromEpochSeconds(it))
         }
 
-    private fun checkVc(data: JsonElement?) =
-        data?.jsonObject?.get(VcClaims.V2.NotAfter.getValue())?.jsonPrimitive?.let {
+    private fun checkVc(data: JsonObject?) =
+        data?.get(VcClaims.V2.NotAfter.getValue())?.jsonPrimitive?.let {
             Pair(VcClaims.V2.NotAfter.getValue(), Instant.parse(it.content))
-        } ?: data?.jsonObject?.get(VcClaims.V1.NotAfter.getValue())?.jsonPrimitive?.let {
+        } ?: data?.get(VcClaims.V1.NotAfter.getValue())?.jsonPrimitive?.let {
             Pair(VcClaims.V1.NotAfter.getValue(), Instant.parse(it.content))
         }
 

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/NotBeforeDatePolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/NotBeforeDatePolicy.kt
@@ -22,10 +22,10 @@ class NotBeforeDatePolicy : CredentialWrapperValidatorPolicy(
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         var successfulKey = ""
         fun getEpochTimestamp(key: String) =
-            data.jsonObject[key]?.jsonPrimitive?.longOrNull?.let { Instant.fromEpochSeconds(it) }.also {
+            data[key]?.jsonPrimitive?.longOrNull?.let { Instant.fromEpochSeconds(it) }.also {
                 successfulKey = key
             }
 

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/RevocationPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/RevocationPolicy.kt
@@ -6,9 +6,9 @@ import kotlinx.serialization.json.*
 abstract class RevocationPolicyMp : CredentialWrapperValidatorPolicy(
     "revoked_status_list", "Verifies Credential Status"
 )  {
-    abstract override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any>
+    abstract override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any>
 }
 
 expect class RevocationPolicy(): RevocationPolicyMp {
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any>
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any>
 }

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/WebhookPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/WebhookPolicy.kt
@@ -24,16 +24,19 @@ class WebhookPolicy : CredentialWrapperValidatorPolicy(
     "Sends the credential data to an webhook URL as HTTP POST, and returns the verified status based on the webhooks set status code (success = 200 - 299)."
 ) {
 
-    val http = HttpClient {
-        install(ContentNegotiation) {
-            json()
+    companion object {
+        private val http = HttpClient {
+            install(ContentNegotiation) {
+                json()
+            }
         }
     }
+
     @JvmBlocking
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         val url = (args as JsonPrimitive).content
 
         val response = http.post(url) {

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/vp/HolderBindingPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/vp/HolderBindingPolicy.kt
@@ -4,10 +4,7 @@ import id.walt.credentials.schemes.JwsSignatureScheme.JwsOption
 import id.walt.credentials.verification.CredentialWrapperValidatorPolicy
 import id.walt.credentials.verification.HolderBindingException
 import id.walt.crypto.utils.JwsUtils.decodeJws
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.*
 import love.forte.plugin.suspendtrans.annotation.JsPromise
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
 import love.forte.plugin.suspendtrans.annotation.JvmBlocking
@@ -24,10 +21,10 @@ class HolderBindingPolicy : CredentialWrapperValidatorPolicy(
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
-        val presenterDid = data.jsonObject[JwsOption.ISSUER]!!.jsonPrimitive.content
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
+        val presenterDid = data[JwsOption.ISSUER]!!.jsonPrimitive.content
 
-        val vp = data.jsonObject["vp"]?.jsonObject ?: throw IllegalArgumentException("No \"vp\" field in VP!")
+        val vp = data["vp"]?.jsonObject ?: throw IllegalArgumentException("No \"vp\" field in VP!")
 
         val credentials =
             vp["verifiableCredential"]?.jsonArray ?: throw IllegalArgumentException("No \"verifiableCredential\" field in \"vp\"!")

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/vp/MaximumCredentialsPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/vp/MaximumCredentialsPolicy.kt
@@ -19,16 +19,10 @@ class MaximumCredentialsPolicy : CredentialWrapperValidatorPolicy(
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         val n = (args as JsonPrimitive).int
 
-        when (data) {
-            is JsonObject -> data["vp"]!!.jsonObject["verifiableCredential"]?.jsonArray
-            is JsonArray -> data
-            else -> throw IllegalArgumentException("Can")
-        }
-
-        val presentedCount = data.jsonObject["vp"]!!.jsonObject["verifiableCredential"]?.jsonArray?.count()
+        val presentedCount = data["vp"]!!.jsonObject["verifiableCredential"]?.jsonArray?.count()
             ?: return Result.success(JsonObject(mapOf("policy_available" to JsonPrimitive(false))))
 
         val success = presentedCount <= n

--- a/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/vp/MinimumCredentialsPolicy.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/verification/policies/vp/MinimumCredentialsPolicy.kt
@@ -19,9 +19,9 @@ class MinimumCredentialsPolicy : CredentialWrapperValidatorPolicy(
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         val n = (args as JsonPrimitive).int
-        val presentedCount = data.jsonObject["vp"]!!.jsonObject["verifiableCredential"]?.jsonArray?.count()
+        val presentedCount = data["vp"]!!.jsonObject["verifiableCredential"]?.jsonArray?.count()
             ?: return Result.success(JsonObject(mapOf("policy_available" to JsonPrimitive(false))))
 
         val success = presentedCount >= n

--- a/waltid-libraries/waltid-verifiable-credentials/src/jsMain/kotlin/id/walt/credentials/verification/policies/RevocationPolicy.js.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/jsMain/kotlin/id/walt/credentials/verification/policies/RevocationPolicy.js.kt
@@ -1,11 +1,11 @@
 package id.walt.credentials.verification.policies
 
-import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 
 //@JsPromise
 //@JsExport.Ignore
 actual class RevocationPolicy: RevocationPolicyMp()  {
-    actual override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    actual override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         TODO("Not yet implemented")
     }
 }

--- a/waltid-libraries/waltid-verifiable-credentials/src/jvmMain/kotlin/id/walt/credentials/verification/policies/RevocationPolicy.jvm.kt
+++ b/waltid-libraries/waltid-verifiable-credentials/src/jvmMain/kotlin/id/walt/credentials/verification/policies/RevocationPolicy.jvm.kt
@@ -18,7 +18,7 @@ import java.util.zip.GZIPInputStream
 actual class RevocationPolicy  : RevocationPolicyMp() {
     @JvmBlocking
     @JvmAsync
-    actual override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    actual override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
 
         var successfulKey = ""
 
@@ -26,7 +26,7 @@ actual class RevocationPolicy  : RevocationPolicyMp() {
             successfulKey = key
         }
 
-        val credentialStatus = data.jsonObject["vc"]?.jsonObject?.get("credentialStatus")
+        val credentialStatus = data["vc"]?.jsonObject?.get("credentialStatus")
             ?: return Result.success(
                 JsonObject(mapOf("policy_available" to JsonPrimitive(false)))
             )

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/policies/PresentationDefinitionPolicy.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/policies/PresentationDefinitionPolicy.kt
@@ -11,14 +11,14 @@ class PresentationDefinitionPolicy : CredentialWrapperValidatorPolicy(
     "Verifies that with an Verifiable Presentation at minimum the list of credentials `request_credentials` has been presented."
 ) {
 
-    override suspend fun verify(data: JsonElement, args: Any?, context: Map<String, Any>): Result<Any> {
+    override suspend fun verify(data: JsonObject, args: Any?, context: Map<String, Any>): Result<Any> {
         val presentationDefinition = context["presentationDefinition"] as? PresentationDefinition
             ?: throw IllegalArgumentException("No presentationDefinition in context!")
 
         val requestedTypes = presentationDefinition.primitiveVerificationGetTypeList()
 
         val presentedTypes =
-            data.jsonObject["vp"]!!.jsonObject["verifiableCredential"]?.jsonArray?.mapNotNull {
+            data["vp"]!!.jsonObject["verifiableCredential"]?.jsonArray?.mapNotNull {
                 it.jsonPrimitive.contentOrNull?.decodeJws()?.payload
                     ?.jsonObject?.get("vc")?.jsonObject?.get("type")?.jsonArray?.last()?.jsonPrimitive?.contentOrNull
             } ?: emptyList()


### PR DESCRIPTION
This PR allows verification policies of the types CredentialDataValidatorPolicy, CredentialWrapperValidatorPolicy, JwtVerificationPolicy to be implemented from Java.

## Examples

Examples for Java implemented policies are seen below:

### Example 1 (Simple)

```java
public class CustomCredentialDataValidatorPolicy extends JavaCredentialDataValidatorPolicy {
    public CustomCredentialDataValidatorPolicy() {
        super("java-custom-data-validator", "This is a custom data validator for Java");
    }

    @NotNull
    @Override
    public Object javaVerify(@NotNull JsonObject data, @Nullable Object args, @NotNull Map<String, ?> context) {
        if (!data.containsKey("my_verification")) {
            throw new IllegalArgumentException("Required attribute not found!");
        }

        String myVerificationContent = ((JsonPrimitive) Objects.requireNonNull(data.get("my_verification"))).getContent();

        if (!myVerificationContent.equalsIgnoreCase("hello world")) {
            throw new IllegalArgumentException("Greet the world!");
        }

        return myVerificationContent;
    }
}
```

### Example 2 (Advanced)
```java
public class CustomCredentialWrapperValidatorPolicy extends JavaCredentialWrapperValidatorPolicy {
    public CustomCredentialWrapperValidatorPolicy() {
        super("java-custom-credential-wrapper-validator", "This is a custom credential wrapper validator for Java");
    }

    @NotNull
    @Override
    public Object javaVerify(@NotNull JsonObject data, @Nullable Object args, @NotNull Map<String, ?> context) {
        // Getting the 'presenterDid' from data
        JsonElement issuerElement = data.get(JwsSignatureScheme.JwsOption.ISSUER);
        if (!(issuerElement instanceof JsonPrimitive)) {
            throw new IllegalArgumentException("Missing or invalid issuer in data");
        }
        String presenterDid = ((JsonPrimitive) issuerElement).getContent();

        // Getting the 'vp' from data
        JsonElement vpElement = data.get("vp");
        if (!(vpElement instanceof JsonObject vp)) {
            throw new IllegalArgumentException("No \"vp\" field in VP!");
        }

        // Getting the 'verifiableCredential' from 'vp'
        JsonElement credentialsElement = vp.get("verifiableCredential");
        if (!(credentialsElement instanceof JsonArray credentials)) {
            throw new IllegalArgumentException("No \"verifiableCredential\" field in \"vp\"!");
        }

        // Processing the credentials to get 'credentialSubjects'
        List<String> credentialSubjects = credentials.stream()
                .map(it -> {
                    if (!(it instanceof JsonPrimitive primitive)) {
                        throw new IllegalArgumentException("Invalid credential in \"verifiableCredential\"!");
                    }
                    String content = primitive.getContent();
                    JwsUtils.JwsParts decodedJws = JwsUtils.INSTANCE.decodeJws(content, false, false);
                    JsonObject payload = decodedJws.getPayload();
                    JsonElement subElement = payload.get("sub");
                    if (!(subElement instanceof JsonPrimitive)) {
                        throw new IllegalArgumentException("Invalid 'sub' in payload!");
                    }
                    return ((JsonPrimitive) subElement).getContent().split("#")[0];
                })
                .collect(Collectors.toList());

        // Returning the result based on 'credentialSubjects'
        boolean allMatch = credentialSubjects.stream().allMatch(sub -> sub.equals(presenterDid));
        if (allMatch) {
            return presenterDid;
        } else {
            throw new HolderBindingException(presenterDid, credentialSubjects);
        }
    }
}
```