### PR TITLE
feat: Default issuer configurable in wallet-api

### DIFF
--- a/waltid-services/waltid-wallet-api/config/registration-defaults.conf
+++ b/waltid-services/waltid-wallet-api/config/registration-defaults.conf
@@ -9,6 +9,14 @@ defaultDidConfig: {
     method: jwk
 }
 
+defaultIssuerConfig: {
+    did = "did:web:walt.id",
+    description = "walt.id issuer portal",
+    uiEndpoint = "https://portal.walt.id/credentials?ids=",
+    configurationEndpoint = "https://issuer.portal.walt.id/.well-known/openid-credential-issuer",
+    authorized = false,
+}
+
 // -- Hashicorp Vault TSE key example --
 // defaultKeyConfig: {
 //     backend: tse

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/RegistrationDefaultsConfig.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/RegistrationDefaultsConfig.kt
@@ -9,12 +9,22 @@ import kotlinx.serialization.json.JsonPrimitive
 data class RegistrationDefaultsConfig(
     val defaultKeyConfig: KeyGenerationRequest = KeyGenerationRequest(),
     val defaultDidConfig: DidMethodConfig = DidMethodConfig(),
+    val defaultIssuerConfig: IssuerConfig? = null
 ) : WalletConfig() {
 
     @Serializable
     data class DidMethodConfig(
         val method: String = "jwk",
         val config: Map<String, JsonPrimitive> = emptyMap(),
+    )
+
+    @Serializable
+    data class IssuerConfig(
+        val did: String,
+        val description: String,
+        val uiEndpoint: String,
+        val configurationEndpoint: String,
+        val authorized: Boolean
     )
 
     @Transient

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/AccountsService.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/AccountsService.kt
@@ -29,7 +29,10 @@ object AccountsService {
                 WalletServiceManager.createWallet(tenant, registeredUserId)
             }.also { walletId ->
                 //TODO: inject
-                WalletServiceManager.issuerUseCase.add(IssuerDataTransferObject.default(walletId))
+                val issuer = IssuerDataTransferObject.default(walletId)
+                if (issuer != null) {
+                    WalletServiceManager.issuerUseCase.add(issuer)
+                }
             }
 
             val walletService = WalletServiceManager.getWalletService(tenant, registeredUserId, createdInitialWalletId)

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/AccountsService.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/AccountsService.kt
@@ -29,8 +29,7 @@ object AccountsService {
                 WalletServiceManager.createWallet(tenant, registeredUserId)
             }.also { walletId ->
                 //TODO: inject
-                val issuer = IssuerDataTransferObject.default(walletId)
-                if (issuer != null) {
+                IssuerDataTransferObject.default(walletId)?.let { issuer ->
                     WalletServiceManager.issuerUseCase.add(issuer)
                 }
             }

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/issuers/IssuerDataTransferObject.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/issuers/IssuerDataTransferObject.kt
@@ -1,7 +1,5 @@
 package id.walt.webwallet.service.issuers
 
-import id.walt.commons.config.ConfigManager
-import id.walt.webwallet.config.RegistrationDefaultsConfig
 import id.walt.webwallet.db.models.WalletIssuers
 import kotlinx.serialization.Serializable
 import kotlinx.uuid.UUID
@@ -24,18 +22,4 @@ data class IssuerDataTransferObject(
         configurationEndpoint = resultRow[WalletIssuers.configurationEndpoint],
         authorized = resultRow[WalletIssuers.authorized],
     )
-
-    companion object {
-        fun default(wallet: UUID): IssuerDataTransferObject? {
-            val config = ConfigManager.getConfig<RegistrationDefaultsConfig>().defaultIssuerConfig ?: return null
-            return IssuerDataTransferObject(
-                wallet = wallet,
-                did = config.did,
-                description = config.description,
-                uiEndpoint = config.uiEndpoint,
-                configurationEndpoint = config.configurationEndpoint,
-                authorized = config.authorized
-            )
-        }
-    }
 }

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/issuers/IssuerDataTransferObject.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/issuers/IssuerDataTransferObject.kt
@@ -27,19 +27,15 @@ data class IssuerDataTransferObject(
 
     companion object {
         fun default(wallet: UUID): IssuerDataTransferObject? {
-            val defaultGenerationConfig by lazy { ConfigManager.getConfig<RegistrationDefaultsConfig>() }
-            return if (defaultGenerationConfig.defaultIssuerConfig != null) {
-                IssuerDataTransferObject(
-                    wallet = wallet,
-                    did = defaultGenerationConfig.defaultIssuerConfig!!.did,
-                    description = defaultGenerationConfig.defaultIssuerConfig?.description ?: "",
-                    uiEndpoint = defaultGenerationConfig.defaultIssuerConfig!!.uiEndpoint,
-                    configurationEndpoint = defaultGenerationConfig.defaultIssuerConfig!!.configurationEndpoint,
-                    authorized = defaultGenerationConfig.defaultIssuerConfig?.authorized ?: false
-                )
-            } else {
-                null
-            }
+            val config = ConfigManager.getConfig<RegistrationDefaultsConfig>().defaultIssuerConfig ?: return null
+            return IssuerDataTransferObject(
+                wallet = wallet,
+                did = config.did,
+                description = config.description,
+                uiEndpoint = config.uiEndpoint,
+                configurationEndpoint = config.configurationEndpoint,
+                authorized = config.authorized
+            )
         }
     }
 }

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/issuers/IssuerDataTransferObject.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/issuers/IssuerDataTransferObject.kt
@@ -1,5 +1,7 @@
 package id.walt.webwallet.service.issuers
 
+import id.walt.commons.config.ConfigManager
+import id.walt.webwallet.config.RegistrationDefaultsConfig
 import id.walt.webwallet.db.models.WalletIssuers
 import kotlinx.serialization.Serializable
 import kotlinx.uuid.UUID
@@ -24,13 +26,20 @@ data class IssuerDataTransferObject(
     )
 
     companion object {
-        fun default(wallet: UUID) = IssuerDataTransferObject(
-            wallet = wallet,
-            did = "did:web:walt.id",
-            description = "walt.id issuer portal",
-            uiEndpoint = "https://portal.walt.id/credentials?ids=",
-            configurationEndpoint = "https://issuer.portal.walt.id/.well-known/openid-credential-issuer",
-            authorized = false,
-        )
+        fun default(wallet: UUID): IssuerDataTransferObject? {
+            val defaultGenerationConfig by lazy { ConfigManager.getConfig<RegistrationDefaultsConfig>() }
+            return if (defaultGenerationConfig.defaultIssuerConfig != null) {
+                IssuerDataTransferObject(
+                    wallet = wallet,
+                    did = defaultGenerationConfig.defaultIssuerConfig!!.did,
+                    description = defaultGenerationConfig.defaultIssuerConfig?.description ?: "",
+                    uiEndpoint = defaultGenerationConfig.defaultIssuerConfig!!.uiEndpoint,
+                    configurationEndpoint = defaultGenerationConfig.defaultIssuerConfig!!.configurationEndpoint,
+                    authorized = defaultGenerationConfig.defaultIssuerConfig?.authorized ?: false
+                )
+            } else {
+                null
+            }
+        }
     }
 }

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/usecase/issuer/IssuerUseCaseImpl.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/usecase/issuer/IssuerUseCaseImpl.kt
@@ -49,14 +49,18 @@ class IssuerUseCaseImpl(
         }
 
     private suspend fun fetchCredentials(url: String): List<CredentialDataTransferObject> =
