### PR TITLE
Wal 1039 cose lib upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ allprojects {
         google()
         mavenCentral()
         maven("https://maven.waltid.dev/releases")
+        maven("https://maven.waltid.dev/snapshots")
         maven("https://jitpack.io")
     }
 }

--- a/waltid-libraries/credentials/waltid-mdoc-credentials/build.gradle.kts
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/build.gradle.kts
@@ -71,7 +71,7 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
-                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
             }
         }
         val jvmTest by getting {

--- a/waltid-libraries/credentials/waltid-mdoc-credentials/build.gradle.kts
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/build.gradle.kts
@@ -71,7 +71,7 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
-                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
             }
         }
         val jvmTest by getting {

--- a/waltid-libraries/credentials/waltid-mdoc-credentials/build.gradle.kts
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/build.gradle.kts
@@ -10,6 +10,7 @@ group = "id.walt.mdoc-credentials"
 
 repositories {
     mavenCentral()
+    maven("https://maven.waltid.dev/snapshots")
 }
 
 
@@ -70,7 +71,7 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
-                implementation("com.augustcellars.cose:cose-java:1.1.0")
+                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
             }
         }
         val jvmTest by getting {

--- a/waltid-libraries/credentials/waltid-mdoc-credentials/src/jvmMain/kotlin/id/walt/mdoc/COSECryptoProviderKeyInfo.kt
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/src/jvmMain/kotlin/id/walt/mdoc/COSECryptoProviderKeyInfo.kt
@@ -1,6 +1,6 @@
 package id.walt.mdoc
 
-import COSE.AlgorithmID
+import org.cose.java.AlgorithmID
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.cert.X509Certificate

--- a/waltid-libraries/credentials/waltid-mdoc-credentials/src/jvmMain/kotlin/id/walt/mdoc/SimpleCOSECryptoProvider.kt
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/src/jvmMain/kotlin/id/walt/mdoc/SimpleCOSECryptoProvider.kt
@@ -1,6 +1,6 @@
 package id.walt.mdoc
 
-import COSE.*
+import org.cose.java.*
 import cbor.Cbor
 import com.upokecenter.cbor.CBORObject
 import id.walt.mdoc.cose.COSECryptoProvider

--- a/waltid-libraries/credentials/waltid-mdoc-credentials/src/jvmTest/kotlin/id/walt/mdoc/JVMMdocTest.kt
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/src/jvmTest/kotlin/id/walt/mdoc/JVMMdocTest.kt
@@ -1,7 +1,7 @@
 package id.walt.mdoc
 
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import cbor.Cbor
 import com.upokecenter.cbor.CBORObject
 import id.walt.mdoc.cose.COSESign1Serializer

--- a/waltid-libraries/protocols/waltid-openid4vc/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc/build.gradle.kts
@@ -131,7 +131,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-okhttp:$ktor_version")
-                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
                 implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
             }
         }
@@ -160,7 +160,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.10.1")
                 implementation("io.ktor:ktor-client-okhttp:$ktor_version")
 
-                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
                 implementation("com.soywiz.korlibs.krypto:krypto:4.0.10")
 
                 implementation("org.slf4j:slf4j-simple:2.0.16")

--- a/waltid-libraries/protocols/waltid-openid4vc/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc/build.gradle.kts
@@ -131,7 +131,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-okhttp:$ktor_version")
-                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
                 implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
             }
         }
@@ -160,7 +160,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.10.1")
                 implementation("io.ktor:ktor-client-okhttp:$ktor_version")
 
-                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
                 implementation("com.soywiz.korlibs.krypto:krypto:4.0.10")
 
                 implementation("org.slf4j:slf4j-simple:2.0.16")

--- a/waltid-libraries/protocols/waltid-openid4vc/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
             includeGroup("id.walt")
         }
     }
+    maven("https://maven.waltid.dev/snapshots")
     mavenLocal()
 }
 
@@ -130,7 +131,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-okhttp:$ktor_version")
-                implementation("com.augustcellars.cose:cose-java:1.1.0")
+                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
                 implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
             }
         }
@@ -159,7 +160,7 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:1.10.1")
                 implementation("io.ktor:ktor-client-okhttp:$ktor_version")
 
-                implementation("com.augustcellars.cose:cose-java:1.1.0")
+                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
                 implementation("com.soywiz.korlibs.krypto:krypto:4.0.10")
 
                 implementation("org.slf4j:slf4j-simple:2.0.16")

--- a/waltid-libraries/protocols/waltid-openid4vc/src/jvmMain/kotlin/id/walt/oid4vc/util/COSESign1Utils.jvm.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/jvmMain/kotlin/id/walt/oid4vc/util/COSESign1Utils.jvm.kt
@@ -1,7 +1,7 @@
 package id.walt.oid4vc.util
 
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import cbor.Cbor
 import com.nimbusds.jose.util.X509CertUtils
 import com.upokecenter.cbor.CBORObject

