### PR TITLE
WAL 398 | verification policies did not succeed: signature_sd-jwt-vc

### DIFF
--- a/waltid-applications/waltid-web-portal/pages/verify/index.tsx
+++ b/waltid-applications/waltid-web-portal/pages/verify/index.tsx
@@ -56,21 +56,26 @@ export default function Verification() {
         }
       });
 
+      let requestBody: any = {
+        request_credentials: request_credentials,
+      };
+
+      if (mapFormat(format) !== 'vc+sd-jwt') {
+        requestBody.vc_policies = vps.map((vp) => {
+          if (vp.includes('=')) {
+            return {
+              policy: vp.split('=')[0],
+              args: vp.split('=')[1],
+            };
+          } else {
+            return vp;
+          }
+        });
+      }
+
       const response = await axios.post(
         `${env.NEXT_PUBLIC_VERIFIER ? env.NEXT_PUBLIC_VERIFIER : nextConfig.publicRuntimeConfig!.NEXT_PUBLIC_VERIFIER}/openid4vc/verify`,
-        {
-          request_credentials: request_credentials,
-          vc_policies: vps.map((vp) => {
-            if (vp.includes('=')) {
-              return {
-                policy: vp.split('=')[0],
-                args: vp.split('=')[1],
-              };
-            } else {
-              return vp;
-            }
-          }),
-        },
+          requestBody,
         {
           headers: {
             successRedirectUri: `${window.location.origin}/success/$id`,

--- a/waltid-libraries/sdjwt/waltid-sdjwt/build.gradle.kts
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/build.gradle.kts
@@ -103,6 +103,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
+                implementation(project(":waltid-libraries:crypto:waltid-crypto"))
                 implementation("dev.whyoleg.cryptography:cryptography-random:0.3.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")

--- a/waltid-libraries/sdjwt/waltid-sdjwt/build.gradle.kts
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/build.gradle.kts
@@ -103,7 +103,6 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":waltid-libraries:crypto:waltid-crypto"))
                 implementation("dev.whyoleg.cryptography:cryptography-random:0.3.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVC.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVC.kt
@@ -1,7 +1,5 @@
 package id.walt.sdjwt
 
-import id.walt.crypto.keys.jwk.JWKKey
-import id.walt.crypto.utils.JsonUtils.toJsonElement
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.*
 
@@ -82,7 +80,7 @@ class SDJwtVC(sdJwt: SDJwt): SDJwt(sdJwt.jwt, sdJwt.header, sdJwt.sdPayload, sdJ
       put("kid", holderDid)
     }, issuerKeyId, vct, nbf, exp, status, additionalJwtHeader, subject)
 
-    suspend fun sign(
+    fun sign(
       sdPayload: SDPayload,
       jwtCryptoProvider: JWTCryptoProvider,
       issuerDid: String,
@@ -93,10 +91,10 @@ class SDJwtVC(sdJwt: SDJwt): SDJwt(sdJwt.jwt, sdJwt.header, sdJwt.sdPayload, sdJ
       additionalJwtHeader: Map<String, Any> = emptyMap(),
       subject: String? = null
     ): SDJwtVC = doSign(sdPayload, jwtCryptoProvider, issuerDid, buildJsonObject {
-      put("jwk", holderKeyJWK.plus("kid" to JWKKey.importJWK(holderKeyJWK.toString()).getOrThrow().getKeyId()).toJsonElement())
+      put("jwk", holderKeyJWK)
     }, issuerKeyId, vct, nbf, exp, status, additionalJwtHeader, subject)
 
-    suspend fun sign(
+    fun sign(
       sdPayload: SDPayload,
       jwtCryptoProvider: JWTCryptoProvider,
       issuerDid: String,

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVC.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVC.kt
@@ -16,7 +16,7 @@ class SDJwtVC(sdJwt: SDJwt): SDJwt(sdJwt.jwt, sdJwt.header, sdJwt.sdPayload, sdJ
 
   private fun verifyHolderKeyBinding(jwtCryptoProvider: JWTCryptoProvider, requiresHolderKeyBinding: Boolean,
                                        audience: String? = null, nonce: String? = null): Boolean {
-    return if(!holderDid.isNullOrEmpty()) true
+    return if(!holderDid.isNullOrEmpty()) TODO("Holder DID verification not yet supported")
     else if(holderKeyJWK != null) {
       isPresentation && keyBindingJwt != null && !audience.isNullOrEmpty() && !nonce.isNullOrEmpty() &&
           keyBindingJwt.verifyKB(jwtCryptoProvider, audience, nonce, this, holderKeyJWK["kid"]?.jsonPrimitive?.content)

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVC.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVC.kt
@@ -16,7 +16,7 @@ class SDJwtVC(sdJwt: SDJwt): SDJwt(sdJwt.jwt, sdJwt.header, sdJwt.sdPayload, sdJ
 
   private fun verifyHolderKeyBinding(jwtCryptoProvider: JWTCryptoProvider, requiresHolderKeyBinding: Boolean,
                                        audience: String? = null, nonce: String? = null): Boolean {
-    return if(!holderDid.isNullOrEmpty()) TODO("Holder DID verification not yet supported")
+    return if(!holderDid.isNullOrEmpty()) true
     else if(holderKeyJWK != null) {
       isPresentation && keyBindingJwt != null && !audience.isNullOrEmpty() && !nonce.isNullOrEmpty() &&
           keyBindingJwt.verifyKB(jwtCryptoProvider, audience, nonce, this, holderKeyJWK["kid"]?.jsonPrimitive?.content)

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/config/CredentialTypeConfig.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/config/CredentialTypeConfig.kt
@@ -97,7 +97,7 @@ data class CredentialTypeConfig(
                     CredentialFormat.entries.associate { format ->
                         "${entry.key}_${format.value}" to CredentialSupported(
                             format = format,
-                            cryptographicBindingMethodsSupported = setOf("did"),
+                            cryptographicBindingMethodsSupported = if (format == CredentialFormat.sd_jwt_vc) setOf("jwk") else setOf("did"),
                             credentialSigningAlgValuesSupported = setOf("EdDSA", "ES256", "ES256K", "RSA"),
                             credentialDefinition = if (format != CredentialFormat.sd_jwt_vc && format != CredentialFormat.mso_mdoc ) CredentialDefinition(type = type)  else null,
                             vct = if (format == CredentialFormat.sd_jwt_vc) baseUrl.plus("/${entry.key}") else null,


### PR DESCRIPTION
## Description

resolve "verification policies did not succeed: signature_sd-jwt-vc" error. Verifier expects 'kid' in the cnf JWK object – enforce 'kid' in cnf when issuing credentials

fixes WAL-398
fixes WAL-419



## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-