### PR TITLE
fix: cicd compose testing to use the localhost postman environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       artifact: issuer-api
       tag: "waltid/issuer-api:${{ needs.version.outputs.release_version }}"
   compose-test:
-    uses: walt-id/waltid-identity/.github/workflows/docker-compose-testing.yml@70e59bbea44de0b3511bb6bd72faa553e92f7bcf
+    uses: walt-id/waltid-identity/.github/workflows/docker-compose-testing.yml@a35cb7a55c0760097214b15db938d49287fdd96c
     needs: [ version, docker, api-docker ]
     secrets: inherit
     with:

--- a/.github/workflows/docker-compose-testing.yml
+++ b/.github/workflows/docker-compose-testing.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         environment:
-          - ./postman/docker.postman_environment.json
+          - ./postman/localhost.postman_environment.json
         config:
           - {
             collection: ./postman/Postman Collections/Issuance-Presentation Tests.postman_collection.json,
@@ -120,8 +120,6 @@ jobs:
           else
             build_arg="--build"
           fi
-          # required by wallet-api for extra-host to avoid 502 bad gateway
-          sed -i 's/localhost/host.docker.internal/g' .env
           docker compose --profile services --profile tse up -d $build_arg
       - name: Ping services
         timeout-minutes: 5


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

Updates the compose-testing workflow, which is required following the updates from #1197 

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-