-        fetchConfiguration(url).jsonObject["credential_configurations_supported"]!!.jsonObject.entries.map { (key, value) ->
-            val jsonObject = value.jsonObject
-            CredentialDataTransferObject(
-                id = key,
-                format = jsonObject["format"]!!.jsonPrimitive.content,
-                types = jsonObject["types"]!!.jsonArray.map { it.jsonPrimitive.content }
-            )
-        }
+        fetchConfiguration(url).jsonObject["credential_configurations_supported"]?.jsonObject?.entries?.mapNotNull { (key, value) ->
+            value.jsonObject.let { jsonObject ->
+                val format = jsonObject["format"]?.jsonPrimitive?.content
+                val types = jsonObject["types"]?.jsonArray?.map { it.jsonPrimitive.content }
+
+                if (format != null && types != null) {
+                    CredentialDataTransferObject(id = key, format = format, types = types)
+                } else {
+                    null
+                }
+            }
+        } ?: emptyList()
 
     private suspend fun fetchConfiguration(url: String): JsonObject = let {
         json.parseToJsonElement(http.get(url).bodyAsText()).jsonObject

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/usecase/issuer/IssuerUseCaseImpl.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/usecase/issuer/IssuerUseCaseImpl.kt
@@ -49,12 +49,13 @@ class IssuerUseCaseImpl(
         }
 
     private suspend fun fetchCredentials(url: String): List<CredentialDataTransferObject> =
-        fetchConfiguration(url).jsonObject["credentials_supported"]!!.jsonArray.map {
-            CredentialDataTransferObject(id = it.jsonObject["id"]!!.jsonPrimitive.content,
-                format = it.jsonObject["format"]!!.jsonPrimitive.content,
-                types = it.jsonObject["types"]!!.jsonArray.map {
-                    it.jsonPrimitive.content
-                })
+        fetchConfiguration(url).jsonObject["credential_configurations_supported"]!!.jsonObject.entries.map { (key, value) ->
+            val jsonObject = value.jsonObject
+            CredentialDataTransferObject(
+                id = key,
+                format = jsonObject["format"]!!.jsonPrimitive.content,
+                types = jsonObject["types"]!!.jsonArray.map { it.jsonPrimitive.content }
+            )
         }
 
     private suspend fun fetchConfiguration(url: String): JsonObject = let {


### PR DESCRIPTION
Description
Default issuer can be configured through registration-defaults.conf file. Also, this PR fixes the problem with wallet-api not being able to properly process the supported credentials due to response change in https://issuer.portal.walt.id/.well-known/openid-credential-issuer endpoint.

Fixes #462 