### PR TITLE
Fix/api image working dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       version: ${{ needs.version.outputs.release_version }}
       artifact: true
   ebsi-ct-v3:
-    uses: walt-id/waltid-identity/.github/workflows/ebsictv3.yml@834fc56b855b35fe0f71f8a37fe2701f1a8c9150
+    uses: walt-id/waltid-identity/.github/workflows/ebsictv3.yml@08e5e54d8028acba56454e0f1f0c65cc18297a4f
     needs: [ version, docker, api-docker ]
     secrets: inherit
     with:

--- a/.github/workflows/ebsictv3.yml
+++ b/.github/workflows/ebsictv3.yml
@@ -84,7 +84,7 @@ jobs:
             docker build -t $image -f waltid-services/waltid-issuer-api/Dockerfile .
           fi
           
-          docker run --net=host -d -v $PWD/waltid-services/waltid-issuer-api/config:/config --name waltid-issuer-api $image
+          docker run --net=host -d -v $PWD/waltid-services/waltid-issuer-api/config:/waltid-issuer-api/config --name waltid-issuer-api $image
           
           curl --retry 5 --retry-delay 5 --retry-connrefused http://localhost:7002/livez
 

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -20,8 +20,8 @@ services:
       - "$SERVICE_HOST:host-gateway"
       - "waltid.enterprise.localhost:host-gateway"
     volumes:
-      - ./wallet-api/config:/config
-      - ./wallet-api/data:/data
+      - ./wallet-api/config:/waltid-wallet-api/config
+      - ./wallet-api/data:/waltid-wallet-api/data
 
   issuer-api:
     image: ${IMAGE_PREFIX}waltid/issuer-api:${VERSION_TAG:-latest}
@@ -38,7 +38,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./issuer-api/config:/config
+      - ./issuer-api/config:/waltid-issuer-api/config
 
   verifier-api:
     image: ${IMAGE_PREFIX}waltid/verifier-api:${VERSION_TAG:-latest}
@@ -55,7 +55,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./verifier-api/config:/config
+      - ./verifier-api/config:/waltid-verifier-api/config
     environment:
       OPA_SERVER_URL: "http://opa-server:8181"
 

--- a/waltid-applications/waltid-web-portal/k8s/deployment-dev.yaml
+++ b/waltid-applications/waltid-web-portal/k8s/deployment-dev.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: web-portal
-          image: waltid/portal:dev
+          image: waltid/portal:__DEFAULT_IMAGE_TAG__
           imagePullPolicy: Always
           env:
             - name: NEXT_PUBLIC_VC_REPO

--- a/waltid-services/waltid-issuer-api/build.gradle.kts
+++ b/waltid-services/waltid-issuer-api/build.gradle.kts
@@ -236,6 +236,9 @@ ktor {
         )
     }
     jib {
+        container {
+            workingDirectory = "/waltid-issuer-api"
+        }
         from {
             platforms {
                 platform {

--- a/waltid-services/waltid-issuer-api/k8s/deployment-dev.yaml
+++ b/waltid-services/waltid-issuer-api/k8s/deployment-dev.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: issuer
-          image: waltid/issuer-api:dev
+          image: waltid/issuer-api:__DEFAULT_IMAGE_TAG__
           imagePullPolicy: Always
           volumeMounts:
             - name: issuer-web-config

--- a/waltid-services/waltid-verifier-api/build.gradle.kts
+++ b/waltid-services/waltid-verifier-api/build.gradle.kts
@@ -232,6 +232,7 @@ ktor {
     jib {
         container {
             mainClass = "id.walt.verifier.MainKt"
+            workingDirectory = "/waltid-verifier-api"
         }
         from {
             platforms {

--- a/waltid-services/waltid-verifier-api/k8s/deployment-dev.yaml
+++ b/waltid-services/waltid-verifier-api/k8s/deployment-dev.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: verifier
-          image: waltid/verifier-api:dev
+          image: waltid/verifier-api:__DEFAULT_IMAGE_TAG__
           imagePullPolicy: Always
           volumeMounts:
             - name: verifier-web-config

--- a/waltid-services/waltid-wallet-api/build.gradle.kts
+++ b/waltid-services/waltid-wallet-api/build.gradle.kts
@@ -265,6 +265,9 @@ ktor {
         )
     }
     jib {
+        container {
+            workingDirectory = "/waltid-wallet-api"
+        }
         from {
             platforms {
                 platform {

--- a/waltid-services/waltid-wallet-api/k8s/deployment-dev.yaml
+++ b/waltid-services/waltid-wallet-api/k8s/deployment-dev.yaml
@@ -108,7 +108,7 @@ spec:
               name: wallet-data
       containers:
         - name: wallet-api
-          image: waltid/wallet-api:dev
+          image: waltid/wallet-api:__DEFAULT_IMAGE_TAG__
 
           imagePullPolicy: Always
           volumeMounts:
@@ -179,7 +179,7 @@ spec:
     spec:
       containers:
         - name: waltid-dev-wallet
-          image: waltid/waltid-dev-wallet:dev
+          image: waltid/waltid-dev-wallet:__DEFAULT_IMAGE_TAG__
           imagePullPolicy: Always
           env:
             - name: NUXT_PUBLIC_ISSUER_CALLBACK_URL
@@ -208,7 +208,7 @@ spec:
     spec:
       containers:
         - name: waltid-demo-wallet
-          image: waltid/waltid-demo-wallet:dev
+          image: waltid/waltid-demo-wallet:__DEFAULT_IMAGE_TAG__
           imagePullPolicy: Always
           env:
             - name: NUXT_PUBLIC_ISSUER_CALLBACK_URL


### PR DESCRIPTION
Added "workingDirectory" to the Gradle Jib configuration to maintain the same volume mounting behavior when building the Docker image with Ktor instead of a Dockerfile.