### PR TITLE
Make it easier to register key type in KeyManager from Java

### DIFF
--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyGenerationRequest.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyGenerationRequest.kt
@@ -9,4 +9,6 @@ data class KeyGenerationRequest(
     val keyType: KeyType = KeyType.Ed25519,
 
     var config: JsonObject? = null,
-)
+) {
+    fun getConfigAsMap() = config?.toMap() ?: emptyMap()
+}

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyManager.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyManager.kt
@@ -35,11 +35,15 @@ object KeyManager {
         }
     }
 
+    fun registerByType(type: KType, typeId: String, createFunction: suspend (KeyGenerationRequest) -> Key) {
+        types[typeId] = type
+        keyTypeGeneration[typeId] = createFunction
+    }
+
     inline fun <reified T : Key> register(typeId: String, noinline createFunction: suspend (KeyGenerationRequest) -> T) {
         keyManagerLogger().trace { "Registering key type \"$typeId\" to ${T::class.simpleName}..." }
         val type = typeOf<T>()
-        types[typeId] = type
-        keyTypeGeneration[typeId] = createFunction
+        registerByType(type, typeId, createFunction)
     }
 
     suspend fun createKey(generationRequest: KeyGenerationRequest): Key {
@@ -59,7 +63,8 @@ object KeyManager {
         Json.decodeFromJsonElement(serializer(type), JsonObject(fields)) as Key
     }?.apply { init() } ?: error("No type in serialized key")
 
-    fun resolveSerializedKeyBlocking(jsonString: String) = resolveSerializedKeyBlocking(json = Json.parseToJsonElement(jsonString).jsonObject)
+    fun resolveSerializedKeyBlocking(jsonString: String) =
+        resolveSerializedKeyBlocking(json = Json.parseToJsonElement(jsonString).jsonObject)
 
 }
 

--- a/waltid-libraries/crypto/waltid-crypto/src/jvmMain/kotlin/id/walt/crypto/keys/KeyManagerJavaExtensions.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/jvmMain/kotlin/id/walt/crypto/keys/KeyManagerJavaExtensions.kt
@@ -1,0 +1,28 @@
+package id.walt.crypto.keys
+
+import kotlin.jvm.internal.Reflection
+
+object KeyManagerJavaExtensions {
+
+    /**
+     * Use like this from Java:
+     * ```
+     * KeyManagerJavaExtensions.INSTANCE.register(MyJavaBasedKey.class, "theTypeId",
+     *     keyGenerationRequest -> {
+     *         String backend = keyGenerationRequest.getBackend();
+     *         KeyType keyType = keyGenerationRequest.getKeyType();
+     *
+     *         // Return key here
+     *         return null;
+     *     }
+     * );
+     * ```
+     */
+    fun register(javaClass: Class<out Key>, typeId: String, createFunction: (KeyGenerationRequest) -> Key) =
+        KeyManager.registerByType(
+            type = Reflection.typeOf(javaClass),
+            typeId = typeId,
+            createFunction = createFunction
+        )
+
+}


### PR DESCRIPTION
Make it easier to register key type in KeyManager from Java
Fixes #657

Use like this:
```java
KeyManagerJavaExtensions.INSTANCE.register(MyJavaBasedKey.class, "theTypeId",
    keyGenerationRequest -> {
        String backend = keyGenerationRequest.getBackend();
        KeyType keyType = keyGenerationRequest.getKeyType();

        // Return key here
        return null;
    }
);
```