### PR TITLE
fix: add IACA notBefore to OpenAPI example to prevent startup validation failure

### DIFF
--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/web/controllers/onboarding/openapi/DocumentSignerDocs.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/web/controllers/onboarding/openapi/DocumentSignerDocs.kt
@@ -64,7 +64,8 @@ object DocumentSignerDocs {
                                 "commonName": "Example IACA",
                                 "issuerAlternativeNameConf": {
                                     "uri": "https://iaca.example.com"
-                                }
+                                },
+                                "notBefore": "2025-01-01T00:00:00Z"
                             },
                             "iacaKey": {
                                 "type": "jwk",


### PR DESCRIPTION
## Description

The "Custom validity period" example in DocumentSignerDocs.kt specifies a DS notBefore date (2026-01-01) but omits the IACA notBefore, causing it to default to Clock.System.now(). After January 1, 2026, this fails the validation in DocumentSignerOnboardingRequest that requires IACA.notBefore <= DS.notBefore.

This is a follow-up to PR #1364 which removed the "notBefore cannot be in the past" validation but did not address this cross-certificate validation issue.

Fixes #1420 

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [x] code cleanup and self-review
- [x] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-