### PR TITLE
ci: add optional release-version input for test-deployment

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -2,7 +2,10 @@ name: Deploy manually to test environment
 
 on:
   workflow_dispatch:
-
+    inputs:
+      release_version:
+        description: 'Custom version'
+        required: false
 jobs:
   build:
     name: "Deploy to test environment"
@@ -16,9 +19,15 @@ jobs:
       - uses: actions/checkout@v3
       - name: Calculate release version
         run: |
-          BRANCH=$(echo ${{ github.ref }} | sed -e 's/refs\/heads\///' -e 's/\//-/g')
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-          echo "release_version=1.0.$(date +'%g%m%d%H%M')-${BRANCH}" >> $GITHUB_ENV
+          if [ "${{ inputs.release_version }}" == "" ]; then
+            echo "Using computed value"
+            BRANCH=$(echo ${{ github.ref }} | sed -e 's/refs\/heads\///' -e 's/\//-/g')
+            echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+            echo "release_version=1.0.$(date +'%g%m%d%H%M')-${BRANCH}" >> $GITHUB_ENV
+          else
+            echo "Using provided input"
+            echo "release_version=${{ inputs.release_version }}" >> $GITHUB_ENV
+          fi
       - name: Set version
         run: |
           sed -i "s/1.0.0-SNAPSHOT/${{ env.release_version }}/g" build.gradle.kts


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

Updates test-deployment github action to allow the provision of custom release-version.

## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-