### PR TITLE
add support for multiple status values

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusPolicyAttribute.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/model/StatusPolicyAttribute.kt
@@ -15,22 +15,35 @@ sealed class StatusPolicyArgument
 @Serializable
 @JsonClassDiscriminator("discriminator")
 sealed class StatusPolicyAttribute : StatusPolicyArgument() {
-    abstract val value: UInt
+    abstract val value: UInt?
+    abstract val values: List<UInt>?
+    
+    fun getAllowedValues(): List<UInt> = values?.takeIf { it.isNotEmpty() } ?: listOfNotNull(value)
 }
 
 @Serializable
 @SerialName("w3c")
 data class W3CStatusPolicyAttribute(
-    override val value: UInt,
+    override val value: UInt? = null,
+    override val values: List<UInt>? = null,
     val purpose: String,
     val type: String,
-) : StatusPolicyAttribute()
+) : StatusPolicyAttribute() {
+    init {
+        require(value != null || !values.isNullOrEmpty()) { "Either 'value' or 'values' must be provided" }
+    }
+}
 
 @Serializable
 @SerialName("ietf")
 data class IETFStatusPolicyAttribute(
-    override val value: UInt,
-) : StatusPolicyAttribute()
+    override val value: UInt? = null,
+    override val values: List<UInt>? = null,
+) : StatusPolicyAttribute() {
+    init {
+        require(value != null || !values.isNullOrEmpty()) { "Either 'value' or 'values' must be provided" }
+    }
+}
 
 @Serializable
 @SerialName("w3c-list")

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/StatusValidatorBase.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/validator/StatusValidatorBase.kt
@@ -85,8 +85,9 @@ abstract class StatusValidatorBase<K : StatusContent, M : id.walt.policies2.vc.p
         }
         val binaryString = bitValue.joinToString("")
         val intValue = binToInt(binaryString)
-        if (intValue.toUInt() != attribute.value) {
-            throw StatusVerificationError("Status validation failed: expected ${attribute.value}, but got $intValue")
+        val allowedValues = attribute.getAllowedValues()
+        if (intValue.toUInt() !in allowedValues) {
+            throw StatusVerificationError("Status validation failed: expected one of $allowedValues, but got $intValue")
         }
     }
 

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/jvmTest/kotlin/id/walt/policies2/vc/status/validator/IETFStatusValidatorTests.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/jvmTest/kotlin/id/walt/policies2/vc/status/validator/IETFStatusValidatorTests.kt
@@ -49,6 +49,10 @@ class IETFStatusValidatorTests : StatusValidatorTestsBase<IETFEntry, IETFStatusP
         value = value
     )
 
+    override fun createAttributeWithValues(scenario: TestScenario, values: List<UInt>) = IETFStatusPolicyAttribute(
+        values = values
+    )
+
     override fun createStatusContent(scenario: TestScenario, size: Int) = IETFStatusContent(
         list = "encoded_ietf_list_default",
         size = size

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/jvmTest/kotlin/id/walt/policies2/vc/status/validator/StatusValidatorTestsBase.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/jvmTest/kotlin/id/walt/policies2/vc/status/validator/StatusValidatorTestsBase.kt
@@ -43,6 +43,7 @@ abstract class StatusValidatorTestsBase<M : StatusEntry, K : StatusPolicyAttribu
     protected abstract fun createStatusValidator(): StatusValidator<M, K>
     protected abstract fun createEntry(scenario: TestScenario, size: Int = 1): M
     protected abstract fun createAttribute(scenario: TestScenario, value: UInt): K
+    protected abstract fun createAttributeWithValues(scenario: TestScenario, values: List<UInt>): K
     protected abstract fun createStatusContent(scenario: TestScenario, size: Int): T
     protected abstract fun getBitRepresentationStrategy(): BitRepresentationStrategy
     protected abstract fun setupBitValueReader(statusSize: Int, scenario: TestScenario, bitValue: List<Char>)
@@ -86,6 +87,56 @@ abstract class StatusValidatorTestsBase<M : StatusEntry, K : StatusPolicyAttribu
         @DisplayName("Should successfully validate zero values")
         fun shouldValidateZeroValues(scenario: TestScenario) = runTest {
             testSuccessfulValidation(scenario, statusSize = 1, bitValue = listOf('0'), expectedValue = 0u)
+        }
+    }
+
+    @Nested
+    @DisplayName("Multi-value validation scenarios")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class MultiValueValidationScenarios {
+
+        fun getTestScenarios() = this@StatusValidatorTestsBase.getTestScenarios()
+
+        @ParameterizedTest
+        @MethodSource("getTestScenarios")
+        @DisplayName("Should successfully validate when actual value matches one of multiple allowed values")
+        fun shouldValidateWhenValueMatchesOneOfMultiple(scenario: TestScenario) = runTest {
+            val entry = createEntry(scenario, size = 2)
+            val attribute = createAttributeWithValues(scenario, listOf(0u, 1u, 2u)) // Allow 0, 1, or 2
+            val content = createStatusContent(scenario, size = 2)
+
+            setupValidationScenario(scenario, content, listOf('1', '0'), 2) // binary 10 = 2
+
+            val result = sut.validate(entry, attribute)
+            assertTrue(result.isSuccess)
+        }
+
+        @ParameterizedTest
+        @MethodSource("getTestScenarios")
+        @DisplayName("Should successfully validate when actual value matches first of multiple allowed values")
+        fun shouldValidateWhenValueMatchesFirst(scenario: TestScenario) = runTest {
+            val entry = createEntry(scenario, size = 1)
+            val attribute = createAttributeWithValues(scenario, listOf(0u, 1u)) // Allow 0 or 1
+            val content = createStatusContent(scenario, size = 1)
+
+            setupValidationScenario(scenario, content, listOf('0'), 1) // binary 0 = 0
+
+            val result = sut.validate(entry, attribute)
+            assertTrue(result.isSuccess)
+        }
+
+        @ParameterizedTest
+        @MethodSource("getTestScenarios")
+        @DisplayName("Should fail validation when actual value not in allowed values list")
+        fun shouldFailWhenValueNotInAllowedList(scenario: TestScenario) = runTest {
+            val entry = createEntry(scenario, size = 2)
+            val attribute = createAttributeWithValues(scenario, listOf(0u, 1u)) // Allow only 0 or 1
+            val content = createStatusContent(scenario, size = 2)
+
+            setupValidationScenario(scenario, content, listOf('1', '1'), 2) // binary 11 = 3
+
+            val exception = assertThrows<StatusVerificationError> { sut.validate(entry, attribute).getOrThrow() }
+            assertEquals("Status validation failed: expected one of [0, 1], but got 3", exception.message)
         }
     }
 
