### PR TITLE
restore issuance status callbacks that got lost during refactoring

### DIFF
--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/IssuerApi.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/IssuerApi.kt
@@ -4,7 +4,7 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 
-class IssuerApi(private val client: HttpClient) {
+class IssuerApi(private val client: HttpClient, private val cbUrl: String? = null) {
     suspend fun jwt(request: IssuanceRequest, output: ((String) -> Unit)? = null) = issue(
         name = "/openid4vc/jwt/issue - issue jwt credential",
         url = "/openid4vc/jwt/issue",
@@ -47,6 +47,9 @@ class IssuerApi(private val client: HttpClient) {
     private suspend fun issue(name: String, url: String, request: IssuanceRequest, output: ((String) -> Unit)? = null) =
         test(name) {
             client.post(url) {
+                if(!cbUrl.isNullOrEmpty()) {
+                    header("statusCallbackUri", cbUrl)
+                }
                 setBody(request)
             }.expectSuccess().apply {
                 output?.invoke(body<String>())

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/WaltidServicesE2ETests.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/WaltidServicesE2ETests.kt
@@ -225,7 +225,10 @@ class WaltidServicesE2ETests {
 
         //region -Issuer / offer url-
         lateinit var offerUrl: String
-        val issuerApi = IssuerApi(client)
+        val issuerApi = IssuerApi(client,
+        // uncomment the following line, to test status callbacks, update webhook id as required.
+        //    "https://webhook.site/d879094b-2275-4ae7-b1c5-ebfb9f08dfdb"
+        )
         val issuanceRequest = Json.decodeFromJsonElement<IssuanceRequest>(jwtCredential)
         println("issuance-request:")
         println(issuanceRequest)


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

During refactoring some code wrt issuance status callbacks got lost and is now recovered.

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-