### PR TITLE
feat: [WAL-1592] Set Web Wallet default key type secp256r1

### DIFF
--- a/docker-compose/wallet-api/config/registration-defaults.conf
+++ b/docker-compose/wallet-api/config/registration-defaults.conf
@@ -1,7 +1,7 @@
 // Setup what key should be generated on registration
 defaultKeyConfig: {
     backend: jwk
-    keyType: Ed25519
+    keyType: secp256r1
 }
 
 // Setup what DID should be generated based on above above defined key on registration

--- a/waltid-services/waltid-wallet-api/config/registration-defaults.conf
+++ b/waltid-services/waltid-wallet-api/config/registration-defaults.conf
@@ -1,7 +1,7 @@
 // Setup what key should be generated on registration
 defaultKeyConfig: {
     backend: jwk
-    keyType: Ed25519
+    keyType: secp256r1
 }
 
 // Setup what DID should be generated based on above above defined key on registration

--- a/waltid-services/waltid-wallet-api/k8s/deployment-dev.yaml
+++ b/waltid-services/waltid-wallet-api/k8s/deployment-dev.yaml
@@ -43,6 +43,9 @@ data:
         }
     }
   registration-defaults.conf: |
+    defaultKeyConfig: {
+      keyType: secp256r1
+    }
     defaultIssuerConfig: {
       did = "did:web:walt.id",
       description = "walt.id issuer portal",

--- a/waltid-services/waltid-wallet-api/k8s/deployment-prod.yaml
+++ b/waltid-services/waltid-wallet-api/k8s/deployment-prod.yaml
@@ -44,6 +44,9 @@ data:
         }
     }
   registration-defaults.conf: |
+    defaultKeyConfig: {
+      keyType: secp256r1
+    }
     defaultIssuerConfig: {
       did = "did:web:walt.id",
       description = "walt.id issuer portal",


### PR DESCRIPTION
Changed default key type for new registered users to secp256r1. This allows new users also to put mDL and mDocs credentials into their wallet.

## Type of Change
- [x] configuration change 
- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-