### PR TITLE
feat: add support for RSA 6144

### DIFF
--- a/waltid-libraries/crypto/waltid-cose/src/commonMain/kotlin/id/walt/cose/CoseCrypto.kt
+++ b/waltid-libraries/crypto/waltid-cose/src/commonMain/kotlin/id/walt/cose/CoseCrypto.kt
@@ -60,4 +60,5 @@ fun KeyType.toCoseAlgorithm(): Int? = when (this) {
     KeyType.RSA -> Cose.Algorithm.RS256
     KeyType.RSA3072 -> Cose.Algorithm.RS384
     KeyType.RSA4096 -> Cose.Algorithm.RS512
+    KeyType.RSA6144 -> Cose.Algorithm.RS512
 }

--- a/waltid-libraries/crypto/waltid-crypto-aws/src/main/kotlin/id.walt.crypto.keys.aws/AWSKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto-aws/src/main/kotlin/id.walt.crypto.keys.aws/AWSKey.kt
@@ -64,6 +64,7 @@ class AWSKey(
             KeyType.RSA -> "RSASSA_PKCS1_V1_5_SHA_256"
             KeyType.RSA3072 -> "RSASSA_PKCS1_V1_5_SHA_384"
             KeyType.RSA4096 -> "RSASSA_PKCS1_V1_5_SHA_512"
+            KeyType.RSA6144 -> throw KeyTypeNotSupportedException(keyType.name)
             KeyType.Ed25519 -> throw KeyTypeNotSupportedException(keyType.name)
         }
     }
@@ -256,6 +257,7 @@ $encodedPk
             KeyType.RSA -> "RSA_2048"
             KeyType.RSA3072 -> "RSA_3072"
             KeyType.RSA4096 -> "RSA_4096"
