### PR TITLE
fix: verification result return type for sd-jwt-vc-signature-policy credential branch

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/SdJwtVCSignaturePolicy.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/SdJwtVCSignaturePolicy.kt
@@ -19,106 +19,103 @@ import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 
 expect object JWTCryptoProviderManager {
-  fun getDefaultJWTCryptoProvider(keys: Map<String, Key>): JWTCryptoProvider
+    fun getDefaultJWTCryptoProvider(keys: Map<String, Key>): JWTCryptoProvider
 }
 
-class SdJwtVCSignaturePolicy(): JwtVerificationPolicy() {
-  override val name = "signature_sd-jwt-vc"
-  override val description =
-    "Checks a SD-JWT-VC credential by verifying its cryptographic signature using the key referenced by the DID in `iss`."
-  override val supportedVCFormats = setOf(VCFormat.sd_jwt_vc)
+class SdJwtVCSignaturePolicy() : JwtVerificationPolicy() {
+    override val name = "signature_sd-jwt-vc"
+    override val description =
+        "Checks a SD-JWT-VC credential by verifying its cryptographic signature using the key referenced by the DID in `iss`."
+    override val supportedVCFormats = setOf(VCFormat.sd_jwt_vc)
 
-  private suspend fun resolveIssuerKeyFromSdJwt(sdJwt: SDJwtVC): Key {
-    val kid = sdJwt.issuer ?: randomUUIDString()
-    return if(DidUtils.isDidUrl(kid)) {
-      DidService.resolveToKey(kid).getOrThrow()
-    } else {
-        val x5c = sdJwt.header.get("x5c")?.jsonArray?.lastOrNull()
-            ?: throw IllegalArgumentException("x5c header parameter is missing or empty.")
-        JWKKey.importPEM(x5c.jsonPrimitive.content).getOrThrow().let { JWKKey(it.exportJWK(), kid) }
-    }
-  }
-
-  private suspend fun resolveIssuerKeysFromSdJwt(sdJwt: SDJwtVC): Set<Key> {
-    val kid = sdJwt.issuer ?: randomUUIDString()
-    return if(DidUtils.isDidUrl(kid)) {
-      DidService.resolveToKeys(kid).getOrThrow()
-    } else {
-        val x5c = sdJwt.header.get("x5c")?.jsonArray?.lastOrNull()
-            ?: throw IllegalArgumentException("x5c header parameter is missing or empty.")
-        val key = JWKKey.importPEM(x5c.jsonPrimitive.content).getOrThrow().let { JWKKey(it.exportJWK(), kid) }
-        setOf(key)
-    }
-  }
-
-  @OptIn(ExperimentalJsExport::class)
-  @JvmBlocking
-  @JvmAsync
-  @JsPromise
-  @JsExport.Ignore
-  override suspend fun verify(credential: String, args: Any?, context: Map<String, Any>): Result<Any> {
-    return runCatching {
-      val sdJwtVC = SDJwtVC.parse(credential)
-
-      if(!sdJwtVC.isPresentation) {
-        // Get all possible issuer keys from the DID document
-        val issuerKeys = resolveIssuerKeysFromSdJwt(sdJwtVC)
-
-        if (issuerKeys.isEmpty()) {
-          throw VerificationException("No issuer keys found in the DID document")
+    private suspend fun resolveIssuerKeyFromSdJwt(sdJwt: SDJwtVC): Key {
+        val kid = sdJwt.issuer ?: randomUUIDString()
+        return if (DidUtils.isDidUrl(kid)) {
+            DidService.resolveToKey(kid).getOrThrow()
+        } else {
+            val x5c = sdJwt.header.get("x5c")?.jsonArray?.lastOrNull()
+                ?: throw IllegalArgumentException("x5c header parameter is missing or empty.")
+            JWKKey.importPEM(x5c.jsonPrimitive.content).getOrThrow().let { JWKKey(it.exportJWK(), kid) }
         }
-
-        // Try to verify with each key
-          // Return the first successful result or the last error
-          issuerKeys.firstSuccessOrThrow(
-              { failures ->
-                  VerificationException(
-                      message = "Verification failed with all keys from the DID document",
-                      cause = failures.lastOrNull()
-                  )
-              }) { it.verifyJws(credential) }
-
-      } else {
-        // For presentations, get all possible issuer keys
-        val issuerKeys = resolveIssuerKeysFromSdJwt(sdJwtVC)
-        val issuerKey = issuerKeys.firstOrNull()
-          ?: throw VerificationException("No issuer keys found in the DID document")
-
-        val holderKey = JWKKey.importJWK(sdJwtVC.holderKeyJWK.toString()).getOrThrow()
-
-        // Create a map of all possible issuer keys by their key IDs
-        val keyMap = issuerKeys.associateBy { it.getKeyId() }.toMutableMap()
-
-        // Add the default key ID mapping
-        keyMap[sdJwtVC.keyID ?: issuerKey.getKeyId()] = issuerKey
-        // Add the holder key
-        keyMap[holderKey.getKeyId()] = holderKey
-
-        val verificationResult = sdJwtVC.verifyVC(
-          JWTCryptoProviderManager.getDefaultJWTCryptoProvider(keyMap),
-          requiresHolderKeyBinding = true,
-          context["clientId"]?.toString(),
-          context["challenge"]?.toString()
-        )
-
-        if (!verificationResult.verified) {
-          throw VerificationException("SD-JWT verification failed")
-        }
-
-        sdJwtVC.undisclosedPayload
-      }
     }
-  }
+
+    private suspend fun resolveIssuerKeysFromSdJwt(sdJwt: SDJwtVC): Set<Key> {
+        val kid = sdJwt.issuer ?: randomUUIDString()
+        return if (DidUtils.isDidUrl(kid)) {
+            DidService.resolveToKeys(kid).getOrThrow()
+        } else {
+            val x5c = sdJwt.header.get("x5c")?.jsonArray?.lastOrNull()
+                ?: throw IllegalArgumentException("x5c header parameter is missing or empty.")
+            val key = JWKKey.importPEM(x5c.jsonPrimitive.content).getOrThrow().let { JWKKey(it.exportJWK(), kid) }
+            setOf(key)
+        }
+    }
+
+    @OptIn(ExperimentalJsExport::class)
+    @JvmBlocking
+    @JvmAsync
+    @JsPromise
+    @JsExport.Ignore
+    override suspend fun verify(credential: String, args: Any?, context: Map<String, Any>): Result<Any> {
+        return runCatching {
+            val sdJwtVC = SDJwtVC.parse(credential)
+
+            if (!sdJwtVC.isPresentation) {
+                // Get all possible issuer keys from the DID document
+                val issuerKeys = resolveIssuerKeysFromSdJwt(sdJwtVC)
+
+                if (issuerKeys.isEmpty()) {
+                    throw VerificationException("No issuer keys found in the DID document")
+                }
+
+                // Try to verify with each key
+                // Return the first successful result or the last error
+                issuerKeys.firstSuccessOrThrow(
+                    { failures ->
+                        VerificationException(
+                            message = "Verification failed with all keys from the DID document",
+                            cause = failures.lastOrNull()
+                        )
+                    }) { it.verifyJws(credential) }
+
+            } else {
+                // For presentations, get all possible issuer keys
+                val issuerKeys = resolveIssuerKeysFromSdJwt(sdJwtVC)
+                val issuerKey =
+                    issuerKeys.firstOrNull() ?: throw VerificationException("No issuer keys found in the DID document")
+
+                val holderKey = JWKKey.importJWK(sdJwtVC.holderKeyJWK.toString()).getOrThrow()
+
+                // Create a map of all possible issuer keys by their key IDs
+                val keyMap = issuerKeys.associateBy { it.getKeyId() }.toMutableMap()
+
+                // Add the default key ID mapping
+                keyMap[sdJwtVC.keyID ?: issuerKey.getKeyId()] = issuerKey
+                // Add the holder key
+                keyMap[holderKey.getKeyId()] = holderKey
+
+                val verificationResult = sdJwtVC.verifyVC(
+                    JWTCryptoProviderManager.getDefaultJWTCryptoProvider(keyMap),
+                    requiresHolderKeyBinding = true,
+                    context["clientId"]?.toString(),
+                    context["challenge"]?.toString()
+                )
+
+                if (!verificationResult.verified) {
+                    throw VerificationException("SD-JWT verification failed")
+                }
+
+                sdJwtVC.undisclosedPayload
+            }
+        }
+    }
+
     private inline fun <T, R> Collection<T>.firstSuccessOrThrow(
-        exceptionProvider: (List<Throwable>) -> Exception,
-        block: (T) -> R
+        exceptionProvider: (List<Throwable>) -> Exception, block: (T) -> R
     ): R {
         val failures = mutableListOf<Throwable>()
         return firstNotNullOfOrNull { item ->
-            runCatching { block(item) }.fold(
-                onSuccess = { it },
-                onFailure = { failures.add(it); null }
-            )
+            runCatching { block(item) }.fold(onSuccess = { it }, onFailure = { failures.add(it); null })
         } ?: throw exceptionProvider(failures)
     }
 }


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

Fixes `SdJwtVCSignaturePolicy` verify method to return `Result<JsonElement>` instead of `Result<Result<JsonElement>>` for successful verification in the _credential_ conditional branch following https://github.com/walt-id/waltid-identity/pull/986 updates. Returning `Result<Result<*>>` fails the JSON conversion in [JsonUtils](https://github.com/walt-id/waltid-identity/blob/168dbdae307540e87d4ce04c0902698f6052f0ec/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/utils/JsonUtils.kt#L15) when called by [PolicyResultSurrogate](https://github.com/walt-id/waltid-identity/blob/f47e1c2bd6bdd45a43bb4f93499580d8888c12ee/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/models/PolicyResult.kt#L19) causing errors such as:
```json
{
    "exception": true,
    "id": "IllegalArgumentException",
    "status": "Bad Request",
    "code": "400",
    "message": "Unknown type: Result, was: Success({\"...\"})"
}
```

Updates the error handling logic: throws a `VerificationException` with a consistent message, using the last failed verification attempt as its cause when available. Also, applies code formatting and optimizes imports.

Fixes WAL-1573

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [x] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-