### PR TITLE
hotfix: set wallet credential format column default value

### DIFF
--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/db/models/WalletCredentials.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/db/models/WalletCredentials.kt
@@ -29,7 +29,7 @@ object WalletCredentials : Table("credentials") {
 
     val deletedOn = timestamp("deleted_on").nullable().default(null)
     val pending = bool("pending").default(false)
-    val format = varchar("format", 32)
+    val format = varchar("format", 32).default(CredentialFormat.jwt_vc_json.value)
 
     override val primaryKey = PrimaryKey(wallet, id)
 }


### PR DESCRIPTION
## Description

When kotlin-exposed attempts to add the missing table / columns (format column for wallet-credentials table), it fails for tables that already have records.
This hotfix sets the wallet-credential format column to have a default value - `CredentialFormat.jwt_vc_json`.
Since the wallet-api couldn't claim until now other credential types than jwt and sdjwt, this solution is safe (both being covered by the aforementioned format). But a proper solution would be introducing a db migration strategy.