### PR TITLE
fix: [WAL-1410] open api schema generation for objects which inherit from JsonDataObject

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/AuthorizationDetails.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/AuthorizationDetails.kt
@@ -38,7 +38,7 @@ data class AuthorizationDetails @OptIn(ExperimentalSerializationApi::class) cons
     @Serializable(ClaimDescriptorNamespacedMapSerializer::class) val claims: Map<String, Map<String, ClaimDescriptor>>? = null,
     @SerialName("credential_definition") val credentialDefinition: CredentialDefinition? = null,
     val locations: List<String>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = json.encodeToJsonElement(AuthorizationDetailsSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/ClaimDescriptor.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/ClaimDescriptor.kt
@@ -19,9 +19,9 @@ data class ClaimDescriptor(
     val mandatory: Boolean? = null,
     @SerialName("value_type") val valueType: String? = null,
     @Serializable(DisplayPropertiesListSerializer::class) val display: List<DisplayProperties>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
-    val nestedClaims: Map<String, ClaimDescriptor> = customParameters.filterValues { it is JsonObject }
+    val nestedClaims: Map<String, ClaimDescriptor> = customParameters!!.filterValues { it is JsonObject }
         .mapValues { fromJSON(it.value.jsonObject) }
 
     override fun toJSON() = Json.encodeToJsonElement(ClaimDescriptorSerializer, this).jsonObject

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/CredentialOffer.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/CredentialOffer.kt
@@ -71,7 +71,7 @@ sealed class CredentialOffer : JsonDataObject() {
 
         @SerialName("credential_configuration_ids") val credentialConfigurationIds: JsonArray,
 
-        override val customParameters: Map<String, JsonElement> = mapOf()
+        override val customParameters: Map<String, JsonElement>? = mapOf()
     ) : CredentialOffer() {
 
         class Builder(credentialIssuer: String) : CredentialOffer.Builder<Draft13>(credentialIssuer) {
@@ -95,7 +95,7 @@ sealed class CredentialOffer : JsonDataObject() {
 
         @SerialName("credentials") val credentials: JsonArray,
 
-        override val customParameters: Map<String, JsonElement> = mapOf()
+        override val customParameters: Map<String, JsonElement>? = mapOf()
     ) : CredentialOffer() {
 
         class Builder(

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/CredentialSupported.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/CredentialSupported.kt
@@ -81,7 +81,7 @@ data class CredentialSupported(
     @Serializable(ClaimDescriptorNamespacedMapSerializer::class) val claims: Map<String, Map<String, ClaimDescriptor>>? = null,
     val order: List<String>? = null,
     @SerialName("sdJwtVcTypeMetadata") val sdJwtVcTypeMetadata: SDJWTVCTypeMetadata? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
 
     override fun toJSON(): JsonObject = Json.encodeToJsonElement(CredentialSupportedSerializer, this).jsonObject

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/DisplayProperties.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/DisplayProperties.kt
@@ -32,7 +32,7 @@ data class DisplayProperties(
     @SerialName("background_color") val backgroundColor: String? = null,
     @SerialName("background_image") @Serializable(LogoPropertiesSerializer::class) val backgroundImage: LogoProperties? = null,
     @SerialName("text_color") val textColor: String? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf(),
+    override val customParameters: Map<String, JsonElement>? = mapOf(),
 ) : JsonDataObject() {
     override fun toJSON(): JsonObject = Json.encodeToJsonElement(DisplayPropertiesSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/JsonDataObject.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/JsonDataObject.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.json.*
 
 @Serializable
 abstract class JsonDataObject {
-    abstract val customParameters: Map<String, JsonElement>
+    abstract val customParameters: Map<String, JsonElement>?
     abstract fun toJSON(): JsonObject
     fun toJSONString() = toJSON().toString()
 }

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/LogoProperties.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/LogoProperties.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.json.jsonObject
 data class LogoProperties(
     val url: String? = null,
     @SerialName("alt_text") val altText: String? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON(): JsonObject = Json.encodeToJsonElement(LogoPropertiesSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/OfferedCredential.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/OfferedCredential.kt
@@ -17,7 +17,7 @@ data class OfferedCredential(
     @SerialName("credential_definition") val credentialDefinition: CredentialDefinition? = null,
     @SerialName("proof_types_supported") val proofTypesSupported: Map<ProofType, ProofTypeMetadata>? = null,
     @SerialName("cryptographic_binding_methods_supported") val cryptographicBindingMethodsSupported: Set<String>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(OfferedCredentialSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/OpenIDClientMetadata.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/OpenIDClientMetadata.kt
@@ -41,7 +41,7 @@ data class OpenIDClientMetadata(
     @SerialName("default_acr_values") val defaultAcrValues: List<String>? = null,
     @SerialName("initiate_login_uri") val initiateLoginUri: String? = null,
     @SerialName("request_uris") val requestUris: List<String>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(OpenIDClientMetadataSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/OpenIDProviderMetadata.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/OpenIDProviderMetadata.kt
@@ -186,7 +186,7 @@ sealed class OpenIDProviderMetadata() : JsonDataObject() {
         @SerialName("credentials_supported") @Serializable(CredentialSupportedArraySerializer::class) val credentialSupported: Map<String, CredentialSupported>? = null,
         @SerialName("authorization_server") val authorizationServer: String? = null,
 
-        override val customParameters: Map<String, JsonElement> = mapOf()
+        override val customParameters: Map<String, JsonElement>? = mapOf()
 
     ) : OpenIDProviderMetadata() {
 
@@ -275,7 +275,7 @@ sealed class OpenIDProviderMetadata() : JsonDataObject() {
         @SerialName("authorization_servers") val authorizationServers: Set<String>? = null,
         @SerialName("pre-authorized_grant_anonymous_access_supported") val preAuthorizedGrantAnonymousAccessSupport: Boolean? = null,
 
-        override val customParameters: Map<String, JsonElement> = mapOf()
+        override val customParameters: Map<String, JsonElement>? = mapOf()
 
     ) : OpenIDProviderMetadata() {
         fun getVctByCredentialConfigurationId(credentialConfigurationId: String) =

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/ProofOfPossession.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/ProofOfPossession.kt
@@ -21,7 +21,7 @@ data class ProofOfPossession @OptIn(ExperimentalSerializationApi::class) private
     val jwt: String? = null,
     val cwt: String? = null,
     val ldp_vp: JsonObject? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(ProofOfPossessionSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/SupportedVPFormat.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/SupportedVPFormat.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.jsonObject
 @Serializable
 data class SupportedVPFormat(
     val alg_values_supported: Set<String>,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(SupportedVPFormatSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/DescriptorMapping.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/DescriptorMapping.kt
@@ -19,7 +19,7 @@ data class DescriptorMapping(
     val format: VCFormat? = null,
     val path: String,
     @SerialName("path_nested") val pathNested: DescriptorMapping? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
 
     override fun toJSON(): JsonObject {

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptor.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptor.kt
@@ -23,7 +23,7 @@ data class InputDescriptor(
     @Serializable(InputDescriptorConstraintsSerializer::class) val constraints: InputDescriptorConstraints? = null,
     @Serializable(InputDescriptorSchemaListSerializer::class) val schema: List<InputDescriptorSchema>? = null,
     val group: Set<String>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(InputDescriptorSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorConstraints.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorConstraints.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.jsonObject
 data class InputDescriptorConstraints(
     @Serializable(InputDescriptorFieldListSerializer::class) val fields: List<InputDescriptorField>? = null,
     @SerialName("limit_disclosure") val limitDisclosure: DisclosureLimitation? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(InputDescriptorConstraintsSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorField.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorField.kt
@@ -21,7 +21,7 @@ data class InputDescriptorField(
     val filter: JsonObject? = null,
     val optional: Boolean? = null,
     @SerialName("intent_to_retain") val intentToRetain: Boolean? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON(): JsonObject {
         TODO("Not yet implemented")

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorSchema.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/InputDescriptorSchema.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.JsonObject
 @Serializable
 data class InputDescriptorSchema(
     val uri: String,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>?= mapOf()
 ) : JsonDataObject() {
     override fun toJSON(): JsonObject {
         TODO("Not yet implemented")

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/OutputDescriptor.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/OutputDescriptor.kt
@@ -14,7 +14,7 @@ data class OutputDescriptor(
     val id: String,
     val schema: String,
     val name: String? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(OutputDescriptorSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/PresentationDefinition.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/PresentationDefinition.kt
@@ -19,7 +19,7 @@ data class PresentationDefinition(
     val purpose: String? = null,
     @Serializable(VCFormatMapSerializer::class) val format: Map<VCFormat, VCFormatDefinition>? = null,
     @SerialName("submission_requirements") @Serializable(SubmissionRequirementListSerializer::class) val submissionRequirements: List<SubmissionRequirement>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(PresentationDefinitionSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/PresentationSubmission.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/PresentationSubmission.kt
@@ -15,7 +15,7 @@ data class PresentationSubmission(
     val id: String,
     @SerialName("definition_id") val definitionId: String,
     @SerialName("descriptor_map") @Serializable(DescriptorMappingListSerializer::class) val descriptorMap: List<DescriptorMapping>,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(PresentationSubmissionSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/SubmissionRequirement.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/SubmissionRequirement.kt
@@ -24,7 +24,7 @@ data class SubmissionRequirement(
     val count: Int? = null,
     val min: Int? = null,
     val max: Int? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf(),
+    override val customParameters: Map<String, JsonElement>?= mapOf(),
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(SubmissionRequirementSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/VCFormat.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/data/dif/VCFormat.kt
@@ -18,7 +18,7 @@ import kotlinx.serialization.json.jsonObject
 data class VCFormatDefinition(
     val alg: Set<String>? = null,
     val proof_type: Set<String>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
 
     override fun toJSON() = Json.encodeToJsonElement(VCFormatDefinitionSerializer, this).jsonObject

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/requests/AuthorizationJSONRequest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/requests/AuthorizationJSONRequest.kt
@@ -17,7 +17,7 @@ data class AuthorizationJSONRequest(
     override val scope: Set<String> = setOf(),
     override val state: String? = null,
     override val nonce: String? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject(), IAuthorizationRequest {
     override fun toJSON() = Json.encodeToJsonElement(AuthorizationJSONRequestSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/requests/BatchCredentialRequest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/requests/BatchCredentialRequest.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.jsonObject
 @Serializable
 data class BatchCredentialRequest(
     @SerialName("credential_requests") @Serializable(CredentialRequestListSerializer::class) val credentialRequests: List<CredentialRequest>,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>?= mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = Json.encodeToJsonElement(BatchCredentialRequestSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/requests/CredentialRequest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/requests/CredentialRequest.kt
@@ -28,7 +28,7 @@ data class CredentialRequest(
     @SerialName("credential_definition") val credentialDefinition: CredentialDefinition? = null,
     @SerialName("types") val types: List<String>? = null,
     @SerialName("display") val display: List<DisplayProperties>? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON() = json.encodeToJsonElement(CredentialRequestSerializer, this).jsonObject
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/AuthorizationDirectPostResponse.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/AuthorizationDirectPostResponse.kt
@@ -15,7 +15,7 @@ data class AuthorizationDirectPostResponse(
     @SerialName("redirect_uri") val redirectUri: String? = null,
     val error: String?,
     @SerialName("error_description") val errorDescription: String?,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
 
     override fun toJSON() = Json.encodeToJsonElement(AuthorizationDirectPostResponseSerializer, this).jsonObject

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/CredentialResponse.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/CredentialResponse.kt
@@ -27,7 +27,7 @@ data class CredentialResponse private constructor(
     val error: String? = null,
     @SerialName("error_description") val errorDescription: String? = null,
     @SerialName("error_uri") val errorUri: String? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     val isSuccess get() = (format != null && credential != null) || isDeferred
     val isDeferred get() = acceptanceToken != null

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/PushedAuthorizationResponse.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/PushedAuthorizationResponse.kt
@@ -17,7 +17,7 @@ data class PushedAuthorizationResponse private constructor(
     @SerialName("expires_in") val expiresIn: Duration? = null,
     val error: String? = null,
     @SerialName("error_description") val errorDescription: String? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     val isSuccess get() = requestUri != null
     override fun toJSON(): JsonObject = Json.encodeToJsonElement(PushedAuthorizationResponseSerializer, this).jsonObject

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/TokenResponse.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/responses/TokenResponse.kt
@@ -40,7 +40,7 @@ data class TokenResponse private constructor(
     @SerialName("error_description") val errorDescription: String? = null,
     @SerialName("error_uri") val errorUri: String? = null,
     @Transient val jwsParts: JwsUtils.JwsParts? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>?= mapOf()
 ) : JsonDataObject(), IHTTPDataObject {
     val isSuccess get() = accessToken != null || (vpToken != null && presentationSubmission != null)
     override fun toJSON() = Json.encodeToJsonElement(TokenResponseSerializer, this).jsonObject
@@ -150,7 +150,7 @@ data class TokenResponse private constructor(
             error?.let { put("error", listOf(it)) }
             errorDescription?.let { put("error_description", listOf(it)) }
             errorUri?.let { put("error_uri", listOf(it)) }
-            putAll(customParameters.mapValues { listOf(it.value.toString()) })
+            putAll(customParameters!!.mapValues { listOf(it.value.toString()) })
         }
     }
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/data/dif/VCFormatDefinitionTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/data/dif/VCFormatDefinitionTest.kt
@@ -1,0 +1,58 @@
+package id.walt.oid4vc.data.dif
+
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VCFormatDefinitionTest {
+
+    @Test
+    fun `custom parameters are set although json object is empty`() {
+        val definition = Json.decodeFromString<VCFormatDefinition>(
+            """
+            {}
+        """.trimIndent()
+        )
+        assertNotNull(definition)
+        assertNotNull(definition.customParameters)
+        assertTrue(definition.customParameters.isEmpty())
+    }
+
+    @Test
+    fun `customParameters is not in json object although it is initialized with empty map`() {
+        val definition = VCFormatDefinition(
+            alg = setOf("RS256", "RS384", "RS512"),
+            proof_type = setOf("RS256", "RS384", "RS512"),
+        )
+        assertNotNull(definition.customParameters)
+        val json = definition.toJSON()
+        assertNull(json["customParameters"])
+        assertNotNull(json)
+    }
+
+    @Test
+    fun `customParameters is not in json object although it is initialized with empty map parameter`() {
+        val json = VCFormatDefinition(
+            alg = setOf("RS256", "RS384", "RS512"),
+            proof_type = setOf("RS256", "RS384", "RS512"),
+            customParameters = mapOf()
+        ).toJSON()
+        assertNull(json["customParameters"])
+        assertNotNull(json)
+    }
+
+    @Test
+    fun `customParameters is in json object when parameter is given`() {
+        val json = VCFormatDefinition(
+            alg = setOf("RS256", "RS384", "RS512"),
+            proof_type = setOf("RS256", "RS384", "RS512"),
+            customParameters = mapOf("param1" to JsonPrimitive("value 1"))
+        ).toJSON()
+        assertNull(json["customParameters"])
+        assertNotNull(json)
+    }
+}

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/JsonDataObject.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/JsonDataObject.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.json.*
 
 @Serializable
 abstract class JsonDataObject {
-    abstract val customParameters: Map<String, JsonElement>
+    abstract val customParameters: Map<String, JsonElement>?
     abstract fun toJSON(): JsonObject
     fun toJSONString() = toJSON().toString()
 }

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJWTVCTypeMetadata.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJWTVCTypeMetadata.kt
@@ -19,7 +19,7 @@ data class SDJWTVCTypeMetadata(
     @SerialName("extends#integrity") val extendsIntegrity: String? = null,
     @SerialName("schema#integrity") val schemaIntegrity: String? = null,
     @SerialName("schema_uri#integrity") val schemaUriIntegrity: String? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf()
+    override val customParameters: Map<String, JsonElement>? = mapOf()
 ) : JsonDataObject() {
     override fun toJSON(): JsonObject = Json.encodeToJsonElement(SDJWTVCTypeMetadataSerializer, this).jsonObject
 

--- a/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/entrawallet/core/service/exchange/IssuanceServiceBase.kt
+++ b/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/entrawallet/core/service/exchange/IssuanceServiceBase.kt
@@ -111,7 +111,7 @@ abstract class IssuanceServiceBase {
         credential: String,
     ): CredentialDataResult {
         val credentialEncoding =
-            processedOffer.credentialResponse.customParameters["credential_encoding"]?.jsonPrimitive?.content
+            processedOffer.credentialResponse.customParameters!!["credential_encoding"]?.jsonPrimitive?.content
                 ?: "issuer-signed"
         logger.debug { "Parsed credential encoding: $credentialEncoding" }
 

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/LspPotentialIssuance.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/LspPotentialIssuance.kt
@@ -201,8 +201,8 @@ class LspPotentialIssuance(val client: HttpClient) {
                 setBody(credReq.toJSON())
             }.body<JsonObject>().let { CredentialResponse.fromJSON(it) }
             assertTrue(credResp.isSuccess)
-            assertContains(credResp.customParameters.keys, "credential_encoding")
-            assertEquals("issuer-signed", credResp.customParameters["credential_encoding"]!!.jsonPrimitive.content)
+            assertContains(credResp.customParameters!!.keys, "credential_encoding")
+            assertEquals("issuer-signed", credResp.customParameters!!["credential_encoding"]!!.jsonPrimitive.content)
             assertNotNull(credResp.credential)
             val mdoc = MDoc(
                 credReq.docType!!.toDataElement(), IssuerSigned.fromMapElement(

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/OidcApi.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/OidcApi.kt
@@ -306,7 +306,7 @@ object OidcApi : CIProvider() {
                     }
 
                     val redirectUri = when (authMethod) {
-                        AuthenticationMethod.VP_TOKEN, AuthenticationMethod.ID_TOKEN -> authReq.clientMetadata!!.customParameters["authorization_endpoint"]?.jsonPrimitive?.content
+                        AuthenticationMethod.VP_TOKEN, AuthenticationMethod.ID_TOKEN -> authReq.clientMetadata!!.customParameters!!["authorization_endpoint"]?.jsonPrimitive?.content
                             ?: "openid://"
 
                         else -> if (authReq.isReferenceToPAR) {

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/PresentationSessionInfo.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/PresentationSessionInfo.kt
@@ -55,7 +55,7 @@ data class PresentationSessionInfo(
     val tokenResponse: TokenResponse? = null,
     val verificationResult: Boolean? = null,
     val policyResults: JsonObject? = null,
-    override val customParameters: Map<String, JsonElement> = mapOf(),
+    override val customParameters: Map<String, JsonElement>? = mapOf(),
 ) : JsonDataObject() {
     override fun toJSON() = buildJsonObject {
         put("id", JsonPrimitive(id))

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceBase.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceBase.kt
@@ -63,7 +63,7 @@ abstract class IssuanceServiceBase {
         credential: String,
     ): CredentialDataResult {
         val credentialEncoding =
-            processedOffer.credentialResponse.customParameters["credential_encoding"]?.jsonPrimitive?.content
+            processedOffer.credentialResponse.customParameters!!["credential_encoding"]?.jsonPrimitive?.content
                 ?: "issuer-signed"
         logger.debug { "Parsed credential encoding: $credentialEncoding" }
 


### PR DESCRIPTION
needed to make property JsonDataObject.customParameters nullable, so schema generator knows, this property is not  required. This is needed because an empty customParameters map will not be serialized as empty object "{}". An empty customParameters will result in NOT serializing the property at all.

## Description

Provide a clear and concise description of the changes made in this pull request:



## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [x] code cleanup and self-review
- [x] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-