### PR TITLE
fix: decodeJwsPart function

### DIFF
--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/utils/JwsUtils.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/utils/JwsUtils.kt
@@ -2,6 +2,7 @@ package id.walt.crypto.utils
 
 import id.walt.crypto.keys.KeyType
 import id.walt.crypto.utils.Base64Utils.base64UrlToBase64
+import id.walt.crypto.utils.Base64Utils.base64toBase64Url
 import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
 import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import kotlinx.serialization.encodeToString
@@ -26,7 +27,7 @@ object JwsUtils {
     }
 
     fun String.decodeJwsPart(): JsonObject =
-        Json.parseToJsonElement(this.decodeFromBase64Url().decodeToString()).jsonObject
+        Json.parseToJsonElement(this.base64toBase64Url().decodeFromBase64Url().decodeToString()).jsonObject
 
     data class JwsParts(val header: JsonObject, val payload: JsonObject, val signature: String) {
         override fun toString() = "${Json.encodeToString(header).encodeToByteArray().encodeToBase64Url()}.${


### PR DESCRIPTION
## Description
During the presentation flow some credentials (BankId, KycCheckCredential) were failing to decode JWT while others were working fine (OpenBadge) and the problem seems to be decodeJwsPart function was assuming every credential to be base64URL but it was not always the case.