### PR TITLE
[Android] - jws signing, rm of deprecated android fun, android key params when generating key

### DIFF
--- a/waltid-libraries/credentials/waltid-mdoc-credentials/src/commonMain/kotlin/id/walt/Values.kt
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/src/commonMain/kotlin/id/walt/Values.kt
@@ -1,4 +1,4 @@
-package id.walt
+package id.walt.mdoc
 
 object Values {
     const val version = "1.SNAPSHOT"

--- a/waltid-libraries/crypto/waltid-crypto-android/build.gradle.kts
+++ b/waltid-libraries/crypto/waltid-crypto-android/build.gradle.kts
@@ -78,11 +78,19 @@ kotlin {
     }
 
     sourceSets {
+
+        all {
+            languageSettings.optIn("kotlin.ExperimentalStdlibApi")
+            languageSettings.optIn("kotlin.uuid.ExperimentalUuidApi")
+            languageSettings.optIn("kotlin.io.encoding.ExperimentalEncodingApi")
+        }
+
         val androidMain by getting {
             dependencies {
                 api(project(":waltid-libraries:crypto:waltid-crypto"))
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
                 implementation("io.github.oshai:kotlin-logging:7.0.0")
+                implementation ("com.hierynomus:asn-one:0.6.0")
             }
         }
         val androidInstrumentedTest by getting {
@@ -111,9 +119,13 @@ kotlin {
                     val usernameFile = File("$rootDir/secret_maven_username.txt")
                     val passwordFile = File("$rootDir/secret_maven_password.txt")
 
-                    val secretMavenUsername = envUsername ?: usernameFile.let { if (it.isFile) it.readLines().first() else "" }
+                    val secretMavenUsername = envUsername ?: usernameFile.let {
+                        if (it.isFile) it.readLines().first() else ""
+                    }
                     //println("Deploy username length: ${secretMavenUsername.length}")
-                    val secretMavenPassword = envPassword ?: passwordFile.let { if (it.isFile) it.readLines().first() else "" }
+                    val secretMavenPassword = envPassword ?: passwordFile.let {
+                        if (it.isFile) it.readLines().first() else ""
+                    }
 
                     //if (secretMavenPassword.isBlank()) {
                     //   println("WARNING: Password is blank!")

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidInstrumentedTest/kotlin/id/walt/crypto/keys/AndroidKeyTest.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidInstrumentedTest/kotlin/id/walt/crypto/keys/AndroidKeyTest.kt
@@ -92,12 +92,10 @@ class AndroidKeyTest {
     @Test
     fun create_then_load_key() = runTest {
         val randomKid = UUID.randomUUID().toString()
-        val key = AndroidKey.generate(KeyType.secp256r1, JwkKeyMeta(randomKid))
+        val key = AndroidKey.generate(KeyType.secp256r1, AndroidKeyParameters(randomKid))
         assertNotNull(key, "Should return key just created.")
         val loaded = AndroidKey.load(KeyType.secp256r1, randomKid)
         assertNotNull(loaded,"Should return loaded key.")
         assertEquals(key.getKeyId(), loaded.getKeyId(), "kid's are not equal")
     }
-
-
 }

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyCreator.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyCreator.kt
@@ -1,6 +1,11 @@
 package id.walt.crypto.keys
 
 interface AndroidKeyCreator {
-    suspend fun generate(type: KeyType, metadata: JwkKeyMeta? = null): AndroidKey
+    suspend fun generate(type: KeyType, metadata: AndroidKeyParameters? = null): AndroidKey
 }
+
+data class AndroidKeyParameters(
+    val keyId: String,
+    val isProtected: Boolean = false
+)
 

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyGenerator.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyGenerator.kt
@@ -7,6 +7,7 @@ import java.security.KeyPairGenerator
 import java.security.spec.ECGenParameterSpec
 import java.util.UUID
 import javax.security.auth.x500.X500Principal
+import kotlin.uuid.Uuid
 
 object AndroidKeyGenerator : AndroidKeyCreator {
 
@@ -15,7 +16,8 @@ object AndroidKeyGenerator : AndroidKeyCreator {
     const val ANDROID_KEYSTORE = "AndroidKeyStore"
 
     // Create an instance using key type
-    override suspend fun generate(type: KeyType, metadata: JwkKeyMeta?): AndroidKey {
+    override suspend fun generate(type: KeyType, metadata: AndroidKeyParameters?): AndroidKey {
+
         val alias = metadata?.keyId ?: "$KEY_PAIR_ALIAS_PREFIX${UUID.randomUUID()}"
         KeyPairGenerator.getInstance(getAlgorithmFor(type), ANDROID_KEYSTORE).apply {
             initialize(
@@ -43,8 +45,7 @@ object AndroidKeyGenerator : AndroidKeyCreator {
 
                     // Set of padding schemes with which the key can be used when signing/verifying
                     setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
-
-                    setUserAuthenticationRequired(true)
+                    setUserAuthenticationRequired(metadata?.isProtected ?: false)
                     build()
                 }
             )

--- a/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyGenerator.kt
+++ b/waltid-libraries/crypto/waltid-crypto-android/src/androidMain/kotlin/id/walt/crypto/keys/AndroidKeyGenerator.kt
@@ -45,8 +45,6 @@ object AndroidKeyGenerator : AndroidKeyCreator {
                     setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
 
                     setUserAuthenticationRequired(true)
-                    setUserAuthenticationValidityDurationSeconds(5)
-
                     build()
                 }
             )


### PR DESCRIPTION
## Description

For JWS in AndroidKey - wrong signingInput and wrong signatureFormat was used
For MDoc Values file - just the package, otherwise there was duplicity with SDJWT Values file
For AndroidKey - specific data class that describes keychain restrictions on key when generating it. Not all keys needs to be secured etc. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
