### PR TITLE
Making logger being transient and excluded from serialization flow

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies/src/jvmMain/kotlin/id/walt/policies/policies/RevocationPolicy.jvm.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies/src/jvmMain/kotlin/id/walt/policies/policies/RevocationPolicy.jvm.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.*
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
 import love.forte.plugin.suspendtrans.annotation.JvmBlocking
@@ -19,6 +20,7 @@ import java.util.zip.GZIPInputStream
 
 @Serializable
 actual class RevocationPolicy : RevocationPolicyMp() {
+    @Transient
     private val logger = KotlinLogging.logger {}
 
     @JvmBlocking


### PR DESCRIPTION
This PR addresses the Redis serialization issue described in [walt-id/waltid-identity#993](https://github.com/walt-id/waltid-identity/issues/993) by marking the logger in `RevocationPolicy.kt` as `@Transient`.