### PR TITLE
Default statusSize to 1 in W3CEntry

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/status/model/Entry.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/status/model/Entry.kt
@@ -19,7 +19,7 @@ data class W3CEntry(
     @SerialName("statusListIndex")
     override val index: ULong,
     @SerialName("statusSize")
-    val size: Int,
+    val size: Int = 1,
     @SerialName("statusListCredential")
     override val uri: String,
     @SerialName("statusMessage")


### PR DESCRIPTION
## Description

According to the [W3C Bitstring Status List specification](https://www.w3.org/TR/vc-bitstring-status-list/), the statusSize field is optional and defaults to 1 when not present.

See https://www.w3.org/TR/vc-bitstring-status-list/#bitstringstatuslistentry, 

> The statusSize indicates the size of the status entry in bits. statusSize MAY be provided. If statusSize is not present as a property of the credentialStatus, then statusSize MUST be processed as 1.

Error received when using `credential-status` or `revoked-status-list` policy.

```
"policyResults" => array:4 [▼
  0 => array:4 [▶]
  1 => array:4 [▶]
  2 => array:4 [▶]
  3 => array:5 [▼
	"policy" => "credential-status"
	"description" => "Verifies Credential Status"
	"args" => array:4 [▶]
	"is_success" => false
	"error" => """
	  kotlinx.serialization.MissingFieldException: Field 'statusSize' is required for type with serial name 'id.walt.policies.policies.status.model.W3CEntry', but it was missing ◀
	  \tat kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:20)
	  \tat id.walt.policies.policies.status.model.W3CEntry.<init>(Entry.kt:13)
	  \tat id.walt.policies.policies.status.model.W3CEntry.<init>(Entry.kt)
	  \tat id.walt.policies.policies.status.model.W3CEntry$$serializer.deserialize(Entry.kt:13)
	  \tat id.walt.policies.policies.status.model.W3CEntry$$serializer.deserialize(Entry.kt:13)
	  \tat kotlinx.serialization.json.internal.AbstractJsonTreeDecoder.decodeSerializableValue(TreeJsonDecoder.kt:351)
	  \tat kotlinx.serialization.json.internal.TreeJsonDecoderKt.readJson(TreeJsonDecoder.kt:25)
	  \tat kotlinx.serialization.json.Json.decodeFromJsonElement(Json.kt:170)
	  \tat id.walt.policies.policies.status.content.JsonElementParser.parse(JsonElementParser.kt:12)
	  \tat id.walt.policies.policies.status.StatusPolicyImplementation.processW3C-0E7RQCE(StatusPolicyImplementation.kt:80)
	  \tat id.walt.policies.policies.status.StatusPolicyImplementation.processStatusEntry-0E7RQCE(StatusPolicyImplementation.kt:75)
	  \tat id.walt.policies.policies.status.StatusPolicyImplementation.verifyWithAttributes-0E7RQCE(StatusPolicyImplementation.kt:70)
	  \tat id.walt.policies.policies.StatusPolicy.verify-BWLJW6A(StatusPolicy.kt:42)
	  \tat id.walt.policies.Verifier.runPolicyRequest-BWLJW6A(Verifier.kt:80)
	  \tat id.walt.policies.Verifier$runPolicyRequests$2$1$1.invokeSuspend(Verifier.kt:132)
	  \tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	  \tat kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	  \tat kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
	  \tat kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:94)
	  \tat kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:70)
	  \tat kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	  \tat kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
	  \tat kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	  \tat id.walt.verifier.oidc.OIDCVerifierService.doVerify(OIDCVerifierService.kt:188)
	  \tat id.walt.oid4vc.providers.OpenIDCredentialVerifier.verify(OpenIDCredentialVerifier.kt:137)
	  \tat id.walt.verifier.oidc.VerifierService.verify-0E7RQCE(VerifierService.kt:198)
	  \tat id.walt.verifier.VerifierApiKt$verifierApi$1$2$2.invokeSuspend(VerifierApi.kt:128)
	  \tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	  \tat kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	  \tat kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	  \tat kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	  \tat kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	  \tat kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	  \tat kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	  \tat kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
	  """
  ]
]
```
## Type of Change

- [x] bug fix - change which fixes an issue


## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

I would expect that this is not a breaking change but a bug fix as it did not comply with the standard and returns an error when it was not provided.