### PR TITLE
Annex C fixes

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/VerificationSessionSetupData.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/VerificationSessionSetupData.kt
@@ -313,10 +313,10 @@ data class DcApiAnnexCFlowSetup(
         require(!parsedOrigin.nonComplexTrailingSlash) {
             "Your provided origin \"$origin\" has a trailing slash ('/' at the end), this will be silently dropped by OS handlers when using DC API. Remove the trailing slash to avoid errors."
         }
-        coreInput.dcqlQuery?.let {
+        coreInput?.dcqlQuery?.let {
             require(it == core.dcqlQuery) { "core_flow.dcql_query must match docType/requestedElements" }
         }
-        coreInput.policies?.let {
+        coreInput?.policies?.let {
             require(it == core.policies) { "core_flow.policies must match policies" }
         }
     }


### PR DESCRIPTION
Resolves WAL-746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Verification session setup now accepts an optional, private core override while keeping the publicly exposed core computed from other inputs.
  * Validation updated to conditionally validate any provided core override fields against the computed core.
  * Notifications provided via the optional override are now included in the generated core flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->