+            KeyType.RSA6144 -> throw KeyTypeNotSupportedException(type.name)
             KeyType.Ed25519 -> throw KeyTypeNotSupportedException(type.name)
         }
 

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyType.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyType.kt
@@ -51,7 +51,8 @@ enum class KeyType(val jwsAlg: String, val jwkKty: String, val jwkCurve: String?
     // WARNING: do not remove this enum name. There might be old keys existing with it.
     RSA(jwsAlg = "RS256", jwkKty = "RSA", jwkCurve = null, oid = "1.2.840.113549.1.1.11"),
     RSA3072(jwsAlg = "RS384", jwkKty = "RSA", jwkCurve = null, oid = "1.2.840.113549.1.1.12"),
-    RSA4096(jwsAlg = "RS512", jwkKty = "RSA", jwkCurve = null, oid = "1.2.840.113549.1.1.13")
+    RSA4096(jwsAlg = "RS512", jwkKty = "RSA", jwkCurve = null, oid = "1.2.840.113549.1.1.13"),
+    RSA6144(jwsAlg = "RS512", jwkKty = "RSA", jwkCurve = null, oid = "1.2.840.113549.1.1.13") // RSA 6144 estimate strength is 176bits, SHA512 ~256bits
 
     // TODO: Ed448(jwsAlg = "Ed448", oid = null)
     // TODO: X25519(jwsAlg = "X25519", oid = null)

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyType.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/KeyType.kt
@@ -59,15 +59,23 @@ enum class KeyType(val jwsAlg: String, val jwkKty: String, val jwkCurve: String?
     // TODO: X448(jwsAlg = "X448", oid = null)
 }
 
+
 object KeyTypes {
     val EC_KEYS = KeyType.entries.filter { it.jwkKty == "EC" }
     val RSA_KEYS = KeyType.entries.filter { it.jwkKty == "RSA" }
 
-    /** kty -> crv mapping */
-    val JWK_MAPPING = KeyType.entries.associateBy { it.jwkKty to it.jwkCurve }
+    /** (kty, crv) mapping for key types that are uniquely identifiable via JWK metadata. */
+    val JWK_MAPPING = KeyType.entries
+        .filterNot { it.jwkKty == "RSA" }
+        .associateBy { it.jwkKty to it.jwkCurve }
 
+    /**
+     * Resolves key type from JWK kty/crv metadata only.
+     * RSA sizes cannot be distinguished this way, so RSA defaults to KeyType.RSA.
+     */
     fun getKeyTypeByJwkId(jwkKty: String, jwkCrv: String?): KeyType =
         when (jwkKty) {
+            "RSA" -> KeyType.RSA
             "EC" if jwkCrv == "P-256K" -> KeyType.secp256k1
             else -> JWK_MAPPING[jwkKty to jwkCrv]
                 ?: throw IllegalArgumentException("Unknown JWK combination: kty=$jwkKty, crv=$jwkCrv")

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/aws/AWSKeyRestAPI.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/aws/AWSKeyRestAPI.kt
@@ -114,6 +114,7 @@ class AWSKeyRestAPI(
             KeyType.RSA -> "RSASSA_PKCS1_V1_5_SHA_256"
             KeyType.RSA3072 -> "RSASSA_PKCS1_V1_5_SHA_384"
             KeyType.RSA4096 -> "RSASSA_PKCS1_V1_5_SHA_512"
+            KeyType.RSA6144 -> "RSASSA_PKCS1_V1_5_SHA_512"
             KeyType.Ed25519 -> throw KeyTypeNotSupportedException(keyType.name)
         }
     }
@@ -607,6 +608,7 @@ $public
             KeyType.RSA -> "RSA_2048"
             KeyType.RSA3072 -> "RSA_3072"
             KeyType.RSA4096 -> "RSA_4096"
+            KeyType.RSA6144 -> throw KeyTypeNotSupportedException(type.name) // AWS doesn't support RSA 6144
             KeyType.Ed25519 -> throw KeyTypeNotSupportedException(type.name)
         }
 

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/aws/AWSKeyRestAPI.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/aws/AWSKeyRestAPI.kt
@@ -114,7 +114,7 @@ class AWSKeyRestAPI(
             KeyType.RSA -> "RSASSA_PKCS1_V1_5_SHA_256"
             KeyType.RSA3072 -> "RSASSA_PKCS1_V1_5_SHA_384"
             KeyType.RSA4096 -> "RSASSA_PKCS1_V1_5_SHA_512"
-            KeyType.RSA6144 -> "RSASSA_PKCS1_V1_5_SHA_512"
+            KeyType.RSA6144 -> throw KeyTypeNotSupportedException(keyType.name)
             KeyType.Ed25519 -> throw KeyTypeNotSupportedException(keyType.name)
         }
     }

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/oci/OCIKeyRestApi.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/oci/OCIKeyRestApi.kt
@@ -125,7 +125,7 @@ class OCIKeyRestApi(
             KeyType.RSA -> "SHA_256_RSA_PKCS1_V1_5"
             KeyType.RSA3072 -> "SHA_384_RSA_PKCS1_V1_5"
             KeyType.RSA4096 -> "SHA_512_RSA_PKCS1_V1_5"
-            KeyType.RSA6144 -> "SHA_512_RSA_PKCS1_V1_5"
+            KeyType.RSA6144 -> throw KeyTypeNotSupportedException(keyType.name)
             KeyType.secp256k1, KeyType.Ed25519 -> throw KeyTypeNotSupportedException(keyType.name)
         }
     }

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/oci/OCIKeyRestApi.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/oci/OCIKeyRestApi.kt
@@ -125,6 +125,7 @@ class OCIKeyRestApi(
             KeyType.RSA -> "SHA_256_RSA_PKCS1_V1_5"
             KeyType.RSA3072 -> "SHA_384_RSA_PKCS1_V1_5"
             KeyType.RSA4096 -> "SHA_512_RSA_PKCS1_V1_5"
+            KeyType.RSA6144 -> "SHA_512_RSA_PKCS1_V1_5"
             KeyType.secp256k1, KeyType.Ed25519 -> throw KeyTypeNotSupportedException(keyType.name)
         }
     }
