### PR TITLE
chore: docker run conf issuer API readme

### DIFF
--- a/waltid-services/waltid-issuer-api/README.md
+++ b/waltid-services/waltid-issuer-api/README.md
@@ -122,7 +122,7 @@ Run the following commands from the waltid-identity root path:
 
 ```shell
 docker build -t waltid/issuer-api -f waltid-services/waltid-issuer-api/Dockerfile .
-docker run -p 7003:7003 waltid/issuer-api -- --webPort=7003 --baseUrl=http://localhost:7003
+docker run -p 7002:7002 waltid/issuer-api -- --webPort=7002 --baseUrl=http://localhost:7002
 ```
 
 Or, run with local config directory:


### PR DESCRIPTION
## Description

change issuer run port in README from 7003 to 7002