### PR TITLE
Fixing broken test in the CLI

### DIFF
--- a/waltid-applications/waltid-cli/src/jvmTest/kotlin/id/walt/cli/commands/WaltIdDidCreateCmdTest.kt
+++ b/waltid-applications/waltid-cli/src/jvmTest/kotlin/id/walt/cli/commands/WaltIdDidCreateCmdTest.kt
@@ -194,7 +194,7 @@ class WaltIdDidCreateCmdTest {
         for (keyFile in keyFileList) {
             val tempOutputFile = "${randomUUID()}.json"
             File(tempOutputFile).deleteOnExit()
-            assertContains(command.test("-j -k $keyFile -o $tempOutputFile").output, "did:key:z[a-km-zA-HJ-NP-Z1-9]+".toRegex())
+            assertContains(command.test("-j -k \"$keyFile\" -o '$tempOutputFile'").output, "did:key:z[a-km-zA-HJ-NP-Z1-9]+".toRegex())
         }
     }
 


### PR DESCRIPTION
## Description

The build process was failing on my local environment. The reason was a failing unit test. 

```
> Task :waltid-applications:waltid-cli:jvmTest

WaltIdDidCreateCmdTest[jvm] > should succeed creating a DID key using jwk_jcs-pub with all key types()[jvm] FAILED
    org.opentest4j.AssertionFailedError at WaltIdDidCreateCmdTest.kt:197
```

## Type of Change

- [ x ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ x ] code cleanup and self-review
- [ x ] unit + e2e test coverage
- [ x ] documentation updated accordingly

## Breaking

No.

- \-