@@ -201,7 +252,7 @@ abstract class StatusValidatorTestsBase<M : StatusEntry, K : StatusPolicyAttribu
             setupBitValueReader(3, scenario, listOf('1', '0', '1')) // binary 101 = 5
 
             val exception = assertThrows<StatusVerificationError> { sut.validate(entry, attribute).getOrThrow() }
-            assertEquals("Status validation failed: expected 7, but got 5", exception.message)
+            assertEquals("Status validation failed: expected one of [7], but got 5", exception.message)
         }
     }
 

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/jvmTest/kotlin/id/walt/policies2/vc/status/validator/W3CStatusValidatorTests.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/jvmTest/kotlin/id/walt/policies2/vc/status/validator/W3CStatusValidatorTests.kt
@@ -56,6 +56,12 @@ class W3CStatusValidatorTests : StatusValidatorTestsBase<W3CEntry, W3CStatusPoli
         type = scenario.statusType
     )
 
+    override fun createAttributeWithValues(scenario: TestScenario, values: List<UInt>) = W3CStatusPolicyAttribute(
+        values = values,
+        purpose = "revocation",
+        type = scenario.statusType
+    )
+
     override fun createStatusContent(scenario: TestScenario, size: Int) = W3CStatusContent(
         type = scenario.statusType,
         purpose = "revocation",

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier-openapi/src/main/kotlin/id/walt/verifier2/openapi/VerificationSessionCreateOpenApi.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier-openapi/src/main/kotlin/id/walt/verifier2/openapi/VerificationSessionCreateOpenApi.kt
@@ -49,11 +49,11 @@ object VerificationSessionCreateOpenApi {
                 example("[openid4vp-http][w3c vc] basic w3c policies (signature, expiration, not-before, allowed-issuer, regex)") {
                     value = Verifier2OpenApiExamples.openid4vpHttpW3cVcBasic
                 }
-                example("[openid4vp-http][w3c vc] credential status for TokenStatusList") {
-                    value = Verifier2OpenApiExamples.openid4vpHttpW3cVcCredentialStatusTokenStatusList
-                }
                 example("[openid4vp-http][w3c vc] credential status for BitstringStatusList") {
                     value = Verifier2OpenApiExamples.openid4vpHttpW3cVcCredentialStatusBitstringStatusList
+                }
+                example("[openid4vp-http][w3c vc] credential status for BitstringStatusList (multiple allowed values)") {
+                    value = Verifier2OpenApiExamples.openid4vpHttpW3cVcCredentialStatusBitstringStatusListMultipleValues
                 }
                 example("[openid4vp-http][w3c vc] credential status for multiple BitstringStatusList") {
                     value = Verifier2OpenApiExamples.openid4vpHttpW3cVcCredentialStatusMultipleBitstringStatusList
@@ -100,6 +100,12 @@ object VerificationSessionCreateOpenApi {
                 example("[openid4vp-http][sd-jwt pid]") { value = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID }
                 example("[openid4vp-http][iso pid]") { value = CrossDeviceFlowSetup.EXAMPLE_ISO_PID }
                 example("[openid4vp-http][iso mdl & photo-id]") { value = CrossDeviceFlowSetup.EXAMPLE_MDL_OR_PHOTOID }
+                example("[openid4vp-http][iso mdl] credential status for TokenStatusList") {
+                    value = Verifier2OpenApiExamples.openid4vpHttpMdocCredentialStatusTokenStatusList
+                }
+                example("[openid4vp-http][iso mdl] credential status for TokenStatusList (multiple allowed values)") {
+                    value = Verifier2OpenApiExamples.openid4vpHttpMdocCredentialStatusTokenStatusListMultipleValues
+                }
                 example("[openid4vp-http][iso photo-id] vical") { value = Verifier2OpenApiExamples.openid4vpHttpIsoPhotoIdVical }
 
                 example("[openid4vp-dc_api][iso mdl] unsigned & unencrypted") { value = DcApiAnnexDFlowSetup.EX_UNSIGNED_UNENCRYPTED_MDL }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier-openapi/src/main/kotlin/id/walt/verifier2/openapi/Verifier2OpenApiExamples.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier-openapi/src/main/kotlin/id/walt/verifier2/openapi/Verifier2OpenApiExamples.kt
@@ -77,18 +77,19 @@ object Verifier2OpenApiExamples {
         )
     )
 
-    val openid4vpHttpW3cVcCredentialStatusTokenStatusList = CrossDeviceFlowSetup(
+    val openid4vpHttpMdocCredentialStatusTokenStatusList = CrossDeviceFlowSetup(
         core = GeneralFlowConfig(
             DcqlQuery(
                 credentials = listOf(
                     CredentialQuery(
-                        id = "example_openbadge_jwt_vc",
-                        format = CredentialFormat.JWT_VC_JSON,
-                        meta = JwtVcJsonMeta(
-                            typeValues = listOf(listOf("VerifiableCredential", "OpenBadgeCredential"))
+                        id = "example_mdl",
+                        format = CredentialFormat.MSO_MDOC,
+                        meta = MsoMdocMeta(
+                            doctypeValue = "org.iso.18013.5.1.mDL"
                         ),
                         claims = listOf(
-                            ClaimsQuery(pathStrings = listOf("name"))
+                            ClaimsQuery(pathStrings = listOf("org.iso.18013.5.1", "family_name")),
+                            ClaimsQuery(pathStrings = listOf("org.iso.18013.5.1", "given_name"))
                         )
                     )
                 )
@@ -99,6 +100,37 @@ object Verifier2OpenApiExamples {
                         StatusPolicy(
                             argument = IETFStatusPolicyAttribute(
                                 value = 0u
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+    val openid4vpHttpMdocCredentialStatusTokenStatusListMultipleValues = CrossDeviceFlowSetup(
+        core = GeneralFlowConfig(
+            DcqlQuery(
+                credentials = listOf(
+                    CredentialQuery(
+                        id = "example_mdl",
+                        format = CredentialFormat.MSO_MDOC,
+                        meta = MsoMdocMeta(
+                            doctypeValue = "org.iso.18013.5.1.mDL"
+                        ),
+                        claims = listOf(
+                            ClaimsQuery(pathStrings = listOf("org.iso.18013.5.1", "family_name")),
+                            ClaimsQuery(pathStrings = listOf("org.iso.18013.5.1", "given_name"))
+                        )
+                    )
+                )
+            ),
+            policies = DefinedVerificationPolicies(
+                vc_policies = VCPolicyList(
+                    listOf(
+                        StatusPolicy(
+                            argument = IETFStatusPolicyAttribute(
+                                values = listOf(0u, 1u)
                             )
                         )
                     )
@@ -129,6 +161,38 @@ object Verifier2OpenApiExamples {
                         StatusPolicy(
                             argument = W3CStatusPolicyAttribute(
                                 value = 0u,
+                                purpose = "Revocation",
+                                type = Values.BITSTRING_STATUS_LIST
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+    val openid4vpHttpW3cVcCredentialStatusBitstringStatusListMultipleValues = CrossDeviceFlowSetup(
+        core = GeneralFlowConfig(
+            DcqlQuery(
+                credentials = listOf(
+                    CredentialQuery(
+                        id = "example_openbadge_jwt_vc",
+                        format = CredentialFormat.JWT_VC_JSON,
+                        meta = JwtVcJsonMeta(
+                            typeValues = listOf(listOf("VerifiableCredential", "OpenBadgeCredential"))
+                        ),
+                        claims = listOf(
+                            ClaimsQuery(pathStrings = listOf("name"))
+                        )
+                    )
+                )
+            ),
+            policies = DefinedVerificationPolicies(
+                vc_policies = VCPolicyList(
+                    listOf(
+                        StatusPolicy(
+                            argument = W3CStatusPolicyAttribute(
+                                values = listOf(0u, 1u),
                                 purpose = "Revocation",
                                 type = Values.BITSTRING_STATUS_LIST
                             )


### PR DESCRIPTION
Resolves WAL-908

ES: https://github.com/walt-id/waltid-identity-enterprise/pull/417
Docs: https://github.com/walt-id/waltid-docs/pull/253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status policies now support multiple allowed numeric values for validation.

* **Improvements**
  * Validation checks against a set of allowed values and reports expected values as a list when failing.

* **Tests**
  * Added parameterized tests covering multi-value success and failure scenarios.

* **Documentation / Examples**
  * Updated API request examples to demonstrate single- and multi-value status-policy usage and added new example variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->