### PR TITLE
feat: allow empty credential configurations in credential issuer meta…

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/metadata/issuer/CredentialIssuerMetadata.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/metadata/issuer/CredentialIssuerMetadata.kt
@@ -66,9 +66,6 @@ data class CredentialIssuerMetadata(
         notificationEndpoint?.let { validateEndpointUrl("notification_endpoint", it) }
         nonceEndpoint?.let { validateEndpointUrl("nonce_endpoint", it) }
 
-        require(credentialConfigurationsSupported.isNotEmpty()) {
-            "credential_configurations_supported must not be empty"
-        }
         require(credentialConfigurationsSupported.keys.all { it.isNotBlank() }) {
             "credential_configurations_supported keys must not be blank"
         }

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/metadata/issuer/CredentialIssuerMetadataTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/metadata/issuer/CredentialIssuerMetadataTest.kt
@@ -38,14 +38,13 @@ class CredentialIssuerMetadataTest {
     // credential_endpoint can be any scheme; validation only ensures host is present
 
     @Test
-    fun `credential configurations supported must not be empty`() {
-        assertFailsWith<IllegalArgumentException> {
-            CredentialIssuerMetadata(
-                credentialIssuer = "https://issuer.example",
-                credentialEndpoint = "https://issuer.example/credential",
-                credentialConfigurationsSupported = emptyMap(),
-            )
-        }
+    fun `credential configurations supported may be empty`() {
+        val metadata = CredentialIssuerMetadata(
+            credentialIssuer = "https://issuer.example",
+            credentialEndpoint = "https://issuer.example/credential",
+            credentialConfigurationsSupported = emptyMap(),
+        )
+        assertEquals(emptyMap(), metadata.credentialConfigurationsSupported)
     }
 
     @Test


### PR DESCRIPTION
…data

## Description

Provide a clear and concise description of the changes made in this pull request:

## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality

## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential issuer metadata validation by removing the requirement for at least one credential configuration to be present. The system now permits credential issuers to be configured with an empty credential configurations map while maintaining validation that any present configuration keys are properly formatted. This provides greater flexibility in credential issuer setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->