### PR TITLE
Enable 'runtime' feature for integration tests

### DIFF
--- a/waltid-services/waltid-integration-tests/config/_features.conf
+++ b/waltid-services/waltid-integration-tests/config/_features.conf
@@ -2,6 +2,7 @@ enabledFeatures = [
     stopwatch,
     external-signature-endpoints,
     trusted-ca,
+    runtime
     # entra,
     # lsp-potential
     # ...

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/Main.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/Main.kt
@@ -56,10 +56,11 @@ suspend fun main(args: Array<String>) {
 fun webWalletSetup() {
     log.info { "Setting up wallet ..." }
 
-    runCatching { DidWebResolver.enableHttps(ConfigManager.getConfig<RuntimeConfig>().enableDidWebResolverHttps) }.onFailure {
-        log.error(it) { "Could not load `enableDidWebResolverHttps` from runtime config. " + it.message }
+    runCatching {
+        DidWebResolver.enableHttps(ConfigManager.getConfig<RuntimeConfig>().enableDidWebResolverHttps)
+    }.onFailure {
+        log.error(it) { "Could not load `enableDidWebResolverHttps` from runtime config. Feature 'runtime' might not be enabled. " + it.message }
     }
-
     Security.addProvider(BouncyCastleProvider())
 }
 


### PR DESCRIPTION
## Description

Enable 'runtime' feature in the wallet for integration tests. This allows resolving DIDs via http instead of https

## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [x] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-