### PR TITLE
Fix/credential metadata display

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/OfferedCredentialResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/OfferedCredentialResolver.kt
@@ -106,7 +106,7 @@ object OfferedCredentialResolver {
      * @return Display name or null if not available
      */
     fun getDisplayName(resolvedOffer: ResolvedCredentialOffer): String? {
-        return resolvedOffer.configuration.display?.firstOrNull()?.name
+        return resolvedOffer.configuration.credentialMetadata?.display?.firstOrNull()?.name
     }
 
     /**

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/OfferedCredentialResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/OfferedCredentialResolverTest.kt
@@ -1,0 +1,123 @@
+package id.waltid.openid4vci.wallet.metadata
+
+import id.walt.openid4vci.CredentialFormat
+import id.walt.openid4vci.metadata.issuer.ClaimDescription
+import id.walt.openid4vci.metadata.issuer.ClaimDisplay
+import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
+import id.walt.openid4vci.metadata.issuer.CredentialDisplay
+import id.walt.openid4vci.metadata.issuer.CredentialDisplayBackgroundImage
+import id.walt.openid4vci.metadata.issuer.CredentialDisplayLogo
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.CredentialMetadata
+import id.walt.openid4vci.offers.CredentialOffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class OfferedCredentialResolverTest {
+
+    private fun issuerMetadata(configuration: CredentialConfiguration): CredentialIssuerMetadata =
+        CredentialIssuerMetadata(
+            credentialIssuer = "https://issuer.example.com",
+            credentialEndpoint = "https://issuer.example.com/openid4vci/credential",
+            credentialConfigurationsSupported = mapOf(
+                "identity_credential" to configuration,
+            ),
+        )
+
+    @Test
+    fun `resolves offered credentials and returns display name from credential metadata`() {
+        val configuration = CredentialConfiguration(
+            format = CredentialFormat.SD_JWT_VC,
+            credentialMetadata = CredentialMetadata(
+                display = listOf(
+                    CredentialDisplay(
+                        name = "Identity Credential",
+                        locale = "en-US",
+                        logo = CredentialDisplayLogo(
+                            uri = "https://issuer.example.com/assets/identity-logo.png",
+                            altText = "Identity credential logo",
+                        ),
+                        description = "Government-issued identity credential",
+                        backgroundColor = "#12107c",
+                        backgroundImage = CredentialDisplayBackgroundImage(
+                            uri = "https://issuer.example.com/assets/identity-bg.png",
+                        ),
+                        textColor = "#FFFFFF",
+                    ),
+                ),
+                claims = listOf(
+                    ClaimDescription(
+                        path = listOf("given_name"),
+                        display = listOf(
+                            ClaimDisplay(name = "Given Name", locale = "en-US"),
+                            ClaimDisplay(name = "Vorname", locale = "de-DE"),
+                        ),
+                    ),
+                    ClaimDescription(
+                        path = listOf("family_name"),
+                        display = listOf(
+                            ClaimDisplay(name = "Family Name", locale = "en-US"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val offer = CredentialOffer(
+            credentialIssuer = "https://issuer.example.com",
+            credentialConfigurationIds = listOf("identity_credential"),
+        )
+
+        val resolved = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata(configuration))
+        val displayName = OfferedCredentialResolver.getDisplayName(resolved.single())
+
+        assertEquals(1, resolved.size)
+        assertEquals("identity_credential", resolved.single().credentialConfigurationId)
+        assertEquals("Identity Credential", displayName)
+        assertEquals("Given Name", resolved.single().configuration.credentialMetadata?.claims?.get(0)?.display?.get(0)?.name)
+        assertEquals("Vorname", resolved.single().configuration.credentialMetadata?.claims?.get(0)?.display?.get(1)?.name)
+    }
+
+    @Test
+    fun `throws when offered credential configuration id is missing`() {
+        val offer = CredentialOffer(
+            credentialIssuer = "https://issuer.example.com",
+            credentialConfigurationIds = listOf("unknown_id"),
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            OfferedCredentialResolver.resolveOfferedCredentials(
+                offer = offer,
+                metadata = issuerMetadata(
+                    CredentialConfiguration(format = CredentialFormat.SD_JWT_VC),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `validate offered credentials returns false when at least one id is unsupported`() {
+        val metadata = issuerMetadata(CredentialConfiguration(format = CredentialFormat.SD_JWT_VC))
+        val offer = CredentialOffer(
+            credentialIssuer = "https://issuer.example.com",
+            credentialConfigurationIds = listOf("identity_credential", "unknown_id"),
+        )
+
+        assertTrue(!OfferedCredentialResolver.validateOfferedCredentials(offer, metadata))
+    }
+
+    @Test
+    fun `display name is null when credential metadata display is absent`() {
+        val configuration = CredentialConfiguration(format = CredentialFormat.SD_JWT_VC)
+        val offer = CredentialOffer(
+            credentialIssuer = "https://issuer.example.com",
+            credentialConfigurationIds = listOf("identity_credential"),
+        )
+
+        val resolved = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata(configuration))
+        assertNull(OfferedCredentialResolver.getDisplayName(resolved.single()))
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/metadata/issuer/CredentialConfiguration.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/metadata/issuer/CredentialConfiguration.kt
@@ -52,19 +52,11 @@ data class CredentialConfiguration(
     val proofTypesSupported: Map<String, ProofType>? = null,
     @SerialName("credential_metadata")
     val credentialMetadata: CredentialMetadata? = null,
-    @SerialName("display")
-    val display: List<CredentialDisplay>? = null,
     val customParameters: Map<String, JsonElement>? = null,
 ) {
     init {
         scope?.let { value ->
             require(value.isNotBlank()) { "scope must not be blank" }
-        }
-        display?.let { entries ->
-            val locales = entries.mapNotNull { it.locale }
-            require(locales.size == locales.distinct().size) {
-                "display entries must not duplicate locales"
-            }
         }
         cryptographicBindingMethodsSupported?.let { methods ->
             require(methods.isNotEmpty()) {
@@ -162,10 +154,6 @@ internal object CredentialConfigurationSerializer : KSerializer<CredentialConfig
             value.credentialMetadata?.let {
                 put("credential_metadata", Json.encodeToJsonElement(CredentialMetadata.serializer(), it))
             }
-            value.display?.let {
-                val serializer = ListSerializer(CredentialDisplay.serializer())
-                put("display", Json.encodeToJsonElement(serializer, it))
-            }
         }
         val merged = value.customParameters?.let { extras ->
             buildJsonObject {
@@ -208,10 +196,6 @@ internal object CredentialConfigurationSerializer : KSerializer<CredentialConfig
             },
             credentialMetadata = jsonObject["credential_metadata"]?.let {
                 lenientJson.decodeFromJsonElement(CredentialMetadata.serializer(), it)
-            },
-            display = jsonObject["display"]?.let {
-                val serializer = ListSerializer(CredentialDisplay.serializer())
-                lenientJson.decodeFromJsonElement(serializer, it)
             },
             customParameters = customParameters,
         )

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/metadata/issuer/credentialconfiguration/CredentialConfigurationDisplayTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/metadata/issuer/credentialconfiguration/CredentialConfigurationDisplayTest.kt
@@ -3,33 +3,58 @@ package id.walt.openid4vci.metadata.issuer.credentialconfiguration
 import id.walt.openid4vci.CredentialFormat
 import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
 import id.walt.openid4vci.metadata.issuer.CredentialDisplay
+import id.walt.openid4vci.metadata.issuer.CredentialMetadata
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class CredentialConfigurationDisplayTest {
 
+    private val json = Json { ignoreUnknownKeys = false }
+
     @Test
-    fun `display locales must be unique`() {
+    fun `credential metadata display locales must be unique`() {
         assertFailsWith<IllegalArgumentException> {
             CredentialConfiguration(
                 format = CredentialFormat.SD_JWT_VC,
-                display = listOf(
-                    CredentialDisplay(name = "Credential", locale = "en"),
-                    CredentialDisplay(name = "Credential 2", locale = "en"),
+                credentialMetadata = CredentialMetadata(
+                    display = listOf(
+                        CredentialDisplay(name = "Credential", locale = "en"),
+                        CredentialDisplay(name = "Credential 2", locale = "en"),
+                    ),
                 ),
             )
         }
     }
 
     @Test
-    fun `display name must not be blank`() {
+    fun `credential metadata display name must not be blank`() {
         assertFailsWith<IllegalArgumentException> {
             CredentialConfiguration(
                 format = CredentialFormat.SD_JWT_VC,
-                display = listOf(
-                    CredentialDisplay(name = " "),
+                credentialMetadata = CredentialMetadata(
+                    display = listOf(
+                        CredentialDisplay(name = " "),
+                    ),
                 ),
             )
+        }
+    }
+
+    @Test
+    fun `top level display is rejected and must use credential metadata display`() {
+        val payload = """
+            {
+              "format": "sd_jwt_vc",
+              "display": [
+                { "name": "Credential", "locale": "en-US" }
+              ]
+            }
+        """.trimIndent()
+
+        assertFailsWith<SerializationException> {
+            json.decodeFromString<CredentialConfiguration>(payload)
         }
     }
 }


### PR DESCRIPTION
## Description

Provide a clear and concise description of the changes made in this pull request:

## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality

## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Credential display information is now retrieved from a different location within the credential metadata structure.
  * The `display` field has been removed from the credential configuration model.

* **Tests**
  * Added comprehensive test coverage for credential display resolution and metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->