### PR TITLE
[Android] create key with specified kid, load created key from android keystore

### DIFF
--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidInstrumentedTest/kotlin/id/walt/crypto/keys/AndroidKeyTest.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidInstrumentedTest/kotlin/id/walt/crypto/keys/AndroidKeyTest.kt
@@ -4,8 +4,13 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.UUID
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
 
 
 @RunWith(AndroidJUnit4::class)
@@ -75,6 +80,23 @@ class AndroidKeyTest {
         val result = keyPair.verifyRaw(signed, plaintext)
 
         assertTrue { result.isSuccess }
+    }
+
+    @Test
+    fun load_not_existing_key() = runTest {
+        val randomKid = UUID.randomUUID().toString()
+        val key = AndroidKey.load(KeyType.secp256r1, randomKid)
+        assertNull(key, "Should not load key that does not exist.")
+    }
+
+    @Test
+    fun create_then_load_key() = runTest {
+        val randomKid = UUID.randomUUID().toString()
+        val key = AndroidKey.generate(KeyType.secp256r1, JwkKeyMeta(randomKid))
+        assertNotNull(key, "Should return key just created.")
+        val loaded = AndroidKey.load(KeyType.secp256r1, randomKid)
+        assertNotNull(loaded,"Should return loaded key.")
+        assertEquals(key.getKeyId(), loaded.getKeyId(), "kid's are not equal")
     }
 
 

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKey.kt
@@ -126,7 +126,10 @@ class AndroidKey() : Key() {
         return "$encodedHeaders.$encodedPayload.$encodedSignature"
     }
 
-    override suspend fun verifyRaw(signed: ByteArray, detachedPlaintext: ByteArray?): Result<ByteArray> {
+    override suspend fun verifyRaw(
+        signed: ByteArray,
+        detachedPlaintext: ByteArray?
+    ): Result<ByteArray> {
         check(detachedPlaintext != null) { "An detached plaintext is needed." }
 
         val certificate: Certificate = keyStore.getCertificate(internalKeyId)
@@ -200,7 +203,10 @@ class AndroidKey() : Key() {
 
     private fun getSignature(): Signature {
         val sig = when (keyType) {
-            KeyType.secp256k1 -> Signature.getInstance("SHA256withECDSA", "BC")//Legacy SunEC curve disabled
+            KeyType.secp256k1 -> Signature.getInstance(
+                "SHA256withECDSA",
+                "BC"
+            )//Legacy SunEC curve disabled
             KeyType.secp256r1 -> Signature.getInstance("SHA256withECDSA")
             KeyType.Ed25519 -> Signature.getInstance("Ed25519")
             KeyType.RSA -> Signature.getInstance("SHA256withRSA")
@@ -209,10 +215,13 @@ class AndroidKey() : Key() {
         return sig
     }
 
-    companion object : AndroidKeyCreator {
+    companion object : AndroidKeyCreator, AndroidKeyLoader {
         override suspend fun generate(
             type: KeyType,
             metadata: JwkKeyMeta?,
         ): AndroidKey = AndroidKeyGenerator.generate(type, metadata)
+
+        override suspend fun load(type: KeyType, keyId: String): AndroidKey? =
+            AndroidKeystoreLoader.load(type, keyId)
     }
 }

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyCreator.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyCreator.kt
@@ -3,3 +3,4 @@ package id.walt.crypto.keys
 interface AndroidKeyCreator {
     suspend fun generate(type: KeyType, metadata: JwkKeyMeta? = null): AndroidKey
 }
+

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyGenerator.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyGenerator.kt
@@ -16,8 +16,7 @@ object AndroidKeyGenerator : AndroidKeyCreator {
 
     // Create an instance using key type
     override suspend fun generate(type: KeyType, metadata: JwkKeyMeta?): AndroidKey {
-        val uniqueId = UUID.randomUUID().toString()
-        val alias = "$KEY_PAIR_ALIAS_PREFIX$uniqueId"
+        val alias = metadata?.keyId ?: "$KEY_PAIR_ALIAS_PREFIX${UUID.randomUUID()}"
         KeyPairGenerator.getInstance(getAlgorithmFor(type), ANDROID_KEYSTORE).apply {
             initialize(
                 KeyGenParameterSpec.Builder(

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyLoader.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyLoader.kt
@@ -1,0 +1,5 @@
+package id.walt.crypto.keys
+
+interface AndroidKeyLoader {
+    suspend fun load(type: KeyType, keyId: String): AndroidKey?
+}

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeystoreLoader.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeystoreLoader.kt
@@ -1,0 +1,19 @@
+package id.walt.crypto.keys
+
+import java.security.KeyStore
+
+object AndroidKeystoreLoader : AndroidKeyLoader {
+    const val ANDROID_KEYSTORE = "AndroidKeyStore"
+
+    val keyStore by lazy {
+        KeyStore.getInstance(ANDROID_KEYSTORE).apply {
+            load(null)
+        }
+    }
+
+    override suspend fun load(type: KeyType, keyId: String): AndroidKey? =
+        when (keyStore.getEntry(keyId, null)) {
+            is KeyStore.PrivateKeyEntry -> AndroidKey(KeyAlias(keyId), type)
+            else -> null
+        }
+}


### PR DESCRIPTION
## Description

Adding ability to provide keyId when generating android key in keystore, if not provided, uuid witll be then used.
Adding ability to load generated key.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


