### PR TITLE
CI stability: wait for healthy services and harden npm install retries

### DIFF
--- a/docker-compose/ping.sh
+++ b/docker-compose/ping.sh
@@ -24,7 +24,8 @@ ping()
     done
 
     attempt=1
-    until response="$(curl -fsS "$livez_url" 2>/dev/null)" && [[ "$response" == *'"status":"Healthy"'* ]]; do
+    until response="$(curl -fsS "$livez_url" 2>/dev/null)" \
+        && printf '%s' "$response" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"Healthy"'; do
         if [[ "$attempt" -ge "$max_attempts" ]]; then
             echo "${service}-api did not become healthy in time"
             curl -sS "$livez_url" || true

--- a/docker-compose/ping.sh
+++ b/docker-compose/ping.sh
@@ -1,21 +1,41 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -eu pipefail
-set echo off
+set -euo pipefail
 
 # functions
 ping()
 {
-    local service=$1
-    local port=$2
-    shift; shift;
-    COMMENTS=$@
-    echo "Pending $service-api"
-    until $(nc -zv localhost "$port"); do
+    local service="$1"
+    local port="$2"
+    local livez_url="http://localhost:${port}/livez"
+    local max_attempts=60
+    local attempt=1
+
+    echo "Waiting for ${service}-api on ${livez_url}"
+
+    until nc -z localhost "$port" >/dev/null 2>&1; do
+        if [[ "$attempt" -ge "$max_attempts" ]]; then
+            echo "${service}-api did not open port ${port} in time"
+            return 1
+        fi
         printf '.'
-        sleep 5
+        sleep 2
+        ((attempt++))
     done
-    echo "$service-api livez!"
+
+    attempt=1
+    until response="$(curl -fsS "$livez_url" 2>/dev/null)" && [[ "$response" == *'"status":"Healthy"'* ]]; do
+        if [[ "$attempt" -ge "$max_attempts" ]]; then
+            echo "${service}-api did not become healthy in time"
+            curl -sS "$livez_url" || true
+            return 1
+        fi
+        printf '.'
+        sleep 2
+        ((attempt++))
+    done
+
+    echo "${service}-api is healthy"
 }
 
 # main

--- a/waltid-applications/waltid-credentials/Dockerfile
+++ b/waltid-applications/waltid-credentials/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:alpine AS buildstage
+FROM node:22-alpine AS buildstage
 COPY ./package.json /build/
 WORKDIR /build
 RUN npm config set fetch-retries 5 \
@@ -9,7 +9,7 @@ COPY ./ /build
 
 RUN npm run build
 # RUN
-FROM docker.io/node:alpine
+FROM node:22-alpine
 
 # Create non-root user
 RUN addgroup -g 10001 -S appgroup && \

--- a/waltid-applications/waltid-credentials/Dockerfile
+++ b/waltid-applications/waltid-credentials/Dockerfile
@@ -1,7 +1,10 @@
 FROM docker.io/node:alpine AS buildstage
 COPY ./package.json /build/
 WORKDIR /build
-RUN npm install
+RUN npm config set fetch-retries 5 \
+    && npm config set fetch-retry-mintimeout 20000 \
+    && npm config set fetch-retry-maxtimeout 120000 \
+    && npm install --no-audit --no-fund
 COPY ./ /build
 
 RUN npm run build

--- a/waltid-applications/waltid-web-portal/Dockerfile
+++ b/waltid-applications/waltid-web-portal/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-slim AS buildstage
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.11.1 --activate
 
 COPY waltid-applications/waltid-web-portal/. /build
 


### PR DESCRIPTION
## Summary
- wait for real service health (/livez returns Healthy), not only open ports, before compose API tests run
- harden credentials image dependency install with npm fetch retry/backoff settings
- pin pnpm for the OSS portal Docker build to avoid package-manager drift on Node 20 runners

## Why
Recent WAL-741 PR runs surfaced unrelated CI flakes in shared pipeline infrastructure:
- compose tests sometimes start while wallet service is still Unhealthy (503 on /livez)
- UI image builds occasionally fail during npm/pnpm dependency installation

## Evidence
- compose-test failure example: https://github.com/walt-id/waltid-identity/actions/runs/25482741895/job/74772571475?pr=1694
- compose-test failure example: https://github.com/walt-id/waltid-identity/actions/runs/25481482441/job/74768019784?pr=1695
- docker vc-repository failure example: https://github.com/walt-id/waltid-identity/actions/runs/25445108131/job/74758020634?pr=1694

## Cross-repo alignment
- ESS counterpart PR: https://github.com/walt-id/waltid-identity-enterprise/pull/447
- WAL-741 OSS feature PRs depending on stable CI:
  - https://github.com/walt-id/waltid-identity/pull/1694
  - https://github.com/walt-id/waltid-identity/pull/1695

## Scope
This PR contains only CI/stability fixes and no WAL-741 feature logic.