### PR TITLE
Feature/wal 921

### DIFF
--- a/waltid-applications/waltid-credentials/src/content/3.w3c-credentials/OpenBadgeCredential.md
+++ b/waltid-applications/waltid-credentials/src/content/3.w3c-credentials/OpenBadgeCredential.md
@@ -4,37 +4,50 @@
 
 ```json
 {
-    "@context": ["https://www.w3.org/2018/credentials/v1", "https://purl.imsglobal.org/spec/ob/v3p0/context.json"],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+    "https://purl.imsglobal.org/spec/ob/v3p0/extensions.json"
+  ],
+  "id": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
+  "type": [
+    "VerifiableCredential",
+    "OpenBadgeCredential"
+  ],
+  "issuer": {
+    "type": [
+      "Profile"
+    ],
     "id": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
-    "type": ["VerifiableCredential", "OpenBadgeCredential"],
-    "name": "JFF x vc-edu PlugFest 3 Interoperability",
-    "issuer": {
-        "type": ["Profile"],
-        "id": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
-        "name": "Jobs for the Future (JFF)",
-        "url": "https://www.jff.org/",
-        "image": "https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/images/JFF_LogoLockup.png"
-    },
-    "issuanceDate": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
-    "expirationDate": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
-    "credentialSubject": {
-        "id": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
-        "type": ["AchievementSubject"],
-        "achievement": {
-            "id": "urn:uuid:ac254bd5-8fad-4bb1-9d29-efd938536926",
-            "type": ["Achievement"],
-            "name": "JFF x vc-edu PlugFest 3 Interoperability",
-            "description": "This wallet supports the use of W3C Verifiable Credentials and has demonstrated interoperability during the presentation request workflow during JFF x VC-EDU PlugFest 3.",
-            "criteria": {
-                "type": "Criteria",
-                "narrative": "Wallet solutions providers earned this badge by demonstrating interoperability during the presentation request workflow. This includes successfully receiving a presentation request, allowing the holder to select at least two types of verifiable credentials to create a verifiable presentation, returning the presentation to the requestor, and passing verification of the presentation and the included credentials."
-            },
-            "image": {
-                "id": "https://w3c-ccg.github.io/vc-ed/plugfest-3-2023/images/JFF-VC-EDU-PLUGFEST3-badge-image.png",
-                "type": "Image"
-            }
-        }
+    "name": "Jobs for the Future (JFF)",
+    "url": "https://www.jff.org/",
+    "image": "https://w3c-ccg.github.io/vc-ed/plugfest-1-2022/images/JFF_LogoLockup.png"
+  },
+  "validFrom": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
+  "name": "Example University Degree",
+  "credentialSubject": {
+    "id": "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION",
+    "type": [
+      "AchievementSubject"
+    ],
+    "achievement": {
+      "id": "https://example.com/achievements/21st-century-skills/teamwork",
+      "type": [
+        "Achievement"
+      ],
+      "criteria": {
+        "narrative": "Team members are nominated for this badge by their peers and recognized upon review by Example Corp management."
+      },
+      "description": "This badge recognizes the development of the capacity to collaborate within a group environment.",
+      "name": "Teamwork"
     }
+  },
+  "credentialSchema": [
+    {
+      "id": "https://purl.imsglobal.org/spec/ob/v3p0/schema/json/ob_v3p0_achievementcredential_schema.json",
+      "type": "1EdTechJsonSchemaValidator2019"
+    }
+  ]
 }
 ```
 
@@ -42,11 +55,11 @@
 
 ```json
 {
-    "claims": {
-        "Achievement Name": "$.credentialSubject.achievement.name",
-        "Achievement Description": "$.credentialSubject.achievement.description",
-        "Criteria Narrative": "$.credentialSubject.achievement.criteria.narrative"
-    }
+  "claims": {
+    "Achievement Name": "$.credentialSubject.achievement.name",
+    "Achievement Description": "$.credentialSubject.achievement.description",
+    "Criteria Narrative": "$.credentialSubject.achievement.criteria.narrative"
+  }
 }
 ```
 
@@ -54,14 +67,13 @@
 
 ```json
 {
-    "id": "<uuid>",
-    "issuer": {
-        "id": "<issuerDid>"
-    },
-    "credentialSubject": {
-        "id": "<subjectDid>"
-    },
-    "issuanceDate": "<timestamp>",
-    "expirationDate": "<timestamp-in:365d>"
+  "id": "<uuid>",
+  "issuer": {
+    "id": "<issuerDid>"
+  },
+  "credentialSubject": {
+    "id": "<subjectDid>"
+  },
+  "validFrom": "<timestamp>"
 }
 ```

--- a/waltid-libraries/credentials/waltid-digital-credentials-examples/src/commonMain/kotlin/id/walt/credentials/examples/SdJwtExamples.kt
+++ b/waltid-libraries/credentials/waltid-digital-credentials-examples/src/commonMain/kotlin/id/walt/credentials/examples/SdJwtExamples.kt
@@ -119,9 +119,239 @@ object SdJwtExamples {
         eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImRjK3NkLWp3dCIsICJraWQiOiAiZG9jLXNpZ25lci0wNS0yNS0yMDIyIn0.eyJfc2QiOiBbIjA5dktySk1PbHlUV00wc2pwdV9wZE9CVkJRMk0xeTNLaHBINTE1blhrcFkiLCAiMnJzakdiYUMwa3k4bVQwcEpyUGlvV1RxMF9kYXcxc1g3NnBvVWxnQ3diSSIsICJFa084ZGhXMGRIRUpidlVIbEVfVkNldUM5dVJFTE9pZUxaaGg3WGJVVHRBIiwgIklsRHpJS2VpWmREd3BxcEs2WmZieXBoRnZ6NUZnbldhLXNONndxUVhDaXciLCAiSnpZakg0c3ZsaUgwUjNQeUVNZmVadTZKdDY5dTVxZWhabzdGN0VQWWxTRSIsICJQb3JGYnBLdVZ1Nnh5bUphZ3ZrRnNGWEFiUm9jMkpHbEFVQTJCQTRvN2NJIiwgIlRHZjRvTGJnd2Q1SlFhSHlLVlFaVTlVZEdFMHc1cnREc3JaemZVYW9tTG8iLCAiamRyVEU4WWNiWTRFaWZ1Z2loaUFlX0JQZWt4SlFaSUNlaVVRd1k5UXF4SSIsICJqc3U5eVZ1bHdRUWxoRmxNXzNKbHpNYVNGemdsaFFHMERwZmF5UXdMVUs0Il0sICJpc3MiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9pc3N1ZXIiLCAiaWF0IjogMTY4MzAwMDAwMCwgImV4cCI6IDE4ODMwMDAwMDAsICJ2Y3QiOiAiaHR0cHM6Ly9jcmVkZW50aWFscy5leGFtcGxlLmNvbS9pZGVudGl0eV9jcmVkZW50aWFsIiwgIl9zZF9hbGciOiAic2hhLTI1NiIsICJjbmYiOiB7Imp3ayI6IHsia3R5IjogIkVDIiwgImNydiI6ICJQLTI1NiIsICJ4IjogIlRDQUVSMTladnUzT0hGNGo0VzR2ZlNWb0hJUDFJTGlsRGxzN3ZDZUdlbWMiLCAieSI6ICJaeGppV1diWk1RR0hWV0tWUTRoYlNJaXJzVmZ1ZWNDRTZ0NGpUOUYySFpRIn19fQ.cWT4VMs1G0iqUt-ajx98dCwq0I4djdqC9vX6ELCpjYBNrhRNK6u3wds9cSwB8REuA1RRCE9BprDDyjOVDLgLvg~WyIyR0xDNDJzS1F2ZUNmR2ZyeU5STjl3IiwgImdpdmVuX25hbWUiLCAiSm9obiJd~WyJlbHVWNU9nM2dTTklJOEVZbnN4QV9BIiwgImZhbWlseV9uYW1lIiwgIkRvZSJd~WyI2SWo3dE0tYTVpVlBHYm9TNXRtdlZBIiwgImVtYWlsIiwgImpvaG5kb2VAZXhhbXBsZS5jb20iXQ~WyJlSThaV205UW5LUHBOUGVOZW5IZGhRIiwgInBob25lX251bWJlciIsICIrMS0yMDItNTU1LTAxMDEiXQ~WyJRZ19PNjR6cUF4ZTQxMmExMDhpcm9BIiwgImFkZHJlc3MiLCB7InN0cmVldF9hZGRyZXNzIjogIjEyMyBNYWluIFN0IiwgImxvY2FsaXR5IjogIkFueXRvd24iLCAicmVnaW9uIjogIkFueXN0YXRlIiwgImNvdW50cnkiOiAiVVMifV0~WyJBSngtMDk1VlBycFR0TjRRTU9xUk9BIiwgImJpcnRoZGF0ZSIsICIxOTQwLTAxLTAxIl0~WyJQYzMzSk0yTGNoY1VfbEhnZ3ZfdWZRIiwgImlzX292ZXJfMTgiLCB0cnVlXQ~WyJHMDJOU3JRZmpGWFE3SW8wOXN5YWpBIiwgImlzX292ZXJfMjEiLCB0cnVlXQ~WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgImlzX292ZXJfNjUiLCB0cnVlXQ~
     """.trimIndent()*/
 
-    // SD-JWT **VCDM**
+    // SD-JWT **VCDM** (V2 context)
     //language=JSON
-    val sdJwtVcDmExample = """
+    val sdJwtVcDmV2Example = """
+        {
+          "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "http://data.europa.eu/snb/model/context/edc-ap"
+          ],
+          "vct": "empl:europeanDigitalCredential",
+
+          "id": "http://example.org/credential132",
+
+          "valid_from": "2010-10-01T00:00:00",
+          "valid_until": "2024-09-25T00:00:00",
+
+          "authentic_source": {
+            "id": "http://example.org/issuer565049",
+            "type": "Organisation",
+            "legalName": {
+              "en": "some legal name",
+              "fr": "un nom légal"
+            },
+            "eIDASIdentifier": {
+              "id": "http://example.org/126839",
+              "type": "LegalIdentifier",
+              "notation": "126839",
+              "spatial": {
+                "id": "http://publications.europa.eu/resource/authority/country/FRA",
+                "type": "Concept",
+                "inScheme": {
+                  "id": "http://publications.europa.eu/resource/authority/country",
+                  "type": "ConceptScheme"
+                }
+              }
+            },
+
+            "location": {
+              "id": "http://example.org/loc1",
+              "type": "Location",
+              "address": {
+                "id": "http://example.org/add1",
+                "type": "Address",
+                "countryCode": {
+                  "id": "http://publications.europa.eu/resource/authority/country/FRA",
+                  "type": "Concept",
+                  "inScheme": {
+                    "id": "http://publications.europa.eu/resource/authority/country",
+                    "type": "ConceptScheme"
+                  }
+                }
+              }
+            }
+          },
+
+          "credentialProfiles": {
+            "id": "http://data.europa.eu/snb/credential/bdc47cb449",
+            "type": "Concept",
+            "inScheme": {
+              "id": "http://data.europa.eu/snb/credential/25831c2",
+              "type": "ConceptScheme"
+            }
+          },
+
+          "displayParameter": {
+            "id": "http://example.org/display1",
+            "type": "DisplayParameter",
+            "title": {
+              "en": "Some kind of credential"
+            },
+            "primaryLanguage": {
+              "id": "http://publications.europa.eu/resource/authority/language/ENG",
+              "type": "Concept",
+              "inScheme": {
+                "id": "http://publications.europa.eu/resource/authority/language",
+                "type": "ConceptScheme"
+              }
+            },
+
+            "language": [
+              {
+                "id": "http://publications.europa.eu/resource/authority/language/ENG",
+                "type": "Concept",
+                "inScheme": {
+                  "id": "http://publications.europa.eu/resource/authority/language",
+                  "type": "ConceptScheme"
+                }
+              },
+              {
+                "id": "http://publications.europa.eu/resource/authority/language/FRA",
+                "type": "Concept",
+                "inScheme": {
+                  "id": "http://publications.europa.eu/resource/authority/language",
+                  "type": "ConceptScheme"
+                }
+              }
+            ],
+
+            "individualDisplay": [
+              {
+                "id": "http://example.org/individualDisplay1",
+                "type": "IndividualDisplay",
+                "language": {
+                  "id": "http://publications.europa.eu/resource/authority/language/ENG",
+                  "type": "Concept",
+                  "inScheme": {
+                    "id": "http://publications.europa.eu/resource/authority/language",
+                    "type": "ConceptScheme"
+                  }
+                },
+                "displayDetail": [
+                  {
+                    "id": "http://example.org/displayDetail1",
+                    "type": "DisplayDetail",
+                    "image": {
+                      "id": "http://example.org/image1",
+                      "type": "MediaObject",
+                      "content": "",
+                      "contentEncoding": {
+                        "id": "http://data.europa.eu/snb/encoding/6146cde7dd",
+                        "type": "Concept",
+                        "inScheme": {
+                          "id": "http://data.europa.eu/snb/encoding/25831c2",
+                          "type": "ConceptScheme"
+                        }
+                      },
+                      "contentType": {
+                        "id": "http://publications.europa.eu/resource/authority/file-type/JPEG",
+                        "type": "Concept",
+                        "inScheme": {
+                          "id": "http://publications.europa.eu/resource/authority/file-type",
+                          "type": "ConceptScheme"
+                        }
+                      }
+                    },
+                    "page": 1
+                  }
+                ]
+              }
+            ]
+          },
+
+          "claims": {
+            "id": "http://example.org/pid1",
+            "type": "Person",
+            "birthName": {
+              "en": "Maxi"
+            },
+            "familyName": {
+              "en": "Power"
+            },
+            "fullName": {
+              "en": "Max Power"
+            },
+            "givenName": {
+              "en": "Max"
+            },
+            "hasClaim": {
+              "id": "http://example.org/cl1",
+              "type": "LearningAchievement",
+              "awardedBy": {
+                "id": "http://example.org/awardingProcess1",
+                "type": "AwardingProcess",
+                "awardingBody": {
+                  "id": "http://example.org/org1",
+                  "type": "Organisation",
+                  "legalName": {
+                    "en": "some legal name of the organisation"
+                  },
+                  "location": {
+                    "id": "http://example.org/loc2",
+                    "type": "Location",
+                    "address": {
+                      "id": "http://example.org/add2",
+                      "type": "Address",
+                      "countryCode": {
+                        "id": "http://publications.europa.eu/resource/authority/country/FRA",
+                        "type": "Concept",
+                        "inScheme": {
+                          "id": "http://publications.europa.eu/resource/authority/country",
+                          "type": "ConceptScheme"
+                        }
+                      }
+                    }
+                  }
+                },
+                "educationalSystemNote": {
+                  "id": "http://example.org/someEducationalSystem",
+                  "type": "Concept",
+                  "definition": {
+                    "en": "the definition of the the concept for the educational system"
+                  }
+                }
+              },
+              "title": {
+                "en": "some kind of learning achievement",
+                "fr": "une sorte de réussite scolaire"
+              }
+            }
+          },
+
+          "evidence": {
+            "elm:evidence": {
+              "id": "http://example.org/evidence123",
+              "dcType": {
+                "id": "http://data.europa.eu/snb/evidence-type/c_18016257",
+                "type": "Concept",
+                "inScheme": {
+                  "id": "http://data.europa.eu/snb/evidence-type/25831c2",
+                  "type": "ConceptScheme"
+                }
+              }
+            }
+          },
+
+          "terms_of_use": {
+            "elm:terms_of_use": {
+              "id": "http://example.org/termsOfUse1",
+              "type": "TermsOfUse"
+            }
+          },
+
+          "status": {
+            "elm:credential_status": {
+              "id": "http://example.org/credentialStatus1",
+              "type": "CredentialStatus"
+            }
+          }
+        }
+    """.trimIndent()
+
+    // SD-JWT **VCDM** (V1.1 context)
+    //language=JSON
+    val sdJwtVcDmV11Example = """
         {
           "@context": [
             "https://www.w3.org/2018/credentials/v1",

--- a/waltid-libraries/credentials/waltid-digital-credentials-examples/src/commonMain/kotlin/id/walt/credentials/examples/W3CExamples.kt
+++ b/waltid-libraries/credentials/waltid-digital-credentials-examples/src/commonMain/kotlin/id/walt/credentials/examples/W3CExamples.kt
@@ -4,6 +4,8 @@ import id.walt.credentials.formats.AbstractW3C
 import kotlinx.serialization.json.Json
 
 object W3CExamples {
+
+    // ── W3C V2 (unsigned) ──
     //language=JSON
     val w3cCredential = """
         {
@@ -25,6 +27,32 @@ object W3CExamples {
         }
     """.trimIndent()
     val w3cCredentialValues = mapOf(
+        "issuer" to "https://university.example/issuers/565049",
+        "subject" to "did:example:ebfeb1f712ebc6f1c276e12ec21"
+    )
+
+    // ── W3C V1.1 (unsigned) ──
+    //language=JSON
+    val w3cV11Credential = """
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://www.w3.org/2018/credentials/examples/v1"
+          ],
+          "id": "http://university.example/credentials/3732",
+          "type": ["VerifiableCredential", "ExampleDegreeCredential"],
+          "issuer": "https://university.example/issuers/565049",
+          "issuanceDate": "2010-01-01T00:00:00Z",
+          "credentialSubject": {
+            "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+            "degree": {
+              "type": "ExampleBachelorDegree",
+              "name": "Bachelor of Arts"
+            }
+          }
+        }
+    """.trimIndent()
+    val w3cV11CredentialValues = mapOf(
         "issuer" to "https://university.example/issuers/565049",
         "subject" to "did:example:ebfeb1f712ebc6f1c276e12ec21"
     )
@@ -66,6 +94,43 @@ object W3CExamples {
         "subject" to "did:example:ebfeb1f712ebc6f1c276e12ec21"
     )
 
+    // application/vc (V1.1)
+    //language=JSON
+    val dipEcdsaSignedW3CV11Credential = """
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://www.w3.org/2018/credentials/examples/v1"
+          ],
+          "id": "http://university.example/credentials/3732",
+          "type": [
+            "VerifiableCredential",
+            "ExampleDegreeCredential"
+          ],
+          "issuer": "https://university.example/issuers/565049",
+          "issuanceDate": "2010-01-01T00:00:00Z",
+          "credentialSubject": {
+            "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+            "degree": {
+              "type": "ExampleBachelorDegree",
+              "name": "Bachelor of Science and Arts"
+            }
+          },
+          "proof": {
+            "type": "DataIntegrityProof",
+            "created": "2025-02-25T01:47:38Z",
+            "verificationMethod": "did:key:zDnaehK1RvsyuH7E1qSEp17iUwzYUvMnaz4vXTtXunvBzNZNk",
+            "cryptosuite": "ecdsa-rdfc-2019",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "zjV78p6RWm6uZCoFyx4D5xLg5GMdEnhtrG4LJU5PH6Tf3kHAHoSmqvXNipsZbRtV1KuCwt83zr9qLjX3zuNkHCwW"
+          }
+        }
+    """.trimIndent()
+    val dipEcdsaSignedW3CV11CredentialValues = mapOf(
+        "issuer" to "https://university.example/issuers/565049",
+        "subject" to "did:example:ebfeb1f712ebc6f1c276e12ec21"
+    )
+
     // application/vc
     //language=JSON
     val dipEddsaSignedW3CCredential = """
@@ -99,6 +164,43 @@ object W3CExamples {
         }
     """.trimIndent()
     val dipEddsaSignedW3CCredentialValues = mapOf(
+        "issuer" to "https://university.example/issuers/565049",
+        "subject" to "did:example:ebfeb1f712ebc6f1c276e12ec21"
+    )
+
+    // application/vc (V1.1)
+    //language=JSON
+    val dipEddsaSignedW3CV11Credential = """
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://www.w3.org/2018/credentials/examples/v1"
+          ],
+          "id": "http://university.example/credentials/3732",
+          "type": [
+            "VerifiableCredential",
+            "ExampleDegreeCredential"
+          ],
+          "issuer": "https://university.example/issuers/565049",
+          "issuanceDate": "2010-01-01T00:00:00Z",
+          "credentialSubject": {
+            "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+            "degree": {
+              "type": "ExampleBachelorDegree",
+              "name": "Bachelor of Science and Arts"
+            }
+          },
+          "proof": {
+            "type": "DataIntegrityProof",
+            "created": "2025-02-25T01:47:38Z",
+            "verificationMethod": "did:key:z6MkkZwCZavHWfRQAu9WbrDGJrSyxQV6Y3v44GdJeX8X3Vtu",
+            "cryptosuite": "eddsa-rdfc-2022",
+            "proofPurpose": "assertionMethod",
+            "proofValue": "z2SLLvvKkaiM23MphyzXZ3AMiWRHop7VJR8mtWDnH2YUC6K33QFE3rxaJhuLrdAfCVFAiajRY3FyiDRqKmTM2C8rk"
+          }
+        }
+    """.trimIndent()
+    val dipEddsaSignedW3CV11CredentialValues = mapOf(
         "issuer" to "https://university.example/issuers/565049",
         "subject" to "did:example:ebfeb1f712ebc6f1c276e12ec21"
     )

--- a/waltid-libraries/credentials/waltid-digital-credentials/src/commonMain/kotlin/id/walt/credentials/CredentialParser.kt
+++ b/waltid-libraries/credentials/waltid-digital-credentials/src/commonMain/kotlin/id/walt/credentials/CredentialParser.kt
@@ -71,11 +71,11 @@ object CredentialParser {
         else -> throw UnsupportedOperationException("Unsupported JSON type: $this")
     }
 
-    fun getCredentialDataIssuer(data: JsonObject) = data["issuer"].getItAsStringOrId() ?: data["vc"]["issuer"].getItAsStringOrId()
+    fun getCredentialDataIssuer(data: JsonObject) = data["issuer"].getItAsStringOrId() ?: data["vc"]?.jsonObject?.get("issuer")?.getItAsStringOrId()
     fun getJwtHeaderOrDataIssuer(data: JsonObject) = data.getString("iss") ?: getCredentialDataIssuer(data)
 
     fun getCredentialDataSubject(data: JsonObject) =
-        data["credentialSubject"].getItAsStringOrId() ?: data["vc"]["credentialSubject"].getItAsStringOrId()
+        data["credentialSubject"].getItAsStringOrId() ?: data["vc"]?.jsonObject?.get("credentialSubject")?.getItAsStringOrId()
 
     fun getJwtHeaderOrDataSubject(data: JsonObject) = data.getString("sub") ?: getCredentialDataSubject(data)
 
@@ -330,8 +330,9 @@ object CredentialParser {
                         )
             }
 
-            payload.contains("@context") || payload.contains("type") -> {
-                val w3cModelVersion = detectW3CDataModelVersion(payload)
+            payload.contains("@context") || payload.contains("type") || (payload.containsKey("vc") && (payload["vc"]?.jsonObject?.contains("@context") == true || payload["vc"]?.jsonObject?.contains("type") == true)) -> {
+                val w3cPayload = if (payload.containsKey("vc")) payload["vc"]!!.jsonObject else payload
+                val w3cModelVersion = detectW3CDataModelVersion(w3cPayload)
                 val credential = when (w3cModelVersion) {
                     W3CSubType.W3C_1_1 -> W3C11(
                         disclosables = containedDisclosablesSaveable,
@@ -381,7 +382,49 @@ object CredentialParser {
             }
 
             payload.contains("vc") -> {
-                parseSdJwt(credential, header, payload["vc"]!!.jsonObject, signature)
+                val subPayload = payload["vc"]!!.jsonObject
+                if (subPayload.contains("_sd")) {
+                    parseSdJwt(credential, header, subPayload, signature)
+                } else {
+                    // W3C credential wrapped in vc claim with SD-JWT envelope but no selective disclosures.
+                    // @context may be absent from vc top-level (e.g. nested inside credentialSubject),
+                    // so fall back to validFrom (DM2) / issuanceDate (DM1.1) for version detection.
+                    val w3cModelVersion = when {
+                        subPayload.contains("@context") -> detectW3CDataModelVersion(subPayload)
+                        subPayload.contains("validFrom") -> W3CSubType.W3C_2
+                        subPayload.contains("issuanceDate") -> W3CSubType.W3C_1_1
+                        else -> null
+                    }
+                    if (w3cModelVersion != null) {
+                        val w3cCredential = when (w3cModelVersion) {
+                            W3CSubType.W3C_1_1 -> W3C11(
+                                disclosables = containedDisclosablesSaveable,
+                                disclosures = availableDisclosures,
+                                signature = SdJwtCredentialSignature(plainSignature, header, availableDisclosures),
+                                signed = signedCredentialWithoutDisclosures,
+                                signedWithDisclosures = credential,
+                                credentialData = fullCredentialData,
+                                originalCredentialData = payload,
+                                issuer = getCredentialDataIssuer(payload),
+                                subject = getCredentialDataSubject(payload)
+                            )
+                            W3CSubType.W3C_2 -> W3C2(
+                                disclosables = containedDisclosablesSaveable,
+                                disclosures = availableDisclosures,
+                                signature = SdJwtCredentialSignature(plainSignature, header, availableDisclosures),
+                                signed = signedCredentialWithoutDisclosures,
+                                signedWithDisclosures = credential,
+                                credentialData = fullCredentialData,
+                                originalCredentialData = payload,
+                                issuer = getCredentialDataIssuer(payload),
+                                subject = getCredentialDataSubject(payload)
+                            )
+                        }
+                        detectedSdjwtSigned(CredentialPrimaryDataType.W3C, w3cModelVersion) to w3cCredential
+                    } else {
+                        throw NotImplementedError("Unknown SD-JWT-signed credential: $credential")
+                    }
+                }
             }
 
             else -> {

--- a/waltid-libraries/credentials/waltid-digital-credentials/src/commonMain/kotlin/id/walt/credentials/CredentialParser.kt
+++ b/waltid-libraries/credentials/waltid-digital-credentials/src/commonMain/kotlin/id/walt/credentials/CredentialParser.kt
@@ -463,20 +463,35 @@ object CredentialParser {
                         proofElement["cryptosuite"]?.jsonPrimitive?.content ?: error("Invalid proof (no cryptosuite)")
 
                         when (proofType) {
-                            "DataIntegrityProof" -> CredentialDetectionResult(
-                                CredentialPrimaryDataType.W3C, W3CSubType.W3C_2, // DataIntegrityProof was introduced with DM 2
-                                SignaturePrimaryType.DATA_INTEGRITY_PROOF
-                            ) to W3C2(
-                                disclosables = containedDisclosablesSaveable,
-                                disclosures = null,
-                                signature = DataIntegrityProofCredentialSignature(proofElement),
-                                signed = credential,
-                                signedWithDisclosures = null,
-                                credentialData = parsedJson,
-
-                                issuer = getCredentialDataIssuer(parsedJson),
-                                subject = getCredentialDataSubject(parsedJson)
-                            )
+                            "DataIntegrityProof" -> {
+                                val dipVersion = detectW3CDataModelVersion(parsedJson)
+                                val signature = DataIntegrityProofCredentialSignature(proofElement)
+                                CredentialDetectionResult(
+                                    CredentialPrimaryDataType.W3C, dipVersion,
+                                    SignaturePrimaryType.DATA_INTEGRITY_PROOF
+                                ) to when (dipVersion) {
+                                    W3CSubType.W3C_2 -> W3C2(
+                                        disclosables = containedDisclosablesSaveable,
+                                        disclosures = null,
+                                        signature = signature,
+                                        signed = credential,
+                                        signedWithDisclosures = null,
+                                        credentialData = parsedJson,
+                                        issuer = getCredentialDataIssuer(parsedJson),
+                                        subject = getCredentialDataSubject(parsedJson)
+                                    )
+                                    W3CSubType.W3C_1_1 -> W3C11(
+                                        disclosables = containedDisclosablesSaveable,
+                                        disclosures = null,
+                                        signature = signature,
+                                        signed = credential,
+                                        signedWithDisclosures = null,
+                                        credentialData = parsedJson,
+                                        issuer = getCredentialDataIssuer(parsedJson),
+                                        subject = getCredentialDataSubject(parsedJson)
+                                    )
+                                }
+                            }
 
                             else -> throw NotImplementedError("Unknown W3C proofType: $proofType")
                         }

--- a/waltid-libraries/credentials/waltid-digital-credentials/src/jvmTest/kotlin/id/walt/credentials/SdJwtExampleList.kt
+++ b/waltid-libraries/credentials/waltid-digital-credentials/src/jvmTest/kotlin/id/walt/credentials/SdJwtExampleList.kt
@@ -19,7 +19,12 @@ object SdJwtExampleList {
             CredentialDetectorTypes.SignaturePrimaryType.UNSIGNED,
             containsDisclosables = true
         ),
-        SdJwtExamples.sdJwtVcDmExample to CredentialDetectionResult(
+        SdJwtExamples.sdJwtVcDmV2Example to CredentialDetectionResult(
+            CredentialPrimaryDataType.SDJWTVC,
+            SDJWTVCSubType.sdjwtvcdm,
+            CredentialDetectorTypes.SignaturePrimaryType.UNSIGNED
+        ),
+        SdJwtExamples.sdJwtVcDmV11Example to CredentialDetectionResult(
             CredentialPrimaryDataType.SDJWTVC,
             SDJWTVCSubType.sdjwtvcdm,
             CredentialDetectorTypes.SignaturePrimaryType.UNSIGNED

--- a/waltid-libraries/credentials/waltid-digital-credentials/src/jvmTest/kotlin/id/walt/credentials/W3CExampleList.kt
+++ b/waltid-libraries/credentials/waltid-digital-credentials/src/jvmTest/kotlin/id/walt/credentials/W3CExampleList.kt
@@ -12,17 +12,32 @@ object W3CExampleList {
             CredentialPrimaryDataType.W3C,
             W3CSubType.W3C_2,
             CredentialDetectorTypes.SignaturePrimaryType.UNSIGNED
-        ), // unsigned
+        ), // unsigned V2
+        W3CExamples.w3cV11Credential to W3CExamples.w3cV11CredentialValues to CredentialDetectionResult(
+            CredentialPrimaryDataType.W3C,
+            W3CSubType.W3C_1_1,
+            CredentialDetectorTypes.SignaturePrimaryType.UNSIGNED
+        ), // unsigned V1.1
         W3CExamples.dipEcdsaSignedW3CCredential to W3CExamples.dipEcdsaSignedW3CCredentialValues to CredentialDetectionResult(
             CredentialPrimaryDataType.W3C,
             W3CSubType.W3C_2,
             CredentialDetectorTypes.SignaturePrimaryType.DATA_INTEGRITY_PROOF
-        ), // DataIntegrityProof: ECDSA
+        ), // DataIntegrityProof: ECDSA (V2)
+        W3CExamples.dipEcdsaSignedW3CV11Credential to W3CExamples.dipEcdsaSignedW3CV11CredentialValues to CredentialDetectionResult(
+            CredentialPrimaryDataType.W3C,
+            W3CSubType.W3C_1_1,
+            CredentialDetectorTypes.SignaturePrimaryType.DATA_INTEGRITY_PROOF
+        ), // DataIntegrityProof: ECDSA (V1.1)
         W3CExamples.dipEddsaSignedW3CCredential to W3CExamples.dipEddsaSignedW3CCredentialValues to CredentialDetectionResult(
             CredentialPrimaryDataType.W3C,
             W3CSubType.W3C_2,
             CredentialDetectorTypes.SignaturePrimaryType.DATA_INTEGRITY_PROOF
-        ), // DataIntegrityProof: EdDSA
+        ), // DataIntegrityProof: EdDSA (V2)
+        W3CExamples.dipEddsaSignedW3CV11Credential to W3CExamples.dipEddsaSignedW3CV11CredentialValues to CredentialDetectionResult(
+            CredentialPrimaryDataType.W3C,
+            W3CSubType.W3C_1_1,
+            CredentialDetectorTypes.SignaturePrimaryType.DATA_INTEGRITY_PROOF
+        ), // DataIntegrityProof: EdDSA (V1.1)
         W3CExamples.dipEcdsaSdSignedW3CCredential to W3CExamples.dipEcdsaSdSignedW3CCredentialValues to CredentialDetectionResult(
             CredentialPrimaryDataType.W3C,
             W3CSubType.W3C_2,

--- a/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/status/reader/W3CStatusValueReader.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/status/reader/W3CStatusValueReader.kt
@@ -13,7 +13,7 @@ class W3CStatusValueReader(
 ) : JwtStatusValueReaderBase<W3CStatusContent>(formatMatcher, parser) {
 
     override fun parseStatusList(payload: JsonObject): W3CStatusContent {
-        val credentialSubject = payload["vc"]!!.jsonObject["credentialSubject"]?.jsonObject!!
+        val credentialSubject = (payload["vc"]?.jsonObject ?: payload)["credentialSubject"]?.jsonObject!!
         logger.debug { "CredentialSubject: $credentialSubject" }
         return jsonModule.decodeFromJsonElement<W3CStatusContent>(credentialSubject)
     }

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/reader/W3CStatusValueReader.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/reader/W3CStatusValueReader.kt
@@ -13,7 +13,7 @@ class W3CStatusValueReader(
 ) : JwtStatusValueReaderBase<W3CStatusContent>(formatMatcher, parser) {
 
     override fun parseStatusList(payload: JsonObject): W3CStatusContent {
-        val credentialSubject = payload["vc"]!!.jsonObject["credentialSubject"]?.jsonObject!!
+        val credentialSubject = (payload["vc"]?.jsonObject ?: payload)["credentialSubject"]?.jsonObject!!
         logger.debug { "CredentialSubject: $credentialSubject" }
         return jsonModule.decodeFromJsonElement<W3CStatusContent>(credentialSubject)
     }

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/CredentialBuilder.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/CredentialBuilder.kt
@@ -7,6 +7,8 @@ import id.walt.w3c.vc.vcs.W3CBaseDataModels
 import id.walt.w3c.vc.vcs.W3CV11DataModel
 import id.walt.w3c.vc.vcs.W3CV2DataModel
 import id.walt.w3c.vc.vcs.W3CVC
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -20,11 +22,14 @@ import kotlin.uuid.ExperimentalUuidApi
 
 @OptIn(ExperimentalJsExport::class)
 @JsExport
+@Serializable
 enum class CredentialBuilderType {
     /** W3C Verifiable Credential version 1.1 */
+    @SerialName("W3CV11")
     W3CV11CredentialBuilder,
 
     /** W3C Verifiable Credential version 2.0 */
+    @SerialName("W3CV2")
     W3CV2CredentialBuilder,
 
     MdocsCredentialBuilder // TODO

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
@@ -179,7 +179,13 @@ object Issuer {
 
         val mapped = this.mergeWithMapping(mappings, mergedContext, dataFunctions)
 
-        val vc = mapped.vc
+        // For VCDM 2.0, rename V1.1-only date fields to their VCDM 2.0 equivalents
+        val vc = if (mapped.vc.isV2()) {
+            val m = mapped.vc.toMutableMap()
+            m.remove("issuanceDate")?.let { v -> if ("validFrom" !in m) m["validFrom"] = v }
+            m.remove("expirationDate")?.let { v -> if ("validUntil" !in m) m["validUntil"] = v }
+            W3CVC(m)
+        } else mapped.vc
         val jwtRes = mapped.results.mapKeys { it.key.removePrefix("jwt:") }.toMutableMap()
 
         fun completeJwtAttributes(attribute: String, completer: () -> JsonElement?) {
@@ -200,14 +206,12 @@ object Issuer {
                     ?: vc[VcClaims.V2.NotAfter.getValue()]?.let { Instant.parse(it.jsonPrimitive.content) }
                         ?.epochSeconds?.let { JsonPrimitive(it) }
             }
-            completeJwtAttributes("iat") {
-                vc["issuanceDate"]?.let { Instant.parse(it.jsonPrimitive.content) }
-                    ?.epochSeconds?.let { JsonPrimitive(it) }
-            }
-            completeJwtAttributes("nbf") {
-                vc["issuanceDate"]?.let { Instant.parse(it.jsonPrimitive.content) }
-                    ?.epochSeconds?.let { JsonPrimitive(it) }
-            }
+            // V1.1 uses issuanceDate, V2.0 uses validFrom — try both
+            val issuanceInstant =
+                (vc[VcClaims.V1.NotBefore.getValue()] ?: vc[VcClaims.V2.NotBefore.getValue()])
+                    ?.let { Instant.parse(it.jsonPrimitive.content) }
+            completeJwtAttributes("iat") { issuanceInstant?.epochSeconds?.let { JsonPrimitive(it) } }
+            completeJwtAttributes("nbf") { issuanceInstant?.epochSeconds?.let { JsonPrimitive(it) } }
         }
 
         return IssuanceInformation(vc, jwtRes)

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
@@ -82,9 +82,7 @@ object Issuer {
             issuerId = issuerId,
             issuerKid = getKidHeader(issuerKey, issuerDid),
             subjectDid = subjectDid,
-            additionalJwtHeader = additionalJwtHeader.toMutableMap().apply {
-                put("typ", "JWT".toJsonElement())
-            },
+            additionalJwtHeader = additionalJwtHeader,
             additionalJwtOptions = additionalJwtOptions.toMutableMap().apply {
                 putAll(jwtOptions)
             }

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/schemes/JwsSignatureScheme.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/schemes/JwsSignatureScheme.kt
@@ -42,13 +42,22 @@ class JwsSignatureScheme : SignatureScheme {
     data class KeyInfo(val keyId: String, val key: Key)
     data class KeysInfo(val keyId: String, val keys: Set<Key>)
 
-    fun toPayload(data: JsonObject, jwtOptions: Map<String, JsonElement> = emptyMap()) =
-        mapOf(
-            JwsOption.ISSUER to jwtOptions[JwsOption.ISSUER],
-            JwsOption.SUBJECT to jwtOptions[JwsOption.SUBJECT],
-            JwsOption.VC to data,
-            *(jwtOptions.entries.map { it.toPair() }.toTypedArray())
-        ).toJsonObject()
+    fun toPayload(data: JsonObject, jwtOptions: Map<String, JsonElement> = emptyMap(), wrapInVc: Boolean = true) =
+        if (wrapInVc) {
+            mapOf(
+                JwsOption.ISSUER to jwtOptions[JwsOption.ISSUER],
+                JwsOption.SUBJECT to jwtOptions[JwsOption.SUBJECT],
+                JwsOption.VC to data,
+                *(jwtOptions.entries.map { it.toPair() }.toTypedArray())
+            ).toJsonObject()
+        } else {
+            mapOf(
+                JwsOption.ISSUER to jwtOptions[JwsOption.ISSUER],
+                JwsOption.SUBJECT to jwtOptions[JwsOption.SUBJECT],
+                *(data.entries.map { it.toPair() }.toTypedArray()),
+                *(jwtOptions.entries.map { it.toPair() }.toTypedArray())
+            ).toJsonObject()
+        }
 
     @JvmBlocking
     @JvmAsync
@@ -113,9 +122,10 @@ class JwsSignatureScheme : SignatureScheme {
         jwtHeaders: Map<String, JsonElement> = emptyMap(),
         /** Set additional options in the JWT payload */
         jwtOptions: Map<String, JsonElement> = emptyMap(),
+        wrapInVc: Boolean = true
     ): String {
         val payload = Json.encodeToString(
-            toPayload(data, jwtOptions)
+            toPayload(data, jwtOptions, wrapInVc)
         ).encodeToByteArray()
 
         return key.signJws(payload, jwtHeaders)

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/vc/vcs/W3CVC.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/vc/vcs/W3CVC.kt
@@ -47,6 +47,15 @@ data class W3CVC(
     fun toJson(): String = Json.encodeToString(content)
     fun toPrettyJson(): String = prettyJson.encodeToString(content)
 
+    fun isV2(): Boolean {
+        val context = get("@context") ?: return false
+        return when (context) {
+            is JsonArray -> context.any { it.jsonPrimitive.contentOrNull == "https://www.w3.org/ns/credentials/v2" }
+            is JsonPrimitive -> context.contentOrNull == "https://www.w3.org/ns/credentials/v2"
+            else -> false
+        }
+    }
+
     @JvmBlocking
     @JvmAsync
     @JsPromise
@@ -63,18 +72,28 @@ data class W3CVC(
         additionalJwtOptions: Map<String, JsonElement> = emptyMap()
     ): String {
         val kid = issuerKid ?: issuerKey.getKeyId()
+        val wrapInVc = !isV2()
         val payload = JwsSignatureScheme().toPayload(
             data = this.toJsonObject(),
             jwtOptions = mapOf(
                 JwsOption.ISSUER to JsonPrimitive(issuerId),
                 JwsOption.SUBJECT to JsonPrimitive(subjectDid),
                 *(additionalJwtOptions.entries.map { it.toPair() }.toTypedArray())
-            )
+            ),
+            wrapInVc = wrapInVc
         )
 
         val sdPayload = SDPayload.createSDPayload(
             payload,
-            SDMapBuilder(disclosureMap.decoyMode).addField(JwsOption.VC, sd = false, children = disclosureMap).build()
+            if (wrapInVc) {
+                SDMapBuilder(disclosureMap.decoyMode).addField(
+                    JwsOption.VC,
+                    sd = false,
+                    children = disclosureMap
+                ).build()
+            } else {
+                disclosureMap
+            }
         )
         val signable = Json.encodeToString(sdPayload.undisclosedPayload).toByteArray()
 
@@ -119,6 +138,7 @@ data class W3CVC(
                 JwsOption.SUBJECT to JsonPrimitive(subjectDid),
                 *(additionalJwtOptions.entries.map { it.toPair() }.toTypedArray())
             ),
+            wrapInVc = !isV2()
         )
     }
 

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/vc/vcs/W3CVC.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/vc/vcs/W3CVC.kt
@@ -125,14 +125,16 @@ data class W3CVC(
         additionalJwtOptions: Map<String, JsonElement> = emptyMap()
     ): String {
         val kid = issuerKid ?: issuerKey.getKeyId()
+        val typHeader = if (isV2()) "vc+jwt" else "JWT"
+        val baseHeaders = mapOf(
+            JwsHeader.KEY_ID to kid.toJsonElement(),
+            "typ" to typHeader.toJsonElement(),
+        )
 
         return JwsSignatureScheme().sign(
             data = this.toJsonObject(),
             key = issuerKey,
-            jwtHeaders = mapOf(
-                JwsHeader.KEY_ID to kid.toJsonElement(),
-                *(additionalJwtHeader.entries.map { it.toPair() }.toTypedArray())
-            ),
+            jwtHeaders = baseHeaders + additionalJwtHeader,
             jwtOptions = mapOf(
                 JwsOption.ISSUER to JsonPrimitive(issuerId),
                 JwsOption.SUBJECT to JsonPrimitive(subjectDid),

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
@@ -840,19 +840,37 @@ object OpenID4VCI {
         } ?: credentialData
 
         return W3CVC(vcPayload).let { vc ->
-            val builderType = w3cVersion?.let {
-                CredentialBuilderType.valueOf(it)
+            val builderType = w3cVersion?.let { version ->
+                val serialNameMap = mapOf(
+                    "W3CV11" to CredentialBuilderType.W3CV11CredentialBuilder,
+                    "W3CV2" to CredentialBuilderType.W3CV2CredentialBuilder,
+                )
+                CredentialBuilderType.entries.firstOrNull { it.name == version }
+                    ?: serialNameMap[version]
+                    ?: CredentialBuilderType.entries.firstOrNull {
+                        it.name.equals(version, ignoreCase = true)
+                    }
+                    ?: serialNameMap.entries.firstOrNull {
+                        it.key.equals(version, ignoreCase = true)
+                    }?.value
+                    ?: throw CredentialError(
+                        credentialRequest = credentialRequest,
+                        errorCode = CredentialErrorCode.unsupported_credential_type,
+                        message = "Unsupported w3cVersion: '$version'. Supported values: ${
+                            (CredentialBuilderType.entries.map { it.name } + serialNameMap.keys).joinToString { "'$it'" }
+                        }"
+                    )
             }
             val w3cVc = when (builderType) {
                 CredentialBuilderType.W3CV2CredentialBuilder -> {
                     val v2ContextUri = W3CV2DataModel.defaultContext.first()
                     val v11ContextUri = W3CV11DataModel.defaultContext.first()
                     val base = if (vc.isV2()) vc.toMutableMap() else {
-                        val existing = credentialData["@context"]
+                        val existing = vcPayload["@context"]
                             ?.let { if (it is JsonArray) it.map { e -> e.jsonPrimitive.content } else listOf(it.jsonPrimitive.content) }
                             ?: emptyList()
                         val merged = (listOf(v2ContextUri) + existing).distinct()
-                        credentialData.toMutableMap().also { map ->
+                        vcPayload.toMutableMap().also { map ->
                             map["@context"] = JsonArray(merged.map { JsonPrimitive(it) })
                         }
                     }
@@ -866,7 +884,7 @@ object OpenID4VCI {
                 }
                 else -> builderType?.let {
                     val builder = CredentialBuilder(it)
-                    builder.useCredentialSubject(credentialData)
+                    builder.useCredentialSubject(vcPayload)
                     builder.buildW3C()
                 } ?: vc
             }

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
@@ -692,6 +692,7 @@ object OpenID4VCI {
         x5Chain: List<String>? = null,
         display: List<DisplayProperties>? = null,
         sdJwtTypeHeader: String? = null,
+        sdJwtCredentialClaims: JsonObject? = null,
     ): String {
         val proofHeader = credentialRequest.proof?.jwt?.let { JwtUtils.parseJWTHeader(it) }
             ?: throw CredentialError(
@@ -772,9 +773,10 @@ object OpenID4VCI {
         }
 
 
-        val undisclosedPayload = sdPayload.undisclosedPayload.plus(defaultPayloadProperties).let { JsonObject(it) }
+        val extraClaims = sdJwtCredentialClaims ?: emptyMap()
+        val undisclosedPayload = sdPayload.undisclosedPayload.plus(defaultPayloadProperties).plus(extraClaims).let { JsonObject(it) }
 
-        val fullPayload = sdPayload.fullPayload.plus(defaultPayloadProperties).let { JsonObject(it) }
+        val fullPayload = sdPayload.fullPayload.plus(defaultPayloadProperties).plus(extraClaims).let { JsonObject(it) }
 
         val issuerDid = if (DidUtils.isDidUrl(issuerId)) issuerId else null
 

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
@@ -42,6 +42,8 @@ import id.walt.w3c.issuance.Issuer.mergingSdJwtIssue
 import id.walt.w3c.issuance.dataFunctions
 import id.walt.w3c.utils.CredentialDataMergeUtils.mergeSDJwtVCPayloadWithMapping
 import id.walt.w3c.utils.VCFormat
+import id.walt.w3c.vc.vcs.W3CV11DataModel
+import id.walt.w3c.vc.vcs.W3CV2DataModel
 import id.walt.w3c.vc.vcs.W3CVC
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.call.*
@@ -836,14 +838,20 @@ object OpenID4VCI {
             }
             val w3cVc = when (builderType) {
                 CredentialBuilderType.W3CV2CredentialBuilder -> {
+                    val v2ContextUri = W3CV2DataModel.defaultContext.first()
+                    val v11ContextUri = W3CV11DataModel.defaultContext.first()
                     val base = if (vc.isV2()) vc.toMutableMap() else {
                         val existing = credentialData["@context"]
                             ?.let { if (it is JsonArray) it.map { e -> e.jsonPrimitive.content } else listOf(it.jsonPrimitive.content) }
                             ?: emptyList()
-                        val merged = (listOf(id.walt.w3c.vc.vcs.W3CV2DataModel.defaultContext.first()) + existing).distinct()
+                        val merged = (listOf(v2ContextUri) + existing).distinct()
                         credentialData.toMutableMap().also { map ->
                             map["@context"] = JsonArray(merged.map { JsonPrimitive(it) })
                         }
+                    }
+                    (base["@context"] as? JsonArray)?.let { arr ->
+                        val cleaned = arr.filter { it.jsonPrimitive.contentOrNull != v11ContextUri }
+                        if (cleaned.size != arr.size) base["@context"] = JsonArray(cleaned)
                     }
                     base.remove("issuanceDate")?.let { v -> if ("validFrom" !in base) base["validFrom"] = v }
                     base.remove("expirationDate")?.let { v -> if ("validUntil" !in base) base["validUntil"] = v }

--- a/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/commonMain/kotlin/id/walt/oid4vc/OpenID4VCI.kt
@@ -34,6 +34,8 @@ import id.walt.sdjwt.SDJwtVC.Companion.SD_JWT_VC_TYPE_HEADER
 import id.walt.sdjwt.SDJwtVC.Companion.defaultPayloadProperties
 import id.walt.sdjwt.SDMap
 import id.walt.sdjwt.SDPayload
+import id.walt.w3c.CredentialBuilder
+import id.walt.w3c.CredentialBuilderType
 import id.walt.w3c.issuance.Issuer.getKidHeader
 import id.walt.w3c.issuance.Issuer.mergingJwtIssue
 import id.walt.w3c.issuance.Issuer.mergingSdJwtIssue
@@ -809,7 +811,8 @@ object OpenID4VCI {
         selectiveDisclosure: SDMap? = null,
         dataMapping: JsonObject? = null,
         x5Chain: List<String>? = null,
-        display: List<DisplayProperties>? = null
+        display: List<DisplayProperties>? = null,
+        w3cVersion: String? = null
     ): String {
         val proofHeader = credentialRequest.proof?.jwt?.let { JwtUtils.parseJWTHeader(it) }
             ?: throw CredentialError(
@@ -828,6 +831,31 @@ object OpenID4VCI {
         } ?: mapOf()
 
         return W3CVC(credentialData).let { vc ->
+            val builderType = w3cVersion?.let {
+                CredentialBuilderType.valueOf(it)
+            }
+            val w3cVc = when (builderType) {
+                CredentialBuilderType.W3CV2CredentialBuilder -> {
+                    val base = if (vc.isV2()) vc.toMutableMap() else {
+                        val existing = credentialData["@context"]
+                            ?.let { if (it is JsonArray) it.map { e -> e.jsonPrimitive.content } else listOf(it.jsonPrimitive.content) }
+                            ?: emptyList()
+                        val merged = (listOf(id.walt.w3c.vc.vcs.W3CV2DataModel.defaultContext.first()) + existing).distinct()
+                        credentialData.toMutableMap().also { map ->
+                            map["@context"] = JsonArray(merged.map { JsonPrimitive(it) })
+                        }
+                    }
+                    base.remove("issuanceDate")?.let { v -> if ("validFrom" !in base) base["validFrom"] = v }
+                    base.remove("expirationDate")?.let { v -> if ("validUntil" !in base) base["validUntil"] = v }
+                    W3CVC(base)
+                }
+                else -> builderType?.let {
+                    val builder = CredentialBuilder(it)
+                    builder.useCredentialSubject(credentialData)
+                    builder.buildW3C()
+                } ?: vc
+            }
+
             val context = mapOf(
                 "subjectDid" to holderDid,
                 "issuerDid" to issuerId,
@@ -844,7 +872,7 @@ object OpenID4VCI {
                 }
             }
             when (selectiveDisclosure.isNullOrEmpty()) {
-                true -> vc.mergingJwtIssue(
+                true -> w3cVc.mergingJwtIssue(
                     issuerKey = issuerKey,
                     issuerId = issuerId,
                     subjectDid = holderDid ?: "",
@@ -855,7 +883,7 @@ object OpenID4VCI {
                     context = context
                 )
 
-                else -> vc.mergingSdJwtIssue(
+                else -> w3cVc.mergingSdJwtIssue(
                     issuerKey = issuerKey,
                     issuerId = issuerId,
                     subjectDid = holderDid ?: "",

--- a/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/CiJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/CiJvmTest.kt
@@ -241,14 +241,11 @@ class CiJvmTest {
     }
 
     private fun verifyIssuerAndSubjectId(credential: JsonObject, issuerId: String, subjectId: String) {
-        assertEquals(expected = issuerId, actual = credential["issuer"]?.jsonPrimitive?.contentOrNull)
+        val actualIssuer = credential["issuer"]?.jsonPrimitive?.contentOrNull
+        assertEquals(expected = issuerId, actual = actualIssuer)
         //credential["credentialSubject"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull shouldBe subjectId // TODO <-- use this
-        assertEquals(
-            expected = subjectId,
-            actual = credential["credentialSubject"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull?.substringBefore(
-                "#"
-            )
-        ) // FIXME <-- remove
+        val actualSubject = credential["credentialSubject"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull?.substringBefore("#")
+        assertEquals(expected = subjectId, actual = actualSubject)
     }
 
     val issuerPortalRequest =

--- a/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/OpenId4VciTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/OpenId4VciTest.kt
@@ -801,6 +801,19 @@ class OpenId4VciTest {
             })
         }
 
+        val credentialDataV20MixedContext = buildJsonObject {
+            put("@context", JsonArray(listOf(
+                JsonPrimitive("https://www.w3.org/ns/credentials/v2"),
+                JsonPrimitive("https://www.w3.org/2018/credentials/v1"),
+                JsonPrimitive("https://purl.imsglobal.org/spec/ob/v3p0/context.json"),
+            )))
+            put("type", JsonArray(listOf(JsonPrimitive("VerifiableCredential"), JsonPrimitive("OpenBadgeCredential"))))
+            put("issuer", JsonPrimitive(issuerId))
+            put("credentialSubject", buildJsonObject {
+                put("id", JsonPrimitive("did:example:subject"))
+            })
+        }
+
         // Mock proof of possession
         val dummyProof = ProofOfPossession.fromJSON(buildJsonObject {
             put("proof_type", JsonPrimitive("jwt"))
@@ -824,8 +837,10 @@ class OpenId4VciTest {
             w3cVersion = CredentialBuilderType.W3CV11CredentialBuilder.name
         )
         println("VC V1.1: $vcV11")
+        val headerV11 = vcV11.substringBefore("~").decodeJws().header
         val payloadV11 = SDJwt.parse(vcV11).fullPayload
         assertTrue(payloadV11.containsKey("vc"), "V1.1 should have 'vc' claim")
+        assertEquals("JWT", headerV11["typ"]?.jsonPrimitive?.content, "V1.1 typ must be 'JWT'")
 
         // Test V2.0 (should NOT have "vc" claim; credential claims appear directly in JWT payload)
         val vcV20 = OpenID4VCI.generateW3CJwtVC(
@@ -836,10 +851,28 @@ class OpenId4VciTest {
             w3cVersion = CredentialBuilderType.W3CV2CredentialBuilder.name
         )
         println("VC V2.0: $vcV20")
+        val headerV20 = vcV20.substringBefore("~").decodeJws().header
         val payloadV20 = SDJwt.parse(vcV20).fullPayload
         assertFalse(payloadV20.containsKey("vc"), "V2.0 should NOT have 'vc' claim")
         assertEquals(expected = issuerId, actual = payloadV20["issuer"]?.jsonPrimitive?.content)
         assertNotNull(payloadV20["credentialSubject"], "V2.0 should have 'credentialSubject' at top level")
+        val contextV20 = payloadV20["@context"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertTrue("https://www.w3.org/ns/credentials/v2" in contextV20, "V2.0 @context must contain v2 URI")
+        assertFalse("https://www.w3.org/2018/credentials/v1" in contextV20, "V2.0 @context must not contain v1.1 URI")
+        assertEquals("vc+jwt", headerV20["typ"]?.jsonPrimitive?.content, "V2.0 typ must be 'vc+jwt'")
+
+        val vcV20Mixed = OpenID4VCI.generateW3CJwtVC(
+            credentialRequest,
+            credentialData = credentialDataV20MixedContext,
+            issuerKey = issuerKey,
+            issuerId = issuerId,
+            w3cVersion = CredentialBuilderType.W3CV2CredentialBuilder.name
+        )
+        val payloadV20Mixed = SDJwt.parse(vcV20Mixed).fullPayload
+        val contextV20Mixed = payloadV20Mixed["@context"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertFalse("https://www.w3.org/2018/credentials/v1" in contextV20Mixed, "V2.0 @context must not contain v1.1 URI even when present in input")
+        assertTrue("https://www.w3.org/ns/credentials/v2" in contextV20Mixed, "V2.0 @context must retain v2 URI")
+        assertTrue("https://purl.imsglobal.org/spec/ob/v3p0/context.json" in contextV20Mixed, "V2.0 @context must retain other context URIs")
     }
 
     private fun verifyIssuerAndSubjectId(credential: JsonObject, issuerId: String, subjectId: String) {

--- a/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/OpenId4VciTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc/src/jvmTest/kotlin/id/walt/oid4vc/OpenId4VciTest.kt
@@ -221,10 +221,18 @@ class OpenId4VciTest {
         println("// parse and verify credential")
         val credential = credentialResponse.credential.jsonPrimitive.content
         println(">>> Issued credential: $credential")
-        verifyIssuerAndSubjectId(
-            SDJwt.parse(credential).fullPayload["vc"]?.jsonObject!!,
-            ISSUER_DID, WALLET_DID
-        )
+        val fullPayload = SDJwt.parse(credential).fullPayload
+        if (fullPayload.containsKey("vc")) {
+            verifyIssuerAndSubjectId(
+                fullPayload["vc"]?.jsonObject!!,
+                ISSUER_DID, WALLET_DID
+            )
+        } else {
+            verifyIssuerAndSubjectId(
+                fullPayload,
+                ISSUER_DID, WALLET_DID
+            )
+        }
         assertTrue(actual = JwtSignaturePolicy().verify(credential, null, mapOf()).isSuccess)
 
         // test jwt-vc-issuer well-known url with URL path segments
@@ -768,6 +776,70 @@ class OpenId4VciTest {
         //Then VC Stuff
 
 
+    }
+
+    @Test
+    fun testW3CV2CredentialIssuance() = runTest {
+        println("// -------- W3C V2 CREDENTIAL ISSUANCE TEST ----------")
+        val issuerKey = ISSUER_DID_KEY
+        val issuerId = ISSUER_DID
+
+        // V1.1: subject-only data — CredentialBuilder wraps it into a full V1.1 credential
+        val credentialDataV11 = buildJsonObject {
+            put("id", JsonPrimitive("did:example:subject"))
+            put("name", JsonPrimitive("Jane Doe"))
+        }
+
+        // V2.0: full VCDM 2.0 credential — used as-is, no vc wrapper should be added
+        val credentialDataV20 = buildJsonObject {
+            put("@context", JsonArray(listOf(JsonPrimitive("https://www.w3.org/ns/credentials/v2"))))
+            put("type", JsonArray(listOf(JsonPrimitive("VerifiableCredential"), JsonPrimitive("VerifiableId"))))
+            put("issuer", JsonPrimitive(issuerId))
+            put("credentialSubject", buildJsonObject {
+                put("id", JsonPrimitive("did:example:subject"))
+                put("name", JsonPrimitive("Jane Doe"))
+            })
+        }
+
+        // Mock proof of possession
+        val dummyProof = ProofOfPossession.fromJSON(buildJsonObject {
+            put("proof_type", JsonPrimitive("jwt"))
+            put("jwt", JsonPrimitive("eyJhbGciOiJFUzI1NiIsImtpZCI6ImRpZDpleGFtcGxlOmhvbGRlciNrZXkifQ.eypub25jZSI6InRlc3QifQ.dummy"))
+        })
+
+        val credentialRequest = CredentialRequest.forOfferedCredential(
+            offeredCredential = OfferedCredential(
+                format = CredentialFormat.jwt_vc_json,
+                credentialDefinition = CredentialDefinition(type = listOf("VerifiableCredential", "VerifiableId"))
+            ),
+            proof = dummyProof
+        )
+
+        // Test V1.1 (should have "vc" claim)
+        val vcV11 = OpenID4VCI.generateW3CJwtVC(
+            credentialRequest,
+            credentialData = credentialDataV11,
+            issuerKey = issuerKey,
+            issuerId = issuerId,
+            w3cVersion = CredentialBuilderType.W3CV11CredentialBuilder.name
+        )
+        println("VC V1.1: $vcV11")
+        val payloadV11 = SDJwt.parse(vcV11).fullPayload
+        assertTrue(payloadV11.containsKey("vc"), "V1.1 should have 'vc' claim")
+
+        // Test V2.0 (should NOT have "vc" claim; credential claims appear directly in JWT payload)
+        val vcV20 = OpenID4VCI.generateW3CJwtVC(
+            credentialRequest,
+            credentialData = credentialDataV20,
+            issuerKey = issuerKey,
+            issuerId = issuerId,
+            w3cVersion = CredentialBuilderType.W3CV2CredentialBuilder.name
+        )
+        println("VC V2.0: $vcV20")
+        val payloadV20 = SDJwt.parse(vcV20).fullPayload
+        assertFalse(payloadV20.containsKey("vc"), "V2.0 should NOT have 'vc' claim")
+        assertEquals(expected = issuerId, actual = payloadV20["issuer"]?.jsonPrimitive?.content)
+        assertNotNull(payloadV20["credentialSubject"], "V2.0 should have 'credentialSubject' at top level")
     }
 
     private fun verifyIssuerAndSubjectId(credential: JsonObject, issuerId: String, subjectId: String) {

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/core/DefaultOAuth2Provider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/core/DefaultOAuth2Provider.kt
@@ -231,6 +231,7 @@ class DefaultOAuth2Provider(
         selectiveDisclosure: SDMap?,
         x5Chain: List<String>?,
         display: List<DisplayProperties>?,
+        w3cVersion: String?,
     ): CredentialResponseResult {
         val handler = config.credentialEndpointHandlers.get(configuration.format)
             ?: return CredentialResponseResult.Failure(
@@ -249,6 +250,7 @@ class DefaultOAuth2Provider(
             selectiveDisclosure = selectiveDisclosure,
             x5Chain = x5Chain,
             display = display,
+            w3cVersion = w3cVersion,
         )
     }
 

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/core/OAuth2Provider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/core/OAuth2Provider.kt
@@ -85,6 +85,7 @@ interface OAuth2Provider {
         selectiveDisclosure: SDMap? = null,
         x5Chain: List<String>? = null,
         display: List<DisplayProperties>? = null,
+        w3cVersion: String? = null,
     ): CredentialResponseResult
 
     fun writeCredentialError(request: CredentialRequest, error: OAuthError): CredentialResponseHttp

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/credential/SdJwtVcCredentialHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/credential/SdJwtVcCredentialHandler.kt
@@ -32,6 +32,7 @@ class SdJwtVcCredentialHandler : CredentialEndpointHandler {
         selectiveDisclosure: SDMap?,
         x5Chain: List<String>?,
         display: List<DisplayProperties>?,
+        w3cVersion: String?,
     ): CredentialResponseResult {
         return try {
             val oid4vcFormat = when (configuration.format) {

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/credential/W3cJwtVcCredentialHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/credential/W3cJwtVcCredentialHandler.kt
@@ -32,6 +32,7 @@ class W3cJwtVcCredentialHandler : CredentialEndpointHandler {
         selectiveDisclosure: SDMap?,
         x5Chain: List<String>?,
         display: List<DisplayProperties>?,
+        w3cVersion: String?,
     ): CredentialResponseResult {
         return try {
             val oid4vcFormat = when (configuration.format) {
@@ -62,6 +63,7 @@ class W3cJwtVcCredentialHandler : CredentialEndpointHandler {
                 dataMapping = dataMapping,
                 x5Chain = x5Chain,
                 display = display,
+                w3cVersion = w3cVersion,
             )
 
             CredentialResponseResult.Success(

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/endpoints/credential/CredentialEndpointHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/endpoints/credential/CredentialEndpointHandler.kt
@@ -22,5 +22,6 @@ fun interface CredentialEndpointHandler {
         selectiveDisclosure: SDMap?,
         x5Chain: List<String>?,
         display: List<DisplayProperties>?,
+        w3cVersion: String?,
     ): CredentialResponseResult
 }

--- a/waltid-services/waltid-issuer-api/src/test/kotlin/id/walt/issuance2/NewIssuanceStub.kt
+++ b/waltid-services/waltid-issuer-api/src/test/kotlin/id/walt/issuance2/NewIssuanceStub.kt
@@ -219,10 +219,18 @@ suspend fun main() {
     println("// parse and verify credential")
     val credential = credentialResponse.credential!!.jsonPrimitive.content
     println(">>> Issued credential: $credential")
-    verifyIssuerAndSubjectId(
-        SDJwt.parse(credential).fullPayload["vc"]?.jsonObject!!,
-        testIssuerDid, TEST_WALLET_DID_WEB1
-    )
+    val fullPayload = SDJwt.parse(credential).fullPayload
+    if (fullPayload.containsKey("vc")) {
+        verifyIssuerAndSubjectId(
+            fullPayload["vc"]?.jsonObject!!,
+            testIssuerDid, TEST_WALLET_DID_WEB1
+        )
+    } else {
+        verifyIssuerAndSubjectId(
+            fullPayload,
+            testIssuerDid, TEST_WALLET_DID_WEB1
+        )
+    }
     check(JwtSignaturePolicy().verify(credential, null, mapOf()).isSuccess)
 }
 


### PR DESCRIPTION
This pull request introduces comprehensive improvements to support and correctly handle both W3C Verifiable Credential Data Model (VCDM) 1.1 and 2.0 versions throughout the credential issuance, parsing, and verification flows. The changes ensure that VCDM 2.0 credentials use their updated field names and context, and that the codebase can flexibly process credentials in either version, including when wrapped in JWT or SD-JWT envelopes. Additional enhancements include improved parsing logic, more robust test coverage, and expanded OpenID4VCI support for specifying the W3C version.

**W3C VCDM 2.0 Support and Compatibility**

- Added logic to detect VCDM 2.0 credentials via the `@context` field and to rename V1.1 date fields (`issuanceDate`/`expirationDate`) to their V2.0 equivalents (`validFrom`/`validUntil`) during issuance, ensuring correct field mapping for V2.0 credentials. (`W3CVC.kt`, `Issuer.kt`) [[1]](diffhunk://#diff-28de7c4ea314dba93ecb07cf515648bb047a5d41bb9f8d83136c5d0dd65edb61R50-R58) [[2]](diffhunk://#diff-4b915edbbd1b582eef79588417420e1190c80c5e610c36e06dcc72abdb11de23L182-R188)
- Updated JWT payload and SD-JWT selective disclosure handling to avoid unnecessary `vc` wrapping for V2.0 credentials, and to use the correct field names in JWT claims (`iat`/`nbf`). (`W3CVC.kt`, `JwsSignatureScheme.kt`) [[1]](diffhunk://#diff-28de7c4ea314dba93ecb07cf515648bb047a5d41bb9f8d83136c5d0dd65edb61R75-R96) [[2]](diffhunk://#diff-5216786d4f585042adaec975cfd237dd486fbbf12a77f27e2edab62c70733251L45-R60) [[3]](diffhunk://#diff-5216786d4f585042adaec975cfd237dd486fbbf12a77f27e2edab62c70733251R125-R128) [[4]](diffhunk://#diff-28de7c4ea314dba93ecb07cf515648bb047a5d41bb9f8d83136c5d0dd65edb61R141) [[5]](diffhunk://#diff-4b915edbbd1b582eef79588417420e1190c80c5e610c36e06dcc72abdb11de23L203-R214)

**Credential Parsing and Verification Improvements**

- Enhanced parsing logic to robustly extract issuer and subject from both top-level and nested (`vc`) fields, and to correctly handle credentials that might be wrapped or unwrapped, or missing certain fields. (`CredentialParser.kt`, `W3CStatusValueReader.kt`) [[1]](diffhunk://#diff-c91029644fc5d07a281a7fdb4ba02632085a909ab2d567f962f686b2f310fedeL74-R78) [[2]](diffhunk://#diff-c91029644fc5d07a281a7fdb4ba02632085a909ab2d567f962f686b2f310fedeL333-R335) [[3]](diffhunk://#diff-c91029644fc5d07a281a7fdb4ba02632085a909ab2d567f962f686b2f310fedeL384-R427) [[4]](diffhunk://#diff-3fbdac89e177fed5b4d93e872601846a2029d198c008866e516f381809ec19ddL16-R16) [[5]](diffhunk://#diff-96f273255d2c39b744804f17b52a22794bab49d91d5921f3aea487f9a89f56c1L16-R16)

**OpenID4VCI Protocol Enhancements**

- Extended OpenID4VCI to allow specifying the desired W3C version for credential issuance, with logic to build, map, and issue credentials accordingly, including correct context and field mapping for V2.0. (`OpenID4VCI.kt`) [[1]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dR37-R38) [[2]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dL812-R815) [[3]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dR834-R858) [[4]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dL847-R875) [[5]](diffhunk://#diff-db7442d3c06dbd9eacb10da0609fb901486c7de2c43789e67e535b7839cf250dL858-R886)

**Testing and Validation**

- Improved test utilities and test cases to verify issuer and subject IDs for both wrapped and unwrapped credentials, and to ensure that credentials conform to the expected data model version and structure. (`CiJvmTest.kt`, `OpenId4VciTest.kt`) [[1]](diffhunk://#diff-38291e0879c612e44fdb2ff8f5dde4505d3f3c9943dae578bf1d185fd2dba15aL244-R248) [[2]](diffhunk://#diff-c97191a60e38cf843363d627fce24a28de705fffdbf50fecafe277876cca8e6fR224-R235)

These changes collectively ensure robust, future-proof handling of W3C credentials across multiple versions and issuance flows, with improved reliability and flexibility in both core libraries and protocol implementations.