### PR TITLE
fix: add tolerance on date policy test seconds assertions

### DIFF
--- a/waltid-libraries/credentials/waltid-verifiable-credentials/src/jvmTest/kotlin/id/walt/credentials/verification/policies/DatePolicyTestBase.kt
+++ b/waltid-libraries/credentials/waltid-verifiable-credentials/src/jvmTest/kotlin/id/walt/credentials/verification/policies/DatePolicyTestBase.kt
@@ -86,4 +86,15 @@ abstract class DatePolicyTestBase {
             }
         } ?: put(claim, Json.encodeToJsonElement(instant))
     }
+
+    companion object {
+        @JvmStatic
+        protected fun withTolerance(value: Long, tolerance: Int = 5): ClosedRange<Long> =
+            object : ClosedRange<Long> {
+                override val endInclusive: Long
+                    get() = value + tolerance
+                override val start: Long
+                    get() = value - tolerance
+            }
+    }
 }

--- a/waltid-libraries/credentials/waltid-verifiable-credentials/src/jvmTest/kotlin/id/walt/credentials/verification/policies/ExpirationDatePolicyTest.kt
+++ b/waltid-libraries/credentials/waltid-verifiable-credentials/src/jvmTest/kotlin/id/walt/credentials/verification/policies/ExpirationDatePolicyTest.kt
@@ -116,7 +116,7 @@ class ExpirationDatePolicyTest : DatePolicyTestBase() {
             assert(json.containsKey("date_seconds"))
             assert(json["date_seconds"]!!.jsonPrimitive.content == exp.epochSeconds.toString())
             assert(json.containsKey("expires_in_seconds"))
-            assert(json["expires_in_seconds"]!!.jsonPrimitive.content == (exp - Clock.System.now()).inWholeSeconds.toString())
+            assert(json["expires_in_seconds"]!!.jsonPrimitive.content.toLong() in withTolerance((exp - Clock.System.now()).inWholeSeconds))
         }
 
         private fun assertFailureResult(result: Result<Any>, claim: Claims, exp: Instant) {
@@ -126,7 +126,7 @@ class ExpirationDatePolicyTest : DatePolicyTestBase() {
             assert(exception.policyAvailable)
             assert(exception.key == claim.getValue())
             assert(exception.date.epochSeconds == exp.epochSeconds)
-            assert(exception.expiredSinceSeconds == (Clock.System.now() - exp).inWholeSeconds)
+            assert(exception.expiredSinceSeconds in withTolerance((Clock.System.now() - exp).inWholeSeconds))
         }
     }
 }

--- a/waltid-libraries/credentials/waltid-verifiable-credentials/src/jvmTest/kotlin/id/walt/credentials/verification/policies/NotBeforeDatePolicyTest.kt
+++ b/waltid-libraries/credentials/waltid-verifiable-credentials/src/jvmTest/kotlin/id/walt/credentials/verification/policies/NotBeforeDatePolicyTest.kt
@@ -116,7 +116,7 @@ class NotBeforeDatePolicyTest : DatePolicyTestBase() {
             assert(json.containsKey("date_seconds"))
             assert(json["date_seconds"]!!.jsonPrimitive.content == nbf.epochSeconds.toString())
             assert(json.containsKey("available_since_seconds"))
-            assert(json["available_since_seconds"]!!.jsonPrimitive.content == (Clock.System.now() - nbf).inWholeSeconds.toString())
+            assert(json["available_since_seconds"]!!.jsonPrimitive.content.toLong() in withTolerance((Clock.System.now() - nbf).inWholeSeconds))
         }
 
         private fun assertFailureResult(result: Result<Any>, claim: Claims, nbf: Instant) {
@@ -126,7 +126,7 @@ class NotBeforeDatePolicyTest : DatePolicyTestBase() {
             assert(exception.policyAvailable)
             assert(exception.key == claim.getValue())
             assert(exception.date.epochSeconds == nbf.epochSeconds)
-            assert(exception.availableInSeconds == (nbf - Clock.System.now()).inWholeSeconds)
+            assert(exception.availableInSeconds in withTolerance((nbf - Clock.System.now()).inWholeSeconds))
         }
     }
 }


### PR DESCRIPTION
## Description

Adds tolerance when asserting `available_since_seconds` and `expires_in_seconds`.

Fixes #694 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
