### PR TITLE
Feature/wal 479

### DIFF
--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
@@ -67,12 +67,14 @@ object Issuer {
         additionalJwtOptions: Map<String, JsonElement>,
         display: JsonArray = JsonArray(emptyList()),
         completeJwtWithDefaultCredentialData: Boolean = true,
+        context: Map<String, JsonElement>? = null,
     ) = mergingToVc(
         issuerId = issuerId,
         subjectDid = subjectDid,
         mappings = mappings,
         display = display,
-        completeJwtWithDefaultCredentialData = completeJwtWithDefaultCredentialData
+        completeJwtWithDefaultCredentialData = completeJwtWithDefaultCredentialData,
+        context = context
     ).run {
         val issuerDid = if (DidUtils.isDidUrl(issuerId)) issuerId else null
         w3cVc.signJws(
@@ -106,12 +108,14 @@ object Issuer {
 
         completeJwtWithDefaultCredentialData: Boolean = true,
         disclosureMap: SDMap,
+        context: Map<String, JsonElement>? = null,
     ) = mergingToVc(
         issuerId = issuerId,
         subjectDid = subjectDid,
         mappings = mappings,
         display = display,
-        completeJwtWithDefaultCredentialData
+        completeJwtWithDefaultCredentialData,
+        context = context
     ).run {
         val issuerDid = if (DidUtils.isDidUrl(issuerId)) issuerId else null
         w3cVc.signSdJwt(
@@ -149,8 +153,9 @@ object Issuer {
         mappings: JsonObject,
         display: JsonArray? = null,
         completeJwtWithDefaultCredentialData: Boolean = true,
+        context: Map<String, JsonElement>? = null,
     ): IssuanceInformation {
-        val context = mapOf(
+        val mergedContext = mapOf(
             "issuerId" to issuerId,
             "issuerDid" to (if (DidUtils.isDidUrl(issuerId)) issuerId else null),
             "subjectDid" to subjectDid,
@@ -163,15 +168,16 @@ object Issuer {
 
                 else -> value.toString().isNotEmpty()
             }
-        }
-            .mapValues { (_, value) ->
-                when (value) {
-                    is JsonElement -> value
-                    else -> JsonPrimitive(value.toString())
-                }
+        }.mapValues { (_, value) ->
+            when (value) {
+                is JsonElement -> value
+                else -> JsonPrimitive(value.toString())
             }
+        }.toMutableMap().apply {
+            context?.let { putAll(it) }
+        }
 
-        val mapped = this.mergeWithMapping(mappings, context, dataFunctions)
+        val mapped = this.mergeWithMapping(mappings, mergedContext, dataFunctions)
 
         val vc = mapped.vc
         val jwtRes = mapped.results.mapKeys { it.key.removePrefix("jwt:") }.toMutableMap()

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
@@ -726,6 +726,7 @@ object OpenID4VCI {
                 mapping = dataMapping ?: JsonObject(emptyMap()),
                 context = mapOf(
                     "subjectDid" to holderDid,
+                    "issuerDid" to issuerId,
                     "display" to Json.encodeToJsonElement(display ?: emptyList()).jsonArray,
                 ).filterValues {
                     when (it) {
@@ -827,6 +828,21 @@ object OpenID4VCI {
         } ?: mapOf()
 
         return W3CVC(credentialData).let { vc ->
+            val context = mapOf(
+                "subjectDid" to holderDid,
+                "issuerDid" to issuerId,
+                "display" to Json.encodeToJsonElement(display ?: emptyList()).jsonArray,
+            ).filterValues {
+                when (it) {
+                    is JsonElement -> it !is JsonNull && (it !is JsonObject || it.jsonObject.isNotEmpty()) && (it !is JsonArray || it.jsonArray.isNotEmpty())
+                    else -> it != null && it.toString().isNotEmpty()
+                }
+            }.mapValues { (_, value) ->
+                when (value) {
+                    is JsonElement -> value
+                    else -> JsonPrimitive(value.toString())
+                }
+            }
             when (selectiveDisclosure.isNullOrEmpty()) {
                 true -> vc.mergingJwtIssue(
                     issuerKey = issuerKey,
@@ -835,7 +851,8 @@ object OpenID4VCI {
                     mappings = dataMapping ?: JsonObject(emptyMap()),
                     additionalJwtHeader = additionalJwtHeaders,
                     display = Json.encodeToJsonElement(display ?: emptyList()).jsonArray,
-                    additionalJwtOptions = emptyMap()
+                    additionalJwtOptions = emptyMap(),
+                    context = context
                 )
 
                 else -> vc.mergingSdJwtIssue(
@@ -846,7 +863,8 @@ object OpenID4VCI {
                     additionalJwtHeaders = additionalJwtHeaders,
                     additionalJwtOptions = emptyMap(),
                     display = Json.encodeToJsonElement(display ?: emptyList()).jsonArray,
-                    disclosureMap = selectiveDisclosure
+                    disclosureMap = selectiveDisclosure,
+                    context = context
                 )
             }
         }

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/openapi/issuerapi/MdocDocs.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/openapi/issuerapi/MdocDocs.kt
@@ -102,7 +102,12 @@ object MdocDocs {
             },
             "x5Chain": [
                 "-----BEGIN CERTIFICATE-----\nMIICCTCCAbCgAwIBAgIUfqyiArJZoX7M61/473UAVi2/UpgwCgYIKoZIzj0EAwIwKDELMAkGA1UEBhMCQVQxGTAXBgNVBAMMEFdhbHRpZCBUZXN0IElBQ0EwHhcNMjUwNjAyMDY0MTEzWhcNMjYwOTAyMDY0MTEzWjAzMQswCQYDVQQGEwJBVDEkMCIGA1UEAwwbV2FsdGlkIFRlc3QgRG9jdW1lbnQgU2lnbmVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPzp6eVSAdXERqAp8q8OuDEhl2ILGAaoaQXTJ2sD2g5Xp3CFQDMrMpR/SQ0jt/jTOqExk1PRzjQ79aKpIsJM1mqOBrDCBqTAfBgNVHSMEGDAWgBTxCn2nWMrE70qXb614U14BweY2azAdBgNVHQ4EFgQUx5qkOLC4lpl1xpYZGmF9HLxtp0gwDgYDVR0PAQH/BAQDAgeAMBoGA1UdEgQTMBGGD2h0dHBzOi8vd2FsdC5pZDAVBgNVHSUBAf8ECzAJBgcogYxdBQECMCQGA1UdHwQdMBswGaAXoBWGE2h0dHBzOi8vd2FsdC5pZC9jcmwwCgYIKoZIzj0EAwIDRwAwRAIgHTap3c6yCUNhDVfZWBPMKj9dCWZbrME03kh9NJTbw1ECIAvVvuGll9O21eR16SkJHHAA1pPcovhcTvF9fz9cc66M\n-----END CERTIFICATE-----\n"
-            ]
+            ],
+            "mapping": {
+                "id": "<uuid>",
+                "issuanceDate": "<timestamp>",
+                "expirationDate": "<timestamp-in:365d>"
+            }
         }
     """.trimIndent()
     )


### PR DESCRIPTION
This pull request enhances the flexibility and extensibility of the credential issuance flow by introducing support for passing a custom `context` map throughout the issuance process. The changes primarily affect how credential context data is merged and propagated in both the core issuance logic and the OpenID4VCI protocol integration. Additionally, a documentation example is updated to include a sample mapping.

**Enhancements to credential issuance context handling:**

* Added an optional `context` parameter to the main issuance functions in `Issuer`, allowing callers to inject additional context data into the credential issuance process. This context is merged with default values and used in mapping and signing operations. [[1]](diffhunk://#diff-4b915edbbd1b582eef79588417420e1190c80c5e610c36e06dcc72abdb11de23R70-R77) [[2]](diffhunk://#diff-4b915edbbd1b582eef79588417420e1190c80c5e610c36e06dcc72abdb11de23R111-R118) [[3]](diffhunk://#diff-4b915edbbd1b582eef79588417420e1190c80c5e610c36e06dcc72abdb11de23R156-R158) [[4]](diffhunk://#diff-4b915edbbd1b582eef79588417420e1190c80c5e610c36e06dcc72abdb11de23L166-R180)

**Integration with OpenID4VCI protocol:**

* Updated `OpenID4VCI` to construct and pass a `context` map (including `subjectDid`, `issuerDid`, and `display`) when issuing credentials, ensuring that context is properly filtered, encoded, and forwarded to the issuance functions. [[1]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dR729) [[2]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dR831-R845) [[3]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dL838-R855) [[4]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dL849-R867)

**Documentation update:**

* Added a `mapping` example to the sample credential issuance JSON in the OpenAPI documentation for `MdocDocs`, illustrating how to specify field mappings for issued credentials.