### PR TITLE
[Kotlin - JVM] Implement RFC 9901 Array Element Disclosures

### DIFF
--- a/waltid-libraries/sdjwt/waltid-sdjwt-ios/src/iosTest/kotlin/SDJwtTestIOS.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt-ios/src/iosTest/kotlin/SDJwtTestIOS.kt
@@ -10,6 +10,7 @@ import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.dataUsingEncoding
 import id.walt.sdjwt.HMACJWTCryptoProvider
+import id.walt.sdjwt.ObjectPropertyDisclosure
 import id.walt.sdjwt.SDJwt
 import id.walt.sdjwt.SDMap
 import id.walt.sdjwt.SDMapBuilder
@@ -57,7 +58,7 @@ class SDJwtTestIOS {
         assertEquals(expected = 1, actual = sdJwt.disclosures.size)
         assertEquals(
             expected = "sub",
-            actual = sdJwt.digestedDisclosures[sdJwt.undisclosedPayload[SDJwt.DIGESTS_KEY]!!.jsonArray[0].jsonPrimitive.content]!!.key
+            actual = (sdJwt.digestedDisclosures[sdJwt.undisclosedPayload[SDJwt.DIGESTS_KEY]!!.jsonArray[0].jsonPrimitive.content]!! as ObjectPropertyDisclosure).key
         )
         assertEquals(expected = originalClaimsSet, actual = Json.parseToJsonElement(sdJwt.fullPayload.toString()).jsonObject)
 

--- a/waltid-libraries/sdjwt/waltid-sdjwt/README.md
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/README.md
@@ -25,6 +25,7 @@
 * [Usage with NPM/NodeJs (JavaScript)](#usage-with-npmnodejs-javascript)
 * [Sign SD-JWT tokens](#create-and-sign-an-sd-jwt-using-the-nimbusds-based-jwt-crypto-provider)
 * [Present SD-JWT tokens with selection of disclosed and undisclosed payload fields](#present-an-sd-jwt)
+* [Disclose individual array elements](#array-element-selective-disclosure)
 * [Parse and verify SD-JWT tokens, resolving original payload with disclosed fields](#parse-and-verify-an-sd-jwt-using-the-nimbusds-based-jwt-crypto-provider)
 * [Integrate with your choice of framework or library, for cryptography and key management, on your platform](#integrate-with-custom-jwt-crypto-provider)
 
@@ -46,6 +47,7 @@ verifiable credentials according to the **SD-JWT-VC** specification:
     * Create digests for SD fields and insert into JWT body payload
     * Create and append encoded disclosure strings for SD fields to JWT token
     * Add random or fixed number of **decoy digests** on each nested object property
+* **Array-element selective disclosure** — disclose individual elements of an array independently (RFC 9901 §4.2.2)
 * **Present** SD-JWT tokens
     * Selection of fields to be disclosed
     * Support for appending optional holder binding
@@ -199,6 +201,71 @@ eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI0NTYiLCJfc2QiOlsiaGx6ZmpmMDRvNVp
 eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI0NTYiLCJfc2QiOlsiaGx6ZmpmMDRvNVpzTFIyNWhhNGMtWS05SFcyRFVseGNnaU1ZZDMyNE5nWSJdfQ.2fsLqzujWt0hS0peLS8JLHyyo3D5KCDkNnHcBYqQwVo~WyJ4RFk5VjBtOG43am82ZURIUGtNZ1J3Iiwic3ViIiwiMTIzIl0~
 eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI0NTYiLCJfc2QiOlsiaGx6ZmpmMDRvNVpzTFIyNWhhNGMtWS05SFcyRFVseGNnaU1ZZDMyNE5nWSJdfQ.2fsLqzujWt0hS0peLS8JLHyyo3D5KCDkNnHcBYqQwVo~WyJ4RFk5VjBtOG43am82ZURIUGtNZ1J3Iiwic3ViIiwiMTIzIl0~
 eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiI0NTYiLCJfc2QiOlsiaGx6ZmpmMDRvNVpzTFIyNWhhNGMtWS05SFcyRFVseGNnaU1ZZDMyNE5nWSJdfQ.2fsLqzujWt0hS0peLS8JLHyyo3D5KCDkNnHcBYqQwVo~WyJ4RFk5VjBtOG43am82ZURIUGtNZ1J3Iiwic3ViIiwiMTIzIl0~
+```
+
+#### Array-element selective disclosure
+
+The library supports disclosing individual array elements independently, per RFC 9901 §4.2.2.
+Each disclosable element is replaced on the wire with a `{"...": "<digest>"}` wrapper; a holder
+chooses which elements to reveal.
+
+**Path-DSL** — index, wildcard, and nested forms:
+
+| Path | Selects |
+| --- | --- |
+| `nationalities.[0]` | logical index 0 |
+| `nationalities.[]` | every logical index (wildcard) |
+| `cars.[].make` | the `make` property of every entry |
+| `contacts.[0].[2]` | element `[2]` of nested array under index 0 |
+
+`[N]` refers to **logical** position in the original payload — decoys interleaved on the wire
+do not advance the index.
+
+```kotlin
+val sharedSecret = "ef23f749-7238-481a-815c-f0c2157dfa8e"
+
+fun arrayDisclosureExample() {
+    val cryptoProvider = SimpleJWTCryptoProvider(JWSAlgorithm.HS256, MACSigner(sharedSecret), MACVerifier(sharedSecret))
+
+    // Issuer payload: each element of `nationalities` is independently disclosable.
+    val fullPayload = buildJsonObject {
+        put("sub", "123")
+        put("nationalities", buildJsonArray { add("US"); add("DE") })
+    }
+    val issuanceMap = SDMap.generateSDMap(listOf("nationalities.[]"))
+    val sdPayload = SDPayload.createSDPayload(fullPayload, issuanceMap)
+    val sdJwt = SDJwt.sign(sdPayload, cryptoProvider)
+
+    // Holder presents only nationalities[0] = "US".
+    val presentationMap = SDMap.generateSDMap(listOf("nationalities.[0]"))
+    val presented = sdJwt.present(presentationMap)
+
+    // Verifier sees `sub` (plain) and `nationalities = ["US"]`.
+    val verified = SDJwt.verifyAndParse(presented.toString(), cryptoProvider)
+    println(verified.sdJwt.fullPayload)
+}
+```
+
+_Example output_
+
+```json
+{"sub":"123","nationalities":["US"]}
+```
+
+The same flow works with manually-constructed `SDMap`s when more control is needed (e.g. mixing
+disclosable and non-disclosable indices, or attaching decoys per array level):
+
+```kotlin
+val issuanceMap = SDMap(mapOf(
+    "nationalities" to SDField(
+        sd = false,
+        arrayChildren = SDArray(
+            elements = listOf(SDField(sd = true), SDField(sd = true)),
+            decoyMode = DecoyMode.FIXED,
+            decoys = 2,
+        )
+    )
+))
 ```
 
 #### Parse and verify an SD-JWT using the NimbusDS-based JWT crypto provider

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/PathToken.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/PathToken.kt
@@ -1,0 +1,48 @@
+package id.walt.sdjwt
+
+/**
+ * One segment of a dotted JSON path used by [SDMap.generateSDMap]. A path string is split on
+ * `.` into segments, each of which is one of three forms:
+ * - [Key] — a named object property (e.g. `firstName`)
+ * - [Index] — a specific array index, written `[N]` for some non-negative integer N
+ * - [Wildcard] — every element of an array, written `[]`
+ */
+internal sealed class PathToken {
+    data class Key(val name: String) : PathToken()
+    data class Index(val value: Int) : PathToken()
+    object Wildcard : PathToken()
+
+    companion object {
+        /**
+         * Tokenise a dotted JSON path into its constituent [PathToken]s.
+         *
+         * @throws IllegalArgumentException if any segment is empty or malformed.
+         */
+        fun tokenize(path: String): List<PathToken> = path.split(".").map { segment ->
+            when {
+                segment.isEmpty() ->
+                    throw IllegalArgumentException("Empty path segment in '$path'")
+                segment == "[]" ->
+                    Wildcard
+                segment.startsWith("[") && segment.endsWith("]") -> {
+                    val index = segment.substring(1, segment.length - 1).toIntOrNull()
+                        ?: throw IllegalArgumentException("Malformed array index segment: '$segment'")
+                    if (index < 0) throw IllegalArgumentException("Array index must be non-negative: '$segment'")
+                    Index(index)
+                }
+                segment.contains('[') || segment.contains(']') ->
+                    throw IllegalArgumentException("Malformed path segment: '$segment'")
+                else -> Key(segment)
+            }
+        }
+    }
+}
+
+/**
+ * Given a list of paths (each a list of remaining tokens at the current depth), drop any
+ * paths that have already terminated and group the rest by their first token, mapping each
+ * member to its tail (the tokens beyond the first).
+ */
+internal fun List<List<PathToken>>.groupByFirstToken(): Map<PathToken, List<List<PathToken>>> =
+    filter { tokens -> tokens.isNotEmpty() }
+        .groupBy({ tokens -> tokens.first() }, { tokens -> tokens.drop(1) })

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDArray.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDArray.kt
@@ -1,0 +1,54 @@
+package id.walt.sdjwt
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+
+/**
+ * Selective-disclosure descriptor for a JSON array. Each entry in [elements] controls the
+ * corresponding index in the source array; [wildcard], if set, applies to any index not
+ * covered by [elements] (e.g. with a path like `"colors.[]"`).
+ */
+@Suppress("NON_EXPORTABLE_TYPE")
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+@Serializable
+class SDArray(
+    val elements: List<SDField> = emptyList(),
+    val wildcard: SDField? = null,
+    val decoyMode: DecoyMode = DecoyMode.NONE,
+    val decoys: Int = 0,
+) {
+    init {
+        require(decoys >= 0) { "decoys must be non-negative, got $decoys" }
+    }
+
+    @JsExport.Ignore
+    fun toJSON(): JsonObject = buildJsonObject {
+        put("elements", buildJsonArray {
+            elements.forEach { add(it.toJSON()) }
+        })
+        wildcard?.also { put("wildcard", it.toJSON()) }
+        put("decoyMode", decoyMode.name)
+        put("decoys", decoys)
+    }
+
+    @JsExport.Ignore
+    companion object {
+        @JsExport.Ignore
+        fun fromJSON(json: JsonObject): SDArray {
+            val elements = json["elements"]?.jsonArray
+                ?.map { SDField.fromJSON(it) }
+                ?: emptyList()
+            val wildcard = json["wildcard"]?.let { SDField.fromJSON(it.jsonObject) }
+            val decoyMode = json["decoyMode"]?.let { DecoyMode.fromJSON(it) } ?: DecoyMode.NONE
+            val decoys = json["decoys"]?.jsonPrimitive?.int ?: 0
+            return SDArray(elements, wildcard, decoyMode, decoys)
+        }
+
+        @JsExport.Ignore
+        fun fromJSON(json: String): SDArray =
+            fromJSON(Json.parseToJsonElement(json).jsonObject)
+    }
+}

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDField.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDField.kt
@@ -12,7 +12,11 @@ private val log = KotlinLogging.logger { }
  * Selective disclosure information for a given payload field
  * @param sd          **Issuance:** field is made selectively disclosable if *true*, **Presentation:** field should be _disclosed_ if *true*, or _undisclosed_ if *false*
  * @param children    Not null, if field is an object. Contains SDMap for the properties of the object
+ * @param arrayChildren  Not null, if field is an array whose elements are selectively disclosable.
+ *                       Contains [SDArray] describing the per-index settings.
+ *                       Mutually exclusive with [children].
  * @see SDMap
+ * @see SDArray
  */
 @Suppress("NON_EXPORTABLE_TYPE")
 @OptIn(ExperimentalJsExport::class)
@@ -21,7 +25,13 @@ private val log = KotlinLogging.logger { }
 data class SDField(
     val sd: Boolean,
     val children: SDMap? = null,
+    val arrayChildren: SDArray? = null,
 ) {
+    init {
+        require(children == null || arrayChildren == null) {
+            "SDField cannot have both children (object) and arrayChildren (array) set"
+        }
+    }
 
     @JsExport.Ignore
     fun toJSON(): JsonObject {
@@ -29,6 +39,9 @@ data class SDField(
             put("sd", sd)
             children?.also {
                 put("children", it.toJSON())
+            }
+            arrayChildren?.also {
+                put("arrayChildren", it.toJSON())
             }
         }
     }
@@ -47,7 +60,14 @@ data class SDField(
                         is JsonNull -> null
                         else -> error("Error parsing SDField.children from JSON element")
                     }
-                }
+                },
+                arrayChildren = json.jsonObject["arrayChildren"]?.let { arrayChildren ->
+                    when (arrayChildren) {
+                        is JsonObject -> SDArray.fromJSON(arrayChildren)
+                        is JsonNull -> null
+                        else -> error("Error parsing SDField.arrayChildren from JSON element")
+                    }
+                },
             )
         }
     }

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwt.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwt.kt
@@ -234,7 +234,11 @@ open class SDJwt internal constructor(
             val matchResult = Regex(SD_JWT_PATTERN).matchEntire(sdJwt)
                 ?: throw IllegalArgumentException("Invalid SD-JWT format: $sdJwt")
             val matchedGroups = matchResult.groups as MatchNamedGroupCollection
-            val disclosures = matchedGroups["disclosures"]?.value?.trim(SEPARATOR)?.split(SEPARATOR)?.toSet() ?: setOf()
+            val disclosures = matchedGroups["disclosures"]?.value?.trim(SEPARATOR)?.split(SEPARATOR) ?: emptyList()
+            val uniqueDisclosures = disclosures.toSet()
+            if (uniqueDisclosures.size != disclosures.size) {
+                throw SDJwtVerificationException("Duplicate disclosure in tilde chain")
+            }
 
             return SDJwt(
                 jwt = matchedGroups["sdjwt"]!!.value,
@@ -243,7 +247,7 @@ open class SDJwt internal constructor(
                 ).jsonObject,
                 sdPayload = SDPayload.parse(
                     jwtBody = matchedGroups["body"]!!.value,
-                    disclosures = disclosures
+                    disclosures = uniqueDisclosures
                 ),
                 keyBindingJwt = matchedGroups["kbjwt"]?.value?.let { KeyBindingJwt.parse(it) },
                 isPresentation = matchedGroups["kbjwt"] != null || sdJwt.endsWith("~")

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVerificationException.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDJwtVerificationException.kt
@@ -1,0 +1,4 @@
+package id.walt.sdjwt
+
+/** Thrown when an SD-JWT fails verification. */
+class SDJwtVerificationException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDMap.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDMap.kt
@@ -73,51 +73,116 @@ class SDMap(
             decoys: Int = 0,
         ): SDMap {
             return fullPayload.mapValues { entry ->
-                if (!undisclosedPayload.containsKey(entry.key))
-                    SDField(true)
-                else if (entry.value is JsonObject && undisclosedPayload[entry.key] is JsonObject) {
-                    SDField(
-                        false,
-                        generateSDMap(
-                            entry.value.jsonObject,
-                            undisclosedPayload[entry.key]!!.jsonObject,
-                            decoyMode,
-                            decoys
-                        )
-                    )
-                } else {
-                    SDField(false)
+                val full = entry.value
+                val undisclosed = undisclosedPayload[entry.key]
+                when {
+                    !undisclosedPayload.containsKey(entry.key) -> SDField(true)
+                    full is JsonObject && undisclosed is JsonObject ->
+                        SDField(false, generateSDMap(full, undisclosed, decoyMode, decoys))
+                    full is JsonArray && undisclosed is JsonArray ->
+                        SDField(false, arrayChildren = generateSDArray(full, undisclosed, decoyMode, decoys))
+                    else -> SDField(false)
                 }
             }.toSDMap(decoyMode, decoys)
         }
 
         /**
-         * Generate SDMap based on set of simplified JSON paths
-         * @param jsonPaths Simplified JSON paths, of fields that should be selectively disclosable. e.g.: "credentialSubject.firstName", "credentialSubject.dateOfBirth"
-         * @param decoyMode **For SD-JWT issuance:** Generate decoy digests for this hierarchical level randomly or fixed, set to NONE for parsed SD-JWTs, **for presentation:** _unused_
-         * @param decoys  **For SD-JWT issuance:** Num (fixed mode) or max num (random mode) of decoy digests to add for this hierarchical level. 0 if NONE, **for presentation:** _unused_.
+         * Wrappers in [undisclosedArray] mark the matching [fullArray] index as `sd = true`.
+         * If sizes differ (decoys interleaved), fall back to a non-disclosable [SDArray].
          */
-        fun generateSDMap(jsonPaths: Collection<String>, decoyMode: DecoyMode = DecoyMode.NONE, decoys: Int = 0) =
-            doGenerateSDMap(jsonPaths, decoyMode, decoys, jsonPaths.toSet(), "")
-
-        private fun doGenerateSDMap(
-            jsonPaths: Collection<String>,
-            decoyMode: DecoyMode = DecoyMode.NONE,
+        private fun generateSDArray(
+            fullArray: JsonArray,
+            undisclosedArray: JsonArray,
+            decoyMode: DecoyMode,
             decoys: Int,
-            sdPaths: Set<String>,
-            parent: String,
-        ): SDMap {
-            val pathMap = jsonPaths.map { path -> Pair(path.substringBefore("."), path.substringAfter(".", "")) }
-                .groupBy({ p -> p.first }, { p -> p.second })
-                .mapValues { entry -> entry.value.filterNot { it.isEmpty() } }
-            return pathMap.mapValues {
-                val currentPath = listOf(parent, it.key).filter { it.isNotEmpty() }.joinToString(".")
-                SDField(
-                    sdPaths.contains(currentPath), if (it.value.isNotEmpty()) {
-                        doGenerateSDMap(it.value, decoyMode, decoys, sdPaths, currentPath)
-                    } else null
+        ): SDArray {
+            if (fullArray.size != undisclosedArray.size) {
+                return SDArray(
+                    elements = List(fullArray.size) { SDField(false) },
+                    decoyMode = decoyMode,
+                    decoys = decoys,
                 )
-            }.toSDMap(decoyMode, decoys)
+            }
+            val elements = fullArray.zip(undisclosedArray) { full, wire ->
+                when {
+                    arrayElementWrapperHash(wire) != null -> SDField(true)
+                    full is JsonObject && wire is JsonObject ->
+                        SDField(false, generateSDMap(full, wire, decoyMode, decoys))
+                    full is JsonArray && wire is JsonArray ->
+                        SDField(false, arrayChildren = generateSDArray(full, wire, decoyMode, decoys))
+                    else -> SDField(false)
+                }
+            }
+            return SDArray(elements = elements, decoyMode = decoyMode, decoys = decoys)
+        }
+
+        /**
+         * Generate SDMap based on a set of simplified JSON paths.
+         *
+         * Supported segment forms:
+         * - named keys, e.g. `credentialSubject`, `firstName`
+         * - specific array index, e.g. `nationalities.[0]`
+         * - all array elements (wildcard), e.g. `colors.[]`
+         *
+         * Array index segments must be preceded by a dot: `"colors.[0]"` is valid,
+         * `"colors[0]"` is **not**.
+         *
+         * Examples:
+         * - `"credentialSubject.firstName"`
+         * - `"nationalities.[0]"`
+         * - `"cars.[].make"`
+         * - `"contacts.[0].[2]"`
+         *
+         * @throws IllegalArgumentException for malformed segments or for paths that mix named
+         *   keys and array indices at the same hierarchy level.
+         */
+        fun generateSDMap(jsonPaths: Collection<String>, decoyMode: DecoyMode = DecoyMode.NONE, decoys: Int = 0): SDMap {
+            val tokenized = jsonPaths.map { PathToken.tokenize(it) }
+            return buildSDMap(tokenized, decoyMode, decoys)
+        }
+
+        private fun buildSDMap(paths: List<List<PathToken>>, decoyMode: DecoyMode, decoys: Int): SDMap {
+            val groups = paths.groupByFirstToken()
+            require(groups.keys.all { it is PathToken.Key }) {
+                "Cannot mix named keys and array indices at the same path level: ${groups.keys}"
+            }
+            val fields = groups.entries.associate { (token, tails) ->
+                (token as PathToken.Key).name to fieldFromTails(tails, decoyMode, decoys)
+            }
+            return SDMap(fields, decoyMode, decoys)
+        }
+
+        private fun buildSDArray(paths: List<List<PathToken>>, decoyMode: DecoyMode, decoys: Int): SDArray {
+            val groups = paths.groupByFirstToken()
+            require(groups.keys.all { it is PathToken.Index || it is PathToken.Wildcard }) {
+                "Cannot mix array indices and named keys at the same path level: ${groups.keys}"
+            }
+            val wildcardTails = groups[PathToken.Wildcard].orEmpty()
+            val wildcard = wildcardTails.takeIf { it.isNotEmpty() }
+                ?.let { fieldFromTails(it, decoyMode, decoys) }
+            val maxIndex = groups.keys.filterIsInstance<PathToken.Index>().maxOfOrNull { it.value } ?: -1
+            // Each index inherits the wildcard's tails on top of any explicit ones, so
+            // `[0].city` + `[].zip` discloses both city and zip at index 0.
+            val elements = (0..maxIndex).map { idx ->
+                val merged = groups[PathToken.Index(idx)].orEmpty() + wildcardTails
+                if (merged.isEmpty()) SDField(false) else fieldFromTails(merged, decoyMode, decoys)
+            }
+            return SDArray(elements, wildcard, decoyMode, decoys)
+        }
+
+        private fun fieldFromTails(
+            tails: List<List<PathToken>>,
+            decoyMode: DecoyMode,
+            decoys: Int,
+        ): SDField {
+            val isLeaf = tails.any { it.isEmpty() }
+            val deeper = tails.filter { it.isNotEmpty() }
+            if (deeper.isEmpty()) return SDField(isLeaf)
+            return when (deeper.first().first()) {
+                is PathToken.Key -> SDField(sd = isLeaf, children = buildSDMap(deeper, decoyMode, decoys))
+                is PathToken.Index, PathToken.Wildcard ->
+                    SDField(sd = isLeaf, arrayChildren = buildSDArray(deeper, decoyMode, decoys))
+            }
         }
 
         private fun regenerateSDField(
@@ -126,30 +191,58 @@ class SDMap(
             digestedDisclosure: Map<String, SDisclosure>
         ): SDField {
             return SDField(
-                sd, if (value is JsonObject) {
-                    regenerateSDMap(value.jsonObject, digestedDisclosure)
-                } else null
+                sd,
+                children = if (value is JsonObject) regenerateSDMap(value.jsonObject, digestedDisclosure) else null,
+                arrayChildren = if (value is JsonArray) regenerateSDArray(value, digestedDisclosure) else null,
             )
         }
 
         /**
-         * Regenerate SDMap recursively, from undisclosed payload and digested disclosures map. Used for parsing SD-JWTs.
-         * @param undisclosedPayload  Undisclosed payload as contained in the JWT body of the SD-JWT token.
-         * @param digestedDisclosures Map of digests to disclosures appended to the JWT in the SD-JWT token
+         * Regenerate [SDArray] from a wire array — a structural view used by the `sdMap`
+         * accessor. [SDArray.elements] uses logical indexing: wrappers whose digest doesn't
+         * resolve, or that resolve to a non-array disclosure, are skipped (no logical
+         * position). For strict-mode validation use [SDPayload.fullPayload] /
+         * [SDPayload.verifyDisclosures].
+         */
+        internal fun regenerateSDArray(
+            array: JsonArray,
+            digestedDisclosures: Map<String, SDisclosure>,
+        ): SDArray {
+            val elements = mutableListOf<SDField>()
+            array.forEach { element ->
+                val wrapperHash = arrayElementWrapperHash(element)
+                if (wrapperHash != null) {
+                    val disclosure = digestedDisclosures[wrapperHash] as? ArrayElementDisclosure
+                    if (disclosure != null) {
+                        elements += regenerateSDField(true, disclosure.value, digestedDisclosures)
+                    }
+                } else {
+                    elements += regenerateSDField(false, element, digestedDisclosures)
+                }
+            }
+            return SDArray(elements = elements)
+        }
+
+        /**
+         * Regenerate [SDMap] from an undisclosed payload and disclosures map — a structural
+         * view used by the `sdMap` accessor. Disclosed × plain and disclosed × disclosed
+         * claim-name collisions are not enforced here; for strict-mode validation use
+         * [SDPayload.fullPayload].
          */
         internal fun regenerateSDMap(
             undisclosedPayload: JsonObject,
             digestedDisclosures: Map<String, SDisclosure>
         ): SDMap {
-            return (undisclosedPayload[SDJwt.DIGESTS_KEY]?.jsonArray?.filter { digestedDisclosures.containsKey(it.jsonPrimitive.content) }
-                ?.map { sdEntry ->
-                    digestedDisclosures[sdEntry.jsonPrimitive.content]!!
-                }?.associateBy({ it.key }, { regenerateSDField(true, it.value, digestedDisclosures) }) ?: mapOf())
-                .plus(
-                    undisclosedPayload.filterNot { it.key == SDJwt.DIGESTS_KEY }.mapValues {
-                        regenerateSDField(false, it.value, digestedDisclosures)
-                    }
-                ).toSDMap()
+            val disclosed = undisclosedPayload[SDJwt.DIGESTS_KEY]?.jsonArray
+                ?.filter { digestedDisclosures.containsKey(it.jsonPrimitive.content) }
+                ?.map { digestedDisclosures[it.jsonPrimitive.content]!! }
+                ?.filterIsInstance<ObjectPropertyDisclosure>()
+                ?.associateBy({ it.key }, { regenerateSDField(true, it.value, digestedDisclosures) })
+                ?: emptyMap()
+            val plain = undisclosedPayload.filterNot { it.key == SDJwt.DIGESTS_KEY }.mapValues {
+                regenerateSDField(false, it.value, digestedDisclosures)
+            }
+            return (disclosed + plain).toSDMap()
         }
 
         fun fromJSON(json: JsonObject): SDMap {

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDPayload.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDPayload.kt
@@ -30,102 +30,164 @@ data class SDPayload internal constructor(
     val sDisclosures
         get() = digestedDisclosures.values
 
-    /**
-     * Full payload, with all (selected) disclosures resolved recursively
-     */
-    val fullPayload
-        get() = disclosePayloadRecursively(undisclosedPayload, null)
+    /** Full payload, with all selectively-disclosed claims resolved recursively. */
+    val fullPayload: JsonObject get() = walk(select = null).resolved
+
+    /** SDMap regenerated from undisclosed payload and disclosures. */
+    val sdMap get() = SDMap.regenerateSDMap(undisclosedPayload, digestedDisclosures)
+
+    /** Returns a new [SDPayload] keeping only disclosures the holder selected via [sdMap]. */
+    fun withSelectiveDisclosures(sdMap: Map<String, SDField>): SDPayload {
+        val released = walk(select = sdMap).released
+        return SDPayload(
+            undisclosedPayload = undisclosedPayload,
+            digestedDisclosures = digestedDisclosures.filterValues { it.disclosure in released },
+        )
+    }
+
+    /** Mutable state threaded through one [walk]. */
+    private class WalkState(
+        /** Disclosures not yet seen on the wire; anything left after the walk is unreferenced. */
+        val unconsumed: MutableMap<String, SDisclosure>,
+        /** Every digest seen on the wire; detects duplicates across the whole tree. */
+        val seenDigests: MutableSet<String> = mutableSetOf(),
+        /** Disclosure strings the walk chose to reveal. */
+        val released: MutableSet<String> = mutableSetOf(),
+    )
+
+    private class WalkResult(val resolved: JsonObject, val released: Set<String>)
 
     /**
-     * SDMap regenerated from undisclosed payload and disclosures.
+     * Walks the payload once, shared by verifier and holder paths.
+     * `select == null` reveals everything; otherwise reveals only claims marked `sd = true`.
      */
-    val sdMap
-        get() = SDMap.regenerateSDMap(undisclosedPayload, digestedDisclosures)
+    private fun walk(select: Map<String, SDField>?): WalkResult {
+        val state = WalkState(unconsumed = digestedDisclosures.toMutableMap())
+        val resolved = walkObject(undisclosedPayload, select, state)
+        if (state.unconsumed.isNotEmpty()) {
+            throw SDJwtVerificationException("${state.unconsumed.size} disclosure(s) not referenced by any digest")
+        }
+        return WalkResult(resolved, state.released)
+    }
 
-    private fun disclosePayloadRecursively(
+    private fun walkObject(
         payload: JsonObject,
-        verificationDisclosureMap: MutableMap<String, SDisclosure>?
-    ): JsonObject {
-        return buildJsonObject {
-            payload.forEach { entry ->
-                if (entry.key == SDJwt.DIGESTS_KEY) {
-                    if (entry.value !is JsonArray) throw Exception("SD-JWT contains invalid ${SDJwt.DIGESTS_KEY} element")
-                    entry.value.jsonArray.forEach {
-                        unveilDisclosureIfPresent(
-                            digest = it.jsonPrimitive.content,
-                            objectBuilder = this,
-                            verificationDisclosureMap = verificationDisclosureMap
-                        )
-                    }
-                } else if (entry.value is JsonObject) {
-                    put(
-                        entry.key, disclosePayloadRecursively(
-                            payload = entry.value.jsonObject,
-                            verificationDisclosureMap = verificationDisclosureMap
-                        )
-                    )
-                } else {
-                    put(entry.key, entry.value)
+        select: Map<String, SDField>?,
+        state: WalkState,
+    ): JsonObject = buildJsonObject {
+        payload.forEach { entry ->
+            when (entry.key) {
+                SDJwt.DIGESTS_KEY -> {
+                    val digestArray = entry.value as? JsonArray
+                        ?: throw SDJwtVerificationException("${SDJwt.DIGESTS_KEY} must be a JSON array")
+                    digestArray.forEach { unveilObjectDisclosure(digestString(it), select, state, this) }
                 }
+                ARRAY_ELEMENT_WRAPPER_KEY ->
+                    throw SDJwtVerificationException("Reserved name '${entry.key}' used as a plain claim")
+                else -> putUnique(
+                    entry.key,
+                    recurse(entry.value, select?.get(entry.key), select == null, state),
+                )
             }
         }
     }
 
-    private fun unveilDisclosureIfPresent(
+    private fun unveilObjectDisclosure(
         digest: String,
-        objectBuilder: JsonObjectBuilder,
-        verificationDisclosureMap: MutableMap<String, SDisclosure>?
+        select: Map<String, SDField>?,
+        state: WalkState,
+        builder: JsonObjectBuilder,
     ) {
-        val sDisclosure = verificationDisclosureMap?.remove(digest) ?: digestedDisclosures[digest]
-        if (sDisclosure != null) {
-            objectBuilder.put(
-                sDisclosure.key,
-                if (sDisclosure.value is JsonObject) {
-                    disclosePayloadRecursively(
-                        payload = sDisclosure.value.jsonObject,
-                        verificationDisclosureMap = verificationDisclosureMap
-                    )
-                } else sDisclosure.value
+        if (!state.seenDigests.add(digest)) {
+            throw SDJwtVerificationException("Duplicate digest reference: $digest")
+        }
+        // Decoy or holder-stripped: nothing to reveal.
+        val disc = state.unconsumed.remove(digest) ?: return
+        when (disc) {
+            is ArrayElementDisclosure -> throw SDJwtVerificationException(
+                "Expected an object-property disclosure, got an array-element disclosure"
             )
+            is ObjectPropertyDisclosure -> {
+                if (disc.key == SDJwt.DIGESTS_KEY || disc.key == ARRAY_ELEMENT_WRAPPER_KEY) {
+                    throw SDJwtVerificationException("Reserved name '${disc.key}' used as a disclosed claim")
+                }
+                val release = select == null || select[disc.key]?.sd == true
+                if (!release) return
+                state.released += disc.disclosure
+                builder.putUnique(disc.key, recurse(disc.value, select?.get(disc.key), select == null, state))
+            }
         }
-    }
-
-    private fun filterDisclosures(currPayloadObject: JsonObject, sdMap: Map<String, SDField>): Set<String> {
-        if (currPayloadObject.containsKey(SDJwt.DIGESTS_KEY) && currPayloadObject[SDJwt.DIGESTS_KEY] !is JsonArray) {
-            throw Exception("Invalid ${SDJwt.DIGESTS_KEY} format found")
-        }
-
-        return currPayloadObject.filter { entry -> entry.value is JsonObject && !sdMap[entry.key]?.children.isNullOrEmpty() }
-            .flatMap { entry ->
-                filterDisclosures(entry.value.jsonObject, sdMap[entry.key]!!.children!!)
-            }.plus(
-                currPayloadObject[SDJwt.DIGESTS_KEY]?.jsonArray
-                    ?.asSequence()
-                    ?.map { it.jsonPrimitive.content }
-                    ?.filter { digest -> digestedDisclosures.containsKey(digest) }
-                    ?.map { digest -> digestedDisclosures[digest]!! }
-                    ?.filter { sd -> sdMap[sd.key]?.sd == true }
-                    ?.flatMap { sd ->
-                        listOf(sd.disclosure).plus(
-                            if (sd.value is JsonObject && !sdMap[sd.key]?.children.isNullOrEmpty()) {
-                                filterDisclosures(sd.value, sdMap[sd.key]!!.children!!)
-                            } else listOf()
-                        )
-                    }
-                    ?.toList() ?: listOf()
-            ).toSet()
     }
 
     /**
-     * Payload with selectively disclosed fields and undisclosed fields filtered out.
-     * @param sdMap Map indicating per field (recursively) whether they are selected for disclosure
+     * Walks an array. [sdArray] indexes by **logical** position (decoys don't advance it).
+     * `null` reveals everything; otherwise reveals only elements marked `sd = true`.
      */
-    fun withSelectiveDisclosures(sdMap: Map<String, SDField>): SDPayload {
-        val selectedDisclosures = filterDisclosures(undisclosedPayload, sdMap)
-        return SDPayload(
-            undisclosedPayload = undisclosedPayload,
-            digestedDisclosures = digestedDisclosures.filterValues { selectedDisclosures.contains(it.disclosure) }
-        )
+    private fun walkArray(
+        array: JsonArray,
+        sdArray: SDArray?,
+        state: WalkState,
+    ): JsonArray = buildJsonArray {
+        var logicalIndex = 0
+        array.forEach { element ->
+            val digest = arrayElementWrapperHash(element)
+            if (digest != null) {
+                if (!state.seenDigests.add(digest)) {
+                    throw SDJwtVerificationException("Duplicate digest reference: $digest")
+                }
+                when (val disc = state.unconsumed.remove(digest)) {
+                    is ObjectPropertyDisclosure -> throw SDJwtVerificationException(
+                        "Expected an array-element disclosure, got an object-property disclosure"
+                    )
+                    is ArrayElementDisclosure -> {
+                        val field = sdArray?.fieldAt(logicalIndex)
+                        logicalIndex += 1
+                        val release = sdArray == null || field?.sd == true
+                        if (release) {
+                            state.released += disc.disclosure
+                            add(recurse(disc.value, field, sdArray == null, state))
+                        }
+                    }
+                    null -> { /* decoy or holder-stripped: drop the slot. */ }
+                }
+            } else {
+                val field = sdArray?.fieldAt(logicalIndex)
+                logicalIndex += 1
+                add(recurse(element, field, sdArray == null, state))
+            }
+        }
+    }
+
+    private fun SDArray.fieldAt(logicalIndex: Int): SDField? =
+        elements.getOrNull(logicalIndex) ?: wildcard
+
+    /**
+     * Recurse into a nested value. [releaseAll] carries verifier mode down the tree;
+     * when off, an absent [field] means "reveal nothing under this branch".
+     */
+    private fun recurse(
+        value: JsonElement,
+        field: SDField?,
+        releaseAll: Boolean,
+        state: WalkState,
+    ): JsonElement = when (value) {
+        is JsonObject -> walkObject(value, if (releaseAll) null else (field?.children ?: emptyMap()), state)
+        is JsonArray -> walkArray(value, if (releaseAll) null else (field?.arrayChildren ?: SDArray()), state)
+        else -> value
+    }
+
+    private fun digestString(node: JsonElement): String {
+        val p = node as? JsonPrimitive
+        if (p == null || !p.isString) {
+            throw SDJwtVerificationException("${SDJwt.DIGESTS_KEY} entries must be JSON strings")
+        }
+        return p.content
+    }
+
+    private fun JsonObjectBuilder.putUnique(key: String, value: JsonElement) {
+        if (put(key, value) != null) {
+            throw SDJwtVerificationException("Duplicate claim name '$key' at the same object level")
+        }
     }
 
     /**
@@ -135,15 +197,19 @@ data class SDPayload internal constructor(
         return SDPayload(undisclosedPayload, mapOf())
     }
 
-    /**
-     * Verify digests in JWT payload match with disclosures appended to JWT token.
-     */
-    fun verifyDisclosures() = digestedDisclosures.toMutableMap().also {
-        disclosePayloadRecursively(undisclosedPayload, it)
-    }.isEmpty()
+    /** Returns `false` if [fullPayload] would throw any [SDJwtVerificationException]. */
+    fun verifyDisclosures(): Boolean = try {
+        fullPayload
+        true
+    } catch (_: SDJwtVerificationException) {
+        false
+    }
 
     @JsExport.Ignore // see SDPayloadBuilder for JS support
     companion object {
+        /** Marker key inside an array element that names a digest. */
+        internal const val ARRAY_ELEMENT_WRAPPER_KEY = "..."
+
         val sha256 = SHA256()
 
         private fun digest(value: String): String {
@@ -186,7 +252,7 @@ data class SDPayload internal constructor(
                 add(key)
                 add(value)
             }.toString().encodeToByteArray()).let { disclosure ->
-                SDisclosure(
+                ObjectPropertyDisclosure(
                     disclosure = disclosure,
                     salt = salt,
                     key = key,
@@ -195,12 +261,32 @@ data class SDPayload internal constructor(
             }
         }
 
+        /** A 2-element disclosure `[salt, value]` for an array element. */
+        private fun generateArrayElementDisclosure(value: JsonElement): ArrayElementDisclosure {
+            val salt = generateSalt()
+            val encoded = base64Url.encode(buildJsonArray {
+                add(salt)
+                add(value)
+            }.toString().encodeToByteArray())
+            return ArrayElementDisclosure(disclosure = encoded, salt = salt, value = value)
+        }
+
         private fun digestSDClaim(
             key: String,
             value: JsonElement,
             digests2disclosures: MutableMap<String, SDisclosure>
         ): String {
             val disclosure = generateDisclosure(key, value)
+            return digest(disclosure.disclosure).also {
+                digests2disclosures[it] = disclosure
+            }
+        }
+
+        private fun digestArrayElement(
+            value: JsonElement,
+            digests2disclosures: MutableMap<String, SDisclosure>
+        ): String {
+            val disclosure = generateArrayElementDisclosure(value)
             return digest(disclosure.disclosure).also {
                 digests2disclosures[it] = disclosure
             }
@@ -224,9 +310,28 @@ data class SDPayload internal constructor(
             val sdPayload = removeSDFields(payload, sdMap).toMutableMap()
             val digests = payload.filterKeys { key ->
                 // iterate over all fields that are selectively disclosable AND/OR have nested fields that might be:
-                sdMap[key]?.sd == true || !sdMap[key]?.children.isNullOrEmpty()
+                sdMap[key]?.sd == true || !sdMap[key]?.children.isNullOrEmpty() || sdMap[key]?.arrayChildren != null
             }.map { entry ->
-                if (entry.value !is JsonObject || sdMap[entry.key]?.children.isNullOrEmpty()) {
+                val arrayChildren = sdMap[entry.key]?.arrayChildren
+                if (entry.value is JsonArray && arrayChildren != null) {
+                    // this field is an array with selectively disclosable elements:
+                    val transformedArray = generateSDArray(
+                        array = entry.value.jsonArray,
+                        sdArray = arrayChildren,
+                        digests2disclosures = digests2disclosures
+                    )
+                    if (sdMap[entry.key]?.sd == true) {
+                        // the array itself is also selectively disclosable as a whole:
+                        digestSDClaim(
+                            key = entry.key,
+                            value = transformedArray,
+                            digests2disclosures = digests2disclosures
+                        )
+                    } else {
+                        sdPayload[entry.key] = transformedArray
+                        null
+                    }
+                } else if (entry.value !is JsonObject || sdMap[entry.key]?.children.isNullOrEmpty()) {
                     // this field has no nested elements and/or is selectively disclosable only as a whole:
                     digestSDClaim(
                         key = entry.key,
@@ -260,20 +365,51 @@ data class SDPayload internal constructor(
             }.filterNotNull().toSet()
 
             if (digests.isNotEmpty()) {
-                sdPayload[SDJwt.DIGESTS_KEY] = buildJsonArray {
-                    digests.forEach { add(it) }
-                    if (sdMap.decoyMode != DecoyMode.NONE && sdMap.decoys > 0) {
-                        val numDecoys = when (sdMap.decoyMode) {
-                            DecoyMode.RANDOM -> secureRandom.nextInt(1, sdMap.decoys + 1)
-                            DecoyMode.FIXED -> sdMap.decoys
-                        }
-                        repeat(numDecoys) {
-                            add(digest(generateSalt()))
-                        }
-                    }
-                }
+                val mixed = digests.toMutableList()
+                repeat(numDecoys(sdMap.decoyMode, sdMap.decoys)) { mixed += digest(generateSalt()) }
+                // Shuffle so source claim order doesn't leak through _sd.
+                sdPayload[SDJwt.DIGESTS_KEY] = JsonArray(mixed.shuffled(secureRandom).map { JsonPrimitive(it) })
             }
             return JsonObject(sdPayload)
+        }
+
+        /**
+         * Replace each selectively-disclosable element of [array] with a `{"...": "<digest>"}`
+         * wrapper. Decoys are inserted at random positions; real elements keep their relative
+         * order.
+         */
+        private fun generateSDArray(
+            array: JsonArray,
+            sdArray: SDArray,
+            digests2disclosures: MutableMap<String, SDisclosure>
+        ): JsonArray {
+            val transformed = array.mapIndexed { index, element ->
+                val field = sdArray.elements.getOrNull(index) ?: sdArray.wildcard
+                val nested = if (element is JsonObject && field?.children != null) {
+                    generateSDPayload(element, field.children, digests2disclosures)
+                } else if (element is JsonArray && field?.arrayChildren != null) {
+                    generateSDArray(element, field.arrayChildren, digests2disclosures)
+                } else element
+                if (field?.sd == true) {
+                    val hash = digestArrayElement(nested, digests2disclosures)
+                    buildJsonObject { put(ARRAY_ELEMENT_WRAPPER_KEY, hash) }
+                } else {
+                    nested
+                }
+            }
+            val result = transformed.toMutableList()
+            repeat(numDecoys(sdArray.decoyMode, sdArray.decoys)) {
+                val decoy = buildJsonObject { put(ARRAY_ELEMENT_WRAPPER_KEY, digest(generateSalt())) }
+                result.add(secureRandom.nextInt(result.size + 1), decoy)
+            }
+            return JsonArray(result)
+        }
+
+        /** Number of decoys to add for one hierarchical level. */
+        private fun numDecoys(mode: DecoyMode, decoys: Int): Int = when (mode) {
+            DecoyMode.NONE -> 0
+            DecoyMode.RANDOM -> if (decoys > 0) secureRandom.nextInt(decoys + 1) else 0
+            DecoyMode.FIXED -> decoys
         }
 
         /**
@@ -354,14 +490,49 @@ data class SDPayload internal constructor(
         )
 
         /**
-         * Parse SD payload from JWT body and disclosure strings appended to JWT token
+         * Parse SD payload from JWT body and disclosure strings appended to JWT token.
+         * Two distinct disclosures that hash to the same digest throw
+         * [SDJwtVerificationException]; the caller is responsible for rejecting duplicate
+         * disclosure strings before they collapse into [Set].
+         *
          * @param jwtBody  Undisclosed JWT body payload
          * @param disclosures Encoded disclosure string, as appended to JWT token
          */
         fun parse(jwtBody: String, disclosures: Set<String>): SDPayload {
+            val digestMap = mutableMapOf<String, SDisclosure>()
+            disclosures.forEach { d ->
+                val parsed = SDisclosure.parse(d)
+                val digestStr = digest(d)
+                if (digestMap.put(digestStr, parsed) != null) {
+                    throw SDJwtVerificationException(
+                        "Distinct disclosures hash to the same digest: $digestStr"
+                    )
+                }
+            }
             return SDPayload(
                 undisclosedPayload = Json.parseToJsonElement(jwtBody.decodeFromBase64Url().decodeToString()).jsonObject,
-                digestedDisclosures = disclosures.associate { Pair(digest(it), SDisclosure.parse(it)) })
+                digestedDisclosures = digestMap,
+            )
         }
     }
+}
+
+/**
+ * Returns the digest if [element] is a well-formed array-element wrapper
+ * (`{"...": "<digest-string>"}`), `null` if it isn't a wrapper at all. Throws
+ * [SDJwtVerificationException] when [element] looks like a wrapper (has the `...` key)
+ * but is malformed (extra keys or non-string digest).
+ */
+internal fun arrayElementWrapperHash(element: JsonElement): String? {
+    if (element !is JsonObject || !element.containsKey(SDPayload.ARRAY_ELEMENT_WRAPPER_KEY)) return null
+    if (element.size != 1) {
+        throw SDJwtVerificationException(
+            "Array-element wrapper must have exactly one key, got ${element.size}"
+        )
+    }
+    val v = element[SDPayload.ARRAY_ELEMENT_WRAPPER_KEY] as? JsonPrimitive
+    if (v == null || !v.isString) {
+        throw SDJwtVerificationException("Array-element wrapper digest must be a JSON string")
+    }
+    return v.content
 }

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDisclosure.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonMain/kotlin/id/walt/sdjwt/SDisclosure.kt
@@ -1,44 +1,89 @@
 package id.walt.sdjwt
 
 import id.walt.sdjwt.utils.SdjwtStringUtils.decodeFromBase64Url
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonPrimitive
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 
 /**
- * Selective Disclosure for a given payload field. Contains salt, field key and field value.
- * @param disclosure  The encoded disclosure, as given in the SD-JWT token.
- * @param salt  Salt value
- * @param key Field key
- * @param value Field value
+ * Selective disclosure. Two concrete forms:
+ * - [ObjectPropertyDisclosure] — `[salt, claim_name, claim_value]`
+ * - [ArrayElementDisclosure]    — `[salt, claim_value]`
+ *
+ * Use [parse] to construct the right subtype from a base64url-encoded disclosure string.
+ *
+ * @property disclosure The base64url-encoded disclosure string as it appears in the SD-JWT.
+ * @property salt The salt value (first element of the underlying JSON array).
+ * @property value The disclosed claim value.
  */
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+sealed class SDisclosure {
+    abstract val disclosure: String
+    abstract val salt: String
+    abstract val value: JsonElement
+
+    companion object {
+        fun parse(disclosure: String): SDisclosure {
+            val arr = try {
+                Json.parseToJsonElement(disclosure.decodeFromBase64Url().decodeToString()).jsonArray
+            } catch (e: IllegalArgumentException) {
+                throw SDJwtVerificationException("Invalid selective disclosure", e)
+            } catch (e: SerializationException) {
+                throw SDJwtVerificationException("Invalid selective disclosure", e)
+            } catch (e: IllegalStateException) {
+                throw SDJwtVerificationException("Invalid selective disclosure", e)
+            }
+            return when (arr.size) {
+                3 -> ObjectPropertyDisclosure(
+                    disclosure = disclosure,
+                    salt = requireString(arr[0], "salt"),
+                    key = requireString(arr[1], "claim name"),
+                    value = arr[2],
+                )
+                2 -> ArrayElementDisclosure(
+                    disclosure = disclosure,
+                    salt = requireString(arr[0], "salt"),
+                    value = arr[1],
+                )
+                else -> throw SDJwtVerificationException(
+                    "Invalid selective disclosure: expected a JSON array of 2 or 3 elements, got ${arr.size}"
+                )
+            }
+        }
+
+        private fun requireString(element: JsonElement, name: String): String {
+            val primitive = element as? JsonPrimitive
+                ?: throw SDJwtVerificationException("Invalid selective disclosure: $name must be a JSON string")
+            if (!primitive.isString) {
+                throw SDJwtVerificationException("Invalid selective disclosure: $name must be a JSON string")
+            }
+            return primitive.content
+        }
+    }
+}
+
+/** Selective disclosure for an object property: `[salt, claim_name, claim_value]`. */
 @ConsistentCopyVisibility
 @OptIn(ExperimentalJsExport::class)
 @JsExport
-data class SDisclosure internal constructor(
-    val disclosure: String,
-    val salt: String,
+data class ObjectPropertyDisclosure internal constructor(
+    override val disclosure: String,
+    override val salt: String,
     val key: String,
-    val value: JsonElement
-) {
-    companion object {
-        /**
-         * Parse an encoded disclosure string
-         */
-        fun parse(disclosure: String) =
-            Json.parseToJsonElement(disclosure.decodeFromBase64Url().decodeToString()).jsonArray.let {
-                if (it.size != 3) {
-                    throw Exception("Invalid selective disclosure")
-                }
-                SDisclosure(
-                    disclosure = disclosure,
-                    salt = it[0].jsonPrimitive.content,
-                    key = it[1].jsonPrimitive.content,
-                    value = it[2]
-                )
-            }
-    }
-}
+    override val value: JsonElement,
+) : SDisclosure()
+
+/** Selective disclosure for an array element: `[salt, claim_value]`. */
+@ConsistentCopyVisibility
+@OptIn(ExperimentalJsExport::class)
+@JsExport
+data class ArrayElementDisclosure internal constructor(
+    override val disclosure: String,
+    override val salt: String,
+    override val value: JsonElement,
+) : SDisclosure()

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonTest/kotlin/id/walt/sdjwt/PathTokenTest.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonTest/kotlin/id/walt/sdjwt/PathTokenTest.kt
@@ -1,0 +1,100 @@
+package id.walt.sdjwt
+
+import kotlin.test.*
+
+class PathTokenTest {
+
+    @Test
+    fun tokenize_singleKey() {
+        assertEquals(listOf(PathToken.Key("firstName")), PathToken.tokenize("firstName"))
+    }
+
+    @Test
+    fun tokenize_dottedKeys() {
+        assertEquals(
+            listOf(PathToken.Key("credentialSubject"), PathToken.Key("firstName")),
+            PathToken.tokenize("credentialSubject.firstName")
+        )
+    }
+
+    @Test
+    fun tokenize_specificIndex() {
+        assertEquals(
+            listOf(PathToken.Key("nationalities"), PathToken.Index(0)),
+            PathToken.tokenize("nationalities.[0]")
+        )
+    }
+
+    @Test
+    fun tokenize_wildcard() {
+        assertEquals(
+            listOf(PathToken.Key("colors"), PathToken.Wildcard),
+            PathToken.tokenize("colors.[]")
+        )
+    }
+
+    @Test
+    fun tokenize_wildcardWithProperty() {
+        assertEquals(
+            listOf(PathToken.Key("cars"), PathToken.Wildcard, PathToken.Key("make")),
+            PathToken.tokenize("cars.[].make")
+        )
+    }
+
+    @Test
+    fun tokenize_nestedArrayOfArrays() {
+        assertEquals(
+            listOf(PathToken.Key("contacts"), PathToken.Index(0), PathToken.Index(2)),
+            PathToken.tokenize("contacts.[0].[2]")
+        )
+    }
+
+    @Test
+    fun tokenize_emptySegmentRejected() {
+        assertFails { PathToken.tokenize("a..b") }
+        assertFails { PathToken.tokenize(".a") }
+        assertFails { PathToken.tokenize("a.") }
+    }
+
+    @Test
+    fun tokenize_negativeIndexRejected() {
+        assertFails { PathToken.tokenize("a.[-1]") }
+    }
+
+    @Test
+    fun tokenize_nonNumericIndexRejected() {
+        assertFails { PathToken.tokenize("a.[abc]") }
+    }
+
+    @Test
+    fun tokenize_unbalancedBracketRejected() {
+        assertFails { PathToken.tokenize("a.[]x") }
+        assertFails { PathToken.tokenize("a.[0") }
+        assertFails { PathToken.tokenize("a.0]") }
+    }
+
+    @Test
+    fun groupByFirstToken_emptyPathsAreFilteredOut() {
+        val grouped = listOf(
+            emptyList<PathToken>(),
+            listOf(PathToken.Key("a")),
+        ).groupByFirstToken()
+        assertEquals(setOf(PathToken.Key("a")), grouped.keys)
+        assertEquals(listOf(emptyList<PathToken>()), grouped[PathToken.Key("a")])
+    }
+
+    @Test
+    fun groupByFirstToken_collectsTailsForSharedHead() {
+        val grouped = listOf(
+            listOf(PathToken.Key("a"), PathToken.Key("b")),
+            listOf(PathToken.Key("a"), PathToken.Key("c")),
+            listOf(PathToken.Key("d")),
+        ).groupByFirstToken()
+        assertEquals(setOf(PathToken.Key("a"), PathToken.Key("d")), grouped.keys)
+        assertEquals(
+            listOf(listOf(PathToken.Key("b")), listOf(PathToken.Key("c"))),
+            grouped[PathToken.Key("a")]
+        )
+        assertEquals(listOf(emptyList<PathToken>()), grouped[PathToken.Key("d")])
+    }
+}

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonTest/kotlin/id/walt/sdjwt/SDArrayElementTest.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonTest/kotlin/id/walt/sdjwt/SDArrayElementTest.kt
@@ -1,0 +1,1024 @@
+package id.walt.sdjwt
+
+import id.walt.sdjwt.utils.Base64Utils.encodeToBase64Url
+import kotlinx.serialization.json.*
+import org.kotlincrypto.hash.sha2.SHA256
+import kotlin.test.*
+
+/**
+ * Tests for RFC 9901 array-element selective disclosure.
+ *
+ * Specification references use section numbers from RFC 9901.
+ */
+class SDArrayElementTest {
+
+    // Disclosure parsing (RFC 9901 §4.2.1, §4.2.2, §4.2.3)
+
+    /** RFC §4.2.2: `["lklxF5jMYlGTPUovMNIvCA", "FR"]`. */
+    @Test
+    fun parse_arrayElementDisclosure_FR() {
+        val disclosure = "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0"
+        val parsed = SDisclosure.parse(disclosure)
+        assertIs<ArrayElementDisclosure>(parsed)
+        assertEquals("lklxF5jMYlGTPUovMNIvCA", parsed.salt)
+        assertEquals(JsonPrimitive("FR"), parsed.value)
+        assertEquals(disclosure, parsed.disclosure)
+    }
+
+    /** RFC §5.1 example: SHA-256 of the "US" array-element disclosure. */
+    @Test
+    fun parse_arrayElementDisclosure_US_matchesRfc9901Example() {
+        val disclosure = "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0"
+        val parsed = SDisclosure.parse(disclosure)
+        assertIs<ArrayElementDisclosure>(parsed)
+        assertEquals(JsonPrimitive("US"), parsed.value)
+        val hash = SHA256().digest(disclosure.encodeToByteArray()).encodeToBase64Url()
+        assertEquals("pFndjkZ_VCzmyTa6UjlZo3dh-ko8aIKQc9DlGzhaVYo", hash)
+    }
+
+    /** RFC §5.1 example: SHA-256 of the "DE" array-element disclosure. */
+    @Test
+    fun parse_arrayElementDisclosure_DE_matchesRfc9901Example() {
+        val disclosure = "WyJuUHVvUW5rUkZxM0JJZUFtN0FuWEZBIiwgIkRFIl0"
+        val parsed = SDisclosure.parse(disclosure)
+        assertIs<ArrayElementDisclosure>(parsed)
+        assertEquals(JsonPrimitive("DE"), parsed.value)
+        val hash = SHA256().digest(disclosure.encodeToByteArray()).encodeToBase64Url()
+        assertEquals("7Cf6JkPudry3lcbwHgeZ8khAv1U1OSlerP0VkBJrWZ0", hash)
+    }
+
+    /** RFC §5.1: 3-element object-property disclosure continues to parse. */
+    @Test
+    fun parse_objectPropertyDisclosure_givenName() {
+        val disclosure = "WyIyR0xDNDJzS1F2ZUNmR2ZyeU5STjl3IiwgImdpdmVuX25hbWUiLCAiSm9obiJd"
+        val parsed = SDisclosure.parse(disclosure)
+        assertIs<ObjectPropertyDisclosure>(parsed)
+        assertEquals("2GLC42sKQveCfGfryNRN9w", parsed.salt)
+        assertEquals("given_name", parsed.key)
+        assertEquals(JsonPrimitive("John"), parsed.value)
+    }
+
+    /** RFC §7.1 step 3.c: anything but 2 or 3 elements MUST be rejected. */
+    @Test
+    fun parse_rejectsArrayOfSize1() {
+        val badDisclosure = buildJsonArray { add("onlySalt") }.toString()
+            .encodeToByteArray().encodeToBase64Url()
+        assertFailsWith<SDJwtVerificationException> { SDisclosure.parse(badDisclosure) }
+    }
+
+    @Test
+    fun parse_rejectsArrayOfSize4() {
+        val badDisclosure = buildJsonArray {
+            add("salt"); add("key"); add("value"); add("extra")
+        }.toString().encodeToByteArray().encodeToBase64Url()
+        assertFailsWith<SDJwtVerificationException> { SDisclosure.parse(badDisclosure) }
+    }
+
+    @Test
+    fun parse_rejectsNonStringSalt() {
+        val badDisclosure = buildJsonArray {
+            add(42)
+            add("key")
+            add("value")
+        }.toString().encodeToByteArray().encodeToBase64Url()
+        assertFailsWith<SDJwtVerificationException> { SDisclosure.parse(badDisclosure) }
+    }
+
+    /** Round-trip via the compare-by-key overload must preserve array-element disclosures. */
+    @Test
+    fun generateSDMap_recoversArrayChildrenFromWireWrappers() {
+        val fullPayload = buildJsonObject {
+            put("name", "Alice")
+            put("nationalities", buildJsonArray { add("US"); add("DE") })
+        }
+        val sourceMap = SDMap(
+            mapOf(
+                "name" to SDField(sd = true),
+                "nationalities" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(elements = listOf(SDField(sd = true), SDField(sd = true))),
+                ),
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sourceMap)
+
+        val recovered = SDMap.generateSDMap(
+            fullPayload = sdPayload.fullPayload,
+            undisclosedPayload = sdPayload.undisclosedPayload,
+        )
+        val nationalities = recovered["nationalities"]
+        assertNotNull(nationalities)
+        val arr = nationalities.arrayChildren
+        assertNotNull(arr)
+        assertEquals(2, arr.elements.size)
+        assertTrue(arr.elements.all { it.sd })
+    }
+
+    /** Bad base64url input must surface as [SDJwtVerificationException], not an upstream IAE. */
+    @Test
+    fun parse_rejectsInvalidBase64() {
+        assertFailsWith<SDJwtVerificationException> { SDisclosure.parse("not!valid!base64") }
+    }
+
+    /** Valid base64 of non-JSON content must surface as [SDJwtVerificationException]. */
+    @Test
+    fun parse_rejectsValidBase64ButNotJson() {
+        val notJson = "this is not json".encodeToByteArray().encodeToBase64Url()
+        assertFailsWith<SDJwtVerificationException> { SDisclosure.parse(notJson) }
+    }
+
+    /** Valid JSON that isn't an array (e.g. an object) must surface as [SDJwtVerificationException]. */
+    @Test
+    fun parse_rejectsValidJsonButNotArray() {
+        val notArray = """{"salt":"x","key":"y","value":1}""".encodeToByteArray().encodeToBase64Url()
+        assertFailsWith<SDJwtVerificationException> { SDisclosure.parse(notArray) }
+    }
+
+    // Data-model construction
+
+    @Test
+    fun sdField_arrayChildren_carriesSDArray() {
+        val field = SDField(
+            sd = false,
+            arrayChildren = SDArray(
+                elements = listOf(SDField(sd = true), SDField(sd = false))
+            )
+        )
+        val arr = field.arrayChildren
+        assertNotNull(arr)
+        assertEquals(2, arr.elements.size)
+        assertTrue(arr.elements[0].sd)
+        assertFalse(arr.elements[1].sd)
+        assertNull(field.children)
+    }
+
+    @Test
+    fun sdField_children_carriesSDMap() {
+        val field = SDField(
+            sd = true,
+            children = SDMap(mapOf("x" to SDField(sd = true)))
+        )
+        val children = field.children
+        assertNotNull(children)
+        assertTrue(children["x"]!!.sd)
+        assertNull(field.arrayChildren)
+    }
+
+    @Test
+    fun sdField_rejectsBothChildrenSet() {
+        assertFails {
+            SDField(
+                sd = true,
+                children = SDMap(mapOf()),
+                arrayChildren = SDArray(),
+            )
+        }
+    }
+
+    /** Constructor must reject negative decoy counts up front, not later in `repeat(-1)`. */
+    @Test
+    fun sdArray_rejectsNegativeDecoys() {
+        assertFails { SDArray(decoyMode = DecoyMode.FIXED, decoys = -1) }
+    }
+
+    @Test
+    fun sdArray_wildcard_appliesToAllIndices() {
+        val arr = SDArray(elements = emptyList(), wildcard = SDField(sd = true))
+        assertEquals(0, arr.elements.size)
+        assertNotNull(arr.wildcard)
+        assertTrue(arr.wildcard.sd)
+    }
+
+    @Test
+    fun sdArray_toJson_roundTrips() {
+        val original = SDArray(
+            elements = listOf(SDField(sd = true), SDField(sd = false)),
+            wildcard = SDField(sd = true),
+            decoyMode = DecoyMode.FIXED,
+            decoys = 3,
+        )
+        val json = original.toJSON()
+        val restored = SDArray.fromJSON(json)
+        assertEquals(original.elements.size, restored.elements.size)
+        assertEquals(original.elements[0].sd, restored.elements[0].sd)
+        assertEquals(original.elements[1].sd, restored.elements[1].sd)
+        assertEquals(true, restored.wildcard?.sd)
+        assertEquals(DecoyMode.FIXED, restored.decoyMode)
+        assertEquals(3, restored.decoys)
+    }
+
+    @Test
+    fun sdMap_toJson_roundTrips_regressionGuard() {
+        val original = SDMap(
+            mapOf(
+                "a" to SDField(sd = true),
+                "b" to SDField(sd = false, children = SDMap(mapOf("c" to SDField(sd = true))))
+            ),
+            decoyMode = DecoyMode.RANDOM,
+            decoys = 2,
+        )
+        val restored = SDMap.fromJSON(original.toJSON())
+        assertTrue(restored["a"]!!.sd)
+        assertFalse(restored["b"]!!.sd)
+        val nested = restored["b"]!!.children
+        assertIs<SDMap>(nested)
+        assertTrue(nested["c"]!!.sd)
+        assertEquals(DecoyMode.RANDOM, restored.decoyMode)
+        assertEquals(2, restored.decoys)
+    }
+
+    @Test
+    fun sdMap_regenerationDescribesArrayDisclosures() {
+        val fullPayload = buildJsonObject {
+            put("nationalities", buildJsonArray { add("US"); add("DE") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "nationalities" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(elements = listOf(SDField(sd = true), SDField(sd = false)))
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        val regenerated = sdPayload.sdMap
+        val arr = regenerated["nationalities"]?.arrayChildren
+        assertNotNull(arr)
+        assertEquals(2, arr.elements.size)
+        assertTrue(arr.elements[0].sd, "index 0 was wrapped, regenerated descriptor must mark it SD")
+        assertFalse(arr.elements[1].sd, "index 1 was passed through, regenerated descriptor must mark it not-SD")
+    }
+
+    // Issuance: generation
+
+    @Test
+    fun generation_twoNationalities_bothSD_producesTwoWrappersAtSamePositions() {
+        val fullPayload = buildJsonObject {
+            put("nationalities", buildJsonArray { add("US"); add("DE") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "nationalities" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(elements = listOf(SDField(sd = true), SDField(sd = true)))
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        // Undisclosed payload still exposes nationalities as an array with 2 wrapper entries
+        val nationalities = sdPayload.undisclosedPayload["nationalities"]!!.jsonArray
+        assertEquals(2, nationalities.size)
+        nationalities.forEach {
+            val obj = it.jsonObject
+            assertEquals(1, obj.size)
+            assertTrue(obj.containsKey("..."))
+            assertIs<JsonPrimitive>(obj["..."])
+        }
+
+        // Two disclosures produced, both are array-element (2-element) disclosures
+        assertEquals(2, sdPayload.sDisclosures.size)
+        sdPayload.sDisclosures.forEach { assertIs<ArrayElementDisclosure>(it) }
+
+        // Wrapper hashes match the keys of the disclosure map.
+        val wrapperHashes = nationalities.map { it.jsonObject["..."]!!.jsonPrimitive.content }.toSet()
+        assertEquals(wrapperHashes, sdPayload.digestedDisclosures.keys)
+    }
+
+    @Test
+    fun generation_mixedSdNonSdElements_preservesOrderAndPositions() {
+        val fullPayload = buildJsonObject {
+            put("colors", buildJsonArray { add("red"); add("green"); add("blue") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "colors" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(
+                        elements = listOf(
+                            SDField(sd = false),
+                            SDField(sd = true),
+                            SDField(sd = false),
+                        )
+                    )
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        val colors = sdPayload.undisclosedPayload["colors"]!!.jsonArray
+        assertEquals(3, colors.size)
+        assertEquals(JsonPrimitive("red"), colors[0])
+        assertTrue(colors[1].jsonObject.containsKey("..."))
+        assertEquals(JsonPrimitive("blue"), colors[2])
+
+        assertEquals(1, sdPayload.sDisclosures.size)
+        val disclosure = sdPayload.sDisclosures.single()
+        assertIs<ArrayElementDisclosure>(disclosure)
+        assertEquals(JsonPrimitive("green"), disclosure.value)
+    }
+
+    @Test
+    fun generation_arrayOfObjects_perIndexPropertySD() {
+        val fullPayload = buildJsonObject {
+            put("people", buildJsonArray {
+                add(buildJsonObject { put("name", "Alice"); put("age", 30) })
+            })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "people" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(
+                        elements = listOf(
+                            SDField(
+                                sd = false,
+                                children = SDMap(mapOf("name" to SDField(sd = true)))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        val person0 = sdPayload.undisclosedPayload["people"]!!.jsonArray[0].jsonObject
+        assertFalse(person0.containsKey("name"))
+        assertEquals(JsonPrimitive(30), person0["age"])
+        assertTrue(person0.containsKey(SDJwt.DIGESTS_KEY))
+    }
+
+    @Test
+    fun generation_arrayOfArrays_nestedIndexSD() {
+        val fullPayload = buildJsonObject {
+            put("m", buildJsonArray {
+                add(buildJsonArray { add("a"); add("b") })
+                add(buildJsonArray { add("c"); add("d") })
+            })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "m" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(
+                        elements = listOf(
+                            SDField(
+                                sd = false,
+                                arrayChildren = SDArray(
+                                    elements = listOf(SDField(sd = false), SDField(sd = true))
+                                )
+                            ),
+                            SDField(sd = false),
+                        )
+                    )
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        val inner0 = sdPayload.undisclosedPayload["m"]!!.jsonArray[0].jsonArray
+        assertEquals(2, inner0.size)
+        assertEquals(JsonPrimitive("a"), inner0[0])
+        assertTrue(inner0[1].jsonObject.containsKey("..."))
+
+        assertEquals(1, sdPayload.sDisclosures.size)
+        val d = sdPayload.sDisclosures.single()
+        assertIs<ArrayElementDisclosure>(d)
+        assertEquals(JsonPrimitive("b"), d.value)
+    }
+
+    @Test
+    fun generation_arrayLevelDecoys_FIXED_addsDecoyWrappers() {
+        val fullPayload = buildJsonObject {
+            put("xs", buildJsonArray { add("a") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "xs" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(
+                        elements = listOf(SDField(sd = true)),
+                        decoyMode = DecoyMode.FIXED,
+                        decoys = 3,
+                    )
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        val xs = sdPayload.undisclosedPayload["xs"]!!.jsonArray
+        // 1 real + 3 decoy
+        assertEquals(4, xs.size)
+        xs.forEach { el ->
+            val obj = el.jsonObject
+            assertEquals(1, obj.size)
+            assertTrue(obj.containsKey("..."))
+        }
+
+        // Only 1 disclosure — decoys have no corresponding disclosure
+        assertEquals(1, sdPayload.sDisclosures.size)
+    }
+
+    @Test
+    fun generation_arrayLevelDecoys_RANDOM_addsUpToMax() {
+        val fullPayload = buildJsonObject {
+            put("xs", buildJsonArray { add("a"); add("b") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "xs" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(
+                        elements = listOf(SDField(sd = true), SDField(sd = true)),
+                        decoyMode = DecoyMode.RANDOM,
+                        decoys = 5,
+                    )
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        val xs = sdPayload.undisclosedPayload["xs"]!!.jsonArray
+        assertTrue(xs.size in 2..7, "expected 2 real + [0..5] decoys, got ${xs.size}")
+        assertEquals(2, sdPayload.sDisclosures.size)
+    }
+
+    /**
+     * RFC §4.2.5: decoys exist to obscure the original element count, so they MUST NOT be
+     * trivially distinguishable from real elements. With plain (non-SD) real elements, the
+     * decoys must be interleaved randomly while real elements preserve their relative order.
+     */
+    @Test
+    fun generation_arrayDecoys_areInterleavedAndPreserveRealRelativeOrder() {
+        val fullPayload = buildJsonObject {
+            put("xs", buildJsonArray { add("alpha"); add("beta"); add("gamma") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "xs" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(
+                        elements = listOf(SDField(sd = false), SDField(sd = false), SDField(sd = false)),
+                        decoyMode = DecoyMode.FIXED,
+                        decoys = 4,
+                    )
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+        val xs = sdPayload.undisclosedPayload["xs"]!!.jsonArray
+
+        assertEquals(7, xs.size)
+        assertEquals(0, sdPayload.sDisclosures.size)
+
+        val plainPositions = xs.mapIndexedNotNull { i, el ->
+            (el as? JsonPrimitive)?.takeIf { it.isString }?.content?.let { i to it }
+        }
+        assertEquals(listOf("alpha", "beta", "gamma"), plainPositions.map { it.second })
+        val decoyCount = xs.count { el ->
+            (el as? JsonObject)?.let { it.size == 1 && it.containsKey("...") } == true
+        }
+        assertEquals(4, decoyCount)
+    }
+
+    /**
+     * RFC §4.2.4.1: a claim name MUST NOT appear both as a disclosed claim (referenced from
+     * `_sd`) and as a plain claim. `fullPayload` rejects such payloads.
+     */
+    @Test
+    fun verify_rejectsCollisionBetweenDisclosedAndPlain() {
+        val fullPayload = buildJsonObject { put("name", "Alice") }
+        val sdPayload = SDPayload.createSDPayload(fullPayload, SDMap(mapOf("name" to SDField(sd = true))))
+        val collidedUndisclosed = JsonObject(
+            sdPayload.undisclosedPayload + mapOf("name" to JsonPrimitive("Bob"))
+        )
+        val collided = SDPayload.parse(
+            jwtBody = collidedUndisclosed.toString().encodeToByteArray().encodeToBase64Url(),
+            disclosures = sdPayload.sDisclosures.map { it.disclosure }.toSet()
+        )
+        assertFailsWith<SDJwtVerificationException> { collided.fullPayload }
+    }
+
+    // Verification: happy paths (RFC §7.1)
+
+    @Test
+    fun verify_rfcExample_bothNationalitiesDisclosed() {
+        val sdJwt = SDJwt.parse(RFC_5_1_SD_JWT)
+        val processed = sdJwt.sdPayload.fullPayload
+        val nationalities = processed["nationalities"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(listOf("US", "DE"), nationalities)
+    }
+
+    @Test
+    fun verify_rfcExample_onlyUSDisclosed_omitsMissingElement() {
+        // Drop the DE disclosure from the tilde chain (RFC §7.1 step 3.d).
+        val stripped = RFC_5_1_SD_JWT.replace("~WyJuUHVvUW5rUkZxM0JJZUFtN0FuWEZBIiwgIkRFIl0", "")
+        val sdJwt = SDJwt.parse(stripped)
+        val processed = sdJwt.sdPayload.fullPayload
+        val nationalities = processed["nationalities"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(listOf("US"), nationalities, "undisclosed element must be removed")
+    }
+
+    @Test
+    fun verify_rfcExample_neitherDisclosed_yieldsEmptyArray() {
+        val stripped = RFC_5_1_SD_JWT
+            .replace("~WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0", "")
+            .replace("~WyJuUHVvUW5rUkZxM0JJZUFtN0FuWEZBIiwgIkRFIl0", "")
+        val sdJwt = SDJwt.parse(stripped)
+        val processed = sdJwt.sdPayload.fullPayload
+        assertEquals(0, processed["nationalities"]!!.jsonArray.size)
+    }
+
+    // Verification: normative rejects (RFC 9901 §7.1). fullPayload throws
+    // SDJwtVerificationException for malformed wrappers, wrong-arity disclosures
+    // for the surrounding context, forbidden claim names, name collisions,
+    // duplicate digest references, and unreferenced disclosures.
+
+    /** RFC §4.2.4.2: "There MUST NOT be any other keys in the object." */
+    @Test
+    fun verify_rejectsArrayWrapperWithExtraKeys() {
+        val payload = buildJsonObject {
+            put("arr", buildJsonArray {
+                add(buildJsonObject {
+                    put("...", "pFndjkZ_VCzmyTa6UjlZo3dh-ko8aIKQc9DlGzhaVYo")
+                    put("extra", 1)
+                })
+            })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(
+                "pFndjkZ_VCzmyTa6UjlZo3dh-ko8aIKQc9DlGzhaVYo" to
+                        SDisclosure.parse("WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0")
+            )
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §7.1 3.c.ii.1: object context requires a 3-element disclosure. */
+    @Test
+    fun verify_rejects2ElementDisclosureInObjectContext() {
+        val disclosure = "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0"
+        val hash = SHA256().digest(disclosure.encodeToByteArray()).encodeToBase64Url()
+        val payload = buildJsonObject {
+            put(SDJwt.DIGESTS_KEY, buildJsonArray { add(hash) })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(hash to SDisclosure.parse(disclosure))
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §7.1 3.c.iii.1: array context requires a 2-element disclosure. */
+    @Test
+    fun verify_rejects3ElementDisclosureInArrayContext() {
+        val disclosure = "WyIyR0xDNDJzS1F2ZUNmR2ZyeU5STjl3IiwgImdpdmVuX25hbWUiLCAiSm9obiJd"
+        val hash = SHA256().digest(disclosure.encodeToByteArray()).encodeToBase64Url()
+        val payload = buildJsonObject {
+            put("arr", buildJsonArray {
+                add(buildJsonObject { put("...", hash) })
+            })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(hash to SDisclosure.parse(disclosure))
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §7.1 step 3.c.ii.2: claim name `_sd` or `...` → reject. */
+    @Test
+    fun verify_rejectsObjectPropertyDisclosureWithClaimNameThreeDots() {
+        val malformed = buildJsonArray {
+            add("saltsaltsaltsaltsaltsa")
+            add("...")
+            add("value")
+        }.toString().encodeToByteArray().encodeToBase64Url()
+        val hash = SHA256().digest(malformed.encodeToByteArray()).encodeToBase64Url()
+        val payload = buildJsonObject {
+            put(SDJwt.DIGESTS_KEY, buildJsonArray { add(hash) })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(hash to SDisclosure.parse(malformed))
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    @Test
+    fun verify_rejectsObjectPropertyDisclosureWithClaimName_sd() {
+        val malformed = buildJsonArray {
+            add("saltsaltsaltsaltsaltsa")
+            add("_sd")
+            add("value")
+        }.toString().encodeToByteArray().encodeToBase64Url()
+        val hash = SHA256().digest(malformed.encodeToByteArray()).encodeToBase64Url()
+        val payload = buildJsonObject {
+            put(SDJwt.DIGESTS_KEY, buildJsonArray { add(hash) })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(hash to SDisclosure.parse(malformed))
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §7.1 step 4: a hash encountered more than once MUST be rejected. */
+    @Test
+    fun verify_rejectsDuplicateHashReferences() {
+        val disclosure = "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0"
+        val hash = "pFndjkZ_VCzmyTa6UjlZo3dh-ko8aIKQc9DlGzhaVYo"
+        val payload = buildJsonObject {
+            put("arr", buildJsonArray {
+                add(buildJsonObject { put("...", hash) })
+                add(buildJsonObject { put("...", hash) })
+            })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(hash to SDisclosure.parse(disclosure))
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /**
+     * RFC §4.2.4: every entry of `_sd` MUST be a JSON string. A numeric or boolean entry
+     * must be rejected (object-context counterpart of the wrapper isString check).
+     */
+    @Test
+    fun verify_rejectsNonStringSdEntry() {
+        val payload = buildJsonObject {
+            put(SDJwt.DIGESTS_KEY, buildJsonArray { add(JsonPrimitive(42)) })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = emptyMap(),
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §4.2.4: `_sd` MUST be a JSON array. */
+    @Test
+    fun verify_rejectsNonArraySdValue() {
+        val payload = buildJsonObject {
+            put(SDJwt.DIGESTS_KEY, JsonPrimitive("not-an-array"))
+        }
+        val sdPayload = SDPayload(undisclosedPayload = payload, digestedDisclosures = emptyMap())
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §4.2.4.2: array-element wrapper digest MUST be a JSON string. */
+    @Test
+    fun verify_rejectsWrapperWithNonStringDigest() {
+        val payload = buildJsonObject {
+            put("arr", buildJsonArray {
+                add(buildJsonObject { put("...", JsonPrimitive(42)) })
+            })
+        }
+        val sdPayload = SDPayload(undisclosedPayload = payload, digestedDisclosures = emptyMap())
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /**
+     * RFC §7.1 step 3.c.ii.3: two disclosures referenced from the same `_sd` array sharing
+     * the same claim name MUST be rejected.
+     */
+    @Test
+    fun verify_rejectsDisclosedDisclosedCollision() {
+        // Build two distinct ObjectPropertyDisclosures with the same key, both referenced.
+        val d1 = "WyIyR0xDNDJzS1F2ZUNmR2ZyeU5STjl3IiwgIm5hbWUiLCAiQWxpY2UiXQ"
+        val d2 = "WyJlbHVWNU9nM2dTTklJOEVZbnN4QV9BIiwgIm5hbWUiLCAiQm9iIl0"
+        val h1 = SHA256().digest(d1.encodeToByteArray()).encodeToBase64Url()
+        val h2 = SHA256().digest(d2.encodeToByteArray()).encodeToBase64Url()
+        val payload = buildJsonObject {
+            put(SDJwt.DIGESTS_KEY, buildJsonArray { add(h1); add(h2) })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(h1 to SDisclosure.parse(d1), h2 to SDisclosure.parse(d2)),
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §4.2.4.1: `...` MUST NOT appear as a regular object claim name. */
+    @Test
+    fun verify_rejectsThreeDotsAsPlainClaimName() {
+        val payload = buildJsonObject {
+            put("...", JsonPrimitive("some value"))
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = emptyMap(),
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    /** RFC §7.1 step 4: a disclosure repeated in the tilde chain MUST be rejected. */
+    @Test
+    fun parse_rejectsDuplicateDisclosureInTildeChain() {
+        val d = "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0"
+        // Build a tilde-chain SD-JWT with the same disclosure listed twice.
+        val header = "eyJhbGciOiJub25lIn0"
+        val body = "{}".encodeToByteArray().encodeToBase64Url()
+        val signature = "sig"
+        val sdJwt = "$header.$body.$signature~$d~$d~"
+        assertFailsWith<SDJwtVerificationException> { SDJwt.parse(sdJwt) }
+    }
+
+    /**
+     * Bug guard: `nationalities.[0]` (logical index) must select the first **real** wrapper
+     * even when decoys are interleaved at random wire positions. With the previous wire-index
+     * impl, decoys at slot 0 caused the path DSL to silently miss the real index 0.
+     */
+    @Test
+    fun presentation_pathDslIndexAlignsWithLogicalPositionAcrossDecoys() {
+        val fullPayload = buildJsonObject {
+            put("nationalities", buildJsonArray { add("US"); add("DE"); add("FR") })
+        }
+        val issuedMap = SDMap(
+            mapOf(
+                "nationalities" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(
+                        elements = listOf(SDField(sd = true), SDField(sd = true), SDField(sd = true)),
+                        decoyMode = DecoyMode.FIXED,
+                        decoys = 4,
+                    )
+                )
+            )
+        )
+        val presentationMap = SDMap.generateSDMap(listOf("nationalities.[0]"))
+
+        // Run a few iterations so randomized decoy positions exercise the alignment.
+        repeat(10) {
+            val issued = SDPayload.createSDPayload(fullPayload, issuedMap)
+            val presented = issued.withSelectiveDisclosures(presentationMap)
+            val processed = presented.fullPayload
+            val nationalities = processed["nationalities"]!!.jsonArray
+                .mapNotNull { (it as? JsonPrimitive)?.takeIf { p -> p.isString }?.content }
+            assertEquals(listOf("US"), nationalities, "logical index 0 must always disclose 'US'")
+        }
+    }
+
+    /** RFC §7.1 step 5: unreferenced disclosure MUST be rejected. */
+    @Test
+    fun verify_rejectsUnreferencedDisclosure() {
+        val a = "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0"
+        val b = "WyJuUHVvUW5rUkZxM0JJZUFtN0FuWEZBIiwgIkRFIl0"
+        val hashA = SHA256().digest(a.encodeToByteArray()).encodeToBase64Url()
+        val hashB = SHA256().digest(b.encodeToByteArray()).encodeToBase64Url()
+        val payload = buildJsonObject {
+            put("arr", buildJsonArray {
+                add(buildJsonObject { put("...", hashA) })
+            })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = payload,
+            digestedDisclosures = mapOf(
+                hashA to SDisclosure.parse(a),
+                hashB to SDisclosure.parse(b),     // no corresponding reference in payload
+            )
+        )
+        assertFailsWith<SDJwtVerificationException> { sdPayload.fullPayload }
+    }
+
+    // Recursive disclosure (RFC §4.2.6)
+
+    @Test
+    fun recursiveDisclosure_outerArrayAndInnerElementsAllSD() {
+        val fullPayload = buildJsonObject {
+            put("family_name", "Möbius")
+            put("nationalities", buildJsonArray { add("DE"); add("FR"); add("UK") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "family_name" to SDField(sd = true),
+                "nationalities" to SDField(
+                    sd = true, // outer whole-array disclosure
+                    arrayChildren = SDArray(
+                        elements = listOf(SDField(sd = true), SDField(sd = true), SDField(sd = true))
+                    )
+                )
+            )
+        )
+        val sdPayload = SDPayload.createSDPayload(fullPayload, sdMap)
+
+        // Round-trip: full disclosure yields original payload.
+        val processed = sdPayload.fullPayload
+        assertEquals("Möbius", processed["family_name"]!!.jsonPrimitive.content)
+        val nats = processed["nationalities"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(listOf("DE", "FR", "UK"), nats)
+    }
+
+    /**
+     * RFC §7.1 step 5: stripping the outer object-property disclosure leaves the inner
+     * array-element disclosures unreferenced — the SD-JWT MUST be rejected.
+     */
+    @Test
+    fun recursiveDisclosure_strictModeRejectsUnreferencedInnerElements() {
+        val fullPayload = buildJsonObject {
+            put("family_name", "Möbius")
+            put("nationalities", buildJsonArray { add("DE"); add("FR"); add("UK") })
+        }
+        val sdMap = SDMap(
+            mapOf(
+                "family_name" to SDField(sd = true),
+                "nationalities" to SDField(
+                    sd = true,
+                    arrayChildren = SDArray(
+                        elements = listOf(SDField(sd = true), SDField(sd = true), SDField(sd = true))
+                    )
+                )
+            )
+        )
+        val full = SDPayload.createSDPayload(fullPayload, sdMap)
+        val filtered = full.digestedDisclosures.filterValues {
+            !(it is ObjectPropertyDisclosure && it.key == "nationalities")
+        }
+        val broken = SDPayload(
+            undisclosedPayload = full.undisclosedPayload,
+            digestedDisclosures = filtered,
+        )
+        assertFailsWith<SDJwtVerificationException> { broken.fullPayload }
+    }
+
+    // Presentation (holder selects which array elements to disclose)
+
+    /**
+     * The holder filter must enforce the same strict rules as `fullPayload` — same SD-JWT
+     * cannot pass `withSelectiveDisclosures` and then fail verification.
+     */
+    @Test
+    fun presentation_withSelectiveDisclosuresRejectsMalformedSdJwt() {
+        val malformedPayload = buildJsonObject {
+            put("arr", buildJsonArray {
+                add(buildJsonObject {
+                    put("...", "pFndjkZ_VCzmyTa6UjlZo3dh-ko8aIKQc9DlGzhaVYo")
+                    put("extra", 1) // wrapper extra-key — must be rejected
+                })
+            })
+        }
+        val sdPayload = SDPayload(
+            undisclosedPayload = malformedPayload,
+            digestedDisclosures = mapOf(
+                "pFndjkZ_VCzmyTa6UjlZo3dh-ko8aIKQc9DlGzhaVYo" to
+                        SDisclosure.parse("WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0")
+            ),
+        )
+        val presentationMap = SDMap(mapOf("arr" to SDField(sd = false)))
+        assertFailsWith<SDJwtVerificationException> { sdPayload.withSelectiveDisclosures(presentationMap) }
+    }
+
+    @Test
+    fun presentation_holderWithholdsOneArrayElement() {
+        val fullPayload = buildJsonObject {
+            put("nationalities", buildJsonArray { add("US"); add("DE") })
+        }
+        val issuedMap = SDMap(
+            mapOf(
+                "nationalities" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(elements = listOf(SDField(sd = true), SDField(sd = true)))
+                )
+            )
+        )
+        val issued = SDPayload.createSDPayload(fullPayload, issuedMap)
+
+        // Presentation map: disclose index 0, withhold index 1.
+        val presentationMap = SDMap(
+            mapOf(
+                "nationalities" to SDField(
+                    sd = false,
+                    arrayChildren = SDArray(elements = listOf(SDField(sd = true), SDField(sd = false)))
+                )
+            )
+        )
+        val presented = issued.withSelectiveDisclosures(presentationMap)
+
+        val processed = presented.fullPayload
+        val nationalities = processed["nationalities"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(listOf("US"), nationalities)
+    }
+
+    // Path syntax for building an SDMap from dotted paths with array index / wildcard segments
+
+    @Test
+    fun pathSyntax_specificIndex() {
+        val sdmap = SDMap.generateSDMap(listOf("nationalities.[0]"))
+        val arr = sdmap["nationalities"]?.arrayChildren
+        assertNotNull(arr)
+        assertTrue(arr.elements[0].sd)
+    }
+
+    @Test
+    fun pathSyntax_wildcard() {
+        val sdmap = SDMap.generateSDMap(listOf("colors.[]"))
+        val arr = sdmap["colors"]?.arrayChildren
+        assertNotNull(arr)
+        assertEquals(true, arr.wildcard?.sd)
+    }
+
+    @Test
+    fun pathSyntax_propertyUnderWildcard() {
+        val sdmap = SDMap.generateSDMap(listOf("cars.[].make"))
+        val cars = sdmap["cars"]?.arrayChildren
+        assertNotNull(cars)
+        val wildcardChildren = cars.wildcard?.children
+        assertNotNull(wildcardChildren)
+        assertTrue(wildcardChildren["make"]!!.sd)
+    }
+
+    @Test
+    fun pathSyntax_nestedArrayOfArrays() {
+        val sdmap = SDMap.generateSDMap(listOf("contacts.[0].[2]"))
+        val contacts = sdmap["contacts"]?.arrayChildren
+        assertNotNull(contacts)
+        val inner = contacts.elements[0].arrayChildren
+        assertNotNull(inner)
+        assertTrue(inner.elements[2].sd)
+    }
+
+    /**
+     * Mixing an explicit index past 0 with a wildcard: indices not explicitly listed (0, 1)
+     * should inherit the wildcard's settings instead of being silently overridden by
+     * non-disclosable placeholders.
+     */
+    @Test
+    fun pathSyntax_explicitIndexAndWildcard_indicesInheritWildcard() {
+        val sdmap = SDMap.generateSDMap(listOf("arr.[2]", "arr.[]"))
+        val arr = sdmap["arr"]?.arrayChildren
+        assertNotNull(arr)
+        // Wildcard is set …
+        assertEquals(true, arr.wildcard?.sd)
+        // … and indices 0/1 (not explicitly listed) should be marked sd = true via wildcard,
+        // not the default `SDField(false)` placeholder.
+        assertTrue(arr.elements[0].sd, "index 0 should inherit from wildcard")
+        assertTrue(arr.elements[1].sd, "index 1 should inherit from wildcard")
+        assertTrue(arr.elements[2].sd, "index 2 was explicitly listed")
+    }
+
+    /**
+     * `[0].city + [].zip` means "disclose city at index 0 AND zip at every index". Index 0
+     * must inherit the wildcard's `zip` rule on top of its own `city`.
+     */
+    @Test
+    fun pathSyntax_explicitIndexAndWildcardAtSameLevel_mergesBoth() {
+        val sdmap = SDMap.generateSDMap(listOf("addresses.[0].city", "addresses.[].zip"))
+        val arr = sdmap["addresses"]?.arrayChildren
+        assertNotNull(arr)
+        val zero = arr.elements[0].children
+        assertNotNull(zero)
+        assertEquals(true, zero["city"]?.sd, "city must be disclosable at [0]")
+        assertEquals(true, zero["zip"]?.sd, "zip must be disclosable at [0] via wildcard merge")
+        // Wildcard still serves indices > maxIndex.
+        assertEquals(true, arr.wildcard?.children?.get("zip")?.sd)
+    }
+
+    @Test
+    fun pathSyntax_malformedSegment_throws() {
+        assertFails { SDMap.generateSDMap(listOf("a.[]x")) }
+        assertFails { SDMap.generateSDMap(listOf("a.[-1]")) }
+        assertFails { SDMap.generateSDMap(listOf("a.[abc]")) }
+    }
+
+    // Test helpers and fixtures
+
+    companion object {
+        /**
+         * Full SD-JWT from the RFC 9901 §5.1 example, with all ten disclosures:
+         * eight object-property disclosures and two array-element disclosures
+         * (for the `nationalities` array).
+         */
+        private const val RFC_5_1_SD_JWT =
+            "eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImV4YW1wbGUrc2Qtand0In0." +
+            "eyJfc2QiOiBbIkNyUWU3UzVrcUJBSHQtbk1ZWGdjNmJkdDJTSDVhVFkxc1VfTS1QZ2tqUEkiLCAi" +
+            "SnpZakg0c3ZsaUgwUjNQeUVNZmVadTZKdDY5dTVxZWhabzdGN0VQWWxTRSIsICJQb3JGYnBLdVZ1" +
+            "Nnh5bUphZ3ZrRnNGWEFiUm9jMkpHbEFVQTJCQTRvN2NJIiwgIlRHZjRvTGJnd2Q1SlFhSHlLVlFa" +
+            "VTlVZEdFMHc1cnREc3JaemZVYW9tTG8iLCAiWFFfM2tQS3QxWHlYN0tBTmtxVlI2eVoyVmE1TnJQ" +
+            "SXZQWWJ5TXZSS0JNTSIsICJYekZyendzY002R242Q0pEYzZ2Vks4QmtNbmZHOHZPU0tmcFBJWmRB" +
+            "ZmRFIiwgImdiT3NJNEVkcTJ4Mkt3LXc1d1BFemFrb2I5aFYxY1JEMEFUTjNvUUw5Sk0iLCAianN1" +
+            "OXlWdWx3UVFsaEZsTV8zSmx6TWFTRnpnbGhRRzBEcGZheVF3TFVLNCJdLCAiaXNzIjogImh0dHBz" +
+            "Oi8vaXNzdWVyLmV4YW1wbGUuY29tIiwgImlhdCI6IDE2ODMwMDAwMDAsICJleHAiOiAxODgzMDAw" +
+            "MDAwLCAic3ViIjogInVzZXJfNDIiLCAibmF0aW9uYWxpdGllcyI6IFt7Ii4uLiI6ICJwRm5kamta" +
+            "X1ZDem15VGE2VWpsWm8zZGgta284YUlLUWM5RGxHemhhVllvIn0sIHsiLi4uIjogIjdDZjZKa1B1" +
+            "ZHJ5M2xjYndIZ2VaOGtoQXYxVTFPU2xlclAwVmtCSnJXWjAifV0sICJfc2RfYWxnIjogInNoYS0y" +
+            "NTYiLCAiY25mIjogeyJqd2siOiB7Imt0eSI6ICJFQyIsICJjcnYiOiAiUC0yNTYiLCAieCI6ICJU" +
+            "Q0FFUjE5WnZ1M09IRjRqNFc0dmZTVm9ISVAxSUxpbERsczd2Q2VHZW1jIiwgInkiOiAiWnhqaVdX" +
+            "YlpNUUdIVldLVlE0aGJTSWlyc1ZmdWVjQ0U2dDRqVDlGMkhaUSJ9fX0." +
+            "MczwjBFGtzf-6WMT-hIvYbkb11NrV1WMO-jTijpMPNbswNzZ87wY2uHz-CXo6R04b7jYrpj9mNRAvVssXou1iw" +
+            "~WyIyR0xDNDJzS1F2ZUNmR2ZyeU5STjl3IiwgImdpdmVuX25hbWUiLCAiSm9obiJd" +
+            "~WyJlbHVWNU9nM2dTTklJOEVZbnN4QV9BIiwgImZhbWlseV9uYW1lIiwgIkRvZSJd" +
+            "~WyI2SWo3dE0tYTVpVlBHYm9TNXRtdlZBIiwgImVtYWlsIiwgImpvaG5kb2VAZXhhbXBsZS5jb20iXQ" +
+            "~WyJlSThaV205UW5LUHBOUGVOZW5IZGhRIiwgInBob25lX251bWJlciIsICIrMS0yMDItNTU1LTAxMDEiXQ" +
+            "~WyJRZ19PNjR6cUF4ZTQxMmExMDhpcm9BIiwgInBob25lX251bWJlcl92ZXJpZmllZCIsIHRydWVd" +
+            "~WyJBSngtMDk1VlBycFR0TjRRTU9xUk9BIiwgImFkZHJlc3MiLCB7InN0cmVldF9hZGRyZXNzIjog" +
+            "IjEyMyBNYWluIFN0IiwgImxvY2FsaXR5IjogIkFueXRvd24iLCAicmVnaW9uIjogIkFueXN0YXRlI" +
+            "iwgImNvdW50cnkiOiAiVVMifV0" +
+            "~WyJQYzMzSk0yTGNoY1VfbEhnZ3ZfdWZRIiwgImJpcnRoZGF0ZSIsICIxOTQwLTAxLTAxIl0" +
+            "~WyJHMDJOU3JRZmpGWFE3SW8wOXN5YWpBIiwgInVwZGF0ZWRfYXQiLCAxNTcwMDAwMDAwXQ" +
+            "~WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIlVTIl0" +
+            "~WyJuUHVvUW5rUkZxM0JJZUFtN0FuWEZBIiwgIkRFIl0~"
+    }
+}

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/commonTest/kotlin/id/walt/sdjwt/SDJwtTest.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/commonTest/kotlin/id/walt/sdjwt/SDJwtTest.kt
@@ -77,7 +77,8 @@ class SDJwtTest {
 
         assertContains(map = sdPayload_3.undisclosedPayload, key = SDJwt.DIGESTS_KEY)
         assertFalse(actual = sdPayload_3.undisclosedPayload.keys.any { setOf("sub", "nestedObject").contains(it) })
-        val nestedDisclosure = sdPayload_3.sDisclosures.firstOrNull { sd -> sd.key == "nestedObject" && sd.value is JsonObject }
+        val nestedDisclosure = sdPayload_3.sDisclosures.filterIsInstance<ObjectPropertyDisclosure>()
+            .firstOrNull { sd -> sd.key == "nestedObject" && sd.value is JsonObject }
         assertNotNull(actual = nestedDisclosure)
         assertContains(map = nestedDisclosure.value.jsonObject, key = SDJwt.DIGESTS_KEY)
         assertFalse(actual = nestedDisclosure.value.jsonObject.containsKey("arrProp"))
@@ -113,14 +114,15 @@ class SDJwtTest {
 
         assertContains(map = sdPayload_4.undisclosedPayload, key = SDJwt.DIGESTS_KEY)
         assertFalse(actual = sdPayload_4.undisclosedPayload.keys.any { setOf("sub", "nestedObject").contains(it) })
-        val nestedDisclosure = sdPayload_4.sDisclosures.firstOrNull { sd -> sd.key == "nestedObject" && sd.value is JsonObject }
+        val nestedDisclosure = sdPayload_4.sDisclosures.filterIsInstance<ObjectPropertyDisclosure>()
+            .firstOrNull { sd -> sd.key == "nestedObject" && sd.value is JsonObject }
         assertNotNull(actual = nestedDisclosure)
         assertContains(map = nestedDisclosure.value.jsonObject, key = SDJwt.DIGESTS_KEY)
         assertFalse(actual = nestedDisclosure.value.jsonObject.containsKey("arrProp"))
         val numSdFieldsLevel1 = sdPayload_4.sdMap.count { it.value.sd }
         assertTrue(
             actual = sdPayload_4.undisclosedPayload[SDJwt.DIGESTS_KEY]!!.jsonArray.size in IntRange(
-                numSdFieldsLevel1 + 1,
+                numSdFieldsLevel1,
                 numSdFieldsLevel1 + 5
             )
         )

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/jsMain/kotlin/id/walt/sdjwt/SDJwtJS.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/jsMain/kotlin/id/walt/sdjwt/SDJwtJS.kt
@@ -23,7 +23,7 @@ class SDJwtJS(
             JSON.parse<dynamic>(buildJsonObject {
                 put("disclosure", it.disclosure)
                 put("salt", it.salt)
-                put("key", it.key)
+                put("key", (it as? ObjectPropertyDisclosure)?.key)
                 put("value", it.value)
             }.toString())
         }.toTypedArray()

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/jsTest/kotlin/id.walt.sdjwt/SDJwtTestJS.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/jsTest/kotlin/id.walt.sdjwt/SDJwtTestJS.kt
@@ -43,7 +43,7 @@ class SDJwtTestJS {
         assertEquals(expected = 1, actual = sdJwt.disclosures.size)
         assertEquals(
             expected = "sub",
-            actual = sdJwt.digestedDisclosures[sdJwt.undisclosedPayload[SDJwt.DIGESTS_KEY]!!.jsonArray[0].jsonPrimitive.content]!!.key
+            actual = (sdJwt.digestedDisclosures[sdJwt.undisclosedPayload[SDJwt.DIGESTS_KEY]!!.jsonArray[0].jsonPrimitive.content]!! as ObjectPropertyDisclosure).key
         )
         println("BLA")
         assertEquals(expected = Json.parseToJsonElement(JSON.stringify(originalClaimsSet)).jsonObject, actual = sdJwt.fullPayload)

--- a/waltid-libraries/sdjwt/waltid-sdjwt/src/jvmTest/kotlin/id/walt/sdjwt/SDJwtTestJVM.kt
+++ b/waltid-libraries/sdjwt/waltid-sdjwt/src/jvmTest/kotlin/id/walt/sdjwt/SDJwtTestJVM.kt
@@ -48,7 +48,7 @@ class SDJwtTestJVM {
         assertEquals(expected = 1, actual = sdJwt.disclosures.size)
         assertEquals(
             expected = "sub",
-            actual = sdJwt.digestedDisclosures[sdJwt.undisclosedPayload[SDJwt.DIGESTS_KEY]!!.jsonArray[0].jsonPrimitive.content]!!.key
+            actual = (sdJwt.digestedDisclosures[sdJwt.undisclosedPayload[SDJwt.DIGESTS_KEY]!!.jsonArray[0].jsonPrimitive.content]!! as ObjectPropertyDisclosure).key
         )
         assertContentEquals(
             expected = Json.parseToJsonElement(originalClaimsSet.toString()).jsonObject.toSortedMap().asIterable(),
@@ -113,7 +113,7 @@ class SDJwtTestJVM {
         println(parsedDisclosedJwtVerifyResult.sdJwt.fullPayload.toString())
 
         val forgedDisclosure =
-            parsedDisclosedJwtVerifyResult.sdJwt.jwt + "~" + forgeDislosure(parsedDisclosedJwtVerifyResult.sdJwt.disclosureObjects.first())
+            parsedDisclosedJwtVerifyResult.sdJwt.jwt + "~" + forgeDisclosure(parsedDisclosedJwtVerifyResult.sdJwt.disclosureObjects.first() as ObjectPropertyDisclosure)
         val forgedDisclosureVerifyResult = SDJwt.verifyAndParse(
             forgedDisclosure, cryptoProvider
         )
@@ -122,7 +122,7 @@ class SDJwtTestJVM {
         assertFalse(forgedDisclosureVerifyResult.disclosuresVerified)
     }
 
-    fun forgeDislosure(disclosure: SDisclosure): String {
+    fun forgeDisclosure(disclosure: ObjectPropertyDisclosure): String {
         return Base64.UrlSafe.encode(buildJsonArray {
             add(disclosure.salt)
             add(disclosure.key)
@@ -176,5 +176,34 @@ class SDJwtTestJVM {
             presentedJwtWithKb.keyBindingJwt.sdHash
         )
 
+    }
+
+    /**
+     * End-to-end array-element selective-disclosure flow used as the README example.
+     * Issue an SD-JWT where each `nationalities` element is independently disclosable, then
+     * present revealing only the first. The verifier sees `nationalities = ["US"]`.
+     */
+    @Test
+    fun testArrayElementDisclosureFlow() {
+        val cryptoProvider = SimpleJWTCryptoProvider(JWSAlgorithm.HS256, MACSigner(sharedSecret), MACVerifier(sharedSecret))
+
+        // Issuer payload: each element of `nationalities` is independently disclosable.
+        val fullPayload = buildJsonObject {
+            put("sub", "123")
+            put("nationalities", buildJsonArray { add("US"); add("DE") })
+        }
+        val issuanceMap = SDMap.generateSDMap(listOf("nationalities.[]"))
+        val sdPayload = SDPayload.createSDPayload(fullPayload, issuanceMap)
+        val sdJwt = SDJwt.sign(sdPayload, cryptoProvider)
+
+        // Holder presents only nationalities[0] = "US".
+        val presentationMap = SDMap.generateSDMap(listOf("nationalities.[0]"))
+        val presented = sdJwt.present(presentationMap)
+
+        // Verifier sees `sub` (plain) and `nationalities = ["US"]`.
+        val verified = SDJwt.verifyAndParse(presented.toString(), cryptoProvider)
+        val payload = verified.sdJwt.fullPayload
+        assertEquals("123", payload["sub"]!!.jsonPrimitive.content)
+        assertEquals(listOf("US"), payload["nationalities"]!!.jsonArray.map { it.jsonPrimitive.content })
     }
 }

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/E2ESdJwtTest.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/E2ESdJwtTest.kt
@@ -1,6 +1,7 @@
 import WaltidServicesE2ETests.Companion.ieftSdjwtPresentationRequestPayload
 import WaltidServicesE2ETests.Companion.nameFieldSchemaPresentationRequestPayload
 import WaltidServicesE2ETests.Companion.sdjwtIETFCredential
+import WaltidServicesE2ETests.Companion.sdjwtIETFCredentialWithArrayDisclosure
 import WaltidServicesE2ETests.Companion.sdjwtIETFCredentialWithoutDisclosures
 import WaltidServicesE2ETests.Companion.sdjwtW3CCredential
 import id.walt.crypto.keys.jwk.JWKKey
@@ -217,6 +218,32 @@ class E2ESdJwtTest(
         //endregion -Exchange / presentation-
 
         //delete credential
+        credentialsApi.delete(wallet, newCredential.id)
+    }
+
+    fun testIEFTSDJWTVCWithArrayDisclosure(wallet: Uuid, did: String) = runTest {
+        val issuanceRequest = Json.decodeFromJsonElement<IssuanceRequest>(sdjwtIETFCredentialWithArrayDisclosure)
+        val newCredential = executePreAuthorizedFlow(wallet, issuanceRequest)
+
+        // Wire: each nationalities element is `{"...":"<digest>"}`.
+        val natWire = newCredential.parsedDocument!!["nationalities"]!!.jsonArray
+        assertEquals(2, natWire.size)
+        assertTrue(natWire.all { el ->
+            el is JsonObject && el.size == 1 && el.containsKey("...") &&
+                    (el["..."] as? JsonPrimitive)?.isString == true
+        }, "expected wrappers, got $natWire")
+
+        // Resolved with disclosures: original values.
+        val fullSdJwt = newCredential.document + (newCredential.disclosures?.let { "~$it" } ?: "")
+        val resolved = SDJwtVC.parse(fullSdJwt).fullPayload["nationalities"]!!.jsonArray
+            .map { it.jsonPrimitive.content }
+        assertEquals(listOf("US", "DE"), resolved)
+
+        val verificationId = executePresentation(wallet, ieftSdjwtPresentationRequestPayload, newCredential, did)
+        sessionApi.get(verificationId) {
+            assertTrue(it.tokenResponse?.presentationSubmission != null)
+            assertEquals(it.verificationResult, true)
+        }
         credentialsApi.delete(wallet, newCredential.id)
     }
 

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/ExchangeExternalSignaturesApi.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/ExchangeExternalSignaturesApi.kt
@@ -20,6 +20,8 @@ import id.walt.oid4vc.data.AuthenticationMethod
 import id.walt.oid4vc.data.CredentialFormat
 import id.walt.oid4vc.data.OpenId4VPProfile
 import id.walt.oid4vc.data.ProofType
+import id.walt.sdjwt.ArrayElementDisclosure
+import id.walt.sdjwt.ObjectPropertyDisclosure
 import id.walt.sdjwt.SDField
 import id.walt.sdjwt.SDMap
 import id.walt.sdjwt.SDisclosure
@@ -688,8 +690,13 @@ class ExchangeExternalSignatures(private val e2e: E2ETest) {
             .joinToString("~") { disclosure ->
                 Base64.UrlSafe.encode(buildJsonArray {
                     add(disclosure.salt)
-                    add(disclosure.key)
-                    add(JsonPrimitive("<forged>"))
+                    when (disclosure) {
+                        is ObjectPropertyDisclosure -> {
+                            add(disclosure.key)
+                            add(JsonPrimitive("<forged>"))
+                        }
+                        is ArrayElementDisclosure -> add(JsonPrimitive("<forged>"))
+                    }
                 }.toString().encodeToByteArray()).trimEnd('=')
             }
     }

--- a/waltid-services/waltid-e2e-tests/src/test/kotlin/WaltidServicesE2ETests.kt
+++ b/waltid-services/waltid-e2e-tests/src/test/kotlin/WaltidServicesE2ETests.kt
@@ -85,6 +85,9 @@ class WaltidServicesE2ETests {
         val sdjwtIETFCredentialWithoutDisclosures =
             Json.decodeFromString<JsonElement>(loadResource("issuance/identity-credential-issuance-request-without-disclosures.json")).jsonObject
 
+        val sdjwtIETFCredentialWithArrayDisclosure =
+            Json.decodeFromString<JsonElement>(loadResource("issuance/identity-credential-with-array-issuance-request.json")).jsonObject
+
         val ieftSdjwtPresentationRequestPayload =
             loadResource("presentation/identity-credential-sd-presentation-request.json")
 
@@ -352,6 +355,7 @@ class WaltidServicesE2ETests {
         sdJwtTest.testW3CVC(wallet, did)
         sdJwtTest.testIEFTSDJWTVC(wallet, did)
         sdJwtTest.testIEFTSDJWTVCWithoutDisclosures(wallet, did)
+        sdJwtTest.testIEFTSDJWTVCWithArrayDisclosure(wallet, did)
 
         // Test Authorization Code flow with available authentication methods in Issuer API
         val authorizationCodeFlow = AuthorizationCodeFlow(e2e, testHttpClient(doFollowRedirects = false))

--- a/waltid-services/waltid-e2e-tests/src/test/resources/issuance/identity-credential-with-array-issuance-request.json
+++ b/waltid-services/waltid-e2e-tests/src/test/resources/issuance/identity-credential-with-array-issuance-request.json
@@ -1,0 +1,56 @@
+{
+  "issuerKey": {
+    "type": "jwk",
+    "jwk": {
+      "kty": "OKP",
+      "d": "mDhpwaH6JYSrD2Bq7Cs-pzmsjlLj4EOhxyI-9DM1mFI",
+      "crv": "Ed25519",
+      "kid": "Vzx7l5fh56F3Pf9aR3DECU5BwfrY6ZJe05aiWYWzan8",
+      "x": "T3T4-u1Xz3vAV2JwPNxWfs4pik_JLiArz_WTCvrCFUM"
+    }
+  },
+  "credentialConfigurationId": "identity_credential_vc+sd-jwt",
+  "credentialData": {
+    "given_name": "John",
+    "family_name": "Doe",
+    "email": "johndoe@example.com",
+    "phone_number": "+1-202-555-0101",
+    "address": {
+      "street_address": "123 Main St",
+      "locality": "Anytown",
+      "region": "Anystate",
+      "country": "US"
+    },
+    "birthdate": "1940-01-01",
+    "is_over_18": true,
+    "is_over_21": true,
+    "is_over_65": true,
+    "nationalities": ["US", "DE"]
+  },
+  "mapping": {
+    "id": "<uuid>",
+    "iat": "<timestamp-seconds>",
+    "nbf": "<timestamp-seconds>",
+    "exp": "<timestamp-in-seconds:365d>"
+  },
+  "selectiveDisclosure": {
+    "fields": {
+      "birthdate": {
+        "sd": true
+      },
+      "family_name": {
+        "sd": false
+      },
+      "nationalities": {
+        "sd": false,
+        "arrayChildren": {
+          "elements": [
+            { "sd": true },
+            { "sd": true }
+          ]
+        }
+      }
+    }
+  },
+  "issuerDid": "did:key:z6MkjoRhq1jSNJdLiruSXrFFxagqrztZaXHqHGUTKJbcNywp"
+}

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/models/presentedcredentials/ParsedDisclosure.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/models/presentedcredentials/ParsedDisclosure.kt
@@ -7,6 +7,6 @@ import kotlinx.serialization.json.JsonElement
 data class ParsedDisclosure(
     val disclosure: String,
     val salt: String,
-    val key: String,
+    val key: String?,
     val value: JsonElement,
 )

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/models/presentedcredentials/PresentedJwtVcJsonViewModeFormatter.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/models/presentedcredentials/PresentedJwtVcJsonViewModeFormatter.kt
@@ -1,6 +1,7 @@
 package id.walt.verifier.oidc.models.presentedcredentials
 
 import id.walt.crypto.utils.JwsUtils.decodeJws
+import id.walt.sdjwt.ObjectPropertyDisclosure
 import id.walt.sdjwt.SDJwtVC
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -49,7 +50,7 @@ object PresentedJwtVcJsonViewModeFormatter {
                                     ParsedDisclosure(
                                         disclosure = entry.value.disclosure,
                                         salt = entry.value.salt,
-                                        key = entry.value.key,
+                                        key = (entry.value as? ObjectPropertyDisclosure)?.key,
                                         value = entry.value.value,
                                     )
                                 }

--- a/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/models/presentedcredentials/PresentedSdJwtVcViewModeFormatter.kt
+++ b/waltid-services/waltid-verifier-api/src/main/kotlin/id/walt/verifier/oidc/models/presentedcredentials/PresentedSdJwtVcViewModeFormatter.kt
@@ -1,5 +1,6 @@
 package id.walt.verifier.oidc.models.presentedcredentials
 
+import id.walt.sdjwt.ObjectPropertyDisclosure
 import id.walt.sdjwt.SDJwtVC
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -37,7 +38,7 @@ object PresentedSdJwtVcViewModeFormatter {
                         ParsedDisclosure(
                             disclosure = entry.value.disclosure,
                             salt = entry.value.salt,
-                            key = entry.value.key,
+                            key = (entry.value as? ObjectPropertyDisclosure)?.key,
                             value = entry.value.value,
                         )
                     }


### PR DESCRIPTION
## Description

Kotlin - JVM support for [RFC 9901 4.2.2](https://www.rfc-editor.org/rfc/rfc9901.html#section-4.2.2) Disclosures for Array Elements.

We want to implement the [Verifiable Intent](https://verifiableintent.dev/spec/) specification, which requires [disclosing array elements](https://verifiableintent.dev/spec/credential-format/#43-jwt-payload-always-visible-claims) (see `delegate_payload`).

The `SDArrayElementTest` test class provides test cases to demonstrate the feature based on examples from the RFC.

This PR takes suggestions from an issue I opened https://github.com/walt-id/waltid-identity/issues/1518 regarding simplified JSON paths.

⚠️ I'm no Kotlin guru and I used Claude to build this PR. I did multiple iterations to land on something that I think is reasonable and reviewable.

## Type of Change

- [ ] bug fix - change which fixes an issue
- [x] new feature - change which adds functionality

## Checklist

- [x] code cleanup and self-review
- [x] unit + e2e test coverage
- [x] documentation updated accordingly

## Breaking

The `ParsedDisclosure.key` is now nullable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RFC 9901 array-element selective disclosure: select individual array elements via logical indices, wildcards and nested paths; array-level decoy configuration.

* **Documentation**
  * Added comprehensive README section with Path-DSL and Kotlin end-to-end examples.

* **Bug Fixes**
  * Detect duplicate disclosures in presentation chains; stricter verification and error reporting for malformed disclosures; safer handling of optional disclosure keys.

* **Tests**
  * Extensive unit and end-to-end tests covering array-element disclosures, path parsing, issuance, presentation and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->