### PR TITLE
Hide unnecessary URLs for Annex C creation response

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
@@ -79,7 +79,7 @@ data class Verification2Session(
      * OpenID4VP Authorization Request used for this Verification Session
      */
     val authorizationRequest: AuthorizationRequest,
-    val authorizationRequestUrl: Url,
+    val authorizationRequestUrl: Url?,
 
     val signedAuthorizationRequestJwt: String? = null,
     val ephemeralDecryptionKey: DirectSerializedKey? = null,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreationResponse.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreationResponse.kt
@@ -8,8 +8,8 @@ import kotlinx.serialization.json.JsonObject
 @Serializable
 data class VerificationSessionCreationResponse(
     val sessionId: String,
-    val bootstrapAuthorizationRequestUrl: Url?,
-    val fullAuthorizationRequestUrl: Url,
+    val bootstrapAuthorizationRequestUrl: Url? = null,
+    val fullAuthorizationRequestUrl: Url? = null,
     val creationTarget: String? = null,
 
     // Custom data:

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
@@ -298,7 +298,7 @@ object VerificationSessionCreator {
             bootstrapAuthorizationRequestUrl = if (!isAnnexC) bootstrapAuthorizationRequestUrl else null,
 
             authorizationRequest = authorizationRequest,
-            authorizationRequestUrl = authorizationRequestUrl,
+            authorizationRequestUrl = if (!isAnnexC) authorizationRequestUrl else null,
             signedAuthorizationRequestJwt = signedAuthorizationRequest,
             ephemeralDecryptionKey = ephemeralKey?.let { DirectSerializedKey(it) },
             jwkThumbprint = ephemeralKey?.getPublicKey()?.getThumbprint(),


### PR DESCRIPTION
https://github.com/walt-id/waltid-identity-enterprise/pull/348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced flexibility in the OpenID4VP verifier by making authorization request URLs optional in certain verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->