### PR TITLE
fix: WAL-493 disable tests which use entra.walt.id as did store

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/VpJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/VpJvmTest.kt
@@ -26,9 +26,15 @@ import io.ktor.util.reflect.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.*
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import kotlin.test.*
 import kotlin.time.Duration.Companion.minutes
 
+/*
+ * TODO: remove this test might also be a valid solution - it needs to be verified, if this
+ *       is already be covered in other tests
+ */
+@Disabled("entra.walt.id is not available anymore - need a new did store")
 class VpJvmTest {
 
     val http = HttpClient {


### PR DESCRIPTION
## Description

Disable test which rely on entra.walt.id as  did store to fix the build pipeline


## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [x] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-