--- a/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/MDoc_Test.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/MDoc_Test.kt
@@ -3,8 +3,8 @@
 package id.walt.oid4vc
 
 
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import cbor.Cbor
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.KeyUse

--- a/waltid-libraries/waltid-core-wallet/build.gradle.kts
+++ b/waltid-libraries/waltid-core-wallet/build.gradle.kts
@@ -51,7 +51,7 @@ kotlin {
 
                 // Problematic libraries:
                 implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
             }
         }
         val jvmMain by getting {

--- a/waltid-libraries/waltid-core-wallet/build.gradle.kts
+++ b/waltid-libraries/waltid-core-wallet/build.gradle.kts
@@ -9,6 +9,7 @@ group = "id.walt.wallet"
 
 repositories {
     mavenCentral()
+    maven("https://maven.waltid.dev/snapshots")
 }
 
 kotlin {
@@ -50,7 +51,7 @@ kotlin {
 
                 // Problematic libraries:
                 implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-                implementation("com.augustcellars.cose:cose-java:1.1.0")
+                implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
             }
         }
         val jvmMain by getting {

--- a/waltid-libraries/waltid-core-wallet/build.gradle.kts
+++ b/waltid-libraries/waltid-core-wallet/build.gradle.kts
@@ -51,7 +51,7 @@ kotlin {
 
                 // Problematic libraries:
                 implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-                implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+                implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
             }
         }
         val jvmMain by getting {

--- a/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/wallet/core/service/exchange/ProofOfPossessionFactory.kt
+++ b/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/wallet/core/service/exchange/ProofOfPossessionFactory.kt
@@ -1,6 +1,6 @@
 package id.walt.wallet.core.service.exchange
 
-import COSE.OneKey
+import org.cose.java.OneKey
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.did.dids.DidService
 import id.walt.oid4vc.data.CredentialOffer

--- a/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/wallet/core/service/exchange/ProofOfPossessionParameterFactory.kt
+++ b/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/wallet/core/service/exchange/ProofOfPossessionParameterFactory.kt
@@ -1,6 +1,6 @@
 package id.walt.wallet.core.service.exchange
 
-import COSE.OneKey
+import org.cose.java.OneKey
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.crypto.keys.Key
 import id.walt.crypto.utils.Base64Utils.encodeToBase64

--- a/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/wallet/core/service/oidc4vc/TestCredentialWallet.kt
+++ b/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/wallet/core/service/oidc4vc/TestCredentialWallet.kt
@@ -3,7 +3,7 @@
 package id.walt.wallet.core.service.oidc4vc
 
 
-import COSE.AlgorithmID
+import org.cose.java.AlgorithmID
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.credentials.utils.VCFormat
 import id.walt.crypto.keys.Key

--- a/waltid-services/waltid-e2e-tests/build.gradle.kts
+++ b/waltid-services/waltid-e2e-tests/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     testImplementation("app.softwork:kotlinx-uuid-core:0.1.4")
     testImplementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
     testImplementation("org.bouncycastle:bcpkix-lts8on:2.73.7")
 
     // Multiplatform / Hashes

--- a/waltid-services/waltid-e2e-tests/build.gradle.kts
+++ b/waltid-services/waltid-e2e-tests/build.gradle.kts
@@ -11,6 +11,7 @@ group = "id.walt"
 repositories {
     mavenLocal()
     mavenCentral()
+    maven("https://maven.waltid.dev/snapshots")
 }
 
 dependencies {
@@ -34,7 +35,7 @@ dependencies {
 
     testImplementation("app.softwork:kotlinx-uuid-core:0.1.4")
     testImplementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-    testImplementation("com.augustcellars.cose:cose-java:1.1.0")
+    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
     testImplementation("org.bouncycastle:bcpkix-lts8on:2.73.7")
 
     // Multiplatform / Hashes

--- a/waltid-services/waltid-e2e-tests/build.gradle.kts
+++ b/waltid-services/waltid-e2e-tests/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
     testImplementation("app.softwork:kotlinx-uuid-core:0.1.4")
     testImplementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
     testImplementation("org.bouncycastle:bcpkix-lts8on:2.73.7")
 
     // Multiplatform / Hashes

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/AuthApi.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/AuthApi.kt
@@ -61,6 +61,7 @@ class AuthApi(private val client: HttpClient) {
         client.get("/wallet-api/auth/session").expectSuccess()
     }
 
+    @OptIn(ExperimentalUuidApi::class)
     suspend fun userWallets(expectedAccountId: Uuid, output: ((AccountWalletListing) -> Unit)? = null) =
         test("/wallet-api/wallet/accounts/wallets - get wallets") {
             client.get("/wallet-api/wallet/accounts/wallets").expectSuccess().apply {

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/ExchangeExternalSignaturesApi.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/ExchangeExternalSignaturesApi.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalUuidApi::class)
 
-import COSE.AlgorithmID
+import org.cose.java.AlgorithmID
 import cbor.Cbor
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.commons.interop.LspPotentialInterop

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/LspPotentialIssuance.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/LspPotentialIssuance.kt
@@ -1,5 +1,5 @@
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import cbor.Cbor
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.commons.interop.LspPotentialInterop

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/LspPotentialVerification.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/LspPotentialVerification.kt
@@ -1,7 +1,7 @@
 @file:OptIn(ExperimentalUuidApi::class)
 
 
-import COSE.AlgorithmID
+import org.cose.java.AlgorithmID
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.ECDSAVerifier

--- a/waltid-services/waltid-issuer-api/build.gradle.kts
+++ b/waltid-services/waltid-issuer-api/build.gradle.kts
@@ -103,7 +103,7 @@ dependencies {
     api(project(":waltid-libraries:sdjwt:waltid-sdjwt"))
 
     // crypto
-    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
 
     // Multiplatform / Hashes

--- a/waltid-services/waltid-issuer-api/build.gradle.kts
+++ b/waltid-services/waltid-issuer-api/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
     mavenCentral()
     maven("https://jitpack.io")
     maven("https://maven.waltid.dev/releases")
+    maven("https://maven.waltid.dev/snapshots")
 }
 
 
@@ -102,7 +103,7 @@ dependencies {
     api(project(":waltid-libraries:sdjwt:waltid-sdjwt"))
 
     // crypto
-    implementation("com.augustcellars.cose:cose-java:1.1.0")
+    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
 
     // Multiplatform / Hashes

--- a/waltid-services/waltid-issuer-api/build.gradle.kts
+++ b/waltid-services/waltid-issuer-api/build.gradle.kts
@@ -103,7 +103,7 @@ dependencies {
     api(project(":waltid-libraries:sdjwt:waltid-sdjwt"))
 
     // crypto
-    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
 
     // Multiplatform / Hashes

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/CIProvider.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/CIProvider.kt
@@ -2,8 +2,8 @@
 
 package id.walt.issuer.issuance
 
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import cbor.Cbor
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.util.X509CertUtils

--- a/waltid-services/waltid-issuer-api/src/test/kotlin/id/walt/LspPotentialTest.kt
+++ b/waltid-services/waltid-issuer-api/src/test/kotlin/id/walt/LspPotentialTest.kt
@@ -1,7 +1,7 @@
 package id.walt
 
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import cbor.Cbor
 import com.nimbusds.jose.jwk.JWK
 import com.upokecenter.cbor.CBORObject

--- a/waltid-services/waltid-verifier-api/build.gradle.kts
+++ b/waltid-services/waltid-verifier-api/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
     implementation("io.ktor:ktor-client-okhttp-jvm:${Versions.KTOR_VERSION}")
 
     // Crypto
-    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
 
     // Test

--- a/waltid-services/waltid-verifier-api/build.gradle.kts
+++ b/waltid-services/waltid-verifier-api/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
     mavenCentral()
     maven("https://jitpack.io")
     maven("https://maven.waltid.dev/releases")
+    maven("https://maven.waltid.dev/snapshots")
 }
 
 
@@ -88,7 +89,7 @@ dependencies {
     implementation("io.ktor:ktor-client-okhttp-jvm:${Versions.KTOR_VERSION}")
 
     // Crypto
-    implementation("com.augustcellars.cose:cose-java:1.1.0")
+    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
 
     // Test

--- a/waltid-services/waltid-verifier-api/build.gradle.kts
+++ b/waltid-services/waltid-verifier-api/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
     implementation("io.ktor:ktor-client-okhttp-jvm:${Versions.KTOR_VERSION}")
 
     // Crypto
-    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
 
     // Test

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/lspPotential/LspPotentialVerificationInterop.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/lspPotential/LspPotentialVerificationInterop.kt
@@ -1,7 +1,7 @@
 package id.walt.verifier.lspPotential
 
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import cbor.Cbor
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.ECDSASigner

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/OIDCVerifierService.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/OIDCVerifierService.kt
@@ -2,8 +2,8 @@
 
 package id.walt.verifier.oidc
 
-import COSE.AlgorithmID
-import COSE.OneKey
+import org.cose.java.AlgorithmID
+import org.cose.java.OneKey
 import com.nimbusds.jose.util.X509CertUtils
 import com.upokecenter.cbor.CBORObject
 import id.walt.commons.config.ConfigManager

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/VerificationUseCase.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/VerificationUseCase.kt
@@ -1,6 +1,6 @@
 package id.walt.verifier.oidc
 
-import COSE.AlgorithmID
+import org.cose.java.AlgorithmID
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.ECDSAVerifier
@@ -174,7 +174,7 @@ class VerificationUseCase(
             val redirectUri = sessionVerificationInfo.errorRedirectUri?.replace("\$id", session.id)
 
             logger.debug { "Presentation failed, redirecting to: $redirectUri" }
-            
+
 
             return if (policyResults == null) {
                 Result.failure(FailedVerificationException(redirectUri, IllegalArgumentException("Verification policies did not succeed")))

--- a/waltid-services/waltid-wallet-api/build.gradle.kts
+++ b/waltid-services/waltid-wallet-api/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
     mavenCentral()
     maven("https://jitpack.io")
     maven("https://maven.waltid.dev/releases")
+    maven("https://maven.waltid.dev/snapshots")
 }
 
 tasks.withType<KotlinCompile> {
@@ -140,7 +141,7 @@ dependencies {
     testImplementation(project(":waltid-services:waltid-verifier-api"))
 
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-    implementation("com.augustcellars.cose:cose-java:1.1.0")
+    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
 
     implementation("io.ktor:ktor-client-java:$ktor_version")
 

--- a/waltid-services/waltid-wallet-api/build.gradle.kts
+++ b/waltid-services/waltid-wallet-api/build.gradle.kts
@@ -141,7 +141,7 @@ dependencies {
     testImplementation(project(":waltid-services:waltid-verifier-api"))
 
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-    implementation("org.cose:cose-java:1.1.1-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
 
     implementation("io.ktor:ktor-client-java:$ktor_version")
 

--- a/waltid-services/waltid-wallet-api/build.gradle.kts
+++ b/waltid-services/waltid-wallet-api/build.gradle.kts
@@ -141,7 +141,7 @@ dependencies {
     testImplementation(project(":waltid-services:waltid-verifier-api"))
 
     implementation("com.nimbusds:nimbus-jose-jwt:10.0.1")
-    implementation("org.cose:cose-java:1.1.1-WALTID-SNAPSHOT")
+    implementation("org.cose:cose-java:1.1.1-WALT-SNAPSHOT")
 
     implementation("io.ktor:ktor-client-java:$ktor_version")
 

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/ProofOfPossessionFactory.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/ProofOfPossessionFactory.kt
@@ -1,6 +1,6 @@
 package id.walt.webwallet.service.exchange
 
-import COSE.OneKey
+import org.cose.java.OneKey
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.did.dids.DidService
 import id.walt.oid4vc.data.CredentialOffer

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/ProofOfPossessionParameterFactory.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/ProofOfPossessionParameterFactory.kt
@@ -1,6 +1,6 @@
 package id.walt.webwallet.service.exchange
 
-import COSE.OneKey
+import org.cose.java.OneKey
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.crypto.keys.Key
 import id.walt.crypto.utils.Base64Utils.encodeToBase64

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/oidc4vc/TestCredentialWallet.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/oidc4vc/TestCredentialWallet.kt
@@ -3,7 +3,7 @@
 package id.walt.webwallet.service.oidc4vc
 
 
-import COSE.AlgorithmID
+import org.cose.java.AlgorithmID
 import com.nimbusds.jose.jwk.ECKey
 import id.walt.credentials.utils.VCFormat
 import id.walt.crypto.keys.Key

--- a/waltid-services/waltid-wallet-api/src/test/kotlin/id/walt/webwallet/service/credentials/status/fetch/DefaultStatusListCredentialFetchStrategyTest.kt
+++ b/waltid-services/waltid-wallet-api/src/test/kotlin/id/walt/webwallet/service/credentials/status/fetch/DefaultStatusListCredentialFetchStrategyTest.kt
@@ -72,7 +72,7 @@ class DefaultStatusListCredentialFetchStrategyTest {
 
     object StatusCredentialTestServer {
         var serverStarted = false
-        const val serverPort = 8080
+        const val serverPort = 8085
         const val credentialResourcePath = "credential-status/status-list-credential"
         const val statusCredentialPath = "credentials/%s"
 


### PR DESCRIPTION
## Description

The cose-java library has been updated to use the newer fork from: https://github.com/sbahloul/cose-java

The cose-java library was build on my side, with an updated version of the bouncycastle libraries, "org.bouncycastle:bcprov-lts8on:2.73.7" and "org.bouncycastle:bcpkix-lts8on:2.73.7", to comply with the versions used on our waltid-identity stack and to fix the test errors, that would have broken the build with the conflicting bouncycastle versions.
I uploaded a custom build of the cose-java library to our maven snapshots repository: 
"https://maven.waltid.dev/snapshots".