@@ -284,7 +285,8 @@ class OCIKeyRestApi(
 
         private fun keyTypeToOciKeyMapping(type: KeyType) = when (type) {
             KeyType.secp256r1, KeyType.secp384r1, KeyType.secp521r1 -> "ECDSA"
-            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> "RSA"
+            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096  -> "RSA"
+            KeyType.RSA6144 -> throw KeyTypeNotSupportedException(type.name) // OCI doesn't support RSA larger than 4096
             KeyType.Ed25519, KeyType.secp256k1 -> throw KeyTypeNotSupportedException(type.name)
         }
 
@@ -311,6 +313,7 @@ class OCIKeyRestApi(
                     KeyType.RSA -> 256
                     KeyType.RSA3072 -> 384
                     KeyType.RSA4096 -> 512
+                    KeyType.RSA6144 -> throw KeyTypeNotSupportedException(type.name) // OCI doesn't support RSA6144
                     KeyType.Ed25519, KeyType.secp256k1 -> throw KeyTypeNotSupportedException(type.name)
                 }
                 val requestBody = JsonObject(

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/tse/TSEKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/tse/TSEKey.kt
@@ -305,6 +305,7 @@ class TSEKey(
             KeyType.RSA -> "rsa-2048"
             KeyType.RSA3072 -> "rsa-3072"
             KeyType.RSA4096 -> "rsa-4096"
+            KeyType.RSA6144 -> throw KeyTypeNotSupportedException(type.name) // RSA larger than 4096 is not supported
             KeyType.secp256k1 -> throw KeyTypeNotSupportedException(type.name)
         }
 

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/utils/JsonCanonicalizationUtils.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/utils/JsonCanonicalizationUtils.kt
@@ -27,7 +27,7 @@ object JsonCanonicalizationUtils {
         when (key.keyType) {
             KeyType.Ed25519 -> okpPublicKeyRequiredMembers(it)
             KeyType.secp256k1, KeyType.secp256r1, KeyType.secp384r1, KeyType.secp521r1 -> ecPublicKeyRequiredMembers(it)
-            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> rsaPublicKeyRequiredMembers(it)
+            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> rsaPublicKeyRequiredMembers(it)
         }
     }.toString()
 

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/utils/MultiCodecUtils.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/utils/MultiCodecUtils.kt
@@ -25,7 +25,7 @@ object MultiCodecUtils {
         KeyType.secp256r1 -> 0x1200u
         KeyType.secp384r1 -> 0x1201u
         KeyType.secp521r1 -> 0x1202u
-        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> 0x1205u
+        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> 0x1205u
     }
 
     fun getKeyTypeFromKeyCode(code: UInt): KeyType = when (code) {

--- a/waltid-libraries/crypto/waltid-crypto/src/jvmMain/kotlin/id/walt/crypto/keys/JWKKeyGenerator.jvm.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/jvmMain/kotlin/id/walt/crypto/keys/JWKKeyGenerator.jvm.kt
@@ -36,6 +36,7 @@ object JvmJWKKeyCreator : JWKKeyCreator() {
             KeyType.RSA -> RSAKeyGenerator(metadata?.keySize ?: 2048)
             KeyType.RSA3072 -> RSAKeyGenerator(metadata?.keySize ?: 3072)
             KeyType.RSA4096 -> RSAKeyGenerator(metadata?.keySize ?: 4096)
+            KeyType.RSA6144 -> RSAKeyGenerator(metadata?.keySize ?: 6144)
         }.run {
             if (type == KeyType.secp256k1) {
                 provider(BouncyCastleProviderSingleton.getInstance())
@@ -55,7 +56,7 @@ object JvmJWKKeyCreator : JWKKeyCreator() {
                 KeyType.secp256r1 -> ecRawToJwk(rawPublicKey, Curve.P_256)
                 KeyType.secp384r1 -> ecRawToJwk(rawPublicKey, Curve.P_384)
                 KeyType.secp521r1 -> ecRawToJwk(rawPublicKey, Curve.P_521)
-                KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> rawRsaToJwk(rawPublicKey)
+                KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> rawRsaToJwk(rawPublicKey)
             }
         )
 

--- a/waltid-libraries/crypto/waltid-crypto/src/jvmMain/kotlin/id/walt/crypto/keys/jwk/JWKKey.jvm.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/jvmMain/kotlin/id/walt/crypto/keys/jwk/JWKKey.jvm.kt
@@ -76,7 +76,7 @@ actual class JWKKey actual constructor(
 
     actual override suspend fun getPublicKeyRepresentation(): ByteArray = when (keyType) {
         KeyType.Ed25519 -> _internalJwk.toOctetKeyPair().decodedX
-        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> getRsaPublicKeyBytes(_internalJwk.toRSAKey().toPublicKey())
+        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> getRsaPublicKeyBytes(_internalJwk.toRSAKey().toPublicKey())
         KeyType.secp256k1, KeyType.secp256r1, KeyType.secp384r1, KeyType.secp521r1 -> getECPublicKeyBytes(
             _internalJwk.toECKey().toECPublicKey()
         )
@@ -118,7 +118,7 @@ actual class JWKKey actual constructor(
 
             KeyType.Ed25519 -> throw NotImplementedError("Ed25519 keys cannot be exported as PEM yet.")
 
-            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> _internalJwk.toRSAKey().let {
+            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> _internalJwk.toRSAKey().let {
                 if (hasPrivateKey) {
                     pemObjects.add(PemObject("RSA PRIVATE KEY", it.toRSAPrivateKey().encoded))
                     pemObjects.add(
@@ -154,7 +154,7 @@ actual class JWKKey actual constructor(
 
             KeyType.secp256r1, KeyType.secp384r1, KeyType.secp521r1 -> ECDSASigner(_internalJwk as ECKey)
 
-            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> RSASSASigner(_internalJwk as RSAKey)
+            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> RSASSASigner(_internalJwk as RSAKey)
         }
     }
 
@@ -168,7 +168,7 @@ actual class JWKKey actual constructor(
 
             KeyType.secp256r1, KeyType.secp384r1, KeyType.secp521r1 -> ECDSAVerifier(_internalJwk as ECKey)
 
-            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> RSASSAVerifier(_internalJwk as RSAKey)
+            KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> RSASSAVerifier(_internalJwk as RSAKey)
         }
     }
 
@@ -182,6 +182,7 @@ actual class JWKKey actual constructor(
             KeyType.RSA -> JWSAlgorithm.RS256
             KeyType.RSA3072 -> JWSAlgorithm.RS384
             KeyType.RSA4096 -> JWSAlgorithm.RS512
+            KeyType.RSA6144 -> JWSAlgorithm.RS512
         }
     }
 
@@ -409,9 +410,13 @@ actual class JWKKey actual constructor(
         when (_internalJwk.keyType) {
             com.nimbusds.jose.jwk.KeyType.RSA -> {
                 when (val bitLength = _internalJwk.toRSAKey().modulus.decodeToBigInteger().bitLength()) {
-                    1024, 2048 -> KeyType.RSA
-                    3072 -> KeyType.RSA3072
-                    4096 -> KeyType.RSA4096
+                    // For RSA built from two equal-size primes, the modulus can be either:
+                    // - the nominal size (e.g. 2048), or
+                    // - one bit shorter (e.g. 2047) if the highest bit is 0
+                    in 1023..1024, in 2047..2048 -> KeyType.RSA
+                    in 3071..3072 -> KeyType.RSA3072
+                    in 4095..4096 -> KeyType.RSA4096
+                    in 6143..6144 -> KeyType.RSA6144
                     else -> throw IllegalArgumentException("RSA key has invalid bit size: $bitLength")
                 }
             }
@@ -461,7 +466,7 @@ actual class JWKKey actual constructor(
     private fun getPrivateKey() = when (keyType) {
         KeyType.secp256k1, KeyType.secp256r1, KeyType.secp384r1, KeyType.secp521r1 -> _internalJwk.toECKey().toPrivateKey()
         KeyType.Ed25519 -> decodeEd25519RawPrivateKey(_internalJwk.toOctetKeyPair().d.toString())
-        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> _internalJwk.toRSAKey().toPrivateKey()
+        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> _internalJwk.toRSAKey().toPrivateKey()
     }
 
     fun getInternalPublicKey(): PublicKey = when (keyType) {
@@ -469,7 +474,7 @@ actual class JWKKey actual constructor(
         KeyType.Ed25519 -> _internalJwk.toOctetKeyPair().toPublicKey()
 //        KeyType.Ed25519 -> decodeEd25519RawPublicKey(_internalJwk.toOctetKeyPair())
 //        KeyType.Ed25519 -> _internalJwk.toOctetKeyPair().toPublicKey()
-        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096 -> _internalJwk.toRSAKey().toRSAPublicKey()
+        KeyType.RSA, KeyType.RSA3072, KeyType.RSA4096, KeyType.RSA6144 -> _internalJwk.toRSAKey().toRSAPublicKey()
 //        else -> TODO("Not yet supported: $keyType")
     }
 
@@ -484,6 +489,7 @@ actual class JWKKey actual constructor(
             KeyType.RSA -> Signature.getInstance("SHA256withRSA") // RSASSA-PKCS1-v1_5
             KeyType.RSA3072 -> Signature.getInstance("SHA384withRSA") // RSASSA-PKCS1-v1_5
             KeyType.RSA4096 -> Signature.getInstance("SHA512withRSA") // RSASSA-PKCS1-v1_5
+            KeyType.RSA6144 -> Signature.getInstance("SHA512withRSA") // RSASSA-PKCS1-v1_5
         }
 
     private fun decodeEd25519RawPrivateKey(base64: String): PrivateKey {


### PR DESCRIPTION
## Description

[Cybernetica SplitKey](https://cyber.ee/products/splitkey/) RSA keys are 6K. To use SplitKey as holder keys, Cybernetica needs RSA 6K support in walt.id.

**Feature:**
General support for RSA 6144 keys. Most cloud HSM don't support RSA 6144, but this PR adds general support for RSA 6144, like verifying proof JWT signed with RSA 6144 keys.

**Fix:**
Fix RSA key decoding, when modulus starts with 0 bit. 

`BigInteger.bitLength()` returns one bit shorter length if the highest bit is 0. https://github.com/walt-id/waltid-identity/pull/1665/changes#diff-4d54c6159b94b7f941484f634ec932a16e5b1b7fa9761ca55d6ddfbb16236d77R413-R419

## Type of Change

- [x] bug fix - change which fixes an issue
- [x] new feature - change which adds functionality

## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for RSA 6144-bit keys across key generation, import/export, JWK/JWS/COSE handling, multicodec, and canonicalized RSA public-key output.

* **Bug Fixes / Behavior**
  * Explicitly reject RSA 6144 where platforms do not support it (AWS, OCI, TSE), avoiding ambiguous fall-through behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->