### PR TITLE
add support for status passthrough in issuer

### DIFF
--- a/waltid-libraries/credentials/waltid-mdoc-credentials/README.md
+++ b/waltid-libraries/credentials/waltid-mdoc-credentials/README.md
@@ -309,7 +309,9 @@ val identifierListEntry = Status(
 )
 ```
 
-Note that the two revocation methods discussed here are **mutually exclusive**.
+Note that **ISO/IEC 18013-5 clause 9.1.2.6 (MSO revocation)** requires a single mechanism per MSO: the
+status element shall contain `identifier_list` when using the identifier list mechanism, and shall
+contain `status_list` when using the status list mechanism — the two are therefore **mutually exclusive**.
 
 #### Create, parse and verify a mdoc (mDL) request
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
@@ -688,6 +688,7 @@ object OpenID4VCI {
         x5Chain: List<String>? = null,
         display: List<DisplayProperties>? = null,
         sdJwtTypeHeader: String? = null,
+        sdJwtCredentialClaims: JsonObject? = null,
     ): String {
         val proofHeader = credentialRequest.proof?.jwt?.let { JwtUtils.parseJWTHeader(it) }
             ?: throw CredentialError(
@@ -721,8 +722,14 @@ object OpenID4VCI {
             if (!it.isNullOrEmpty() && DidUtils.isDidUrl(it)) it.substringBefore("#") else null
         }
 
+        val credentialPayload = sdJwtCredentialClaims?.let { extra ->
+            JsonObject(credentialData.toMutableMap().apply {
+                extra.forEach { (k, v) -> put(k, v) }
+            })
+        } ?: credentialData
+
         val sdPayload = SDPayload.createSDPayload(
-            fullPayload = credentialData.mergeSDJwtVCPayloadWithMapping(
+            fullPayload = credentialPayload.mergeSDJwtVCPayloadWithMapping(
                 mapping = dataMapping ?: JsonObject(emptyMap()),
                 context = mapOf(
                     "subjectDid" to holderDid,
@@ -809,7 +816,8 @@ object OpenID4VCI {
         selectiveDisclosure: SDMap? = null,
         dataMapping: JsonObject? = null,
         x5Chain: List<String>? = null,
-        display: List<DisplayProperties>? = null
+        display: List<DisplayProperties>? = null,
+        credentialStatus: JsonElement? = null,
     ): String {
         val proofHeader = credentialRequest.proof?.jwt?.let { JwtUtils.parseJWTHeader(it) }
             ?: throw CredentialError(
@@ -827,7 +835,11 @@ object OpenID4VCI {
             mapOf(JWTClaims.Header.x5c to JsonArray(it.map { cert -> cert.toJsonElement() }))
         } ?: mapOf()
 
-        return W3CVC(credentialData).let { vc ->
+        val vcPayload = credentialStatus?.let { status ->
+            JsonObject(credentialData.toMutableMap().apply { put("credentialStatus", status) })
+        } ?: credentialData
+
+        return W3CVC(vcPayload).let { vc ->
             val context = mapOf(
                 "subjectDid" to holderDid,
                 "issuerDid" to issuerId,

--- a/waltid-services/waltid-integration-tests/src/test/kotlin/id/walt/integrationtests/IssuanceCredentialStatusIntegrationTest.kt
+++ b/waltid-services/waltid-integration-tests/src/test/kotlin/id/walt/integrationtests/IssuanceCredentialStatusIntegrationTest.kt
@@ -1,0 +1,154 @@
+package id.walt.integrationtests
+
+import id.walt.commons.testing.utils.ServiceTestUtils.loadResource
+import id.walt.issuer.issuance.IssuanceRequest
+import id.walt.issuer.issuance.openapi.issuerapi.MdocDocs
+import id.walt.mdoc.doc.MDoc
+import id.walt.oid4vc.util.JwtUtils
+import id.walt.test.integration.loadJsonResource
+import id.walt.test.integration.tests.AbstractIntegrationTest
+import id.walt.w3c.schemes.JwsSignatureScheme
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/** Credential-status issuance ([IssuanceRequest] injection); package avoids Gradle exclude `id/walt/test/integration/**` unless `-PrunIntegrationTests`. */
+class IssuanceCredentialStatusIntegrationTest : AbstractIntegrationTest() {
+
+    @Test
+    fun issueJwtVcWithCredentialStatus() = runTest {
+        val credentialStatusEntry = buildJsonObject {
+            put("type", "BitstringStatusListEntry")
+            put("statusPurpose", "revocation")
+            put("statusListCredential", "https://status.integration.example/lists/1")
+            put("statusListIndex", "424242")
+        }
+        val req = IssuanceRequest(
+            issuerKey = loadJsonResource("issuance/key.json"),
+            issuerDid = loadResource("issuance/did.txt"),
+            credentialConfigurationId = "OpenBadgeCredential_jwt_vc_json",
+            credentialData = loadJsonResource("issuance/openbadgecredential.json"),
+            mapping = loadJsonResource("issuance/mapping.json"),
+            credentialStatus = buildJsonArray { add(credentialStatusEntry) },
+        )
+        val offerUrl = issuerApi.issueJwtCredential(req)
+        defaultWalletApi.resolveCredentialOffer(offerUrl)
+        val claimed = defaultWalletApi.claimCredential(offerUrl)
+        assertEquals(1, claimed.size)
+
+        val jwtPayload = JwtUtils.parseJWTPayload(claimed.first().document)
+        val vc = jwtPayload[JwsSignatureScheme.JwsOption.VC]?.jsonObject
+            ?: error("JWT payload missing vc claim")
+        val embedded = vc["credentialStatus"]
+            ?: error("credentialStatus not embedded in issued VC")
+
+        assertTrue(embedded is JsonArray, "credentialStatus must be a JSON array")
+        assertEquals(1, embedded.jsonArray.size)
+        val first = embedded.jsonArray.first().jsonObject
+        assertEquals("BitstringStatusListEntry", first["type"]?.jsonPrimitive?.content)
+        assertEquals(
+            "https://status.integration.example/lists/1",
+            first["statusListCredential"]?.jsonPrimitive?.content,
+        )
+        assertEquals("424242", first["statusListIndex"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun issueSdJwtVcWithMergedStatusClaim() = runTest {
+        val base = Json.decodeFromJsonElement(serializer<IssuanceRequest>(), loadJsonResource(
+            "issuance/identity-credential-no-disclosures-no-mapping.json",
+        ))
+        val expectedUri = "https://status.integration.example/statuslists/99"
+        val req = base.copy(
+            sdJwtCredentialClaims = buildJsonObject {
+                put(
+                    "status",
+                    buildJsonObject {
+                        put("idx", JsonPrimitive(142))
+                        put("uri", JsonPrimitive(expectedUri))
+                    },
+                )
+            },
+        )
+
+        val offerUrl = issuerApi.issueSdJwtCredential(req)
+        defaultWalletApi.resolveCredentialOffer(offerUrl)
+        val claimed = defaultWalletApi.claimCredential(offerUrl)
+        assertEquals(1, claimed.size)
+
+        val sdJwtDocument = claimed.first().document
+        val jwtPart = sdJwtDocument.substringBefore('~')
+        val payload = JwtUtils.parseJWTPayload(jwtPart)
+
+        val status = payload["status"]?.jsonObject ?: error("missing top-level status claim on SD-JWT VC")
+        assertEquals(142L, status["idx"]?.jsonPrimitive?.longOrNull ?: status["idx"]?.jsonPrimitive?.intOrNull?.toLong())
+        assertEquals(expectedUri, status["uri"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun issueMdocWithStatusListInMso() = runTest {
+        val expectedUri = "https://status.integration.example/statuslists/mdoc1"
+        val req = MdocDocs.mdlBaseIssuanceExample.copy(
+            mdocStatus = buildJsonObject {
+                put(
+                    "status_list",
+                    buildJsonObject {
+                        put("idx", JsonPrimitive(142))
+                        put("uri", JsonPrimitive(expectedUri))
+                    },
+                )
+            },
+        )
+
+        val offerUrl = issuerApi.issueMdocCredential(req)
+        val mDocWallet = environment.getMdocWalletApi()
+        val claimed = mDocWallet.claimCredential(offerUrl)
+        assertEquals(1, claimed.size)
+
+        val mDoc = MDoc.fromCBORHex(claimed.first().document)
+        val statusList = assertNotNull(mDoc.MSO?.status?.statusList, "expected MSO.status.status_list")
+        assertEquals(142u, statusList.index)
+        assertEquals(expectedUri, statusList.uri)
+    }
+
+    @Test
+    fun issueMdocWithIdentifierListInMso() = runTest {
+        val expectedUri = "https://status.integration.example/identifierlists/2"
+        val req = MdocDocs.mdlBaseIssuanceExample.copy(
+            mdocStatus = buildJsonObject {
+                put(
+                    "identifier_list",
+                    buildJsonObject {
+                        put("id", JsonPrimitive("abcd"))
+                        put("uri", JsonPrimitive(expectedUri))
+                    },
+                )
+            },
+        )
+
+        val offerUrl = issuerApi.issueMdocCredential(req)
+        val mDocWallet = environment.getMdocWalletApi()
+        val claimed = mDocWallet.claimCredential(offerUrl)
+        assertEquals(1, claimed.size)
+
+        val mDoc = MDoc.fromCBORHex(claimed.first().document)
+        val idList = assertNotNull(mDoc.MSO?.status?.identifierList, "expected MSO.status.identifier_list")
+        assertContentEquals(byteArrayOf(0xab.toByte(), 0xcd.toByte()), idList.id)
+        assertEquals(expectedUri, idList.uri)
+    }
+}

--- a/waltid-services/waltid-integration-tests/src/test/kotlin/id/walt/test/integration/tests/IssuanceCredentialStatusIntegrationTest.kt
+++ b/waltid-services/waltid-integration-tests/src/test/kotlin/id/walt/test/integration/tests/IssuanceCredentialStatusIntegrationTest.kt
@@ -1,4 +1,4 @@
-package id.walt.integrationtests
+package id.walt.test.integration.tests
 
 import id.walt.commons.testing.utils.ServiceTestUtils.loadResource
 import id.walt.issuer.issuance.IssuanceRequest
@@ -6,7 +6,6 @@ import id.walt.issuer.issuance.openapi.issuerapi.MdocDocs
 import id.walt.mdoc.doc.MDoc
 import id.walt.oid4vc.util.JwtUtils
 import id.walt.test.integration.loadJsonResource
-import id.walt.test.integration.tests.AbstractIntegrationTest
 import id.walt.w3c.schemes.JwsSignatureScheme
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -27,7 +26,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-/** Credential-status issuance ([IssuanceRequest] injection); package avoids Gradle exclude `id/walt/test/integration/**` unless `-PrunIntegrationTests`. */
 class IssuanceCredentialStatusIntegrationTest : AbstractIntegrationTest() {
 
     @Test

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/CIProvider.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/CIProvider.kt
@@ -23,6 +23,7 @@ import id.walt.mdoc.dataelement.DataElement
 import id.walt.mdoc.dataelement.json.toDataElement
 import id.walt.mdoc.doc.MDocBuilder
 import id.walt.mdoc.mso.DeviceKeyInfo
+import id.walt.mdoc.mso.Status
 import id.walt.mdoc.mso.ValidityInfo
 import id.walt.oid4vc.OpenID4VC
 import id.walt.oid4vc.OpenID4VCI
@@ -340,6 +341,7 @@ open class CIProvider(
                             DisplayProperties.fromJSON(it.jsonObject)
                         },
                         x5Chain = x5c,
+                        sdJwtCredentialClaims = request.sdJwtCredentialClaims,
                     ).also {
                         if (!issuanceSession.callbackUrl.isNullOrEmpty())
                             sendCallback(
@@ -359,8 +361,8 @@ open class CIProvider(
                         selectiveDisclosure = request.selectiveDisclosure,
                         dataMapping = request.mapping,
                         x5Chain = x5c,
-                        display = credentialRequest.display
-
+                        display = credentialRequest.display,
+                        credentialStatus = request.credentialStatus,
                     ).also {
                         if (!issuanceSession.callbackUrl.isNullOrEmpty())
                             sendCallback(
@@ -455,6 +457,8 @@ open class CIProvider(
             )
         )
 
+        val mdocIssuerStatus: Status? = request.mdocStatus?.toMdocIssuerStatusOrNull()
+
         val mdoc = MDocBuilder(
             credentialRequest.docType
                 ?: throw CredentialError(
@@ -487,7 +491,8 @@ open class CIProvider(
                 )
             ),
             cryptoProvider = cryptoProvider,
-            keyID = keyID
+            keyID = keyID,
+            status = mdocIssuerStatus,
         ).also {
             if (!issuanceSession.callbackUrl.isNullOrEmpty())
                 sendCallback(

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/IssuanceCredentialStatus.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/IssuanceCredentialStatus.kt
@@ -5,74 +5,169 @@ import id.walt.mdoc.mso.IdentifierListInfo
 import id.walt.mdoc.mso.Status
 import id.walt.mdoc.mso.StatusListInfo
 import io.ktor.server.plugins.BadRequestException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
+import java.net.URI
+import java.net.URISyntaxException
 import java.util.Base64
 
 internal fun JsonObject.toMdocIssuerStatusOrNull(): Status? {
     if (isEmpty()) return null
     val statusListEl = this["status_list"]
     val identifierListEl = this["identifier_list"]
-    when {
-        statusListEl != null && identifierListEl != null ->
-            throw BadRequestException("mdoc status_list and identifier_list are mutually exclusive")
+    if (statusListEl.isPresentJson() && identifierListEl.isPresentJson()) {
+        throw BadRequestException(
+            "Only one of status_list or identifier_list may be set. ISO/IEC 18013-5 clause 9.1.2.6 " +
+                "(MSO revocation) requires the identifier list mechanism to use identifier_list and " +
+                "the status list mechanism to use status_list — not both.",
+        )
+    }
+    return when {
+        statusListEl.isPresentJson() ->
+            MdocIssuerStatusJsonParser.parseStatusList(statusListEl.requireJsonObject("status_list"))
 
-        statusListEl != null -> {
-            val sl = statusListEl.jsonObject
-            val idxEl = sl["idx"] ?: throw BadRequestException("status_list.idx is required")
-            val uriEl = sl["uri"] ?: throw BadRequestException("status_list.uri is required")
-            val idx = idxEl.jsonPrimitive.longOrNull?.toUInt()
-                ?: idxEl.jsonPrimitive.intOrNull?.toUInt()
-                ?: throw BadRequestException("status_list.idx must be a non-negative integer")
-            val uri = uriEl.jsonPrimitive.content
-            val certificate = sl["certificate"]?.let { cert ->
-                decodeBinaryJsonPrimitive(cert.jsonPrimitive)
-            }
-            return Status(statusList = StatusListInfo(index = idx, uri = uri, certificate = certificate))
-        }
-
-        identifierListEl != null -> {
-            val il = identifierListEl.jsonObject
-            val uriEl = il["uri"] ?: throw BadRequestException("identifier_list.uri is required")
-            val uri = uriEl.jsonPrimitive.content
-            val idBytes = il["id"]?.jsonPrimitive?.let(::decodeBinaryJsonPrimitive)
-                ?: throw BadRequestException("identifier_list.id is required (hex or base64)")
-            val certificate = il["certificate"]?.let { decodeBinaryJsonPrimitive(it.jsonPrimitive) }
-            return Status(identifierList = IdentifierListInfo(id = idBytes, uri = uri, certificate = certificate))
-        }
+        identifierListEl.isPresentJson() ->
+            MdocIssuerStatusJsonParser.parseIdentifierList(identifierListEl.requireJsonObject("identifier_list"))
 
         else -> throw BadRequestException("mdoc status requires status_list or identifier_list")
     }
 }
 
-private fun decodeBinaryJsonPrimitive(p: kotlinx.serialization.json.JsonPrimitive): ByteArray {
-    val raw = p.content.trim().removePrefix("0x")
-    return when {
-        raw.matchesHex() -> decodeHexEven(raw)
-        else -> decodeBase64Lenient(raw)
+private fun JsonElement?.isPresentJson(): Boolean = this != null && this !is JsonNull
+
+private fun JsonElement?.requireJsonObject(field: String): JsonObject =
+    this as? JsonObject ?: throw BadRequestException("$field must be a JSON object")
+
+private object MdocIssuerStatusJsonParser {
+
+    fun parseStatusList(sl: JsonObject): Status {
+        val idxEl = sl["idx"] ?: throw BadRequestException("status_list.idx is required")
+        val uriEl = sl["uri"] ?: throw BadRequestException("status_list.uri is required")
+        val idx = parseNonNegativeUInt(idxEl, "status_list.idx")
+        val uri = parseAbsoluteUri(stringField(uriEl, "status_list.uri"), "status_list.uri")
+        val certificate = sl["certificate"]?.let {
+            decodeBinaryJsonElement(it, "status_list.certificate")
+        }
+        return Status(statusList = StatusListInfo(index = idx, uri = uri, certificate = certificate))
+    }
+
+    fun parseIdentifierList(il: JsonObject): Status {
+        val uriEl = il["uri"] ?: throw BadRequestException("identifier_list.uri is required")
+        val idEl = il["id"] ?: throw BadRequestException("identifier_list.id is required")
+        val uri = parseAbsoluteUri(stringField(uriEl, "identifier_list.uri"), "identifier_list.uri")
+        val idBytes = decodeBinaryJsonElement(idEl, "identifier_list.id")
+        val certificate = il["certificate"]?.let {
+            decodeBinaryJsonElement(it, "identifier_list.certificate")
+        }
+        return Status(identifierList = IdentifierListInfo(id = idBytes, uri = uri, certificate = certificate))
+    }
+
+    private fun stringField(el: JsonElement, fieldPath: String): String {
+        val p = el as? JsonPrimitive ?: throw BadRequestException("$fieldPath must be a JSON string")
+        if (p.isString) return p.content
+        throw BadRequestException("$fieldPath must be a JSON string")
+    }
+
+    private fun parseNonNegativeUInt(el: JsonElement, fieldPath: String): UInt {
+        val p = el as? JsonPrimitive ?: throw BadRequestException("$fieldPath must be a JSON primitive")
+        val longVal = when {
+            p.isString -> p.content.trim().toLongOrNull()
+                ?: throw BadRequestException("$fieldPath must be a non-negative integer")
+            else -> p.longOrNull ?: p.intOrNull?.toLong()
+                ?: throw BadRequestException("$fieldPath must be a non-negative integer")
+        }
+        if (longVal < 0L || longVal > UInt.MAX_VALUE.toLong()) {
+            throw BadRequestException("$fieldPath must be in range 0..${UInt.MAX_VALUE}")
+        }
+        return longVal.toUInt()
+    }
+
+    private fun parseAbsoluteUri(raw: String, fieldPath: String): String {
+        val s = raw.trim()
+        if (s.isEmpty()) {
+            throw BadRequestException("$fieldPath must be a non-blank absolute URI")
+        }
+        val uri = try {
+            URI(s)
+        } catch (e: URISyntaxException) {
+            throw BadRequestException("$fieldPath is not a valid URI: ${e.reason}")
+        }
+        if (!uri.isAbsolute || uri.scheme.isNullOrBlank()) {
+            throw BadRequestException("$fieldPath must be an absolute URI with a non-blank scheme")
+        }
+        return s
+    }
+
+    private fun decodeBinaryJsonElement(el: JsonElement, fieldPath: String): ByteArray {
+        val p = el as? JsonPrimitive ?: throw BadRequestException("$fieldPath must be a JSON primitive")
+        return decodeBinaryString(p.content, fieldPath)
+    }
+
+    /**
+     * Decodes hex (optional `0x` / `0X` prefix) or Base64 (URL-safe or standard, with padding normalized).
+     * If a `0x`/`0X` prefix is present, the remainder is interpreted strictly as hex (no Base64 fallback).
+     */
+    private fun decodeBinaryString(rawInput: String, fieldPath: String): ByteArray {
+        val trimmed = rawInput.trim()
+        if (trimmed.isEmpty()) {
+            throw BadRequestException("$fieldPath must not be blank")
+        }
+        val hadHexPrefix = trimmed.startsWith("0x", ignoreCase = true)
+        val body = if (hadHexPrefix) trimmed.substring(2) else trimmed
+        if (body.isEmpty()) {
+            throw BadRequestException("$fieldPath must not be blank after removing optional 0x prefix")
+        }
+        return if (hadHexPrefix) {
+            if (!body.matchesHex()) {
+                throw BadRequestException(
+                    "$fieldPath: value with 0x/0X prefix must be even-length hex (0-9, a-f or A-F, consistent letter case per digit group)",
+                )
+            }
+            decodeHexEven(body, fieldPath)
+        } else if (body.matchesHex()) {
+            decodeHexEven(body, fieldPath)
+        } else {
+            decodeBase64UrlOrStandard(body, fieldPath)
+        }
+    }
+
+    private fun decodeHexEven(hex: String, fieldPath: String): ByteArray {
+        if (hex.length % 2 != 0) {
+            throw BadRequestException("$fieldPath: hex-encoded value must have even length")
+        }
+        return ByteArray(hex.length / 2) { i ->
+            val hi = hexNibble(hex[i * 2], fieldPath)
+            val lo = hexNibble(hex[i * 2 + 1], fieldPath)
+            ((hi shl 4) or lo).toByte()
+        }
+    }
+
+    private fun hexNibble(c: Char, fieldPath: String): Int = when (c) {
+        in '0'..'9' -> c - '0'
+        in 'a'..'f' -> c - 'a' + 10
+        in 'A'..'F' -> c - 'A' + 10
+        else -> throw BadRequestException("$fieldPath: invalid hex character '$c'")
+    }
+
+    private fun decodeBase64UrlOrStandard(s: String, fieldPath: String): ByteArray {
+        val paddedUrl = padBase64(s)
+        return runCatching { Base64.getUrlDecoder().decode(paddedUrl) }
+            .recoverCatching { Base64.getDecoder().decode(padBase64(s)) }
+            .getOrElse {
+                throw BadRequestException(
+                    "$fieldPath must be even-length hex, or valid Base64 (URL-safe or standard); ${it.message}",
+                )
+            }
+    }
+
+    private fun padBase64(s: String): String {
+        val m = s.length % 4
+        return if (m == 0) s else s + "=".repeat(4 - m)
     }
 }
-
-private fun decodeHexEven(hex: String): ByteArray {
-    require(hex.length % 2 == 0) { "Hex-encoded id must have even length" }
-    return ByteArray(hex.length / 2) { i ->
-        val hi = hexNibble(hex[i * 2])
-        val lo = hexNibble(hex[i * 2 + 1])
-        ((hi shl 4) or lo).toByte()
-    }
-}
-
-private fun hexNibble(c: Char): Int = when (c) {
-    in '0'..'9' -> c - '0'
-    in 'a'..'f' -> c - 'a' + 10
-    in 'A'..'F' -> c - 'A' + 10
-    else -> throw BadRequestException("Invalid hex character in binary field: $c")
-}
-
-private fun decodeBase64Lenient(s: String): ByteArray =
-    runCatching { Base64.getUrlDecoder().decode(s) }
-        .recoverCatching { Base64.getDecoder().decode(s) }
-        .getOrElse { throw BadRequestException("Value must be hex or valid Base64 (standard or URL-safe)") }

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/IssuanceCredentialStatus.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/IssuanceCredentialStatus.kt
@@ -1,0 +1,78 @@
+package id.walt.issuer.issuance
+
+import id.walt.crypto.utils.HexUtils.matchesHex
+import id.walt.mdoc.mso.IdentifierListInfo
+import id.walt.mdoc.mso.Status
+import id.walt.mdoc.mso.StatusListInfo
+import io.ktor.server.plugins.BadRequestException
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import java.util.Base64
+
+internal fun JsonObject.toMdocIssuerStatusOrNull(): Status? {
+    if (isEmpty()) return null
+    val statusListEl = this["status_list"]
+    val identifierListEl = this["identifier_list"]
+    when {
+        statusListEl != null && identifierListEl != null ->
+            throw BadRequestException("mdoc status_list and identifier_list are mutually exclusive")
+
+        statusListEl != null -> {
+            val sl = statusListEl.jsonObject
+            val idxEl = sl["idx"] ?: throw BadRequestException("status_list.idx is required")
+            val uriEl = sl["uri"] ?: throw BadRequestException("status_list.uri is required")
+            val idx = idxEl.jsonPrimitive.longOrNull?.toUInt()
+                ?: idxEl.jsonPrimitive.intOrNull?.toUInt()
+                ?: throw BadRequestException("status_list.idx must be a non-negative integer")
+            val uri = uriEl.jsonPrimitive.content
+            val certificate = sl["certificate"]?.let { cert ->
+                decodeBinaryJsonPrimitive(cert.jsonPrimitive)
+            }
+            return Status(statusList = StatusListInfo(index = idx, uri = uri, certificate = certificate))
+        }
+
+        identifierListEl != null -> {
+            val il = identifierListEl.jsonObject
+            val uriEl = il["uri"] ?: throw BadRequestException("identifier_list.uri is required")
+            val uri = uriEl.jsonPrimitive.content
+            val idBytes = il["id"]?.jsonPrimitive?.let(::decodeBinaryJsonPrimitive)
+                ?: throw BadRequestException("identifier_list.id is required (hex or base64)")
+            val certificate = il["certificate"]?.let { decodeBinaryJsonPrimitive(it.jsonPrimitive) }
+            return Status(identifierList = IdentifierListInfo(id = idBytes, uri = uri, certificate = certificate))
+        }
+
+        else -> throw BadRequestException("mdoc status requires status_list or identifier_list")
+    }
+}
+
+private fun decodeBinaryJsonPrimitive(p: kotlinx.serialization.json.JsonPrimitive): ByteArray {
+    val raw = p.content.trim().removePrefix("0x")
+    return when {
+        raw.matchesHex() -> decodeHexEven(raw)
+        else -> decodeBase64Lenient(raw)
+    }
+}
+
+private fun decodeHexEven(hex: String): ByteArray {
+    require(hex.length % 2 == 0) { "Hex-encoded id must have even length" }
+    return ByteArray(hex.length / 2) { i ->
+        val hi = hexNibble(hex[i * 2])
+        val lo = hexNibble(hex[i * 2 + 1])
+        ((hi shl 4) or lo).toByte()
+    }
+}
+
+private fun hexNibble(c: Char): Int = when (c) {
+    in '0'..'9' -> c - '0'
+    in 'a'..'f' -> c - 'a' + 10
+    in 'A'..'F' -> c - 'A' + 10
+    else -> throw BadRequestException("Invalid hex character in binary field: $c")
+}
+
+private fun decodeBase64Lenient(s: String): ByteArray =
+    runCatching { Base64.getUrlDecoder().decode(s) }
+        .recoverCatching { Base64.getDecoder().decode(s) }
+        .getOrElse { throw BadRequestException("Value must be hex or valid Base64 (standard or URL-safe)") }

--- a/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/IssuanceRequests.kt
+++ b/waltid-services/waltid-issuer-api/src/main/kotlin/id/walt/issuer/issuance/IssuanceRequests.kt
@@ -96,6 +96,24 @@ data class IssuanceRequest(
     val display: List<DisplayProperties>? = null,
     val draft11EncodeOfferedCredentialsByReference: Boolean? = true, //if set to false and only for standard version DRAFT11, offered credentials will be encoded by value, not by reference - required by EBSI Vector
     val issuanceType: String? = null, // IN_TIME, DEFERRED
+
+    /**
+     * Optional [credentialStatus](https://www.w3.org/TR/vc-data-model/#status) for W3C JWT VC payloads.
+     * When set, merged into [credentialData] before signing (overwriting an existing top-level `credentialStatus`).
+     */
+    val credentialStatus: JsonElement? = null,
+
+    /**
+     * Optional extra top-level claims merged into the SD-JWT VC payload before signing (after [credentialData], before mapping).
+     * Use for externally managed revocation metadata such as an IETF Token Status List [`status`](https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/) claim.
+     */
+    val sdJwtCredentialClaims: JsonObject? = null,
+
+    /**
+     * Optional Mobile Security Object status for mdoc (`status_list` **or** `identifier_list`; mutually exclusive).
+     * Matches the ISO/IEC 18013-5 MSO `status` structure encoded as JSON (see `waltid-mdoc-credentials` README).
+     */
+    val mdocStatus: JsonObject? = null,
 ) {
 
     init {

--- a/waltid-services/waltid-issuer-api/src/test/kotlin/id/walt/issuer/issuance/IssuanceCredentialStatusTest.kt
+++ b/waltid-services/waltid-issuer-api/src/test/kotlin/id/walt/issuer/issuance/IssuanceCredentialStatusTest.kt
@@ -1,0 +1,106 @@
+package id.walt.issuer.issuance
+
+import io.ktor.server.plugins.BadRequestException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class IssuanceCredentialStatusTest {
+
+    @Test
+    fun emptyObjectReturnsNull() {
+        assertNull(buildJsonObject { }.toMdocIssuerStatusOrNull())
+    }
+
+    @Test
+    fun statusListAndIdentifierListTogetherRejected() {
+        val ex = assertFailsWith<BadRequestException> {
+            buildJsonObject {
+                put("status_list", buildJsonObject { put("idx", JsonPrimitive(0)); put("uri", JsonPrimitive("https://a.example/s")) })
+                put("identifier_list", buildJsonObject { put("id", JsonPrimitive("00")); put("uri", JsonPrimitive("https://b.example/i")) })
+            }.toMdocIssuerStatusOrNull()
+        }
+        assertTrue(ex.message!!.contains("9.1.2.6"), ex.message)
+        assertTrue(ex.message!!.contains("identifier_list"), ex.message)
+    }
+
+    @Test
+    fun statusListBlankUriRejected() {
+        assertFailsWith<BadRequestException> {
+            buildJsonObject {
+                put(
+                    "status_list",
+                    buildJsonObject {
+                        put("idx", JsonPrimitive(1))
+                        put("uri", JsonPrimitive("   "))
+                    },
+                )
+            }.toMdocIssuerStatusOrNull()
+        }
+    }
+
+    @Test
+    fun statusListRelativeUriRejected() {
+        assertFailsWith<BadRequestException> {
+            buildJsonObject {
+                put(
+                    "status_list",
+                    buildJsonObject {
+                        put("idx", JsonPrimitive(1))
+                        put("uri", JsonPrimitive("/relative/path"))
+                    },
+                )
+            }.toMdocIssuerStatusOrNull()
+        }
+    }
+
+    @Test
+    fun zeroXPrefixInvalidHexNoBase64Fallback() {
+        assertFailsWith<BadRequestException> {
+            buildJsonObject {
+                put(
+                    "identifier_list",
+                    buildJsonObject {
+                        put("id", JsonPrimitive("0xZZ"))
+                        put("uri", JsonPrimitive("https://example.com/l"))
+                    },
+                )
+            }.toMdocIssuerStatusOrNull()
+        }
+    }
+
+    @Test
+    fun statusListParsesNumericIdxAndHttpsUri() {
+        val s = buildJsonObject {
+            put(
+                "status_list",
+                buildJsonObject {
+                    put("idx", JsonPrimitive(142))
+                    put("uri", JsonPrimitive("https://status.example/lists/1"))
+                },
+            )
+        }.toMdocIssuerStatusOrNull()
+        assertEquals(142u, s!!.statusList!!.index)
+        assertEquals("https://status.example/lists/1", s.statusList!!.uri)
+    }
+
+    @Test
+    fun identifierListParsesHexIdWithoutPrefix() {
+        val s = buildJsonObject {
+            put(
+                "identifier_list",
+                buildJsonObject {
+                    put("id", JsonPrimitive("abcd"))
+                    put("uri", JsonPrimitive("https://id.example/lists/2"))
+                },
+            )
+        }.toMdocIssuerStatusOrNull()
+        assertEquals(listOf(0xab.toByte(), 0xcd.toByte()), s!!.identifierList!!.id.toList())
+        assertEquals("https://id.example/lists/2", s.identifierList!!.uri)
+    }
+}


### PR DESCRIPTION
Adds support for passing status to w3c, ietf sdjwt and mdocs (1) credentials in the issuer

Resolves #1676 