### PR TITLE
remove key check to support referenced keys

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/openid4vp/verifier/data/VerificationSessionSetupData.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/openid4vp/verifier/data/VerificationSessionSetupData.kt
@@ -52,14 +52,6 @@ data class GeneralFlowConfig(
     init {
         // Verify if DCQL Query is correct
         dcqlQuery.precheck()
-
-        if (signedRequest) {
-            requireNotNull(key) { "Requested signed request, but did not provide a key (to sign request with)!" }
-        }
-
-        if (encryptedResponse) {
-            requireNotNull(key) { "Requested encrypted response, but did not provide a key (to decrypt response with)!" }
-        }
     }
 }
 


### PR DESCRIPTION
Related to WAL-508

Enterprise: https://github.com/walt-id/waltid-identity-enterprise/pull/326

I removed the constraint for a key to be part of the Data Class as with the reference key it is provided elsewhere and the signing anyway happens in a different step