### PR TITLE
Use host Docker URL in compose CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
       artifact: issuer-api
       tag: "waltid/issuer-api:${{ needs.version.outputs.release_version }}"
   compose-test:
-    uses: walt-id/waltid-identity/.github/workflows/docker-compose-testing.yml@f7b6a96ba6391317d5ad07b0d4589dfbad1770bf
+    uses: walt-id/waltid-identity/.github/workflows/docker-compose-testing.yml@29acc8adb5715ddb198dba0413b5c9af2ac5ba57
     needs: [ version, docker, api-docker ]
     secrets: inherit
     with:

--- a/.github/workflows/docker-compose-testing.yml
+++ b/.github/workflows/docker-compose-testing.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Run stack
         run: |
           cd ./docker-compose
+          sed -i 's/^SERVICE_HOST=.*/SERVICE_HOST=host.docker.internal/' .env
           if [[ "${{ env.use-artifact }}" == "true" ]]; then
             export VERSION_TAG=${{ inputs.tag }}
             build_arg=""


### PR DESCRIPTION
## Summary
- advertise `host.docker.internal` from the docker-compose CI stack instead of `localhost`
- keep runner-facing Postman calls on localhost while generated issuer/verifier URLs remain reachable from service containers

## Context
The compose Postman matrix can fail when `wallet-api` resolves issuer/verifier-generated URLs that point at `localhost`; inside the container that can resolve to the container itself instead of the host-published Caddy port.

## Verification
- `bash -n docker-compose/ping.sh`
- CI validation is also being run from WAL-741 with the same temporary patch.