### PR TITLE
Best-pattern: allow to attach 'cause' (detail) to new exception

### DIFF
--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/exceptions/CryptoExceptions.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/exceptions/CryptoExceptions.kt
@@ -1,29 +1,30 @@
 package id.walt.crypto.exceptions
 
 
-open class CryptoArgumentException(message: String) : IllegalArgumentException(message)
-open class CryptoStateException(message: String) : IllegalStateException(message)
+open class CryptoArgumentException(message: String, cause: Throwable? = null) : IllegalArgumentException(message)
+open class CryptoStateException(message: String, cause: Throwable? = null) : IllegalStateException(message)
 
-class KeyTypeNotSupportedException(type: String) :
+class KeyTypeNotSupportedException(type: String, cause: Throwable? = null) :
     CryptoArgumentException("The key type '$type' is not supported. Please provide a valid key type.")
 
-class KeyBackendNotSupportedException(backend: String) :
+class KeyBackendNotSupportedException(backend: String, cause: Throwable? = null) :
     CryptoArgumentException("The key backend '$backend' is not supported. Ensure you are using a compatible backend.")
 
-class KeyTypeMissingException() :
+class KeyTypeMissingException(cause: Throwable? = null) :
     CryptoArgumentException("The key type is missing from the serialized key. Please include the key type.")
 
 class KeyNotFoundException(
     id: String = "",
-    message: String = "The key with ID '$id' could not be found. Please verify the ID and try again."
+    message: String = "The key with ID '$id' could not be found. Please verify the ID and try again.",
+    cause: Throwable? = null,
 ) : CryptoArgumentException(message)
 
-class SigningException(message: String) :
+class SigningException(message: String, cause: Throwable? = null) :
     CryptoStateException("An error occurred during the signing process: $message")
 
-class VerificationException(message: String) :
+class VerificationException(message: String, cause: Throwable? = null) :
     CryptoStateException("An error occurred during verification: $message")
 
-class MissingSignatureException(message: String) :
+class MissingSignatureException(message: String, cause: Throwable? = null) :
     CryptoStateException("The signature is missing or invalid: $message")
 


### PR DESCRIPTION
## Description

It is always a "best pattern" to allow attaching an original cause when throwing new exceptions.

For example, a KeyNotFoundException in a given Key implementation can be due to different original causes (network error, hardware error, HSM quota exceeded,  ...). Allowing to "attach" the original cause avoids to loose "precious" information to the "sysops" team trying to fix the error in a production environments.

(Unit test did work, e2e test missing -But I guess the change is backward compatible, just adding an optional parameter-)

## Type of Change

- [ ] bug fix - change which fixes an issue
- [X ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-