### PR TITLE
fix: Invalid SdJwt string format #1069

### DIFF
--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwt.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwt.kt
@@ -80,6 +80,7 @@ open class SDJwt internal constructor(
             .plus((if(withKBJwt) keyBindingJwt else null)?.let { listOf(it) }
                 ?: (if (formatForPresentation) listOf("") else listOf()))
             .joinToString(SEPARATOR_STR)
+            .plus(SEPARATOR_STR)
     }
 
     /**


### PR DESCRIPTION
## Description

This PR isn't meant as a final solution more so to ask some insight. I am trying to fix this bug, but cannot figure out what `formatForPresentation` in `SDJwt#toString` function is supposed to do.

As the solution should be if keybind jwt is not present add the postfix "~", but current solution is to only add it if keybind jwt is not present and `isPresentation` is on.

## Type of Change

- [X ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-