### PR TITLE
ci: remove credential-issuer-metadata config for dev + prod env

### DIFF
--- a/waltid-services/waltid-issuer-api/k8s/deployment-dev.yaml
+++ b/waltid-services/waltid-issuer-api/k8s/deployment-dev.yaml
@@ -13,36 +13,6 @@ data:
     authorizeUrl = "https://keycloak.walt-test.cloud/realms/waltid-keycloak-ktor/protocol/openid-connect/auth"
     accessTokenUrl = "https://keycloak.walt-test.cloud/realms/waltid-keycloak-ktor/protocol/openid-connect/token"
     clientId = "issuer_api"
-#  credential-issuer-metadata.conf: |
-#    supportedCredentialTypes = {
-#        BankId = [VerifiableCredential, BankId],
-#        KycChecksCredential = [VerifiableCredential, VerifiableAttestation, KycChecksCredential],
-#        KycCredential = [VerifiableCredential, VerifiableAttestation, KycCredential],
-#        KycDataCredential = [VerifiableCredential, VerifiableAttestation, KycDataCredential],
-#        PassportCh = [VerifiableCredential, VerifiableAttestation, VerifiableId, PassportCh],
-#        PND91Credential = [VerifiableCredential, PND91Credential],
-#        MortgageEligibility = [VerifiableCredential, VerifiableAttestation, VerifiableId, MortgageEligibility],
-#        PortableDocumentA1 = [VerifiableCredential, VerifiableAttestation, PortableDocumentA1],
-#        OpenBadgeCredential = [VerifiableCredential, OpenBadgeCredential],
-#        VaccinationCertificate = [VerifiableCredential, VerifiableAttestation, VaccinationCertificate],
-#        WalletHolderCredential = [VerifiableCredential, WalletHolderCredential],
-#        UniversityDegree = [VerifiableCredential, UniversityDegree],
-#        VerifiableId = [VerifiableCredential, VerifiableAttestation, VerifiableId],
-#        CTWalletSameAuthorisedInTime = [VerifiableCredential, VerifiableAttestation, CTWalletSameAuthorisedInTime],
-#        CTWalletSameAuthorisedDeferred = [VerifiableCredential, VerifiableAttestation, CTWalletSameAuthorisedDeferred],
-#        CTWalletSamePreAuthorisedInTime = [VerifiableCredential, VerifiableAttestation, CTWalletSamePreAuthorisedInTime],
-#        CTWalletSamePreAuthorisedDeferred = [VerifiableCredential, VerifiableAttestation, CTWalletSamePreAuthorisedDeferred],
-#        AlpsTourReservation = [VerifiableCredential, VerifiableAttestation, AlpsTourReservation],
-#        EducationalID = [VerifiableCredential, VerifiableAttestation, EducationalID],
-#        HotelReservation = [VerifiableCredential, VerifiableAttestation, HotelReservation],
-#        Iso18013DriversLicenseCredential = [VerifiableCredential, VerifiableAttestation, Iso18013DriversLicenseCredential],
-#        TaxReceipt = [VerifiableCredential, VerifiableAttestation, TaxReceipt],
-#        VerifiablePortableDocumentA1 = [VerifiableCredential, VerifiableAttestation, VerifiablePortableDocumentA1],
-#        Visa = [VerifiableCredential, VerifiableAttestation, Visa],
-#        eID = [VerifiableCredential, VerifiableAttestation, eID],
-#        NaturalPersonVerifiableID = [VerifiableCredential, VerifiableAttestation, NaturalPersonVerifiableID],
-#        BoardingPass = [VerifiableCredential, VerifiableAttestation, BoardingPass]
-#    }
 ---
 kind: Deployment
 apiVersion: apps/v1

--- a/waltid-services/waltid-issuer-api/k8s/deployment-prod.yaml
+++ b/waltid-services/waltid-issuer-api/k8s/deployment-prod.yaml
@@ -13,36 +13,6 @@ data:
     authorizeUrl = "https://keycloak.walt-test.cloud/realms/waltid-keycloak-ktor/protocol/openid-connect/auth"
     accessTokenUrl = "https://keycloak.walt-test.cloud/realms/waltid-keycloak-ktor/protocol/openid-connect/token"
     clientId = "issuer_api"
-  credential-issuer-metadata.conf: |
-    supportedCredentialTypes = {
-        BankId = [VerifiableCredential, BankId],
-        KycChecksCredential = [VerifiableCredential, VerifiableAttestation, KycChecksCredential],
-        KycCredential = [VerifiableCredential, VerifiableAttestation, KycCredential],
-        KycDataCredential = [VerifiableCredential, VerifiableAttestation, KycDataCredential],
-        PassportCh = [VerifiableCredential, VerifiableAttestation, VerifiableId, PassportCh],
-        PND91Credential = [VerifiableCredential, PND91Credential],
-        MortgageEligibility = [VerifiableCredential, VerifiableAttestation, VerifiableId, MortgageEligibility],
-        PortableDocumentA1 = [VerifiableCredential, VerifiableAttestation, PortableDocumentA1],
-        OpenBadgeCredential = [VerifiableCredential, OpenBadgeCredential],
-        VaccinationCertificate = [VerifiableCredential, VerifiableAttestation, VaccinationCertificate],
-        WalletHolderCredential = [VerifiableCredential, WalletHolderCredential],
-        UniversityDegree = [VerifiableCredential, UniversityDegree],
-        VerifiableId = [VerifiableCredential, VerifiableAttestation, VerifiableId],
-        CTWalletSameAuthorisedInTime = [VerifiableCredential, VerifiableAttestation, CTWalletSameAuthorisedInTime],
-        CTWalletSameAuthorisedDeferred = [VerifiableCredential, VerifiableAttestation, CTWalletSameAuthorisedDeferred],
-        CTWalletSamePreAuthorisedInTime = [VerifiableCredential, VerifiableAttestation, CTWalletSamePreAuthorisedInTime],
-        CTWalletSamePreAuthorisedDeferred = [VerifiableCredential, VerifiableAttestation, CTWalletSamePreAuthorisedDeferred],
-        AlpsTourReservation = [VerifiableCredential, VerifiableAttestation, AlpsTourReservation],
-        EducationalID = [VerifiableCredential, VerifiableAttestation, EducationalID],
-        HotelReservation = [VerifiableCredential, VerifiableAttestation, HotelReservation],
-        Iso18013DriversLicenseCredential = [VerifiableCredential, VerifiableAttestation, Iso18013DriversLicenseCredential],
-        TaxReceipt = [VerifiableCredential, VerifiableAttestation, TaxReceipt],
-        VerifiablePortableDocumentA1 = [VerifiableCredential, VerifiableAttestation, VerifiablePortableDocumentA1],
-        Visa = [VerifiableCredential, VerifiableAttestation, Visa],
-        eID = [VerifiableCredential, VerifiableAttestation, eID],
-        NaturalPersonVerifiableID = [VerifiableCredential, VerifiableAttestation, NaturalPersonVerifiableID],
-        BoardingPass = [VerifiableCredential, VerifiableAttestation, BoardingPass]
-    }
 ---
 kind: Deployment
 apiVersion: apps/v1


### PR DESCRIPTION
## Description

Removes and cleans up the credential-issuer-metadata config from deployments, using by default the values from [CredentialTypeConfig](https://github.com/walt-id/waltid-identity/blob/main/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/config/CredentialTypeConfig.kt). Fixes wal-440.

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-