### PR TITLE
Implement alternative for OIDC login to support Entra ID

### DIFF
--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/OidcConfiguration.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/OidcConfiguration.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class OidcConfiguration(
-    val publicBaseUrl: String = "http://localhost:7101",
+    val publicBaseUrl: String,
     val providerName: String,
     val oidcRealm: String,
     val oidcJwks: String,
@@ -15,7 +15,7 @@ data class OidcConfiguration(
     val logoutUrl: String,
     val clientId: String,
     val clientSecret: String,
-    val keycloakUserApi: String,
+    val keycloakUserApi: String? = null,
 ) : WalletConfig() {
     @Serializable
     data class OidcJwksCacheConfiguration(

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/KeycloakAccountStrategy.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/account/KeycloakAccountStrategy.kt
@@ -65,8 +65,9 @@ object KeycloakAccountStrategy : PasswordAccountStrategy<KeycloakAccountRequest>
             )
                 .toJsonObject()
 
+        require(oidcConfig.keycloakUserApi != null) { "keycloakUserApi missing in oidc.conf" }
         val res =
-            http.post(oidcConfig.keycloakUserApi) {
+            http.post(oidcConfig.keycloakUserApi!!) {
                 contentType(ContentType.Application.Json)
                 headers {
                     append("Content-Type", "application/json")
@@ -259,6 +260,7 @@ object KeycloakAccountStrategy : PasswordAccountStrategy<KeycloakAccountRequest>
 
         val requestBody = requestParams.map { (k, v) -> "$k=$v" }.joinToString("&")
 
+        require(oidcConfig.keycloakUserApi != null) { "keycloakUserApi missing in oidc.conf" }
         val res =
             http.post(oidcConfig.keycloakUserApi + "/" + request.keycloakUserId + "/logout") {
                 contentType(ContentType.Application.Json)

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/web/controllers/auth/oidc/OidcAuthRoutes.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/web/controllers/auth/oidc/OidcAuthRoutes.kt
@@ -6,11 +6,16 @@ import id.walt.webwallet.web.controllers.auth.defaultAuthPath
 import id.walt.webwallet.web.controllers.auth.defaultAuthTags
 import io.github.smiley4.ktoropenapi.get
 import io.github.smiley4.ktoropenapi.route
+import io.klogging.logger
+import io.klogging.noCoLogger
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.response.*
 import io.ktor.server.sessions.*
+
+internal val oidcLogNoco = noCoLogger("OidcAuth")
+internal val oidcLog = logger("OidcAuth")
 
 fun Application.oidcAuthRoutes() = webWalletRoute {
     route(defaultAuthPath, { tags = defaultAuthTags }) {
@@ -21,6 +26,7 @@ fun Application.oidcAuthRoutes() = webWalletRoute {
                     description = "Redirect to OIDC provider for login"
                     response { HttpStatusCode.Found }
                 }) {
+                oidcLog.trace {"OIDC login with provider OK" }
                 call.respondRedirect("oidc-session")
             }
         }
@@ -28,6 +34,7 @@ fun Application.oidcAuthRoutes() = webWalletRoute {
             get("oidc-session", { description = "Configure OIDC session" }) {
                 val principal: OAuthAccessTokenResponse.OAuth2 =
                     call.principal() ?: error("No OAuth principal")
+                oidcLog.trace { "OIDC Session endpoint: principal = $principal" }
 
                 call.sessions.set(OidcTokenSession(principal.accessToken))
 
@@ -37,6 +44,7 @@ fun Application.oidcAuthRoutes() = webWalletRoute {
 
         get("oidc-token", { description = "Returns OIDC token" }) {
             val oidcSession = call.sessions.get<OidcTokenSession>() ?: error("No OIDC session")
+            oidcLog.trace { "OIDC Token: OIDC Session = $oidcSession" }
 
             call.respond(oidcSession.token)
         }


### PR DESCRIPTION
## Description

Web Wallet OIDC login has been mainly tested with Keycloak. Keycloak allows setting various OIDC settings in its IDP config, including having the returned token be a JWT that can be verified against its JWKS. Entra ID will return an opaque token that has to first be redeemed into an id_token with the token endpoint, to be able to verifiy against its JWKS.

This PR adds the necessary handling to redeem a code received through the redirect_uri

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality