### PR TITLE
feat(openid4vci): add issuanceSessionId to pre-authorized code for O(…

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/granttypes/preauthorizedcode/PreAuthorizedCodeTokenEndpoint.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/granttypes/preauthorizedcode/PreAuthorizedCodeTokenEndpoint.kt
@@ -115,6 +115,7 @@ class PreAuthorizedCodeTokenEndpoint(
             additional = buildMap {
                 put("client_id", clientId)
                 put("pre_authorized_code", code)
+                consumed.issuanceSessionId?.let { put("issuance_session_id", it) }
             },
         )
 

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/preauthorized/PreAuthorizedCodeIssuer.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/preauthorized/PreAuthorizedCodeIssuer.kt
@@ -43,6 +43,8 @@ data class PreAuthorizedCodeIssueRequest(
     val session: Session,
     val credentialNonce: String? = null,
     val credentialNonceExpiresAt: Instant? = null,
+    /** Optional issuance session ID for O(1) lookup on credential endpoint */
+    val issuanceSessionId: String? = null,
 )
 
 data class PreAuthorizedCodeIssueResult(
@@ -91,6 +93,7 @@ class DefaultPreAuthorizedCodeIssuer(
                 expiresAt = expiresAt,
                 credentialNonce = request.credentialNonce,
                 credentialNonceExpiresAt = request.credentialNonceExpiresAt,
+                issuanceSessionId = request.issuanceSessionId,
             )
         }
 

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/repository/preauthorized/PreAuthorizedCodeRepository.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/repository/preauthorized/PreAuthorizedCodeRepository.kt
@@ -26,6 +26,9 @@ interface PreAuthorizedCodeRecord {
     val expiresAt: Instant
     val credentialNonce: String?
     val credentialNonceExpiresAt: Instant?
+    /** Optional issuance session ID for O(1) lookup on credential endpoint */
+    val issuanceSessionId: String?
+        get() = null
 }
 
 data class DefaultPreAuthorizedCodeRecord(
@@ -39,4 +42,5 @@ data class DefaultPreAuthorizedCodeRecord(
     override val expiresAt: Instant,
     override val credentialNonce: String?,
     override val credentialNonceExpiresAt: Instant?,
+    override val issuanceSessionId: String? = null,
 ) : PreAuthorizedCodeRecord


### PR DESCRIPTION
…1) lookup

Support session ID propagation through access tokens to enable O(1 credential endpoint lookups instead of O(n) parent-child scans.

Changes:
- Add issuanceSessionId field to PreAuthorizedCodeRecord interface
- Add issuanceSessionId to DefaultPreAuthorizedCodeRecord
- Add issuanceSessionId to PreAuthorizedCodeIssueRequest
- Include issuance_session_id claim in access token when available

This enables credential endpoints to perform direct _id lookups instead of scanning all children under the issuer's parent path.

## Description

Provide a clear and concise description of the changes made in this pull request:

## Type of Change

- [ ] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality

## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-
