### PR TITLE
chore: clean up class references in status policies

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/StatusPolicy.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/StatusPolicy.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.JsonElement
 @SerialName("credential-status")
 class StatusPolicy(
     private val argument: StatusPolicyArgument,
-) : id.walt.policies2.vc.policies.CredentialVerificationPolicy2() {
+) : CredentialVerificationPolicy2() {
 
     override val id: String = "credential-status"
 

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/bit/BitRepresentationStrategy.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/bit/BitRepresentationStrategy.kt
@@ -4,10 +4,10 @@ interface BitRepresentationStrategy {
     operator fun invoke(): IntProgression
 }
 
-class BigEndianRepresentation : id.walt.policies2.vc.policies.status.bit.BitRepresentationStrategy {
+class BigEndianRepresentation : BitRepresentationStrategy {
     override fun invoke(): IntProgression = 7 downTo 0
 }
 
-class LittleEndianRepresentation : id.walt.policies2.vc.policies.status.bit.BitRepresentationStrategy {
+class LittleEndianRepresentation : BitRepresentationStrategy {
     override fun invoke(): IntProgression = 0..7
 }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/bit/BitValueReader.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/bit/BitValueReader.kt
@@ -55,7 +55,7 @@ class BitValueReader(
     }
 
     private fun ByteArray.toBitSequence(): Sequence<Boolean> =
-        this.fold(emptySequence<Boolean>()) { acc, byte ->
+        this.fold(emptySequence()) { acc, byte ->
             acc + bitRepresentationStrategy().map { i -> (byte.toUInt() shr i) and 1u == 1u }.asSequence()
         }
 

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/content/JsonElementParser.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/content/JsonElementParser.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.JsonElement
 
 class JsonElementParser<T>(
     private val serializer: KSerializer<T>
-) : id.walt.policies2.vc.policies.status.content.ContentParser<JsonElement, T> {
+) : ContentParser<JsonElement, T> {
     private val jsonModule = Json { ignoreUnknownKeys = true }
 
     override fun parse(response: JsonElement): T = jsonModule.decodeFromJsonElement(serializer, response)

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/content/JwtParser.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/content/JwtParser.kt
@@ -4,7 +4,7 @@ import id.walt.crypto.utils.Base64Utils.base64UrlDecode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
-class JwtParser : id.walt.policies2.vc.policies.status.content.ContentParser<String, JsonObject> {
+class JwtParser : ContentParser<String, JsonObject> {
 
     override fun parse(response: String): JsonObject = response.substringAfter(".").substringBefore(".")
         .let { Json.decodeFromString<JsonObject>(it.base64UrlDecode().decodeToString()) }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/entry/IETFEntryExtractor.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/entry/IETFEntryExtractor.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 
 class IETFEntryExtractor(
-    private val mdocExtractor: id.walt.policies2.vc.policies.status.entry.EntryExtractor,
-) : id.walt.policies2.vc.policies.status.entry.EntryExtractor {
+    private val mdocExtractor: EntryExtractor,
+) : EntryExtractor {
     override fun extract(data: JsonElement): JsonElement? = data.jsonObject["status"] ?: mdocExtractor.extract(data)
 }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/entry/MDocEntryExtractor.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/entry/MDocEntryExtractor.kt
@@ -5,7 +5,7 @@ import id.walt.mdoc.mso.StatusListInfo
 import id.walt.policies2.vc.policies.status.model.IETFEntry
 import kotlinx.serialization.json.*
 
-class MDocEntryExtractor : id.walt.policies2.vc.policies.status.entry.EntryExtractor {
+class MDocEntryExtractor : EntryExtractor {
     private val json = Json
     override fun extract(data: JsonElement): JsonElement? = data.jsonObject["mdoc"]?.let {
         MDoc.fromCBORHex(it.jsonPrimitive.content).MSO?.status?.statusList?.let {

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/entry/W3CEntryExtractor.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/entry/W3CEntryExtractor.kt
@@ -3,6 +3,6 @@ package id.walt.policies2.vc.policies.status.entry
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 
-class W3CEntryExtractor : id.walt.policies2.vc.policies.status.entry.EntryExtractor {
+class W3CEntryExtractor : EntryExtractor {
     override fun extract(data: JsonElement): JsonElement? = data.jsonObject["credentialStatus"]
 }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/BitstringStatusListExpansionAlgorithm.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/BitstringStatusListExpansionAlgorithm.kt
@@ -7,7 +7,7 @@ import korlibs.io.compression.uncompress
 
 class BitstringStatusListExpansionAlgorithm(
     private val base64UrlHandler: Base64UrlHandler,
-) : id.walt.policies2.vc.policies.status.expansion.StatusListExpansionAlgorithm {
+) : StatusListExpansionAlgorithm {
     override suspend operator fun invoke(bitstring: String): ByteArray {
         val base64UrlResult = base64UrlHandler.decodeBase64Url(bitstring)
         require(base64UrlResult.type == Base64UrlType.Multibase) { "Expecting multibase base64-url, got regular base64-url: $bitstring" }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/RevocationList2020ExpansionAlgorithm.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/RevocationList2020ExpansionAlgorithm.kt
@@ -4,7 +4,7 @@ import id.walt.crypto.utils.Base64Utils.base64Decode
 import korlibs.io.compression.deflate.ZLib
 import korlibs.io.compression.uncompress
 
-class RevocationList2020ExpansionAlgorithm : id.walt.policies2.vc.policies.status.expansion.StatusListExpansionAlgorithm {
+class RevocationList2020ExpansionAlgorithm : StatusListExpansionAlgorithm {
     override suspend operator fun invoke(bitstring: String): ByteArray =
         ZLib.uncompress(bitstring.base64Decode())
 }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/StatusList2021ExpansionAlgorithm.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/StatusList2021ExpansionAlgorithm.kt
@@ -5,7 +5,7 @@ import korlibs.io.compression.deflate.GZIP
 import korlibs.io.compression.uncompress
 
 
-class StatusList2021ExpansionAlgorithm : id.walt.policies2.vc.policies.status.expansion.StatusListExpansionAlgorithm {
+class StatusList2021ExpansionAlgorithm : StatusListExpansionAlgorithm {
     override suspend operator fun invoke(bitstring: String): ByteArray =
         GZIP.uncompress(bitstring.base64Decode())
 }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/TokenStatusListExpansionAlgorithm.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/expansion/TokenStatusListExpansionAlgorithm.kt
@@ -7,7 +7,7 @@ import korlibs.io.compression.uncompress
 
 class TokenStatusListExpansionAlgorithm(
     private val base64UrlHandler: Base64UrlHandler,
-) : id.walt.policies2.vc.policies.status.expansion.StatusListExpansionAlgorithm {
+) : StatusListExpansionAlgorithm {
     override suspend operator fun invoke(bitstring: String): ByteArray {
         val base64UrlResult = base64UrlHandler.decodeBase64Url(bitstring)
         require(base64UrlResult.type == Base64UrlType.Regular) { "Expecting regular base64-url, got: $bitstring" }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/Entry.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/Entry.kt
@@ -26,7 +26,7 @@ data class W3CEntry(
     val statuses: List<Status>? = null,
     @SerialName("statusReference")
     val reference: String? = null,
-) : id.walt.policies2.vc.policies.status.model.StatusEntry() {
+) : StatusEntry() {
     @Serializable
     data class Status(
         @SerialName("status")
@@ -39,7 +39,7 @@ data class W3CEntry(
 data class IETFEntry(
     @SerialName("status_list")
     val statusList: StatusListField,
-) : id.walt.policies2.vc.policies.status.model.StatusEntry() {
+) : StatusEntry() {
     override val index: ULong = statusList.index
     override val uri: String = statusList.uri
 

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusContent.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusContent.kt
@@ -20,7 +20,7 @@ data class W3CStatusContent(
     val purpose: String? = "revocation",
     @SerialName("encodedList")
     override val list: String,
-) : id.walt.policies2.vc.policies.status.model.StatusContent()
+) : StatusContent()
 
 @Serializable
 @SerialName("IETFStatusContent")
@@ -29,4 +29,4 @@ data class IETFStatusContent(
     val size: Int = 1,
     @SerialName("lst")
     override val list: String,
-) : id.walt.policies2.vc.policies.status.model.StatusContent()
+) : StatusContent()

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusError.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusError.kt
@@ -12,16 +12,16 @@ sealed class StatusError : Throwable() {
 @SerialName("STATUS_RETRIEVAL_ERROR")
 data class StatusRetrievalError(
     override val message: String,
-) : id.walt.policies2.vc.policies.status.model.StatusError()
+) : StatusError()
 
 @Serializable
 @SerialName("STATUS_VERIFICATION_ERROR")
 data class StatusVerificationError(
     override val message: String,
-) : id.walt.policies2.vc.policies.status.model.StatusError()
+) : StatusError()
 
 @Serializable
 @SerialName("STATUS_LIST_LENGTH_ERROR")
 data class StatusLengthError(
     override val message: String,
-) : id.walt.policies2.vc.policies.status.model.StatusError()
+) : StatusError()

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusPolicyAttribute.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusPolicyAttribute.kt
@@ -14,7 +14,7 @@ sealed class StatusPolicyArgument
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 @JsonClassDiscriminator("discriminator")
-sealed class StatusPolicyAttribute : id.walt.policies2.vc.policies.status.model.StatusPolicyArgument() {
+sealed class StatusPolicyAttribute : StatusPolicyArgument() {
     abstract val value: UInt
 }
 
@@ -24,19 +24,19 @@ data class W3CStatusPolicyAttribute(
     override val value: UInt,
     val purpose: String,
     val type: String,
-) : id.walt.policies2.vc.policies.status.model.StatusPolicyAttribute()
+) : StatusPolicyAttribute()
 
 @Serializable
 @SerialName("ietf")
 data class IETFStatusPolicyAttribute(
     override val value: UInt,
-) : id.walt.policies2.vc.policies.status.model.StatusPolicyAttribute()
+) : StatusPolicyAttribute()
 
 @Serializable
 @SerialName("w3c-list")
 data class W3CStatusPolicyListArguments(
-    val list: List<id.walt.policies2.vc.policies.status.model.W3CStatusPolicyAttribute>,
-) : id.walt.policies2.vc.policies.status.model.StatusPolicyArgument() {
+    val list: List<W3CStatusPolicyAttribute>,
+) : StatusPolicyArgument() {
     init {
         require(list.isNotEmpty()) { "List cannot be empty" }
         require(list.all { it.type == BITSTRING_STATUS_LIST }) {

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/IETFStatusValidator.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/IETFStatusValidator.kt
@@ -14,7 +14,7 @@ class IETFStatusValidator(
     reader: StatusValueReader<IETFStatusContent>,
     bitValueReaderFactory: BitValueReaderFactory,
     private val expansionAlgorithm: StatusListExpansionAlgorithm,
-) : id.walt.policies2.vc.policies.status.validator.StatusValidatorBase<IETFStatusContent, IETFEntry, IETFStatusPolicyAttribute>(
+) : StatusValidatorBase<IETFStatusContent, IETFEntry, IETFStatusPolicyAttribute>(
     fetcher,
     reader
 ) {

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/StatusValidatorBase.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/StatusValidatorBase.kt
@@ -11,7 +11,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 abstract class StatusValidatorBase<K : StatusContent, M : id.walt.policies2.vc.policies.status.model.StatusEntry, T : StatusPolicyAttribute>(
     private val fetcher: CredentialFetcher,
     private val reader: StatusValueReader<K>,
-) : id.walt.policies2.vc.policies.status.validator.StatusValidator<M, T> {
+) : StatusValidator<M, T> {
     protected val logger = KotlinLogging.logger {}
 
     override suspend fun validate(entry: M, attribute: T): Result<Unit> = runCatching {

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/W3CStatusValidator.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/W3CStatusValidator.kt
@@ -15,7 +15,7 @@ class W3CStatusValidator(
     reader: StatusValueReader<W3CStatusContent>,
     private val bitValueReaderFactory: BitValueReaderFactory,
     private val expansionAlgorithmFactory: StatusListExpansionAlgorithmFactory<W3CStatusContent>,
-) : id.walt.policies2.vc.policies.status.validator.StatusValidatorBase<W3CStatusContent, W3CEntry, W3CStatusPolicyAttribute>(
+) : StatusValidatorBase<W3CStatusContent, W3CEntry, W3CStatusPolicyAttribute>(
     fetcher,
     reader
 ) {


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

Replaces fully qualified class names with direct references for interfaces and base classes throughout the status policy modules. This cleans up artifacts from the migration from the `id.walt.policies2.policies` package to `id.walt.policies2.vc.policies`. This improves code readability and maintainability by reducing verbosity and simplifying type declarations.

## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality


## Checklist

- [x] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal type references throughout the codebase by removing verbose fully-qualified package paths and relying on direct imports for improved code readability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->