### PR TITLE
fix: replace hardcoded alg claim from sign-token with private key jws-alg

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VC.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VC.kt
@@ -368,7 +368,7 @@ object OpenID4VC {
         val headers = (header?.toMutableMap() ?: mutableMapOf())
             .plus(
                 mapOf(
-                    JWTClaims.Header.algorithm to "ES256".toJsonElement(),
+                    JWTClaims.Header.algorithm to privKey.keyType.jwsAlg.toJsonElement(),
                     JWTClaims.Header.type to "jwt".toJsonElement(),
                     JWTClaims.Header.keyID to keyId.toJsonElement()
                 )


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

- use private key's jws-alg in `signToken`

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-