### PR TITLE
Remove walt.yaml mapping in docker compose configuration

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -152,7 +152,6 @@ docker-compose down -v
 
 - wallet API:
     - `wallet-api/config` - wallet configuration
-    - `wallet-api/walt.yaml` - nft configuration
 - issuer API:
     - `issuer-api/config`
 - verifier API:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -22,7 +22,6 @@ services:
       - "waltid.enterprise.localhost:host-gateway"
     volumes:
       - ./wallet-api/config:/waltid-wallet-api/config
-      - ./wallet-api/walt.yaml:/waltid-wallet-api/walt.yaml
       - ./wallet-api/data:/waltid-wallet-api/data
 
   issuer-api:


### PR DESCRIPTION
## Description

The `wallet-api/walt.yaml` file does not exists and is not used anymore. I think this is old configuration.

## Type of Change

- [x] bug fix - change which fixes an issue
