### PR TITLE
feat: [github: #1094] Allow publishing of services to local maven repository

### DIFF
--- a/waltid-services/waltid-issuer-api/build.gradle.kts
+++ b/waltid-services/waltid-issuer-api/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     id("io.ktor.plugin") version "3.1.2" // Versions.KTOR_VERSION
     id("org.owasp.dependencycheck") version "9.2.0"
     id("com.github.jk1.dependency-license-report") version "2.9"
+    id("maven-publish")
     id("com.github.ben-manes.versions")
     application
 }
@@ -165,7 +166,36 @@ application {
     applicationDefaultJvmArgs = listOf("-Dio.ktor.development=$isDevelopment")
 }
 
-/*licenseReport {
-    renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("xyzkit-licenses-report.html", "XYZ Kit"))
-    filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
-}*/
+// Define publication to allow publishing to local maven repo with the command:  ./gradlew publishToMavenLocal
+// This should not be published to https://maven.waltid.dev/ to save storage
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["kotlin"])
+            pom {
+                name.set("walt.id Issuer API REST service")
+                description.set(
+                    """
+                    Kotlin/Java REST service for issuing digital credentials
+                    """.trimIndent()
+                )
+                url.set("https://walt.id")
+
+                licenses {
+                    license {
+                        name.set("Apache License 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("walt.id")
+                        name.set("walt.id")
+                        email.set("office@walt.id")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/waltid-services/waltid-verifier-api/build.gradle.kts
+++ b/waltid-services/waltid-verifier-api/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     id("io.ktor.plugin") version "3.1.2" // Versions.KTOR_VERSION
     id("org.owasp.dependencycheck") version "9.2.0"
     id("com.github.jk1.dependency-license-report") version "2.9"
+    id("maven-publish")
     id("com.github.ben-manes.versions")
     application
 }
@@ -158,7 +159,36 @@ application {
     applicationDefaultJvmArgs = listOf("-Dio.ktor.development=$isDevelopment")
 }
 
-//licenseReport {
-//    renderers = arrayOf<ReportRenderer>(InventoryHtmlReportRenderer("waltid-verifier-licenses-report.html", "walt.id verifier"))
-//    filters = arrayOf<DependencyFilter>(LicenseBundleNormalizer())
-//}
+// Define publication to allow publishing to local maven repo with the command:  ./gradlew publishToMavenLocal
+// This should not be published to https://maven.waltid.dev/ to save storage
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["kotlin"])
+            pom {
+                name.set("walt.id Verifier API REST service")
+                description.set(
+                    """
+                    Kotlin/Java REST service for verifying digital credentials
+                    """.trimIndent()
+                )
+                url.set("https://walt.id")
+
+                licenses {
+                    license {
+                        name.set("Apache License 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("walt.id")
+                        name.set("walt.id")
+                        email.set("office@walt.id")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/waltid-services/waltid-wallet-api/build.gradle.kts
+++ b/waltid-services/waltid-wallet-api/build.gradle.kts
@@ -1,11 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.util.Properties
+import java.util.*
 
 plugins {
     kotlin("jvm")
-    id("io.ktor.plugin") version "3.1.2"
     kotlin("plugin.serialization")
+    id("io.ktor.plugin") version "3.1.2"
+    id("maven-publish")
     id("com.github.ben-manes.versions")
 }
 
@@ -192,4 +193,38 @@ dependencies {
     testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
     testImplementation("io.mockk:mockk:1.13.16")
     testImplementation("io.klogging:klogging-jvm:0.9.1")
+}
+
+// Define publication to allow publishing to local maven repo with the command:  ./gradlew publishToMavenLocal
+// This should not be published to https://maven.waltid.dev/ to save storage
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["kotlin"])
+            pom {
+                name.set("walt.id wallet API REST service")
+                description.set(
+                    """
+                    Kotlin/Java REST service for storing digital credentials
+                    """.trimIndent()
+                )
+                url.set("https://walt.id")
+
+                licenses {
+                    license {
+                        name.set("Apache License 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("walt.id")
+                        name.set("walt.id")
+                        email.set("office@walt.id")
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Description

The gradle command './gradlew publishToMavenLocal' now also includes service artefacts

## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-