### PR TITLE
Update policy query url without the policyName and verify the result response

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/DynamicPolicy.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/DynamicPolicy.kt
@@ -159,13 +159,15 @@ class DynamicPolicy : CredentialDataValidatorPolicy() {
                 "credentialData" to data.toMap()
             ).toJsonObject()
 
-            val response = http.post("${config.opaServer}/v1/data/${config.policyQuery}/${config.policyName}") {
+            val response = http.post("${config.opaServer}/v1/data/${config.policyQuery}") {
                 contentType(ContentType.Application.Json)
                 setBody(mapOf("input" to input))
             }
 
-            val result = response.body<JsonObject>()["result"]?.jsonObject
-                ?: throw DynamicPolicyException("Invalid response from OPA server")
+            val result = response.body<JsonObject>().let { it -> 
+                    it["result"] ?: throw DynamicPolicyException("Invalid response from OPA server") 
+                    it
+                }
 
             Result.success(result)
         } catch (e: Exception) {


### PR DESCRIPTION

1. Remove the queryName from the opa url.
2. Check the result and return the appropriate result JsonObject.

## Description

1. From OPA data api [here](https://www.openpolicyagent.org/docs/latest/rest-api/#data-api), the policyName is not required.
2. Return the proper JsonObject while allowing the ["result"] to be checked.



## Type of Change

- [ x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-