### PR TITLE
BitstringStatusList fix: drop first character of decoding

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies/src/jvmMain/kotlin/id/walt/policies/policies/status/expansion/BitstringStatusListExpansionAlgorithm.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies/src/jvmMain/kotlin/id/walt/policies/policies/status/expansion/BitstringStatusListExpansionAlgorithm.kt
@@ -6,5 +6,5 @@ import java.util.zip.GZIPInputStream
 
 class BitstringStatusListExpansionAlgorithm : StatusListExpansionAlgorithm {
     override operator fun invoke(bitstring: String): InputStream =
-        GZIPInputStream(Base64Utils.urlDecode(bitstring).inputStream())
+        GZIPInputStream(Base64Utils.urlDecode(bitstring.drop(1)).inputStream())
 }


### PR DESCRIPTION
## Description

Current implementation/decoder will fail on _some_ multibase-base64url strings, e.g. `udGVzdDIy`

Change decoder line to drop first character.

More info https://github.com/walt-id/waltid-identity/pull/1103#issuecomment-2996405359

relates to WAL-1532