### PR TITLE
ci: update cache version

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,7 +26,7 @@ jobs:
           git tag v${{ env.release_version }}
           git push --tags
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           git tag v${{ inputs.release_version }}
           git push --tags
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
## Description

Updates the actions/cache version from 2.0 to 4.0, according to https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services.



## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-