### PR TITLE
fix: remove webhook policy from test data causing ietf-sdjwtvc-with-disclosure-verifier2-integration-test to fail

### DIFF
--- a/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/openid4vp/verifier/sdjwt/IETFSdJwtVcWithDisclosureVerifier2IntegrationTest.kt
+++ b/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/openid4vp/verifier/sdjwt/IETFSdJwtVcWithDisclosureVerifier2IntegrationTest.kt
@@ -86,10 +86,6 @@ class IETFSdJwtVcWithDisclosureVerifier2IntegrationTest {
       "expiration",
       "not-before",
       {
-        "policy": "webhook",
-        "url": "https://webhook.site/2ac6171a-cce9-4b89-9fe0-55136da1e2fe"
-      },
-      {
         "policy": "schema",
         "schema": {
           "given_name": "John",


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

Removes webhook policy from test data for `IETFSdJwtVcWithDisclosureVerifier2IntegrationTest`, causing it to fail because of the 3rd party service resource not being available anymore - [webhook url](https://webhook.site/2ac6171a-cce9-4b89-9fe0-55136da1e2fe)

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-