### PR TITLE
set hasPrivateKey to true for AWS, Azure, OCI, and TSE key implementa…

### DIFF
--- a/waltid-libraries/crypto/waltid-crypto-aws/src/main/kotlin/id.walt.crypto.keys.aws/AWSKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto-aws/src/main/kotlin/id.walt.crypto.keys.aws/AWSKey.kt
@@ -38,7 +38,7 @@ class AWSKey(
         }
 
     override val hasPrivateKey: Boolean
-        get() = false
+        get() = true
 
 
     override fun toString(): String = "[AWS ${keyType.name} key @AWS ${config.region} - $id]"

--- a/waltid-libraries/crypto/waltid-crypto-azure/src/main/kotlin/id/walt/crypto/keys/azure/AzureKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto-azure/src/main/kotlin/id/walt/crypto/keys/azure/AzureKey.kt
@@ -34,7 +34,7 @@ class AzureKey(
         }
 
     override val hasPrivateKey: Boolean
-        get() = false
+        get() = true
 
     override fun toString(): String = "[Azure ${keyType.name} key @KeyVault - $id]"
 

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/aws/AWSKeyRestAPI.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/aws/AWSKeyRestAPI.kt
@@ -74,7 +74,7 @@ class AWSKeyRestAPI(
         }
 
     override val hasPrivateKey: Boolean
-        get() = false
+        get() = true
 
     override fun toString(): String = "[AWS ${keyType.name} key @AWS ${config.auth.region} - $id]"
 

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/azure/AzureKeyRestApi.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/azure/AzureKeyRestApi.kt
@@ -96,7 +96,7 @@ class AzureKeyRestApi(
         }
 
     override val hasPrivateKey: Boolean
-        get() = false
+        get() = true
 
     override fun toString(): String = "[Azure ${keyType.name} key @ ${auth.keyVaultUrl} - $id]"
 

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/oci/OCIKeyRestApi.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/oci/OCIKeyRestApi.kt
@@ -71,7 +71,7 @@ class OCIKeyRestApi(
         }
 
     override val hasPrivateKey: Boolean
-        get() = false
+        get() = true
 
     /** returns public key as PEM */
     private suspend fun retrievePublicKey(): Key {

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/tse/TSEKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/tse/TSEKey.kt
@@ -121,7 +121,7 @@ class TSEKey(
     )
 
     override val hasPrivateKey: Boolean
-        get() = TODO("Not yet implemented")
+        get() = true
 
     @JvmBlocking
     @JvmAsync


### PR DESCRIPTION
This pull request updates the implementation of the `hasPrivateKey` property across several key classes for cloud and remote key management systems. The main change is to consistently indicate that these key objects possess a private key, which may affect logic that checks for key capabilities or permissions.

Cloud key provider classes:

* `AWSKey`, `AWSKeyRestAPI`: Changed `hasPrivateKey` to always return `true`, indicating that AWS-managed keys are considered to have a private key. [[1]](diffhunk://#diff-3eb4bbcd8f3aedb994fec9df4780726ccff604b88516de39b949aecf1257489aL41-R41) [[2]](diffhunk://#diff-6e2137649c612dd7d4e262d470357d79d3fd8bbd8775e4c45f63191eedb37c02L77-R77)
* `AzureKey`, `AzureKeyRestApi`: Changed `hasPrivateKey` to always return `true`, indicating that Azure-managed keys are considered to have a private key. [[1]](diffhunk://#diff-9559534c5b6470423eceda149bfe4c2b82d4feeb2ba17e8d306d7c1f9d1c9a93L37-R37) [[2]](diffhunk://#diff-2d0fb95fb9cccd5d6e86f9b6db7773ff2deb7baf53766657fd1a16b5449baa6fL99-R99)
* [`OCIKeyRestApi`](diffhunk://#diff-8490d09b312642ffbec3055659de07e28bb202b42d1930c18a0895d23579db83L74-R74): Changed `hasPrivateKey` to always return `true`, indicating that OCI-managed keys are considered to have a private key.

Other key provider classes:

* [`TSEKey`](diffhunk://#diff-de96730984f1f8d2cbc534bd237334e86c24c24b7ca1ee1bff9ef10ef4c42d96L124-R124): Implemented `hasPrivateKey` to return `true` instead of a placeholder, indicating that TSE keys are considered to have a private key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed private key availability detection for cloud-managed keys (AWS, Azure, OCI, TSE). These keys now correctly report when a private key is available for signing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->