### PR TITLE
fix w3c payload scheme if issued as sd-jwt.

### DIFF
--- a/.run/Issuer.run.xml
+++ b/.run/Issuer.run.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="Issuer" type="JetRunConfigurationType">
-        <option name="ALTERNATIVE_JRE_PATH" value="17"/>
-        <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true"/>
-        <option name="MAIN_CLASS_NAME" value="id.walt.issuer.MainKt"/>
-        <module name="id.walt.waltid-identity.waltid-services.waltid-issuer-api.main"/>
-        <option name="PROGRAM_PARAMETERS" value="-l trace"/>
-        <shortenClasspath name="NONE"/>
-        <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/waltid-services/waltid-issuer-api"/>
-        <method v="2">
-            <option name="Make" enabled="true"/>
-        </method>
-    </configuration>
+  <configuration default="false" name="Issuer" type="JetRunConfigurationType">
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="MAIN_CLASS_NAME" value="id.walt.issuer.MainKt" />
+    <module name="waltid-identity.waltid-services.waltid-issuer-api.main" />
+    <option name="PROGRAM_PARAMETERS" value="-l trace" />
+    <shortenClasspath name="NONE" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/waltid-services/waltid-issuer-api" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
 </component>

--- a/waltid-libraries/credentials/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/issuance/Issuer.kt
+++ b/waltid-libraries/credentials/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/issuance/Issuer.kt
@@ -116,7 +116,8 @@ object Issuer {
         val issuerDid = if(DidUtils.isDidUrl(issuerId)) issuerId else null
         w3cVc.signSdJwt(
             issuerKey = issuerKey,
-            issuerKeyId = getKidHeader(issuerKey, issuerDid),
+            issuerId = issuerId,
+            issuerKid = getKidHeader(issuerKey, issuerDid),
             subjectDid = subjectDid,
             disclosureMap = disclosureMap,
             additionalJwtHeaders = additionalJwtHeaders.toMutableMap().apply {

--- a/waltid-libraries/credentials/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/schemes/JwsSignatureScheme.kt
+++ b/waltid-libraries/credentials/waltid-verifiable-credentials/src/commonMain/kotlin/id/walt/credentials/schemes/JwsSignatureScheme.kt
@@ -1,6 +1,7 @@
 package id.walt.credentials.schemes
 
 import id.walt.crypto.keys.Key
+import id.walt.crypto.utils.JsonUtils.toJsonObject
 import id.walt.crypto.utils.JwsUtils.decodeJws
 import id.walt.did.dids.DidService
 import id.walt.did.dids.DidUtils
@@ -35,6 +36,14 @@ class JwsSignatureScheme : SignatureScheme {
     const val VC = "vc"
   }
 
+  fun toPayload(data: JsonObject, jwtOptions: Map<String, JsonElement> = emptyMap()) =
+    mapOf(
+      JwsOption.ISSUER to jwtOptions[JwsOption.ISSUER],
+      JwsOption.SUBJECT to jwtOptions[JwsOption.SUBJECT],
+      JwsOption.VC to data,
+      *(jwtOptions.entries.map { it.toPair() }.toTypedArray())
+    ).toJsonObject()
+
   /**
    * args:
    * - kid: Key ID
@@ -53,12 +62,7 @@ class JwsSignatureScheme : SignatureScheme {
     jwtOptions: Map<String, JsonElement> = emptyMap(),
   ): String {
     val payload = Json.encodeToString(
-      mapOf(
-        JwsOption.ISSUER to jwtOptions[JwsOption.ISSUER],
-        JwsOption.SUBJECT to jwtOptions[JwsOption.SUBJECT],
-        JwsOption.VC to data,
-        *(jwtOptions.entries.map { it.toPair() }.toTypedArray())
-      )
+      toPayload(data, jwtOptions)
     ).encodeToByteArray()
 
     return key.signJws(payload, jwtHeaders)

--- a/waltid-libraries/credentials/waltid-verifiable-credentials/src/commonTest/kotlin/LocalVcAPITest.kt
+++ b/waltid-libraries/credentials/waltid-verifiable-credentials/src/commonTest/kotlin/LocalVcAPITest.kt
@@ -68,7 +68,8 @@ private suspend fun testDidMethod(didMethod: String, key: JWKKey) {
     // Sign VC with did method (SD-JWT)
     val sdJwt = vc.signSdJwt(
         issuerKey = key,
-        issuerKeyId = did,
+        issuerId = did,
+        issuerKid = did,
         subjectDid = did,
         SDMap(emptyMap()) // empty selective disclosure map, we'll test this elsewhere
     )
@@ -112,7 +113,8 @@ private suspend fun testWeb(key: JWKKey) {
     // Sign VC with WEB (SD-JWT)
     val sdJwt = vc.signSdJwt(
         issuerKey = key,
-        issuerKeyId = didWebResult.did,
+        issuerId = didWebResult.did,
+        issuerKid = didWebResult.did,
         subjectDid = didWebResult.did,
         SDMap(emptyMap()) // empty selective disclosure map, we'll test this elsewhere
     )
@@ -142,7 +144,8 @@ suspend fun testCheqd(key: JWKKey) {
     // Sign VC with CHEQD (SD-JWT)
     val sdJwt = vc.signSdJwt(
         issuerKey = key,
-        issuerKeyId = cheqdid,
+        issuerId = cheqdid,
+        issuerKid = cheqdid,
         subjectDid = cheqdid,
         SDMap(emptyMap()) // empty selective disclosure map, we'll test this elsewhere
     )

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/E2ESdJwtTest.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/E2ESdJwtTest.kt
@@ -1,7 +1,9 @@
 import WaltidServicesE2ETests.Companion.nameFieldSchemaPresentationRequestPayload
 import WaltidServicesE2ETests.Companion.sdjwtCredential
+import id.walt.credentials.schemes.JwsSignatureScheme
 import id.walt.issuer.issuance.IssuanceRequest
 import id.walt.oid4vc.data.dif.PresentationDefinition
+import id.walt.oid4vc.util.JwtUtils
 import id.walt.webwallet.db.models.WalletCredential
 import id.walt.webwallet.web.controllers.exchange.UsePresentationRequest
 import io.ktor.http.*
@@ -11,6 +13,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.assertContains
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -40,6 +43,7 @@ class E2ESdJwtTest(
         exchangeApi.useOfferRequest(wallet, offerUrl, 1) {
             newCredential = it.first()
         }
+        assertContains(JwtUtils.parseJWTPayload(newCredential.document).keys, JwsSignatureScheme.JwsOption.VC)
         //endregion -Exchange / claim-
 
         //region -Verifier / request url-

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/WaltidServicesE2ETests.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/WaltidServicesE2ETests.kt
@@ -6,6 +6,7 @@ import id.walt.commons.featureflag.CommonsFeatureCatalog
 import id.walt.commons.testing.E2ETest
 import id.walt.commons.testing.utils.ServiceTestUtils.loadResource
 import id.walt.commons.web.plugins.httpJson
+import id.walt.credentials.schemes.JwsSignatureScheme
 import id.walt.crypto.keys.KeyGenerationRequest
 import id.walt.crypto.keys.KeyType
 import id.walt.issuer.issuance.IssuanceRequest
@@ -13,6 +14,7 @@ import id.walt.issuer.issuerModule
 import id.walt.issuer.lspPotential.lspPotentialIssuanceTestApi
 import id.walt.oid4vc.data.OpenId4VPProfile
 import id.walt.oid4vc.data.dif.PresentationDefinition
+import id.walt.oid4vc.util.JwtUtils
 import id.walt.verifier.lspPotential.lspPotentialVerificationTestApi
 import id.walt.verifier.verifierModule
 import id.walt.webwallet.config.RegistrationDefaultsConfig
@@ -35,6 +37,7 @@ import io.ktor.server.application.*
 import io.ktor.server.util.*
 import kotlinx.serialization.json.*
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertNotNull
 import kotlin.time.Duration.Companion.minutes
 import kotlin.uuid.ExperimentalUuidApi
@@ -238,6 +241,7 @@ class WaltidServicesE2ETests {
         exchangeApi.resolveCredentialOffer(wallet, offerUrl)
         exchangeApi.useOfferRequest(wallet, offerUrl, 1) {
             val cred = it.first()
+            assertContains(JwtUtils.parseJWTPayload(cred.document).keys, JwsSignatureScheme.JwsOption.VC)
             newCredentialId = cred.id
         }
         //endregion -Exchange / claim-


### PR DESCRIPTION

## Description

fix w3c payload scheme if issued as sd-jwt (wal-368)
add e2e test check to verify vc sub-property
fix issuer ID, kid and subject id in w3c sd-jwts


## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [x] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-