### PR TITLE
fix: gradle workflow reference in build

### DIFF
--- a/.github/actions/gradle-setup-action/action.yml
+++ b/.github/actions/gradle-setup-action/action.yml
@@ -17,7 +17,7 @@ runs:
       with:
         distribution: 'temurin'
         java-version: '21'
-    - name: Gradle wrapper validation
-      uses: gradle/actions/wrapper-validation@v4
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
+    - name: Gradle wrapper validation
+      uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   version:
     uses: walt-id/waltid-identity/.github/workflows/version.yml@266f5c09359450c39019a6da38f2b331e7122918
   gradle-build:
-    uses: walt-id/waltid-identity/.github/workflows/build-gradle.yml@266f5c09359450c39019a6da38f2b331e7122918
+    uses: walt-id/waltid-identity/.github/workflows/gradle.yml@d3e3284f901bef1e6d80b35720fbae5e4b49a95a
     needs: version
     with:
       version: ${{ needs.version.outputs.release_version }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Configure gradle
-        uses: ./.github/actions/gradle-setup-action@266f5c09359450c39019a6da38f2b331e7122918
+        uses: walt-id/waltid-identity/.github/actions/gradle-setup-action@266f5c09359450c39019a6da38f2b331e7122918
       - name: Set version
         run: |
           sed -i "s/1.0.0-SNAPSHOT/${{ inputs.version }}/g" build.gradle.kts

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Configure gradle
-        uses: walt-id/waltid-identity/.github/actions/gradle-setup-action@266f5c09359450c39019a6da38f2b331e7122918
+        uses: walt-id/waltid-identity/.github/actions/gradle-setup-action@f7b46c8ae1c27f1a0873a5ca8dfb0440c77381ec
       - name: Set version
         run: |
           sed -i "s/1.0.0-SNAPSHOT/${{ inputs.version }}/g" build.gradle.kts

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       suffix: -SNAPSHOT
   gradle:
-    uses: walt-id/waltid-identity/.github/workflows/gradle.yml@927c4233610e90dd8a57418662fad7293b7b29a4
+    uses: walt-id/waltid-identity/.github/workflows/gradle.yml@d3e3284f901bef1e6d80b35720fbae5e4b49a95a
     secrets: inherit
     needs: version
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       preferred: ${{ inputs.release_version }}
   gradle:
-    uses: walt-id/waltid-identity/.github/workflows/gradle.yml@927c4233610e90dd8a57418662fad7293b7b29a4
+    uses: walt-id/waltid-identity/.github/workflows/gradle.yml@d3e3284f901bef1e6d80b35720fbae5e4b49a95a
     secrets: inherit
     needs: version
     with:

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       preferred: ${{ inputs.release_version }}
   gradle:
-    uses: walt-id/waltid-identity/.github/workflows/gradle.yml@927c4233610e90dd8a57418662fad7293b7b29a4
+    uses: walt-id/waltid-identity/.github/workflows/gradle.yml@d3e3284f901bef1e6d80b35720fbae5e4b49a95a
     secrets: inherit
     needs: version
     with:


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

- reorders gradle setup and wrapper validation within the composite gradle-setup-action
- fixes action reference in the gradle workflow to full path
- updates gradle workflow references

relates to WAL-839


## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-