### PR TITLE
feat(verifier2): structured failure detail for vc_policies + DCQL (WAL-976, WAL-977)

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/CredentialPolicyResults.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/CredentialPolicyResults.kt
@@ -1,6 +1,7 @@
 package id.walt.policies2.vc
 
 import id.walt.policies2.vc.policies.CredentialVerificationPolicy2
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 
@@ -10,5 +11,8 @@ data class CredentialPolicyResult(
     val success: Boolean,
     var result: JsonElement? = null,
     val error: String? = null,
+    @SerialName("query_id")
+    val queryId: String? = null,
+    @SerialName("credential_index")
+    val credentialIndex: Int? = null,
 )
-

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
 
         jvmTest.dependencies {
             implementation("org.slf4j:slf4j-simple:2.0.17")
+            implementation(identityLibs.ktor.server.test.host)
         }
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionEvent.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionEvent.kt
@@ -11,5 +11,6 @@ enum class SessionEvent {
     credential_policy_results_available,
     dcql_fulfillment_check_failed,
     presentation_validation_failed,
+    wallet_error_response_received,
     data_retention_purge
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
@@ -1,0 +1,72 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package id.walt.verifier2.data
+
+import id.walt.policies2.vc.CredentialPolicyResult
+import id.walt.policies2.vp.policies.VPPolicy2
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
+
+@Serializable
+@JsonClassDiscriminator("type")
+sealed class SessionFailure {
+    abstract val reason: String
+
+    @Serializable
+    @SerialName("presentation_validation")
+    data class PresentationValidation(
+        override val reason: String,
+        @SerialName("failed_policies")
+        val failedPolicies: Map<String, Map<String, VPPolicy2.PolicyRunResult>>,
+    ) : SessionFailure()
+
+    @Serializable
+    @SerialName("dcql_fulfillment")
+    data class DcqlFulfillment(
+        override val reason: String,
+        val failure: DcqlFulfillmentFailure,
+    ) : SessionFailure()
+
+    @Serializable
+    @SerialName("vc_policy_violations")
+    data class VcPolicyViolations(
+        override val reason: String,
+        val violations: List<AttributedCredentialPolicyResult>,
+    ) : SessionFailure()
+
+    @Serializable
+    @SerialName("wallet_error_response")
+    data class WalletErrorResponse(
+        override val reason: String,
+        val error: String,
+        @SerialName("error_description")
+        val errorDescription: String? = null,
+        val state: String? = null,
+    ) : SessionFailure()
+}
+
+@Serializable
+data class DcqlFulfillmentFailure(
+    @SerialName("missing_query_ids")
+    val missingQueryIds: List<String> = emptyList(),
+    @SerialName("unsatisfied_sets")
+    val unsatisfiedSets: List<UnsatisfiedSet> = emptyList(),
+    @SerialName("successfully_validated_query_ids")
+    val successfullyValidatedQueryIds: List<String> = emptyList(),
+)
+
+@Serializable
+data class UnsatisfiedSet(
+    val options: List<List<String>>,
+    val required: Boolean,
+)
+
+@Serializable
+data class AttributedCredentialPolicyResult(
+    @SerialName("query_id")
+    val queryId: String,
+    @SerialName("credential_index")
+    val credentialIndex: Int,
+    val result: CredentialPolicyResult,
+)

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
@@ -32,7 +32,7 @@ sealed class SessionFailure {
     @SerialName("vc_policy_violations")
     data class VcPolicyViolations(
         override val reason: String,
-        val violations: List<AttributedCredentialPolicyResult>,
+        val violations: List<CredentialPolicyResult>,
     ) : SessionFailure()
 
     @Serializable
@@ -59,13 +59,4 @@ data class DcqlFulfillmentFailure(
 @Serializable
 data class UnsatisfiedSet(
     val options: List<List<String>>,
-)
-
-@Serializable
-data class AttributedCredentialPolicyResult(
-    @SerialName("query_id")
-    val queryId: String,
-    @SerialName("credential_index")
-    val credentialIndex: Int,
-    val result: CredentialPolicyResult,
 )

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
@@ -49,11 +49,11 @@ sealed class SessionFailure {
 @Serializable
 data class DcqlFulfillmentFailure(
     @SerialName("missing_query_ids")
-    val missingQueryIds: List<String> = emptyList(),
+    val missingQueryIds: Set<String> = emptySet(),
     @SerialName("unsatisfied_sets")
     val unsatisfiedSets: List<UnsatisfiedSet> = emptyList(),
     @SerialName("successfully_validated_query_ids")
-    val successfullyValidatedQueryIds: List<String> = emptyList(),
+    val successfullyValidatedQueryIds: Set<String> = emptySet(),
 )
 
 @Serializable

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionFailure.kt
@@ -59,7 +59,6 @@ data class DcqlFulfillmentFailure(
 @Serializable
 data class UnsatisfiedSet(
     val options: List<List<String>>,
-    val required: Boolean,
 )
 
 @Serializable

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
@@ -114,6 +114,15 @@ data class Verification2Session(
     var presentedCredentials: Map<String, List<DigitalCredential>>? = null,
 
     var statusReason: String? = null,
+
+    /**
+     * Structured failure detail. Populated when the session ends in [VerificationSessionStatus.FAILED]
+     * (presentation validation, DCQL fulfillment, VC policy violations, or an OID4VP §8.5 wallet
+     * error response). Null for successful sessions or sessions that have not reached a failure
+     * state. Additive — legacy consumers that only read [status]/[statusReason] keep working.
+     */
+    @SerialName("failure")
+    var failure: SessionFailure? = null,
 ) {
 
     fun deletePII() {
@@ -131,6 +140,34 @@ data class Verification2Session(
             policyResult.result?.let { resultElement ->
                 policyResult.result = redactCredentialSubject(resultElement)
             }
+        }
+
+        policyResults?.attributedVcPolicies?.forEach { attributed ->
+            attributed.result.result?.let { resultElement ->
+                attributed.result.result = redactCredentialSubject(resultElement)
+            }
+        }
+
+        policyResults?.attributedSpecificVcPolicies?.values?.forEach { list ->
+            list.forEach { attributed ->
+                attributed.result.result?.let { resultElement ->
+                    attributed.result.result = redactCredentialSubject(resultElement)
+                }
+            }
+        }
+
+        when (val f = failure) {
+            is SessionFailure.PresentationValidation -> f.failedPolicies.values.forEach { inner ->
+                inner.values.forEach { it.results = emptyMap() }
+            }
+
+            is SessionFailure.VcPolicyViolations -> f.violations.forEach { attributed ->
+                attributed.result.result?.let { resultElement ->
+                    attributed.result.result = redactCredentialSubject(resultElement)
+                }
+            }
+
+            null, is SessionFailure.DcqlFulfillment, is SessionFailure.WalletErrorResponse -> Unit
         }
     }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
@@ -4,6 +4,7 @@ import id.walt.credentials.formats.DigitalCredential
 import id.walt.credentials.presentations.formats.VerifiablePresentation
 import id.walt.crypto.keys.DirectSerializedKey
 import id.walt.ktornotifications.core.KtorSessionNotifications
+import id.walt.policies2.vc.CredentialPolicyResult
 import id.walt.policies2.vc.VCPolicyList
 import id.walt.policies2.vp.policies.VPPolicy2
 import id.walt.policies2.vp.policies.VPPolicyList
@@ -130,44 +131,32 @@ data class Verification2Session(
         presentedPresentations = null
         presentedCredentials = null
 
+        fun redactPolicyResult(policyResult: CredentialPolicyResult) {
+            policyResult.result?.let { resultElement ->
+                policyResult.result = redactCredentialSubject(resultElement)
+            }
+        }
+
         policyResults?.vpPolicies?.values?.forEach { innerMap ->
             innerMap.values.forEach { policyResult ->
                 policyResult.results = emptyMap()
             }
         }
 
-        policyResults?.vcPolicies?.forEach { policyResult ->
-            policyResult.result?.let { resultElement ->
-                policyResult.result = redactCredentialSubject(resultElement)
-            }
-        }
-
-        policyResults?.attributedVcPolicies?.forEach { attributed ->
-            attributed.result.result?.let { resultElement ->
-                attributed.result.result = redactCredentialSubject(resultElement)
-            }
-        }
-
-        policyResults?.attributedSpecificVcPolicies?.values?.forEach { list ->
-            list.forEach { attributed ->
-                attributed.result.result?.let { resultElement ->
-                    attributed.result.result = redactCredentialSubject(resultElement)
-                }
-            }
-        }
+        buildList<CredentialPolicyResult> {
+            policyResults?.vcPolicies?.let(::addAll)
+            policyResults?.attributedVcPolicies?.mapTo(this) { it.result }
+            policyResults?.attributedSpecificVcPolicies?.values?.flatten()?.mapTo(this) { it.result }
+            (failure as? SessionFailure.VcPolicyViolations)?.violations?.mapTo(this) { it.result }
+        }.forEach(::redactPolicyResult)
 
         when (val f = failure) {
             is SessionFailure.PresentationValidation -> f.failedPolicies.values.forEach { inner ->
                 inner.values.forEach { it.results = emptyMap() }
             }
 
-            is SessionFailure.VcPolicyViolations -> f.violations.forEach { attributed ->
-                attributed.result.result?.let { resultElement ->
-                    attributed.result.result = redactCredentialSubject(resultElement)
-                }
-            }
-
             null, is SessionFailure.DcqlFulfillment, is SessionFailure.WalletErrorResponse -> Unit
+            is SessionFailure.VcPolicyViolations -> Unit
         }
     }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
@@ -145,9 +145,8 @@ data class Verification2Session(
 
         buildList<CredentialPolicyResult> {
             policyResults?.vcPolicies?.let(::addAll)
-            policyResults?.attributedVcPolicies?.mapTo(this) { it.result }
-            policyResults?.attributedSpecificVcPolicies?.values?.flatten()?.mapTo(this) { it.result }
-            (failure as? SessionFailure.VcPolicyViolations)?.violations?.mapTo(this) { it.result }
+            policyResults?.specificVcPolicies?.values?.flatten()?.let(::addAll)
+            (failure as? SessionFailure.VcPolicyViolations)?.violations?.let(::addAll)
         }.forEach(::redactPolicyResult)
 
         when (val f = failure) {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/Verification2Session.kt
@@ -143,20 +143,15 @@ data class Verification2Session(
             }
         }
 
-        buildList<CredentialPolicyResult> {
+        buildList {
             policyResults?.vcPolicies?.let(::addAll)
             policyResults?.specificVcPolicies?.values?.flatten()?.let(::addAll)
             (failure as? SessionFailure.VcPolicyViolations)?.violations?.let(::addAll)
         }.forEach(::redactPolicyResult)
 
-        when (val f = failure) {
-            is SessionFailure.PresentationValidation -> f.failedPolicies.values.forEach { inner ->
-                inner.values.forEach { it.results = emptyMap() }
-            }
-
-            null, is SessionFailure.DcqlFulfillment, is SessionFailure.WalletErrorResponse -> Unit
-            is SessionFailure.VcPolicyViolations -> Unit
-        }
+        (failure as? SessionFailure.PresentationValidation)?.failedPolicies?.values
+            ?.flatMap { it.values }
+            ?.forEach { it.results = emptyMap() }
     }
 
     private fun redactCredentialSubject(resultElement: JsonElement): JsonElement {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2SessionCredentialPolicyValidation.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2SessionCredentialPolicyValidation.kt
@@ -3,7 +3,6 @@ package id.walt.verifier2.handlers.vpresponse
 import id.walt.credentials.formats.DigitalCredential
 import id.walt.policies2.vc.CredentialPolicyResult
 import id.walt.policies2.vc.policies.PolicyExecutionContext
-import id.walt.verifier2.data.AttributedCredentialPolicyResult
 import id.walt.verifier2.data.Verification2Session
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
@@ -24,12 +23,6 @@ object Verifier2SessionCredentialPolicyValidation {
 
         @SerialName("specific_vc_policies")
         val specificVcPolicies: Map<String, List<CredentialPolicyResult>>,
-
-        @SerialName("attributed_vc_policies")
-        val attributedVcPolicies: List<AttributedCredentialPolicyResult>,
-
-        @SerialName("attributed_specific_vc_policies")
-        val attributedSpecificVcPolicies: Map<String, List<AttributedCredentialPolicyResult>>,
     )
 
     suspend fun validateCredentialPolicies(
@@ -47,16 +40,13 @@ object Verifier2SessionCredentialPolicyValidation {
                         val result = policy.verify(credential, context)
                         log.trace { "'$queryId' credential#$credentialIndex '${policy.id}' result: $result" }
 
-                        val policyResult = CredentialPolicyResult(
+                        CredentialPolicyResult(
                             policy = policy,
                             success = result.isSuccess,
                             result = result.getOrNull(),
-                            error = result.exceptionOrNull()?.message
-                        )
-                        AttributedCredentialPolicyResult(
+                            error = result.exceptionOrNull()?.message,
                             queryId = queryId,
                             credentialIndex = credentialIndex,
-                            result = policyResult,
                         )
                     }
                 }
@@ -72,16 +62,13 @@ object Verifier2SessionCredentialPolicyValidation {
                     async(Dispatchers.Default) {
                         val result = policy.verify(specificCredential, context)
 
-                        val policyResult = CredentialPolicyResult(
+                        queryId to CredentialPolicyResult(
                             policy = policy,
                             success = result.isSuccess,
                             result = result.getOrNull(),
-                            error = result.exceptionOrNull()?.message
-                        )
-                        queryId to AttributedCredentialPolicyResult(
+                            error = result.exceptionOrNull()?.message,
                             queryId = queryId,
                             credentialIndex = credentialIndex,
-                            result = policyResult,
                         )
                     }
                 }
@@ -89,17 +76,15 @@ object Verifier2SessionCredentialPolicyValidation {
         }
 
         // --- Await all policy runs ---
-        val attributedVcResults: List<AttributedCredentialPolicyResult> = generalPolicyJobs.awaitAll()
-        val attributedSpecificPairs: List<Pair<String, AttributedCredentialPolicyResult>> = specificPolicyJobs.awaitAll()
+        val vcResults: List<CredentialPolicyResult> = generalPolicyJobs.awaitAll()
+        val specificPairs: List<Pair<String, CredentialPolicyResult>> = specificPolicyJobs.awaitAll()
 
-        val attributedSpecificResults: Map<String, List<AttributedCredentialPolicyResult>> =
-            attributedSpecificPairs.groupBy({ it.first }, { it.second })
+        val specificResults: Map<String, List<CredentialPolicyResult>> =
+            specificPairs.groupBy({ it.first }, { it.second })
 
         return@coroutineScope CredentialPolicyResults(
-            vcPolicies = attributedVcResults.map { it.result },
-            specificVcPolicies = attributedSpecificResults.mapValues { (_, list) -> list.map { it.result } },
-            attributedVcPolicies = attributedVcResults,
-            attributedSpecificVcPolicies = attributedSpecificResults,
+            vcPolicies = vcResults,
+            specificVcPolicies = specificResults,
         )
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2SessionCredentialPolicyValidation.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2SessionCredentialPolicyValidation.kt
@@ -3,6 +3,7 @@ package id.walt.verifier2.handlers.vpresponse
 import id.walt.credentials.formats.DigitalCredential
 import id.walt.policies2.vc.CredentialPolicyResult
 import id.walt.policies2.vc.policies.PolicyExecutionContext
+import id.walt.verifier2.data.AttributedCredentialPolicyResult
 import id.walt.verifier2.data.Verification2Session
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
@@ -22,7 +23,13 @@ object Verifier2SessionCredentialPolicyValidation {
         val vcPolicies: List<CredentialPolicyResult>,
 
         @SerialName("specific_vc_policies")
-        val specificVcPolicies: Map<String, List<CredentialPolicyResult>>
+        val specificVcPolicies: Map<String, List<CredentialPolicyResult>>,
+
+        @SerialName("attributed_vc_policies")
+        val attributedVcPolicies: List<AttributedCredentialPolicyResult>,
+
+        @SerialName("attributed_specific_vc_policies")
+        val attributedSpecificVcPolicies: Map<String, List<AttributedCredentialPolicyResult>>,
     )
 
     suspend fun validateCredentialPolicies(
@@ -33,18 +40,23 @@ object Verifier2SessionCredentialPolicyValidation {
 
         // --- General VC Policies ---
         val generalPolicyJobs = validatedCredentials.flatMap { (queryId, credentials) ->
-            credentials.flatMap { credential ->
+            credentials.flatMapIndexed { credentialIndex, credential ->
                 policies.vc_policies?.policies.orEmpty().map { policy ->
                     async(Dispatchers.Default) {
-                        log.trace { "Validating '$queryId' credential with policy '${policy.id}': $credential" }
+                        log.trace { "Validating '$queryId' credential#$credentialIndex with policy '${policy.id}': $credential" }
                         val result = policy.verify(credential, context)
-                        log.trace { "'$queryId' credential '${policy.id}' result: $result" }
+                        log.trace { "'$queryId' credential#$credentialIndex '${policy.id}' result: $result" }
 
-                        CredentialPolicyResult(
+                        val policyResult = CredentialPolicyResult(
                             policy = policy,
                             success = result.isSuccess,
                             result = result.getOrNull(),
                             error = result.exceptionOrNull()?.message
+                        )
+                        AttributedCredentialPolicyResult(
+                            queryId = queryId,
+                            credentialIndex = credentialIndex,
+                            result = policyResult,
                         )
                     }
                 }
@@ -55,16 +67,21 @@ object Verifier2SessionCredentialPolicyValidation {
         val specificPolicyJobs = policies.specific_vc_policies.orEmpty().flatMap { (queryId, queryPolicies) ->
             val credentials = validatedCredentials[queryId].orEmpty()
 
-            credentials.flatMap { specificCredential ->
+            credentials.flatMapIndexed { credentialIndex, specificCredential ->
                 queryPolicies.policies.map { policy ->
                     async(Dispatchers.Default) {
                         val result = policy.verify(specificCredential, context)
 
-                        queryId to CredentialPolicyResult(
+                        val policyResult = CredentialPolicyResult(
                             policy = policy,
                             success = result.isSuccess,
                             result = result.getOrNull(),
                             error = result.exceptionOrNull()?.message
+                        )
+                        queryId to AttributedCredentialPolicyResult(
+                            queryId = queryId,
+                            credentialIndex = credentialIndex,
+                            result = policyResult,
                         )
                     }
                 }
@@ -72,17 +89,17 @@ object Verifier2SessionCredentialPolicyValidation {
         }
 
         // --- Await all policy runs ---
-        // Wait for all to finish
-        val vcPolicyResults = generalPolicyJobs.awaitAll()
-        val specificPolicyPairs = specificPolicyJobs.awaitAll()
+        val attributedVcResults: List<AttributedCredentialPolicyResult> = generalPolicyJobs.awaitAll()
+        val attributedSpecificPairs: List<Pair<String, AttributedCredentialPolicyResult>> = specificPolicyJobs.awaitAll()
 
-        // Group the specific results back into a Map<String, List<PolicyResult>>
-        val specificVcPolicyResults = specificPolicyPairs
-            .groupBy({ it.first }, { it.second })
+        val attributedSpecificResults: Map<String, List<AttributedCredentialPolicyResult>> =
+            attributedSpecificPairs.groupBy({ it.first }, { it.second })
 
         return@coroutineScope CredentialPolicyResults(
-            vcPolicies = ArrayList(vcPolicyResults),
-            specificVcPolicies = specificVcPolicyResults
+            vcPolicies = attributedVcResults.map { it.result },
+            specificVcPolicies = attributedSpecificResults.mapValues { (_, list) -> list.map { it.result } },
+            attributedVcPolicies = attributedVcResults,
+            attributedSpecificVcPolicies = attributedSpecificResults,
         )
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2SessionCredentialPolicyValidation.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2SessionCredentialPolicyValidation.kt
@@ -22,7 +22,7 @@ object Verifier2SessionCredentialPolicyValidation {
         val vcPolicies: List<CredentialPolicyResult>,
 
         @SerialName("specific_vc_policies")
-        val specificVcPolicies: Map<String, List<CredentialPolicyResult>>,
+        val specificVcPolicies: Map<String, List<CredentialPolicyResult>>
     )
 
     suspend fun validateCredentialPolicies(
@@ -76,15 +76,17 @@ object Verifier2SessionCredentialPolicyValidation {
         }
 
         // --- Await all policy runs ---
-        val vcResults: List<CredentialPolicyResult> = generalPolicyJobs.awaitAll()
-        val specificPairs: List<Pair<String, CredentialPolicyResult>> = specificPolicyJobs.awaitAll()
+        // Wait for all to finish
+        val vcPolicyResults = generalPolicyJobs.awaitAll()
+        val specificPolicyPairs = specificPolicyJobs.awaitAll()
 
-        val specificResults: Map<String, List<CredentialPolicyResult>> =
-            specificPairs.groupBy({ it.first }, { it.second })
+        // Group the specific results back into a Map<String, List<PolicyResult>>
+        val specificVcPolicyResults = specificPolicyPairs
+            .groupBy({ it.first }, { it.second })
 
         return@coroutineScope CredentialPolicyResults(
-            vcPolicies = vcResults,
-            specificVcPolicies = specificResults,
+            vcPolicies = ArrayList(vcPolicyResults),
+            specificVcPolicies = specificVcPolicyResults
         )
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -15,6 +15,8 @@ import id.walt.verifier2.data.DcApiAnnexCFlowSetup
 import id.walt.verifier2.data.SessionEvent
 import id.walt.verifier2.data.SessionFailure
 import id.walt.verifier2.data.Verification2Session
+import id.walt.verifier2.data.Verification2Session.VerificationSessionStatus.FAILED
+import id.walt.verifier2.data.Verification2Session.VerificationSessionStatus.SUCCESSFUL
 import id.walt.verifier2.data.Verifier2Response
 import id.walt.verifier2.utils.JsonUtils.parseAsJsonObject
 import id.walt.verifier2.verification2.PresentationVerificationEngine
@@ -230,7 +232,7 @@ object Verifier2VPDirectPostHandler {
 
     /**
      * Sealed (= limited option) interface to represent the different forms that
-     * a direct post response can come in.
+     * a direct post response can come in
      */
     sealed interface DirectPostResponse
 
@@ -357,15 +359,12 @@ object Verifier2VPDirectPostHandler {
     ): Map<String, String> {
         log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
 
-        val expectedState = session.authorizationRequest.state
-        if (expectedState != null && responseData.state != expectedState) {
-            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
-        }
+        session.authorizationRequest.state
+            ?.takeIf { it != responseData.state }
+            ?.let { Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError() }
 
-        if (session.status == Verification2Session.VerificationSessionStatus.SUCCESSFUL ||
-            session.status == Verification2Session.VerificationSessionStatus.FAILED
-        ) {
-            log.info { "Session ${session.id} is already terminal (${session.status}); ignoring wallet error response." }
+        if (session.status == SUCCESSFUL || session.status == FAILED) {
+            log.info { "Session ${session.id} already terminal (${session.status}); ignoring wallet error." }
             return mapOf(
                 "status" to "acknowledged",
                 "message" to "Session already terminal; wallet error response ignored.",
@@ -374,7 +373,7 @@ object Verifier2VPDirectPostHandler {
 
         updateSessionCallback(session, SessionEvent.wallet_error_response_received) {
             attempted = true
-            status = Verification2Session.VerificationSessionStatus.FAILED
+            status = FAILED
             statusReason = "Wallet returned OID4VP error: ${responseData.error}"
             failure = SessionFailure.WalletErrorResponse(
                 reason = "Wallet returned OID4VP error response per §8.5",
@@ -384,14 +383,12 @@ object Verifier2VPDirectPostHandler {
             )
         }
 
-        session.redirects?.errorRedirectUri?.let { errorRedirectUri ->
-            return mapOf("redirect_uri" to errorRedirectUri)
-        }
-
-        return mapOf(
-            "status" to "acknowledged",
-            "message" to "Wallet error response recorded.",
-        )
+        return session.redirects?.errorRedirectUri
+            ?.let { mapOf("redirect_uri" to it) }
+            ?: mapOf(
+                "status" to "acknowledged",
+                "message" to "Wallet error response recorded.",
+            )
     }
 
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -38,10 +38,12 @@ object Verifier2VPDirectPostHandler {
 
     suspend fun parseResponseBody(
         responseMode: OpenID4VPResponseMode?,
-        responseData: VpTokenDirectPostResponse,
+        responseData: DirectPostResponse,
         session: Verification2Session,
         ephemeralDecryptionKey: DirectSerializedKey?
     ): Pair<String, String?> = when (responseData) {
+        is ErrorResponseDirectPost -> error("Wallet error responses must be handled before parsing vp_token data")
+
         is DcApiJsonDirectPostResponse -> {
             if (session.setup is DcApiAnnexCFlowSetup) {
                 // Annex C handling
@@ -229,28 +231,17 @@ object Verifier2VPDirectPostHandler {
     /**
      * Sealed (= limited option) interface to represent the different forms that
      * a direct post response can come in.
-     *
-     * Split into two categories:
-     * - [VpTokenDirectPostResponse]: the wallet is attempting to deliver a `vp_token`
-     *   (cleartext, encrypted, or DC API).
-     * - [ErrorResponseDirectPost]: the wallet is rejecting the request per OID4VP §8.5.
-     *
-     * Keeping the two apart lets [parseResponseBody] accept only the vp_token variants
-     * and makes the wallet-error path a separate branch in [handleDirectPost].
      */
     sealed interface DirectPostResponse
 
-    /** Wallet attempts to deliver a `vp_token` (in any of the supported forms). */
-    sealed interface VpTokenDirectPostResponse : DirectPostResponse
-
     /** Custom DC API JSON Object structure */
-    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : VpTokenDirectPostResponse
+    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : DirectPostResponse
 
     /** Encrypted response (Data is in JWT String in URL parameter 'response') */
-    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : VpTokenDirectPostResponse
+    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : DirectPostResponse
 
     /** Cleartext response (Data is directly passed as strings in URL parameter 'vp_token' and 'state') */
-    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : VpTokenDirectPostResponse
+    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : DirectPostResponse
 
     /**
      * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
@@ -288,14 +279,13 @@ object Verifier2VPDirectPostHandler {
         val responseMode = session.authorizationRequest.responseMode
         val isAnnexC = verificationSession.setup is DcApiAnnexCFlowSetup
 
-        val vpTokenResponse: VpTokenDirectPostResponse = when (responseData) {
-            is ErrorResponseDirectPost -> return handleWalletErrorResponse(session, responseData, updateSessionCallback)
-            is VpTokenDirectPostResponse -> responseData
+        if (responseData is ErrorResponseDirectPost) {
+            return handleWalletErrorResponse(session, responseData, updateSessionCallback)
         }
 
         val (vpTokenString, receivedState) = parseResponseBody(
             responseMode = responseMode,
-            responseData = vpTokenResponse,
+            responseData = responseData,
             session = session,
             ephemeralDecryptionKey = session.ephemeralDecryptionKey
         )

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -367,6 +367,11 @@ object Verifier2VPDirectPostHandler {
     ): Map<String, String> {
         log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
 
+        val expectedState = session.authorizationRequest.state
+        if (expectedState != null && responseData.state != expectedState) {
+            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
+        }
+
         if (session.status == Verification2Session.VerificationSessionStatus.SUCCESSFUL ||
             session.status == Verification2Session.VerificationSessionStatus.FAILED
         ) {
@@ -375,11 +380,6 @@ object Verifier2VPDirectPostHandler {
                 "status" to "acknowledged",
                 "message" to "Session already terminal; wallet error response ignored.",
             )
-        }
-
-        val expectedState = session.authorizationRequest.state
-        if (expectedState != null && responseData.state != expectedState) {
-            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
         }
 
         updateSessionCallback(session, SessionEvent.wallet_error_response_received) {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -13,6 +13,7 @@ import id.walt.policies2.vc.policies.PolicyExecutionContext
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
 import id.walt.verifier2.data.DcApiAnnexCFlowSetup
 import id.walt.verifier2.data.SessionEvent
+import id.walt.verifier2.data.SessionFailure
 import id.walt.verifier2.data.Verification2Session
 import id.walt.verifier2.data.Verifier2Response
 import id.walt.verifier2.utils.JsonUtils.parseAsJsonObject
@@ -139,6 +140,9 @@ object Verifier2VPDirectPostHandler {
 
             responseData.vpToken to responseData.state
         }
+
+        is ErrorResponseDirectPost ->
+            error("parseResponseBody called with ErrorResponseDirectPost; handleDirectPost must short-circuit before this")
     }
 
     suspend fun RoutingCall.parseHttpRequestToDirectPostResponse(): DirectPostResponse {
@@ -151,7 +155,16 @@ object Verifier2VPDirectPostHandler {
                 log.trace { "Verification session data - body: $bodyText" }
                 val bodyJsonObject = bodyText.parseAsJsonObject("Could not parse provided body text as JSON object for DC API flow")
 
-                DcApiJsonDirectPostResponse(bodyJsonObject)
+                val errorCode = bodyJsonObject["error"]?.jsonPrimitive?.content
+                if (errorCode != null) {
+                    ErrorResponseDirectPost(
+                        error = errorCode,
+                        errorDescription = bodyJsonObject["error_description"]?.jsonPrimitive?.content,
+                        state = bodyJsonObject["state"]?.jsonPrimitive?.content,
+                    )
+                } else {
+                    DcApiJsonDirectPostResponse(bodyJsonObject)
+                }
             }
 
             else -> {
@@ -159,10 +172,17 @@ object Verifier2VPDirectPostHandler {
                 val responseString = urlParameters["response"]
                 val vpTokenString = urlParameters["vp_token"]
                 val receivedState = urlParameters["state"]
+                val errorCode = urlParameters["error"]
 
-                log.trace { "Verification session data: state = $receivedState, vp_token = $vpTokenString, response = $responseString" }
+                log.trace { "Verification session data: state = $receivedState, vp_token = $vpTokenString, response = $responseString, error = $errorCode" }
 
                 when {
+                    errorCode != null -> ErrorResponseDirectPost(
+                        error = errorCode,
+                        errorDescription = urlParameters["error_description"],
+                        state = receivedState,
+                    )
+
                     responseString != null -> EncryptedResponseStringDirectPostResponse(
                         responseParameter = responseString
                     )
@@ -225,6 +245,17 @@ object Verifier2VPDirectPostHandler {
     data class CleartextDirectPostResponse(val vpToken: String, val state: String) : DirectPostResponse
 
     /**
+     * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
+     * decline → `access_denied`). Body may arrive url-encoded or as JSON and always carries at
+     * least an `error` code; `error_description` and `state` are optional.
+     */
+    data class ErrorResponseDirectPost(
+        val error: String,
+        val errorDescription: String?,
+        val state: String?,
+    ) : DirectPostResponse
+
+    /**
      * Here the receiving of credentials through the Verifiers endpoints
      * (e.g. direct_post endpoint) is handled
      */
@@ -246,6 +277,32 @@ object Verifier2VPDirectPostHandler {
         val session = verificationSession
         val responseMode = session.authorizationRequest.responseMode
         val isAnnexC = verificationSession.setup is DcApiAnnexCFlowSetup
+
+        if (responseData is ErrorResponseDirectPost) {
+            log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
+
+            val expectedState = session.authorizationRequest.state
+            if (expectedState != null && responseData.state != null && responseData.state != expectedState) {
+                Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
+            }
+
+            session.updateSession(SessionEvent.wallet_error_response_received) {
+                attempted = true
+                status = Verification2Session.VerificationSessionStatus.FAILED
+                statusReason = "Wallet returned OID4VP error: ${responseData.error}"
+                failure = SessionFailure.WalletErrorResponse(
+                    reason = "Wallet returned OID4VP error response per §8.5",
+                    error = responseData.error,
+                    errorDescription = responseData.errorDescription,
+                    state = responseData.state,
+                )
+            }
+
+            return mapOf(
+                "status" to "acknowledged",
+                "message" to "Wallet error response recorded.",
+            )
+        }
 
         val (vpTokenString, receivedState) = parseResponseBody(
             responseMode = responseMode,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -38,7 +38,7 @@ object Verifier2VPDirectPostHandler {
 
     suspend fun parseResponseBody(
         responseMode: OpenID4VPResponseMode?,
-        responseData: DirectPostResponse,
+        responseData: VpTokenDirectPostResponse,
         session: Verification2Session,
         ephemeralDecryptionKey: DirectSerializedKey?
     ): Pair<String, String?> = when (responseData) {
@@ -140,9 +140,6 @@ object Verifier2VPDirectPostHandler {
 
             responseData.vpToken to responseData.state
         }
-
-        is ErrorResponseDirectPost ->
-            error("parseResponseBody called with ErrorResponseDirectPost; handleDirectPost must short-circuit before this")
     }
 
     suspend fun RoutingCall.parseHttpRequestToDirectPostResponse(): DirectPostResponse {
@@ -231,24 +228,36 @@ object Verifier2VPDirectPostHandler {
 
     /**
      * Sealed (= limited option) interface to represent the different forms that
-     * a direct post response can come in
+     * a direct post response can come in.
+     *
+     * Split into two categories:
+     * - [VpTokenDirectPostResponse]: the wallet is attempting to deliver a `vp_token`
+     *   (cleartext, encrypted, or DC API).
+     * - [ErrorResponseDirectPost]: the wallet is rejecting the request per OID4VP §8.5.
+     *
+     * Keeping the two apart lets [parseResponseBody] accept only the vp_token variants
+     * and makes the wallet-error path a separate branch in [handleDirectPost].
      */
     sealed interface DirectPostResponse
 
+    /** Wallet attempts to deliver a `vp_token` (in any of the supported forms). */
+    sealed interface VpTokenDirectPostResponse : DirectPostResponse
+
     /** Custom DC API JSON Object structure */
-    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : DirectPostResponse
+    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : VpTokenDirectPostResponse
 
     /** Encrypted response (Data is in JWT String in URL parameter 'response') */
-    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : DirectPostResponse
+    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : VpTokenDirectPostResponse
 
     /** Cleartext response (Data is directly passed as strings in URL parameter 'vp_token' and 'state') */
-    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : DirectPostResponse
+    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : VpTokenDirectPostResponse
 
     /**
      * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
      * decline → `access_denied`). Body may arrive url-encoded or as JSON and always carries at
-     * least an `error` code; `error_description` is optional. `state` is required when it was
-     * present in the Authorization Request.
+     * least an `error` code; `error_description` is optional. `state` is required whenever the
+     * Authorization Request included `state` — [handleDirectPost] rejects mismatched / absent
+     * state with `INVALID_STATE_PARAMETER` in that case.
      */
     data class ErrorResponseDirectPost(
         val error: String,
@@ -279,35 +288,14 @@ object Verifier2VPDirectPostHandler {
         val responseMode = session.authorizationRequest.responseMode
         val isAnnexC = verificationSession.setup is DcApiAnnexCFlowSetup
 
-        if (responseData is ErrorResponseDirectPost) {
-            log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
-
-            val expectedState = session.authorizationRequest.state
-            if (expectedState != null && responseData.state != expectedState) {
-                Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
-            }
-
-            session.updateSession(SessionEvent.wallet_error_response_received) {
-                attempted = true
-                status = Verification2Session.VerificationSessionStatus.FAILED
-                statusReason = "Wallet returned OID4VP error: ${responseData.error}"
-                failure = SessionFailure.WalletErrorResponse(
-                    reason = "Wallet returned OID4VP error response per §8.5",
-                    error = responseData.error,
-                    errorDescription = responseData.errorDescription,
-                    state = responseData.state,
-                )
-            }
-
-            return mapOf(
-                "status" to "acknowledged",
-                "message" to "Wallet error response recorded.",
-            )
+        val vpTokenResponse: VpTokenDirectPostResponse = when (responseData) {
+            is ErrorResponseDirectPost -> return handleWalletErrorResponse(session, responseData, updateSessionCallback)
+            is VpTokenDirectPostResponse -> responseData
         }
 
         val (vpTokenString, receivedState) = parseResponseBody(
             responseMode = responseMode,
-            responseData = responseData,
+            responseData = vpTokenResponse,
             session = session,
             ephemeralDecryptionKey = session.ephemeralDecryptionKey
         )
@@ -364,5 +352,52 @@ object Verifier2VPDirectPostHandler {
         Verifier2Response.Verifier2Error.MALFORMED_VP_TOKEN.throwAsError()
     }
 
+    /**
+     * Handles an OID4VP 1.0 §8.5 wallet error response. Validates `state` echo, marks the
+     * session as `FAILED` with a structured [SessionFailure.WalletErrorResponse], and emits
+     * [SessionEvent.wallet_error_response_received].
+     *
+     * Idempotent: if the session is already in a terminal state, the response is acknowledged
+     * without overwriting any existing outcome.
+     */
+    private suspend fun handleWalletErrorResponse(
+        session: Verification2Session,
+        responseData: ErrorResponseDirectPost,
+        updateSessionCallback: suspend (session: Verification2Session, event: SessionEvent, block: Verification2Session.() -> Unit) -> Unit,
+    ): Map<String, String> {
+        log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
+
+        if (session.status == Verification2Session.VerificationSessionStatus.SUCCESSFUL ||
+            session.status == Verification2Session.VerificationSessionStatus.FAILED
+        ) {
+            log.info { "Session ${session.id} is already terminal (${session.status}); ignoring wallet error response." }
+            return mapOf(
+                "status" to "acknowledged",
+                "message" to "Session already terminal; wallet error response ignored.",
+            )
+        }
+
+        val expectedState = session.authorizationRequest.state
+        if (expectedState != null && responseData.state != expectedState) {
+            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
+        }
+
+        updateSessionCallback(session, SessionEvent.wallet_error_response_received) {
+            attempted = true
+            status = Verification2Session.VerificationSessionStatus.FAILED
+            statusReason = "Wallet returned OID4VP error: ${responseData.error}"
+            failure = SessionFailure.WalletErrorResponse(
+                reason = "Wallet returned OID4VP error response per §8.5",
+                error = responseData.error,
+                errorDescription = responseData.errorDescription,
+                state = responseData.state,
+            )
+        }
+
+        return mapOf(
+            "status" to "acknowledged",
+            "message" to "Wallet error response recorded.",
+        )
+    }
 
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -384,6 +384,10 @@ object Verifier2VPDirectPostHandler {
             )
         }
 
+        session.redirects?.errorRedirectUri?.let { errorRedirectUri ->
+            return mapOf("redirect_uri" to errorRedirectUri)
+        }
+
         return mapOf(
             "status" to "acknowledged",
             "message" to "Wallet error response recorded.",

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -247,7 +247,8 @@ object Verifier2VPDirectPostHandler {
     /**
      * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
      * decline → `access_denied`). Body may arrive url-encoded or as JSON and always carries at
-     * least an `error` code; `error_description` and `state` are optional.
+     * least an `error` code; `error_description` is optional. `state` is required when it was
+     * present in the Authorization Request.
      */
     data class ErrorResponseDirectPost(
         val error: String,
@@ -282,7 +283,7 @@ object Verifier2VPDirectPostHandler {
             log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
 
             val expectedState = session.authorizationRequest.state
-            if (expectedState != null && responseData.state != null && responseData.state != expectedState) {
+            if (expectedState != null && responseData.state != expectedState) {
                 Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
             }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
@@ -11,51 +11,28 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
     private val log = KotlinLogging.logger("DcqlFulfillmentChecker")
 
     @Serializable
-    class DcqlFulfillmentException(override val message: String) : IllegalArgumentException(message)
-
-    sealed class DcqlFulfillmentCheckResult {
-        data object Success : DcqlFulfillmentCheckResult()
-
-        data class Failure(
-            val reason: String,
-            val details: DcqlFulfillmentFailure,
-        ) : DcqlFulfillmentCheckResult()
-    }
+    class DcqlFulfillmentException(
+        override val message: String,
+        val details: DcqlFulfillmentFailure = DcqlFulfillmentFailure(),
+    ) : IllegalArgumentException(message)
 
     /**
      * Checks if the set of successfully validated presentations (identified by their query IDs)
      * fulfills all the requirements of the original DCQL query.
      *
-     * Kept for backward compatibility with external consumers. New code should use
-     * [checkOverallDcqlFulfillmentDetailed], which returns a structured result rather than
-     * encoding failure details inside an exception message.
+     * @param dcqlQuery The original DCQL query sent to the Wallet.
+     * @param successfullyValidatedQueryIds A set of `id`s from `CredentialQuery` for which
+     *                                      at least one valid presentation was received.
+     * @return Success if all DCQL requirements are met; otherwise a [DcqlFulfillmentException]
+     *         with structured failure details.
      *
-     * Note: when multiple required credential_sets are unsatisfied, the exception message
-     * enumerates all of them (rather than short-circuiting on the first).
+     * Note: when multiple required credential_sets are unsatisfied, the exception details enumerate
+     * all of them rather than short-circuiting on the first.
      */
-    @Deprecated(
-        message = "Use checkOverallDcqlFulfillmentDetailed to get structured failure details.",
-        replaceWith = ReplaceWith("checkOverallDcqlFulfillmentDetailed(dcqlQuery, successfullyValidatedQueryIds)")
-    )
     fun checkOverallDcqlFulfillment(
         dcqlQuery: DcqlQuery,
         successfullyValidatedQueryIds: Set<String>
     ): Result<Unit> {
-        return when (val detailed = checkOverallDcqlFulfillmentDetailed(dcqlQuery, successfullyValidatedQueryIds)) {
-            is DcqlFulfillmentCheckResult.Success -> Result.success(Unit)
-            is DcqlFulfillmentCheckResult.Failure -> Result.failure(DcqlFulfillmentException(detailed.reason))
-        }
-    }
-
-    /**
-     * Detailed variant of [checkOverallDcqlFulfillment] (WAL-977). On failure, returns structured
-     * details that the verifier attaches to the session so webhook / /info consumers can see which
-     * required queries or credential sets were missed.
-     */
-    fun checkOverallDcqlFulfillmentDetailed(
-        dcqlQuery: DcqlQuery,
-        successfullyValidatedQueryIds: Set<String>,
-    ): DcqlFulfillmentCheckResult {
         log.debug {
             "Checking overall DCQL fulfillment. Required query IDs from DCQL: ${dcqlQuery.credentials.map { it.id }}, " +
                     "Successfully validated query IDs: $successfullyValidatedQueryIds, " +
@@ -66,6 +43,9 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
 
         // Case 1: No credential_sets are defined in the DCQL query
         if (dcqlQuery.credentialSets.isNullOrEmpty()) {
+            // All individual CredentialQuery entries are implicitly required.
+            // We need to ensure that for every CredentialQuery in the original request,
+            // we have a successfully validated presentation.
             val allOriginalQueryIds = dcqlQuery.credentials.map { it.id }.toSet()
             val missingRequiredQueries = (allOriginalQueryIds - successfullyValidatedQueryIds).toList()
 
@@ -73,33 +53,52 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                 val message = "DCQL Fulfillment Failed (no credential_sets): Missing presentations for required query IDs: $missingRequiredQueries. " +
                         "All individual queries are considered required when no credential_sets are defined."
                 log.warn { message }
-                return DcqlFulfillmentCheckResult.Failure(
-                    reason = message,
-                    details = DcqlFulfillmentFailure(
-                        missingQueryIds = missingRequiredQueries,
-                        unsatisfiedSets = emptyList(),
-                        successfullyValidatedQueryIds = validatedList,
-                    ),
+                return Result.failure(
+                    DcqlFulfillmentException(
+                        message = message,
+                        details = DcqlFulfillmentFailure(
+                            missingQueryIds = missingRequiredQueries,
+                            unsatisfiedSets = emptyList(),
+                            successfullyValidatedQueryIds = validatedList,
+                        ),
+                    )
                 )
             }
             log.debug { "DCQL Fulfillment Succeeded (no credential_sets): All individual queries were satisfied." }
-            return DcqlFulfillmentCheckResult.Success
+            return Result.success(Unit)
         }
 
         // Case 2: credential_sets are defined
+        // We need to check each CredentialSetQuery.
+        // All sets where 'required' is true (or omitted) MUST be satisfied.
         val unsatisfiedRequired = ArrayList<UnsatisfiedSet>()
         for (credentialSetQuery in dcqlQuery.credentialSets) {
             if (credentialSetQuery.required) { // 'required' defaults to true if omitted
+                // This required set must have at least one of its 'options' satisfied.
+                // An option is a list of CredentialQuery IDs.
+                // That option is satisfied if ALL CredentialQuery IDs within it are present
+                // in 'successfullyValidatedQueryIds'.
                 val isThisRequiredSetSatisfied = credentialSetQuery.options.any { optionList ->
-                    optionList.all { queryIdInOption -> successfullyValidatedQueryIds.contains(queryIdInOption) }
+                    // Check if all query IDs in this specific optionList have been successfully validated
+                    val optionSatisfied = optionList.all { queryIdInOption ->
+                        successfullyValidatedQueryIds.contains(queryIdInOption)
+                    }
+                    if (optionSatisfied) {
+                        log.trace { "Required CredentialSet option satisfied: $optionList" }
+                    }
+                    optionSatisfied
                 }
 
                 if (!isThisRequiredSetSatisfied) {
                     unsatisfiedRequired += UnsatisfiedSet(options = credentialSetQuery.options)
                 }
             } else {
+                // For optional sets (required = false), we don't need to fail if they are not met.
+                // We just log whether any option was met for tracing.
                 val isThisOptionalSetSatisfied = credentialSetQuery.options.any { optionList ->
-                    optionList.all { queryIdInOption -> successfullyValidatedQueryIds.contains(queryIdInOption) }
+                    optionList.all { queryIdInOption ->
+                        successfullyValidatedQueryIds.contains(queryIdInOption)
+                    }
                 }
                 log.trace { "Optional CredentialSet satisfaction status: $isThisOptionalSetSatisfied. Options: ${credentialSetQuery.options}" }
             }
@@ -110,17 +109,33 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                     "Unsatisfied sets: ${unsatisfiedRequired.map { it.options }}, " +
                     "Successfully validated query IDs: $successfullyValidatedQueryIds"
             log.warn { message }
-            return DcqlFulfillmentCheckResult.Failure(
-                reason = message,
-                details = DcqlFulfillmentFailure(
-                    missingQueryIds = emptyList(),
-                    unsatisfiedSets = unsatisfiedRequired,
-                    successfullyValidatedQueryIds = validatedList,
-                ),
+            return Result.failure(
+                DcqlFulfillmentException(
+                    message = message,
+                    details = DcqlFulfillmentFailure(
+                        missingQueryIds = emptyList(),
+                        unsatisfiedSets = unsatisfiedRequired,
+                        successfullyValidatedQueryIds = validatedList,
+                    ),
+                )
             )
         }
 
+        // If we've gone through all credential sets and all *required* ones were satisfied,
+        // then the overall DCQL query is considered fulfilled in terms of credential presence.
+        //
+        // Additional check: Are there any credentials in the original dcqlQuery.credentials list
+        // that were NOT part of any credential_set and are thus implicitly required?
+        // The OpenID4VP spec (Section 6.4.2 Selecting Credentials) implies that if credential_sets
+        // is provided, it dictates the selection. If a CredentialQuery is listed in dcqlQuery.credentials
+        // but NOT referenced in any option of any credential_set, its requirement status is ambiguous
+        // by that section alone.
+        // However, a common interpretation is that if credential_sets are used, they fully define
+        // the combination logic. If a credential is required individually AND outside of sets,
+        // it should probably be its own required set with one option.
+        // For now, we assume that if credential_sets are present, they are the definitive source
+        // for what combinations are required.
         log.debug { "DCQL Fulfillment Succeeded: All required credential_sets were satisfied." }
-        return DcqlFulfillmentCheckResult.Success
+        return Result.success(Unit)
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
@@ -39,15 +39,13 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                     "Credential Sets: ${dcqlQuery.credentialSets?.size ?: 0}"
         }
 
-        val validatedList = successfullyValidatedQueryIds.toList()
-
         // Case 1: No credential_sets are defined in the DCQL query
         if (dcqlQuery.credentialSets.isNullOrEmpty()) {
             // All individual CredentialQuery entries are implicitly required.
             // We need to ensure that for every CredentialQuery in the original request,
             // we have a successfully validated presentation.
             val allOriginalQueryIds = dcqlQuery.credentials.map { it.id }.toSet()
-            val missingRequiredQueries = (allOriginalQueryIds - successfullyValidatedQueryIds).toList()
+            val missingRequiredQueries = allOriginalQueryIds - successfullyValidatedQueryIds
 
             if (missingRequiredQueries.isNotEmpty()) {
                 val message = "DCQL Fulfillment Failed (no credential_sets): Missing presentations for required query IDs: $missingRequiredQueries. " +
@@ -59,7 +57,7 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                         details = DcqlFulfillmentFailure(
                             missingQueryIds = missingRequiredQueries,
                             unsatisfiedSets = emptyList(),
-                            successfullyValidatedQueryIds = validatedList,
+                            successfullyValidatedQueryIds = successfullyValidatedQueryIds,
                         ),
                     )
                 )
@@ -113,9 +111,9 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                 DcqlFulfillmentException(
                     message = message,
                     details = DcqlFulfillmentFailure(
-                        missingQueryIds = emptyList(),
+                        missingQueryIds = emptySet(),
                         unsatisfiedSets = unsatisfiedRequired,
-                        successfullyValidatedQueryIds = validatedList,
+                        successfullyValidatedQueryIds = successfullyValidatedQueryIds,
                     ),
                 )
             )

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
@@ -13,6 +13,15 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
     @Serializable
     class DcqlFulfillmentException(override val message: String) : IllegalArgumentException(message)
 
+    sealed class DcqlFulfillmentCheckResult {
+        data object Success : DcqlFulfillmentCheckResult()
+
+        data class Failure(
+            val reason: String,
+            val details: DcqlFulfillmentFailure,
+        ) : DcqlFulfillmentCheckResult()
+    }
+
     /**
      * Checks if the set of successfully validated presentations (identified by their query IDs)
      * fulfills all the requirements of the original DCQL query.
@@ -26,22 +35,21 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
         dcqlQuery: DcqlQuery,
         successfullyValidatedQueryIds: Set<String>
     ): Result<Unit> {
-        val detailed = checkOverallDcqlFulfillmentDetailed(dcqlQuery, successfullyValidatedQueryIds)
-        return detailed.fold(
-            onSuccess = { Result.success(Unit) },
-            onFailure = { Result.failure(it) },
-        )
+        return when (val detailed = checkOverallDcqlFulfillmentDetailed(dcqlQuery, successfullyValidatedQueryIds)) {
+            is DcqlFulfillmentCheckResult.Success -> Result.success(Unit)
+            is DcqlFulfillmentCheckResult.Failure -> Result.failure(DcqlFulfillmentException(detailed.reason))
+        }
     }
 
     /**
-     * Detailed variant of [checkOverallDcqlFulfillment] (WAL-977). On failure, returns a structured
-     * [DcqlFulfillmentFailure] that the verifier attaches to the session so webhook / /info
-     * consumers can see which required queries or credential sets were missed.
+     * Detailed variant of [checkOverallDcqlFulfillment] (WAL-977). On failure, returns structured
+     * details that the verifier attaches to the session so webhook / /info consumers can see which
+     * required queries or credential sets were missed.
      */
     fun checkOverallDcqlFulfillmentDetailed(
         dcqlQuery: DcqlQuery,
         successfullyValidatedQueryIds: Set<String>,
-    ): Result<Unit> {
+    ): DcqlFulfillmentCheckResult {
         log.debug {
             "Checking overall DCQL fulfillment. Required query IDs from DCQL: ${dcqlQuery.credentials.map { it.id }}, " +
                     "Successfully validated query IDs: $successfullyValidatedQueryIds, " +
@@ -59,19 +67,17 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                 val message = "DCQL Fulfillment Failed (no credential_sets): Missing presentations for required query IDs: $missingRequiredQueries. " +
                         "All individual queries are considered required when no credential_sets are defined."
                 log.warn { message }
-                return Result.failure(
-                    StructuredDcqlFulfillmentException(
-                        message = message,
-                        failure = DcqlFulfillmentFailure(
-                            missingQueryIds = missingRequiredQueries,
-                            unsatisfiedSets = emptyList(),
-                            successfullyValidatedQueryIds = validatedList,
-                        ),
-                    )
+                return DcqlFulfillmentCheckResult.Failure(
+                    reason = message,
+                    details = DcqlFulfillmentFailure(
+                        missingQueryIds = missingRequiredQueries,
+                        unsatisfiedSets = emptyList(),
+                        successfullyValidatedQueryIds = validatedList,
+                    ),
                 )
             }
             log.debug { "DCQL Fulfillment Succeeded (no credential_sets): All individual queries were satisfied." }
-            return Result.success(Unit)
+            return DcqlFulfillmentCheckResult.Success
         }
 
         // Case 2: credential_sets are defined
@@ -101,29 +107,17 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                     "Unsatisfied sets: ${unsatisfiedRequired.map { it.options }}, " +
                     "Successfully validated query IDs: $successfullyValidatedQueryIds"
             log.warn { message }
-            return Result.failure(
-                StructuredDcqlFulfillmentException(
-                    message = message,
-                    failure = DcqlFulfillmentFailure(
-                        missingQueryIds = emptyList(),
-                        unsatisfiedSets = unsatisfiedRequired,
-                        successfullyValidatedQueryIds = validatedList,
-                    ),
-                )
+            return DcqlFulfillmentCheckResult.Failure(
+                reason = message,
+                details = DcqlFulfillmentFailure(
+                    missingQueryIds = emptyList(),
+                    unsatisfiedSets = unsatisfiedRequired,
+                    successfullyValidatedQueryIds = validatedList,
+                ),
             )
         }
 
         log.debug { "DCQL Fulfillment Succeeded: All required credential_sets were satisfied." }
-        return Result.success(Unit)
+        return DcqlFulfillmentCheckResult.Success
     }
-
-    /**
-     * Carries the structured [DcqlFulfillmentFailure] through the existing [Result.failure] API
-     * so callers that only need a message (legacy `checkOverallDcqlFulfillment`) still work, while
-     * callers that want structure can downcast.
-     */
-    class StructuredDcqlFulfillmentException(
-        message: String,
-        val failure: DcqlFulfillmentFailure,
-    ) : IllegalArgumentException(message)
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
@@ -26,11 +26,17 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
      * Checks if the set of successfully validated presentations (identified by their query IDs)
      * fulfills all the requirements of the original DCQL query.
      *
-     * @param dcqlQuery The original DCQL query sent to the Wallet.
-     * @param successfullyValidatedQueryIds A set of `id`s from `CredentialQuery` for which
-     *                                      at least one valid presentation was received.
-     * @return True if all DCQL requirements are met, false otherwise.
+     * Kept for backward compatibility with external consumers. New code should use
+     * [checkOverallDcqlFulfillmentDetailed], which returns a structured result rather than
+     * encoding failure details inside an exception message.
+     *
+     * Note: when multiple required credential_sets are unsatisfied, the exception message
+     * enumerates all of them (rather than short-circuiting on the first).
      */
+    @Deprecated(
+        message = "Use checkOverallDcqlFulfillmentDetailed to get structured failure details.",
+        replaceWith = ReplaceWith("checkOverallDcqlFulfillmentDetailed(dcqlQuery, successfullyValidatedQueryIds)")
+    )
     fun checkOverallDcqlFulfillment(
         dcqlQuery: DcqlQuery,
         successfullyValidatedQueryIds: Set<String>
@@ -89,10 +95,7 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
                 }
 
                 if (!isThisRequiredSetSatisfied) {
-                    unsatisfiedRequired += UnsatisfiedSet(
-                        options = credentialSetQuery.options,
-                        required = true,
-                    )
+                    unsatisfiedRequired += UnsatisfiedSet(options = credentialSetQuery.options)
                 }
             } else {
                 val isThisOptionalSetSatisfied = credentialSetQuery.options.any { optionList ->

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification/DcqlFulfillmentChecker.kt
@@ -1,6 +1,8 @@
 package id.walt.verifier2.verification
 
 import id.walt.dcql.models.DcqlQuery
+import id.walt.verifier2.data.DcqlFulfillmentFailure
+import id.walt.verifier2.data.UnsatisfiedSet
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.serialization.Serializable
 
@@ -24,30 +26,47 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
         dcqlQuery: DcqlQuery,
         successfullyValidatedQueryIds: Set<String>
     ): Result<Unit> {
+        val detailed = checkOverallDcqlFulfillmentDetailed(dcqlQuery, successfullyValidatedQueryIds)
+        return detailed.fold(
+            onSuccess = { Result.success(Unit) },
+            onFailure = { Result.failure(it) },
+        )
+    }
+
+    /**
+     * Detailed variant of [checkOverallDcqlFulfillment] (WAL-977). On failure, returns a structured
+     * [DcqlFulfillmentFailure] that the verifier attaches to the session so webhook / /info
+     * consumers can see which required queries or credential sets were missed.
+     */
+    fun checkOverallDcqlFulfillmentDetailed(
+        dcqlQuery: DcqlQuery,
+        successfullyValidatedQueryIds: Set<String>,
+    ): Result<Unit> {
         log.debug {
             "Checking overall DCQL fulfillment. Required query IDs from DCQL: ${dcqlQuery.credentials.map { it.id }}, " +
                     "Successfully validated query IDs: $successfullyValidatedQueryIds, " +
                     "Credential Sets: ${dcqlQuery.credentialSets?.size ?: 0}"
         }
 
+        val validatedList = successfullyValidatedQueryIds.toList()
+
         // Case 1: No credential_sets are defined in the DCQL query
         if (dcqlQuery.credentialSets.isNullOrEmpty()) {
-            // All individual CredentialQuery entries are implicitly required.
-            // We need to ensure that for every CredentialQuery in the original request,
-            // we have a successfully validated presentation.
             val allOriginalQueryIds = dcqlQuery.credentials.map { it.id }.toSet()
-            val missingRequiredQueries = allOriginalQueryIds - successfullyValidatedQueryIds
+            val missingRequiredQueries = (allOriginalQueryIds - successfullyValidatedQueryIds).toList()
 
             if (missingRequiredQueries.isNotEmpty()) {
-                log.warn {
-                    "DCQL Fulfillment Failed (no credential_sets): Missing presentations for required query IDs: $missingRequiredQueries. " +
-                            "All individual queries are considered required when no credential_sets are defined."
-                }
-
+                val message = "DCQL Fulfillment Failed (no credential_sets): Missing presentations for required query IDs: $missingRequiredQueries. " +
+                        "All individual queries are considered required when no credential_sets are defined."
+                log.warn { message }
                 return Result.failure(
-                    DcqlFulfillmentException(
-                        "DCQL Fulfillment Failed (no credential_sets): Missing presentations for required query IDs: $missingRequiredQueries. " +
-                                "All individual queries are considered required when no credential_sets are defined."
+                    StructuredDcqlFulfillmentException(
+                        message = message,
+                        failure = DcqlFulfillmentFailure(
+                            missingQueryIds = missingRequiredQueries,
+                            unsatisfiedSets = emptyList(),
+                            successfullyValidatedQueryIds = validatedList,
+                        ),
                     )
                 )
             }
@@ -56,68 +75,55 @@ object DcqlFulfillmentChecker { // Encapsulating in an object
         }
 
         // Case 2: credential_sets are defined
-        // We need to check each CredentialSetQuery.
-        // All sets where 'required' is true (or omitted) MUST be satisfied.
+        val unsatisfiedRequired = ArrayList<UnsatisfiedSet>()
         for (credentialSetQuery in dcqlQuery.credentialSets) {
             if (credentialSetQuery.required) { // 'required' defaults to true if omitted
-                // This required set must have at least one of its 'options' satisfied.
-                // An option is a list of CredentialQuery IDs.
-                // That option is satisfied if ALL CredentialQuery IDs within it are present
-                // in 'successfullyValidatedQueryIds'.
                 val isThisRequiredSetSatisfied = credentialSetQuery.options.any { optionList ->
-                    // Check if all query IDs in this specific optionList have been successfully validated
-                    val optionSatisfied = optionList.all { queryIdInOption ->
-                        successfullyValidatedQueryIds.contains(queryIdInOption)
-                    }
-                    if (optionSatisfied) {
-                        log.trace { "Required CredentialSet option satisfied: $optionList" }
-                    }
-                    optionSatisfied
+                    optionList.all { queryIdInOption -> successfullyValidatedQueryIds.contains(queryIdInOption) }
                 }
 
                 if (!isThisRequiredSetSatisfied) {
-                    // A required set was not satisfied
-                    log.warn {
-                        "DCQL Fulfillment Failed: A required CredentialSet was not satisfied. " +
-                                "Set options: ${credentialSetQuery.options}, " +
-                                "Successfully validated query IDs: $successfullyValidatedQueryIds"
-                    }
-                    return Result.failure(
-                        DcqlFulfillmentException(
-                            "DCQL Fulfillment Failed: A required CredentialSet was not satisfied. " +
-                                    "Set options: ${credentialSetQuery.options}, " +
-                                    "Successfully validated query IDs: $successfullyValidatedQueryIds"
-                        )
+                    unsatisfiedRequired += UnsatisfiedSet(
+                        options = credentialSetQuery.options,
+                        required = true,
                     )
                 }
             } else {
-                // For optional sets (required = false), we don't need to fail if they are not met.
-                // We just log whether any option was met for tracing.
                 val isThisOptionalSetSatisfied = credentialSetQuery.options.any { optionList ->
-                    optionList.all { queryIdInOption ->
-                        successfullyValidatedQueryIds.contains(queryIdInOption)
-                    }
+                    optionList.all { queryIdInOption -> successfullyValidatedQueryIds.contains(queryIdInOption) }
                 }
                 log.trace { "Optional CredentialSet satisfaction status: $isThisOptionalSetSatisfied. Options: ${credentialSetQuery.options}" }
             }
         }
 
-        // If we've gone through all credential sets and all *required* ones were satisfied,
-        // then the overall DCQL query is considered fulfilled in terms of credential presence.
-        //
-        // Additional check: Are there any credentials in the original dcqlQuery.credentials list
-        // that were NOT part of any credential_set and are thus implicitly required?
-        // The OpenID4VP spec (Section 6.4.2 Selecting Credentials) implies that if credential_sets
-        // is provided, it dictates the selection. If a CredentialQuery is listed in dcqlQuery.credentials
-        // but NOT referenced in any option of any credential_set, its requirement status is ambiguous
-        // by that section alone.
-        // However, a common interpretation is that if credential_sets are used, they fully define
-        // the combination logic. If a credential is required individually AND outside of sets,
-        // it should probably be its own required set with one option.
-        // For now, we assume that if credential_sets are present, they are the definitive source
-        // for what combinations are required.
+        if (unsatisfiedRequired.isNotEmpty()) {
+            val message = "DCQL Fulfillment Failed: ${unsatisfiedRequired.size} required CredentialSet(s) not satisfied. " +
+                    "Unsatisfied sets: ${unsatisfiedRequired.map { it.options }}, " +
+                    "Successfully validated query IDs: $successfullyValidatedQueryIds"
+            log.warn { message }
+            return Result.failure(
+                StructuredDcqlFulfillmentException(
+                    message = message,
+                    failure = DcqlFulfillmentFailure(
+                        missingQueryIds = emptyList(),
+                        unsatisfiedSets = unsatisfiedRequired,
+                        successfullyValidatedQueryIds = validatedList,
+                    ),
+                )
+            )
+        }
 
         log.debug { "DCQL Fulfillment Succeeded: All required credential_sets were satisfied." }
         return Result.success(Unit)
     }
+
+    /**
+     * Carries the structured [DcqlFulfillmentFailure] through the existing [Result.failure] API
+     * so callers that only need a message (legacy `checkOverallDcqlFulfillment`) still work, while
+     * callers that want structure can downcast.
+     */
+    class StructuredDcqlFulfillmentException(
+        message: String,
+        val failure: DcqlFulfillmentFailure,
+    ) : IllegalArgumentException(message)
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
@@ -10,7 +10,6 @@ import id.walt.policies2.vp.policies.VPPolicyRunner
 import id.walt.policies2.vp.policies.VerificationSessionContext
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
 import id.walt.verifier2.data.DcApiAnnexCFlowSetup
-import id.walt.verifier2.data.DcqlFulfillmentFailure
 import id.walt.verifier2.data.SessionEvent
 import id.walt.verifier2.data.SessionFailure
 import id.walt.verifier2.data.Verification2Session
@@ -368,28 +367,20 @@ object PresentationVerificationEngine {
                 successfullyValidatedQueryIds = allSuccessfullyValidatedAndProcessedData.keys // set of query IDs for which we have valid presentations
             )
         }
-        if (dcqlFulfilled?.isSuccess == false) {
-            val dcqlError = dcqlFulfilled.exceptionOrNull()
-            log.error { "The set of validated presentations does not fulfill all DCQL requirements for session ${session.id}, reported error is: $dcqlError" }
-
-            val structuredFailure: DcqlFulfillmentFailure =
-                (dcqlError as? DcqlFulfillmentChecker.StructuredDcqlFulfillmentException)?.failure
-                    ?: DcqlFulfillmentFailure(
-                        successfullyValidatedQueryIds = allSuccessfullyValidatedAndProcessedData.keys.toList(),
-                    )
+        if (dcqlFulfilled is DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Failure) {
+            log.error { "The set of validated presentations does not fulfill all DCQL requirements for session ${session.id}, reported error is: ${dcqlFulfilled.reason}" }
 
             session.updateSession(SessionEvent.validated_credentials_available) {
                 this.failure = SessionFailure.DcqlFulfillment(
-                    reason = dcqlError?.message ?: "DCQL fulfillment failed",
-                    failure = structuredFailure,
+                    reason = dcqlFulfilled.reason,
+                    failure = dcqlFulfilled.details,
                 )
             }
 
             session.failSession(SessionEvent.dcql_fulfillment_check_failed)
 
             throw IllegalArgumentException(
-                "The set of validated presentations does not fulfill all DCQL requirements. DCQL errors are: ${dcqlError?.message}",
-                dcqlError ?: IllegalStateException("DCQL fulfillment failed without underlying cause")
+                "The set of validated presentations does not fulfill all DCQL requirements. DCQL errors are: ${dcqlFulfilled.reason}"
             )
             //Verifier2Response.Verifier2Error.REQUIRED_CREDENTIALS_NOT_PROVIDED.throwAsError()
         }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
@@ -9,6 +9,7 @@ import id.walt.policies2.vp.policies.VPPolicy2
 import id.walt.policies2.vp.policies.VPPolicyRunner
 import id.walt.policies2.vp.policies.VerificationSessionContext
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import id.walt.verifier2.data.AttributedCredentialPolicyResult
 import id.walt.verifier2.data.DcApiAnnexCFlowSetup
 import id.walt.verifier2.data.SessionEvent
 import id.walt.verifier2.data.SessionFailure
@@ -405,7 +406,7 @@ object PresentationVerificationEngine {
             attributedSpecificVcPolicies = credentialPolicyResults.attributedSpecificVcPolicies,
         )
 
-        val vcPolicyViolations: List<id.walt.verifier2.data.AttributedCredentialPolicyResult> =
+        val vcPolicyViolations: List<AttributedCredentialPolicyResult> =
             credentialPolicyResults.attributedVcPolicies.filter { !it.result.success } +
                     credentialPolicyResults.attributedSpecificVcPolicies.values.flatten().filter { !it.result.success }
 
@@ -415,7 +416,9 @@ object PresentationVerificationEngine {
                 verificationSessionPolicyResults.overallSuccess -> Verification2Session.VerificationSessionStatus.SUCCESSFUL
                 else -> Verification2Session.VerificationSessionStatus.FAILED
             }
-            if (!verificationSessionPolicyResults.overallSuccess && vcPolicyViolations.isNotEmpty()) {
+            if (!verificationSessionPolicyResults.overallSuccess) {
+                // Invariant: overallSuccess=false implies at least one attributed failure,
+                // because the flat policy lists are projections of the attributed ones.
                 this.failure = SessionFailure.VcPolicyViolations(
                     reason = "${vcPolicyViolations.size} credential policy violation(s)",
                     violations = vcPolicyViolations,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
@@ -9,7 +9,6 @@ import id.walt.policies2.vp.policies.VPPolicy2
 import id.walt.policies2.vp.policies.VPPolicyRunner
 import id.walt.policies2.vp.policies.VerificationSessionContext
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
-import id.walt.verifier2.data.AttributedCredentialPolicyResult
 import id.walt.verifier2.data.DcApiAnnexCFlowSetup
 import id.walt.verifier2.data.SessionEvent
 import id.walt.verifier2.data.SessionFailure
@@ -403,13 +402,11 @@ object PresentationVerificationEngine {
             vpPolicies = presentationValidationResult,
             vcPolicies = credentialPolicyResults.vcPolicies,
             specificVcPolicies = credentialPolicyResults.specificVcPolicies,
-            attributedVcPolicies = credentialPolicyResults.attributedVcPolicies,
-            attributedSpecificVcPolicies = credentialPolicyResults.attributedSpecificVcPolicies,
         )
 
-        val vcPolicyViolations: List<AttributedCredentialPolicyResult> =
-            credentialPolicyResults.attributedVcPolicies.filter { !it.result.success } +
-                    credentialPolicyResults.attributedSpecificVcPolicies.values.flatten().filter { !it.result.success }
+        val vcPolicyViolations =
+            credentialPolicyResults.vcPolicies.filter { !it.success } +
+                    credentialPolicyResults.specificVcPolicies.values.flatten().filter { !it.success }
 
         session.updateSession(SessionEvent.credential_policy_results_available) {
             this.policyResults = verificationSessionPolicyResults
@@ -418,8 +415,8 @@ object PresentationVerificationEngine {
                 else -> Verification2Session.VerificationSessionStatus.FAILED
             }
             if (!verificationSessionPolicyResults.overallSuccess) {
-                // Invariant: overallSuccess=false implies at least one attributed failure,
-                // because the flat policy lists are projections of the attributed ones.
+                // Invariant: overallSuccess=false implies at least one credential policy failure
+                // in the same lists used to compute the overall result.
                 this.failure = SessionFailure.VcPolicyViolations(
                     reason = "${vcPolicyViolations.size} credential policy violation(s)",
                     violations = vcPolicyViolations,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
@@ -323,7 +323,7 @@ object PresentationVerificationEngine {
                 .filterValues { it.isNotEmpty() }
 
             session.updateSession(SessionEvent.presentation_validation_available) {
-                this.failure = SessionFailure.PresentationValidation(
+                failure = SessionFailure.PresentationValidation(
                     reason = firstError?.message?.let { "Presentation validation failed: $it" }
                         ?: "One or more presentations in vp_token failed validation",
                     failedPolicies = failedPolicies,
@@ -372,7 +372,7 @@ object PresentationVerificationEngine {
             log.error { "The set of validated presentations does not fulfill all DCQL requirements for session ${session.id}, reported error is: ${dcqlFailure.message}" }
 
             session.updateSession(SessionEvent.validated_credentials_available) {
-                this.failure = SessionFailure.DcqlFulfillment(
+                failure = SessionFailure.DcqlFulfillment(
                     reason = dcqlFailure.message,
                     failure = dcqlFailure.details,
                 )
@@ -417,7 +417,7 @@ object PresentationVerificationEngine {
             if (!verificationSessionPolicyResults.overallSuccess) {
                 // Invariant: overallSuccess=false implies at least one credential policy failure
                 // in the same lists used to compute the overall result.
-                this.failure = SessionFailure.VcPolicyViolations(
+                failure = SessionFailure.VcPolicyViolations(
                     reason = "${vcPolicyViolations.size} credential policy violation(s)",
                     violations = vcPolicyViolations,
                 )

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
@@ -10,7 +10,9 @@ import id.walt.policies2.vp.policies.VPPolicyRunner
 import id.walt.policies2.vp.policies.VerificationSessionContext
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
 import id.walt.verifier2.data.DcApiAnnexCFlowSetup
+import id.walt.verifier2.data.DcqlFulfillmentFailure
 import id.walt.verifier2.data.SessionEvent
+import id.walt.verifier2.data.SessionFailure
 import id.walt.verifier2.data.Verification2Session
 import id.walt.verifier2.handlers.vpresponse.ParsedVpToken
 import id.walt.verifier2.handlers.vpresponse.Verifier2SessionCredentialPolicyValidation
@@ -317,6 +319,18 @@ object PresentationVerificationEngine {
                 presentationValidationResult.firstNotNullOfOrNull { it.value.firstNotNullOfOrNull { it.value.errors.firstOrNull() } }
             log.warn { "First error: $firstError" }
 
+            val failedPolicies = presentationValidationResult
+                .mapValues { (_, byPolicy) -> byPolicy.filterValues { it.errors.isNotEmpty() } }
+                .filterValues { it.isNotEmpty() }
+
+            session.updateSession(SessionEvent.presentation_validation_available) {
+                this.failure = SessionFailure.PresentationValidation(
+                    reason = firstError?.message?.let { "Presentation validation failed: $it" }
+                        ?: "One or more presentations in vp_token failed validation",
+                    failedPolicies = failedPolicies,
+                )
+            }
+
             session.failSession(SessionEvent.presentation_validation_failed)
 
             throw IllegalArgumentException( // TODO: custom Exception class
@@ -349,19 +363,33 @@ object PresentationVerificationEngine {
         // Check if the set of validated presentations satisfies the overall DCQL Query
         // (e.g., credential_sets, all *required* CredentialQuery IDs are present in allSuccessfullyValidatedAndProcessedData)
         val dcqlFulfilled = session.authorizationRequest.dcqlQuery?.let { dcqlQuery ->
-            DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
+            DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
                 dcqlQuery = dcqlQuery,
                 successfullyValidatedQueryIds = allSuccessfullyValidatedAndProcessedData.keys // set of query IDs for which we have valid presentations
             )
         }
         if (dcqlFulfilled?.isSuccess == false) {
-            log.error { "The set of validated presentations does not fulfill all DCQL requirements for session ${session.id}, reported error is: ${dcqlFulfilled.exceptionOrNull()}" }
+            val dcqlError = dcqlFulfilled.exceptionOrNull()
+            log.error { "The set of validated presentations does not fulfill all DCQL requirements for session ${session.id}, reported error is: $dcqlError" }
+
+            val structuredFailure: DcqlFulfillmentFailure =
+                (dcqlError as? DcqlFulfillmentChecker.StructuredDcqlFulfillmentException)?.failure
+                    ?: DcqlFulfillmentFailure(
+                        successfullyValidatedQueryIds = allSuccessfullyValidatedAndProcessedData.keys.toList(),
+                    )
+
+            session.updateSession(SessionEvent.validated_credentials_available) {
+                this.failure = SessionFailure.DcqlFulfillment(
+                    reason = dcqlError?.message ?: "DCQL fulfillment failed",
+                    failure = structuredFailure,
+                )
+            }
 
             session.failSession(SessionEvent.dcql_fulfillment_check_failed)
 
             throw IllegalArgumentException(
-                "The set of validated presentations does not fulfill all DCQL requirements. DCQL errors are: ${dcqlFulfilled.exceptionOrNull()?.message}",
-                dcqlFulfilled.exceptionOrNull()!!
+                "The set of validated presentations does not fulfill all DCQL requirements. DCQL errors are: ${dcqlError?.message}",
+                dcqlError ?: IllegalStateException("DCQL fulfillment failed without underlying cause")
             )
             //Verifier2Response.Verifier2Error.REQUIRED_CREDENTIALS_NOT_PROVIDED.throwAsError()
         }
@@ -382,13 +410,25 @@ object PresentationVerificationEngine {
             vpPolicies = presentationValidationResult,
             vcPolicies = credentialPolicyResults.vcPolicies,
             specificVcPolicies = credentialPolicyResults.specificVcPolicies,
+            attributedVcPolicies = credentialPolicyResults.attributedVcPolicies,
+            attributedSpecificVcPolicies = credentialPolicyResults.attributedSpecificVcPolicies,
         )
+
+        val vcPolicyViolations: List<id.walt.verifier2.data.AttributedCredentialPolicyResult> =
+            credentialPolicyResults.attributedVcPolicies.filter { !it.result.success } +
+                    credentialPolicyResults.attributedSpecificVcPolicies.values.flatten().filter { !it.result.success }
 
         session.updateSession(SessionEvent.credential_policy_results_available) {
             this.policyResults = verificationSessionPolicyResults
             this.status = when {
                 verificationSessionPolicyResults.overallSuccess -> Verification2Session.VerificationSessionStatus.SUCCESSFUL
                 else -> Verification2Session.VerificationSessionStatus.FAILED
+            }
+            if (!verificationSessionPolicyResults.overallSuccess && vcPolicyViolations.isNotEmpty()) {
+                this.failure = SessionFailure.VcPolicyViolations(
+                    reason = "${vcPolicyViolations.size} credential policy violation(s)",
+                    violations = vcPolicyViolations,
+                )
             }
         }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
@@ -363,25 +363,26 @@ object PresentationVerificationEngine {
         // Check if the set of validated presentations satisfies the overall DCQL Query
         // (e.g., credential_sets, all *required* CredentialQuery IDs are present in allSuccessfullyValidatedAndProcessedData)
         val dcqlFulfilled = session.authorizationRequest.dcqlQuery?.let { dcqlQuery ->
-            DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+            DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
                 dcqlQuery = dcqlQuery,
                 successfullyValidatedQueryIds = allSuccessfullyValidatedAndProcessedData.keys // set of query IDs for which we have valid presentations
             )
         }
-        if (dcqlFulfilled is DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Failure) {
-            log.error { "The set of validated presentations does not fulfill all DCQL requirements for session ${session.id}, reported error is: ${dcqlFulfilled.reason}" }
+        val dcqlFailure = dcqlFulfilled?.exceptionOrNull() as? DcqlFulfillmentChecker.DcqlFulfillmentException
+        if (dcqlFailure != null) {
+            log.error { "The set of validated presentations does not fulfill all DCQL requirements for session ${session.id}, reported error is: ${dcqlFailure.message}" }
 
             session.updateSession(SessionEvent.validated_credentials_available) {
                 this.failure = SessionFailure.DcqlFulfillment(
-                    reason = dcqlFulfilled.reason,
-                    failure = dcqlFulfilled.details,
+                    reason = dcqlFailure.message,
+                    failure = dcqlFailure.details,
                 )
             }
 
             session.failSession(SessionEvent.dcql_fulfillment_check_failed)
 
             throw IllegalArgumentException(
-                "The set of validated presentations does not fulfill all DCQL requirements. DCQL errors are: ${dcqlFulfilled.reason}"
+                "The set of validated presentations does not fulfill all DCQL requirements. DCQL errors are: ${dcqlFailure.message}"
             )
             //Verifier2Response.Verifier2Error.REQUIRED_CREDENTIALS_NOT_PROVIDED.throwAsError()
         }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
@@ -2,6 +2,7 @@ package id.walt.verifier2.verification2
 
 import id.walt.policies2.vc.CredentialPolicyResult
 import id.walt.policies2.vp.policies.VPPolicy2
+import id.walt.verifier2.data.AttributedCredentialPolicyResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -14,7 +15,22 @@ data class Verifier2PolicyResults(
     val vcPolicies: List<CredentialPolicyResult>,
 
     @SerialName("specific_vc_policies")
-    val specificVcPolicies: Map<String, List<CredentialPolicyResult>>
+    val specificVcPolicies: Map<String, List<CredentialPolicyResult>>,
+
+    /**
+     * Per-credential attributed view of [vcPolicies]. Carries `queryId` + `credentialIndex` so a
+     * vc_policy failure can be pinned to the specific credential that failed (WAL-976).
+     * Null on sessions produced before this field existed.
+     */
+    @SerialName("attributed_vc_policies")
+    val attributedVcPolicies: List<AttributedCredentialPolicyResult>? = null,
+
+    /**
+     * Per-credential attributed view of [specificVcPolicies]. Same shape rationale as
+     * [attributedVcPolicies].
+     */
+    @SerialName("attributed_specific_vc_policies")
+    val attributedSpecificVcPolicies: Map<String, List<AttributedCredentialPolicyResult>>? = null,
 ) {
 
     val overallSuccess: Boolean =

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
@@ -2,7 +2,6 @@ package id.walt.verifier2.verification2
 
 import id.walt.policies2.vc.CredentialPolicyResult
 import id.walt.policies2.vp.policies.VPPolicy2
-import id.walt.verifier2.data.AttributedCredentialPolicyResult
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,21 +15,6 @@ data class Verifier2PolicyResults(
 
     @SerialName("specific_vc_policies")
     val specificVcPolicies: Map<String, List<CredentialPolicyResult>>,
-
-    /**
-     * Per-credential attributed view of [vcPolicies]. Carries `queryId` + `credentialIndex` so a
-     * vc_policy failure can be pinned to the specific credential that failed.
-     * Null on sessions produced before this field existed.
-     */
-    @SerialName("attributed_vc_policies")
-    val attributedVcPolicies: List<AttributedCredentialPolicyResult>? = null,
-
-    /**
-     * Per-credential attributed view of [specificVcPolicies]. Same shape rationale as
-     * [attributedVcPolicies].
-     */
-    @SerialName("attributed_specific_vc_policies")
-    val attributedSpecificVcPolicies: Map<String, List<AttributedCredentialPolicyResult>>? = null,
 ) {
 
     val overallSuccess: Boolean =

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
@@ -19,7 +19,7 @@ data class Verifier2PolicyResults(
 
     /**
      * Per-credential attributed view of [vcPolicies]. Carries `queryId` + `credentialIndex` so a
-     * vc_policy failure can be pinned to the specific credential that failed (WAL-976).
+     * vc_policy failure can be pinned to the specific credential that failed.
      * Null on sessions produced before this field existed.
      */
     @SerialName("attributed_vc_policies")

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/Verifier2PolicyResults.kt
@@ -14,7 +14,7 @@ data class Verifier2PolicyResults(
     val vcPolicies: List<CredentialPolicyResult>,
 
     @SerialName("specific_vc_policies")
-    val specificVcPolicies: Map<String, List<CredentialPolicyResult>>,
+    val specificVcPolicies: Map<String, List<CredentialPolicyResult>>
 ) {
 
     val overallSuccess: Boolean =

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
@@ -16,9 +16,9 @@ class SessionFailureSerializationTest {
         val failure: SessionFailure = SessionFailure.DcqlFulfillment(
             reason = "Required credential_set not satisfied",
             failure = DcqlFulfillmentFailure(
-                missingQueryIds = emptyList(),
+                missingQueryIds = emptySet(),
                 unsatisfiedSets = listOf(UnsatisfiedSet(options = listOf(listOf("pid"), listOf("mdl")))),
-                successfullyValidatedQueryIds = listOf("email"),
+                successfullyValidatedQueryIds = setOf("email"),
             ),
         )
 

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
@@ -16,7 +16,7 @@ class SessionFailureSerializationTest {
             reason = "Required credential_set not satisfied",
             failure = DcqlFulfillmentFailure(
                 missingQueryIds = emptyList(),
-                unsatisfiedSets = listOf(UnsatisfiedSet(options = listOf(listOf("pid"), listOf("mdl")), required = true)),
+                unsatisfiedSets = listOf(UnsatisfiedSet(options = listOf(listOf("pid"), listOf("mdl")))),
                 successfullyValidatedQueryIds = listOf("email"),
             ),
         )

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
@@ -1,6 +1,7 @@
 package id.walt.verifier2.data
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
@@ -26,6 +27,13 @@ class SessionFailureSerializationTest {
 
         assertEquals("dcql_fulfillment", parsed["type"]?.jsonPrimitive?.content)
         assertEquals("Required credential_set not satisfied", parsed["reason"]?.jsonPrimitive?.content)
+        val unsatisfiedSet = parsed["failure"]
+            ?.jsonObject
+            ?.get("unsatisfied_sets")
+            ?.jsonArray
+            ?.first()
+            ?.jsonObject
+        assertEquals(2, unsatisfiedSet?.get("options")?.jsonArray?.size)
 
         val decoded = json.decodeFromString(SessionFailure.serializer(), encoded)
         assertEquals(failure, decoded)

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/data/SessionFailureSerializationTest.kt
@@ -1,0 +1,48 @@
+package id.walt.verifier2.data
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SessionFailureSerializationTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun dcqlFulfillmentFailure_serializesWithTypeDiscriminator() {
+        val failure: SessionFailure = SessionFailure.DcqlFulfillment(
+            reason = "Required credential_set not satisfied",
+            failure = DcqlFulfillmentFailure(
+                missingQueryIds = emptyList(),
+                unsatisfiedSets = listOf(UnsatisfiedSet(options = listOf(listOf("pid"), listOf("mdl")), required = true)),
+                successfullyValidatedQueryIds = listOf("email"),
+            ),
+        )
+
+        val encoded = json.encodeToString(SessionFailure.serializer(), failure)
+        val parsed = json.parseToJsonElement(encoded).jsonObject
+
+        assertEquals("dcql_fulfillment", parsed["type"]?.jsonPrimitive?.content)
+        assertEquals("Required credential_set not satisfied", parsed["reason"]?.jsonPrimitive?.content)
+
+        val decoded = json.decodeFromString(SessionFailure.serializer(), encoded)
+        assertEquals(failure, decoded)
+    }
+
+    @Test
+    fun walletErrorResponse_serializesWithSnakeCaseErrorDescription() {
+        val failure: SessionFailure = SessionFailure.WalletErrorResponse(
+            reason = "Wallet returned OID4VP error response per §8.5",
+            error = "access_denied",
+            errorDescription = "User denied",
+            state = "abc123",
+        )
+        val encoded = json.encodeToString(SessionFailure.serializer(), failure)
+        val parsed = json.parseToJsonElement(encoded).jsonObject
+        assertEquals("wallet_error_response", parsed["type"]?.jsonPrimitive?.content)
+        assertEquals("access_denied", parsed["error"]?.jsonPrimitive?.content)
+        assertEquals("User denied", parsed["error_description"]?.jsonPrimitive?.content)
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
@@ -7,9 +7,7 @@ import id.walt.dcql.models.DcqlQuery
 import id.walt.dcql.models.meta.SdJwtVcMeta
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 class DcqlFulfillmentCheckerTest {
 
@@ -25,12 +23,12 @@ class DcqlFulfillmentCheckerTest {
             credentials = listOf(credentialQuery("pid"), credentialQuery("address")),
         )
 
-        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
             dcqlQuery = query,
             successfullyValidatedQueryIds = setOf("pid"),
         )
 
-        val failure = assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Failure>(result)
+        val failure = result.exceptionOrNull() as DcqlFulfillmentChecker.DcqlFulfillmentException
         assertEquals(listOf("address"), failure.details.missingQueryIds)
         assertTrue(failure.details.unsatisfiedSets.isEmpty())
         assertEquals(listOf("pid"), failure.details.successfullyValidatedQueryIds)
@@ -45,12 +43,12 @@ class DcqlFulfillmentCheckerTest {
             ),
         )
 
-        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
             dcqlQuery = query,
             successfullyValidatedQueryIds = setOf("email"),
         )
 
-        val failure = assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Failure>(result)
+        val failure = result.exceptionOrNull() as DcqlFulfillmentChecker.DcqlFulfillmentException
         assertTrue(failure.details.missingQueryIds.isEmpty())
         assertEquals(1, failure.details.unsatisfiedSets.size)
         assertEquals(listOf(listOf("pid"), listOf("mdl")), failure.details.unsatisfiedSets[0].options)
@@ -67,27 +65,26 @@ class DcqlFulfillmentCheckerTest {
             ),
         )
 
-        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
             dcqlQuery = query,
             successfullyValidatedQueryIds = setOf("pid"),
         )
 
-        assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Success>(result)
+        assertTrue(result.isSuccess)
     }
 
     @Test
     fun success_noCredentialSets_allIdsPresent() {
         val query = DcqlQuery(credentials = listOf(credentialQuery("pid")))
-        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
             dcqlQuery = query,
             successfullyValidatedQueryIds = setOf("pid"),
         )
-        assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Success>(result)
+        assertTrue(result.isSuccess)
     }
 
     @Test
-    @Suppress("DEPRECATION")
-    fun legacyApi_remainsBackwardCompatible() {
+    fun failure_remainsBackwardCompatibleWithThrowableResult() {
         val query = DcqlQuery(credentials = listOf(credentialQuery("pid")))
         val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
             dcqlQuery = query,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
@@ -1,0 +1,103 @@
+package id.walt.verifier2.verification
+
+import id.walt.dcql.models.CredentialFormat
+import id.walt.dcql.models.CredentialQuery
+import id.walt.dcql.models.CredentialSetQuery
+import id.walt.dcql.models.DcqlQuery
+import id.walt.dcql.models.meta.SdJwtVcMeta
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class DcqlFulfillmentCheckerTest {
+
+    private fun credentialQuery(id: String) = CredentialQuery(
+        id = id,
+        format = CredentialFormat.DC_SD_JWT,
+        meta = SdJwtVcMeta(listOf("urn:test:$id")),
+    )
+
+    @Test
+    fun noCredentialSets_missingRequiredIds_producesStructuredFailure() {
+        val query = DcqlQuery(
+            credentials = listOf(credentialQuery("pid"), credentialQuery("address")),
+        )
+
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+            dcqlQuery = query,
+            successfullyValidatedQueryIds = setOf("pid"),
+        )
+
+        assertTrue(result.isFailure, "Expected failure when a required query id is missing")
+        val exception = result.exceptionOrNull() ?: fail("Missing exception on failure")
+        val structured = assertIs<DcqlFulfillmentChecker.StructuredDcqlFulfillmentException>(exception)
+        assertEquals(listOf("address"), structured.failure.missingQueryIds)
+        assertTrue(structured.failure.unsatisfiedSets.isEmpty())
+        assertEquals(listOf("pid"), structured.failure.successfullyValidatedQueryIds)
+    }
+
+    @Test
+    fun credentialSets_requiredSetUnsatisfied_producesUnsatisfiedSet() {
+        val query = DcqlQuery(
+            credentials = listOf(credentialQuery("pid"), credentialQuery("mdl"), credentialQuery("email")),
+            credentialSets = listOf(
+                CredentialSetQuery(options = listOf(listOf("pid"), listOf("mdl")), required = true),
+            ),
+        )
+
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+            dcqlQuery = query,
+            successfullyValidatedQueryIds = setOf("email"),
+        )
+
+        assertTrue(result.isFailure, "Expected failure when a required credential_set is unsatisfied")
+        val structured = assertIs<DcqlFulfillmentChecker.StructuredDcqlFulfillmentException>(result.exceptionOrNull())
+        assertTrue(structured.failure.missingQueryIds.isEmpty())
+        assertEquals(1, structured.failure.unsatisfiedSets.size)
+        assertEquals(listOf(listOf("pid"), listOf("mdl")), structured.failure.unsatisfiedSets[0].options)
+        assertTrue(structured.failure.unsatisfiedSets[0].required)
+        assertEquals(listOf("email"), structured.failure.successfullyValidatedQueryIds)
+    }
+
+    @Test
+    fun credentialSets_optionalSetUnsatisfied_isNotAFailure() {
+        val query = DcqlQuery(
+            credentials = listOf(credentialQuery("pid"), credentialQuery("address")),
+            credentialSets = listOf(
+                CredentialSetQuery(options = listOf(listOf("pid")), required = true),
+                CredentialSetQuery(options = listOf(listOf("address")), required = false),
+            ),
+        )
+
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+            dcqlQuery = query,
+            successfullyValidatedQueryIds = setOf("pid"),
+        )
+
+        assertTrue(result.isSuccess, "Optional unsatisfied sets must not fail DCQL fulfillment")
+    }
+
+    @Test
+    fun success_noCredentialSets_allIdsPresent() {
+        val query = DcqlQuery(credentials = listOf(credentialQuery("pid")))
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillmentDetailed(
+            dcqlQuery = query,
+            successfullyValidatedQueryIds = setOf("pid"),
+        )
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun legacyApi_remainsBackwardCompatible() {
+        val query = DcqlQuery(credentials = listOf(credentialQuery("pid")))
+        val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillment(
+            dcqlQuery = query,
+            successfullyValidatedQueryIds = emptySet(),
+        )
+        assertTrue(result.isFailure)
+        // legacy callers only need a throwable; still get one
+        assertTrue(result.exceptionOrNull() is IllegalArgumentException)
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
@@ -54,7 +54,6 @@ class DcqlFulfillmentCheckerTest {
         assertTrue(failure.details.missingQueryIds.isEmpty())
         assertEquals(1, failure.details.unsatisfiedSets.size)
         assertEquals(listOf(listOf("pid"), listOf("mdl")), failure.details.unsatisfiedSets[0].options)
-        assertTrue(failure.details.unsatisfiedSets[0].required)
         assertEquals(listOf("email"), failure.details.successfullyValidatedQueryIds)
     }
 
@@ -87,6 +86,7 @@ class DcqlFulfillmentCheckerTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun legacyApi_remainsBackwardCompatible() {
         val query = DcqlQuery(credentials = listOf(credentialQuery("pid")))
         val result = DcqlFulfillmentChecker.checkOverallDcqlFulfillment(

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
@@ -29,9 +29,9 @@ class DcqlFulfillmentCheckerTest {
         )
 
         val failure = result.exceptionOrNull() as DcqlFulfillmentChecker.DcqlFulfillmentException
-        assertEquals(listOf("address"), failure.details.missingQueryIds)
+        assertEquals(setOf("address"), failure.details.missingQueryIds)
         assertTrue(failure.details.unsatisfiedSets.isEmpty())
-        assertEquals(listOf("pid"), failure.details.successfullyValidatedQueryIds)
+        assertEquals(setOf("pid"), failure.details.successfullyValidatedQueryIds)
     }
 
     @Test
@@ -52,7 +52,7 @@ class DcqlFulfillmentCheckerTest {
         assertTrue(failure.details.missingQueryIds.isEmpty())
         assertEquals(1, failure.details.unsatisfiedSets.size)
         assertEquals(listOf(listOf("pid"), listOf("mdl")), failure.details.unsatisfiedSets[0].options)
-        assertEquals(listOf("email"), failure.details.successfullyValidatedQueryIds)
+        assertEquals(setOf("email"), failure.details.successfullyValidatedQueryIds)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonTest/kotlin/id/walt/verifier2/verification/DcqlFulfillmentCheckerTest.kt
@@ -30,12 +30,10 @@ class DcqlFulfillmentCheckerTest {
             successfullyValidatedQueryIds = setOf("pid"),
         )
 
-        assertTrue(result.isFailure, "Expected failure when a required query id is missing")
-        val exception = result.exceptionOrNull() ?: fail("Missing exception on failure")
-        val structured = assertIs<DcqlFulfillmentChecker.StructuredDcqlFulfillmentException>(exception)
-        assertEquals(listOf("address"), structured.failure.missingQueryIds)
-        assertTrue(structured.failure.unsatisfiedSets.isEmpty())
-        assertEquals(listOf("pid"), structured.failure.successfullyValidatedQueryIds)
+        val failure = assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Failure>(result)
+        assertEquals(listOf("address"), failure.details.missingQueryIds)
+        assertTrue(failure.details.unsatisfiedSets.isEmpty())
+        assertEquals(listOf("pid"), failure.details.successfullyValidatedQueryIds)
     }
 
     @Test
@@ -52,13 +50,12 @@ class DcqlFulfillmentCheckerTest {
             successfullyValidatedQueryIds = setOf("email"),
         )
 
-        assertTrue(result.isFailure, "Expected failure when a required credential_set is unsatisfied")
-        val structured = assertIs<DcqlFulfillmentChecker.StructuredDcqlFulfillmentException>(result.exceptionOrNull())
-        assertTrue(structured.failure.missingQueryIds.isEmpty())
-        assertEquals(1, structured.failure.unsatisfiedSets.size)
-        assertEquals(listOf(listOf("pid"), listOf("mdl")), structured.failure.unsatisfiedSets[0].options)
-        assertTrue(structured.failure.unsatisfiedSets[0].required)
-        assertEquals(listOf("email"), structured.failure.successfullyValidatedQueryIds)
+        val failure = assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Failure>(result)
+        assertTrue(failure.details.missingQueryIds.isEmpty())
+        assertEquals(1, failure.details.unsatisfiedSets.size)
+        assertEquals(listOf(listOf("pid"), listOf("mdl")), failure.details.unsatisfiedSets[0].options)
+        assertTrue(failure.details.unsatisfiedSets[0].required)
+        assertEquals(listOf("email"), failure.details.successfullyValidatedQueryIds)
     }
 
     @Test
@@ -76,7 +73,7 @@ class DcqlFulfillmentCheckerTest {
             successfullyValidatedQueryIds = setOf("pid"),
         )
 
-        assertTrue(result.isSuccess, "Optional unsatisfied sets must not fail DCQL fulfillment")
+        assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Success>(result)
     }
 
     @Test
@@ -86,7 +83,7 @@ class DcqlFulfillmentCheckerTest {
             dcqlQuery = query,
             successfullyValidatedQueryIds = setOf("pid"),
         )
-        assertTrue(result.isSuccess)
+        assertIs<DcqlFulfillmentChecker.DcqlFulfillmentCheckResult.Success>(result)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -185,6 +185,20 @@ class Verifier2VPDirectPostHandlerParseTest {
         assertEquals(null, session.failure, "must not attach failure to a SUCCESSFUL session")
     }
 
+    @Test
+    fun walletErrorResponse_onTerminalSession_stillRequiresMatchingState() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state").apply {
+            status = Verification2Session.VerificationSessionStatus.SUCCESSFUL
+        }
+
+        assertFailsWith<Throwable> {
+            session.handleWalletError(state = "wrong-state")
+        }
+
+        assertEquals(Verification2Session.VerificationSessionStatus.SUCCESSFUL, session.status)
+        assertEquals(null, session.failure, "invalid replay must not attach failure to terminal session")
+    }
+
     private fun directPostSession(expectedState: String) = Verification2Session(
         setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
         status = Verification2Session.VerificationSessionStatus.ACTIVE,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -22,7 +22,6 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
-import io.ktor.util.AttributeKey
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -35,7 +34,6 @@ import kotlin.test.assertNotNull
 class Verifier2VPDirectPostHandlerParseTest {
 
     private fun parse(contentType: ContentType, body: String): DirectPostResponse {
-        val captured = AttributeKey<DirectPostResponse>("captured-response")
         var parsedOut: DirectPostResponse? = null
 
         testApplication {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -1,0 +1,115 @@
+package id.walt.verifier2.handlers.vpresponse
+
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.CleartextDirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DcApiJsonDirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.EncryptedResponseStringDirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.ErrorResponseDirectPost
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.parseHttpRequestToDirectPostResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.parseUrlEncodedParameters
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.ktor.util.AttributeKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertIs
+
+class Verifier2VPDirectPostHandlerParseTest {
+
+    private fun parse(contentType: ContentType, body: String): DirectPostResponse {
+        val captured = AttributeKey<DirectPostResponse>("captured-response")
+        var parsedOut: DirectPostResponse? = null
+
+        testApplication {
+            application {
+                routing {
+                    post("/test") {
+                        parsedOut = call.parseHttpRequestToDirectPostResponse()
+                        call.respond("ok")
+                    }
+                }
+            }
+            val response = client.post("/test") {
+                contentType(contentType)
+                setBody(body)
+            }
+            check(response.status.value == 200) { "setup call failed: ${response.status}" }
+        }
+
+        return parsedOut ?: error("parseHttpRequestToDirectPostResponse did not return")
+    }
+
+    @Test
+    fun urlEncoded_errorOnly_parsesToErrorResponseDirectPost() {
+        val body = "error=access_denied&error_description=User+denied&state=abc123"
+        val parsed = parse(ContentType.Application.FormUrlEncoded, body)
+
+        val errorResponse = assertIs<ErrorResponseDirectPost>(parsed)
+        assertEquals("access_denied", errorResponse.error)
+        assertEquals("User denied", errorResponse.errorDescription)
+        assertEquals("abc123", errorResponse.state)
+    }
+
+    @Test
+    fun urlEncoded_errorWithoutState_producesErrorResponseWithNullState() {
+        val parsed = parse(ContentType.Application.FormUrlEncoded, "error=access_denied")
+        val errorResponse = assertIs<ErrorResponseDirectPost>(parsed)
+        assertEquals("access_denied", errorResponse.error)
+        assertEquals(null, errorResponse.errorDescription)
+        assertEquals(null, errorResponse.state)
+    }
+
+    @Test
+    fun urlEncoded_vpTokenBody_stillRoutesToCleartextVariant() {
+        val parsed = parse(
+            ContentType.Application.FormUrlEncoded,
+            "vp_token=%7B%22pid%22%3A%5B%22ey...%22%5D%7D&state=abc",
+        )
+        val cleartext = assertIs<CleartextDirectPostResponse>(parsed)
+        assertEquals("abc", cleartext.state)
+    }
+
+    @Test
+    fun urlEncoded_responseBody_stillRoutesToEncryptedVariant() {
+        val parsed = parse(ContentType.Application.FormUrlEncoded, "response=eyAbc")
+        assertIs<EncryptedResponseStringDirectPostResponse>(parsed)
+    }
+
+    @Test
+    fun urlEncoded_emptyBody_stillThrows() {
+        assertFails {
+            parse(ContentType.Application.FormUrlEncoded, "")
+        }
+    }
+
+    @Test
+    fun json_withErrorField_routesToErrorResponseDirectPost() {
+        val body = """{"error":"access_denied","error_description":"User denied","state":"abc"}"""
+        val parsed = parse(ContentType.Application.Json, body)
+        val errorResponse = assertIs<ErrorResponseDirectPost>(parsed)
+        assertEquals("access_denied", errorResponse.error)
+        assertEquals("abc", errorResponse.state)
+    }
+
+    @Test
+    fun json_withoutErrorField_routesToDcApiJson() {
+        val body = """{"data":{"vp_token":{"pid":[]}}}"""
+        val parsed = parse(ContentType.Application.Json, body)
+        assertIs<DcApiJsonDirectPostResponse>(parsed)
+    }
+
+    @Test
+    fun urlEncoded_parsingRoundTrip_spaceEncoding() {
+        // Sanity check that `%20` and `+` both decode to space — the parser must preserve
+        // error_description exactly as the wallet sent it.
+        val params = "error=server_error&error_description=Internal%20server%20problem".parseUrlEncodedParameters()
+        assertEquals("Internal server problem", params["error_description"])
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -148,6 +148,43 @@ class Verifier2VPDirectPostHandlerParseTest {
         assertEquals("expected-state", failure.state)
     }
 
+    @Test
+    fun walletErrorResponse_secondPost_doesNotOverwriteTerminalSession() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state")
+
+        // First POST flips session to FAILED with access_denied
+        session.handleWalletError(state = "expected-state")
+        val failureAfterFirst = assertIs<SessionFailure.WalletErrorResponse>(assertNotNull(session.failure))
+        assertEquals("access_denied", failureAfterFirst.error)
+
+        // Second POST with a different error must not overwrite status/statusReason/failure
+        val events = session.handleWalletError(
+            state = "expected-state",
+            error = "invalid_request",
+            errorDescription = "overwrite attempt",
+        )
+
+        assertEquals(emptyList(), events, "No events should fire for a terminal session")
+        assertEquals(Verification2Session.VerificationSessionStatus.FAILED, session.status)
+        assertEquals("Wallet returned OID4VP error: access_denied", session.statusReason)
+
+        val failureAfterSecond = assertIs<SessionFailure.WalletErrorResponse>(assertNotNull(session.failure))
+        assertEquals("access_denied", failureAfterSecond.error, "original failure must be preserved")
+    }
+
+    @Test
+    fun walletErrorResponse_onSuccessfulSession_doesNotOverwrite() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state").apply {
+            status = Verification2Session.VerificationSessionStatus.SUCCESSFUL
+        }
+
+        val events = session.handleWalletError(state = "expected-state")
+
+        assertEquals(emptyList(), events)
+        assertEquals(Verification2Session.VerificationSessionStatus.SUCCESSFUL, session.status)
+        assertEquals(null, session.failure, "must not attach failure to a SUCCESSFUL session")
+    }
+
     private fun directPostSession(expectedState: String) = Verification2Session(
         setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
         status = Verification2Session.VerificationSessionStatus.ACTIVE,
@@ -160,13 +197,17 @@ class Verifier2VPDirectPostHandlerParseTest {
         requestMode = Verification2Session.RequestMode.REQUEST_URI,
     )
 
-    private suspend fun Verification2Session.handleWalletError(state: String?): List<SessionEvent> {
+    private suspend fun Verification2Session.handleWalletError(
+        state: String?,
+        error: String = "access_denied",
+        errorDescription: String? = "User denied",
+    ): List<SessionEvent> {
         val events = mutableListOf<SessionEvent>()
         handleDirectPost(
             verificationSession = this,
             responseData = ErrorResponseDirectPost(
-                error = "access_denied",
-                errorDescription = "User denied",
+                error = error,
+                errorDescription = errorDescription,
                 state = state,
             ),
             updateSessionCallback = { session, event, block ->

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -1,10 +1,17 @@
 package id.walt.verifier2.handlers.vpresponse
 
+import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import id.walt.verifier2.data.CrossDeviceFlowSetup
+import id.walt.verifier2.data.SessionEvent
+import id.walt.verifier2.data.SessionFailure
+import id.walt.verifier2.data.Verification2Session
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.CleartextDirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DcApiJsonDirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.EncryptedResponseStringDirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.ErrorResponseDirectPost
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.handleDirectPost
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.parseHttpRequestToDirectPostResponse
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -16,11 +23,15 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.ktor.util.AttributeKey
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 
+@OptIn(ExperimentalSerializationApi::class)
 class Verifier2VPDirectPostHandlerParseTest {
 
     private fun parse(contentType: ContentType, body: String): DirectPostResponse {
@@ -111,5 +122,62 @@ class Verifier2VPDirectPostHandlerParseTest {
         // error_description exactly as the wallet sent it.
         val params = "error=server_error&error_description=Internal%20server%20problem".parseUrlEncodedParameters()
         assertEquals("Internal server problem", params["error_description"])
+    }
+
+    @Test
+    fun walletErrorResponse_missingExpectedState_isRejected() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state")
+
+        assertFailsWith<Throwable> {
+            session.handleWalletError(state = null)
+        }
+    }
+
+    @Test
+    fun walletErrorResponse_matchingState_recordsStructuredFailure() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state")
+        val events = session.handleWalletError(state = "expected-state")
+
+        assertEquals(listOf(SessionEvent.wallet_error_response_received), events)
+        assertEquals(Verification2Session.VerificationSessionStatus.FAILED, session.status)
+        assertEquals("Wallet returned OID4VP error: access_denied", session.statusReason)
+
+        val failure = assertIs<SessionFailure.WalletErrorResponse>(assertNotNull(session.failure))
+        assertEquals("access_denied", failure.error)
+        assertEquals("User denied", failure.errorDescription)
+        assertEquals("expected-state", failure.state)
+    }
+
+    private fun directPostSession(expectedState: String) = Verification2Session(
+        setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
+        status = Verification2Session.VerificationSessionStatus.ACTIVE,
+        authorizationRequest = AuthorizationRequest(
+            state = expectedState,
+            responseMode = OpenID4VPResponseMode.DIRECT_POST,
+            responseUri = "https://verifier.example/response",
+        ),
+        authorizationRequestUrl = null,
+        requestMode = Verification2Session.RequestMode.REQUEST_URI,
+    )
+
+    private suspend fun Verification2Session.handleWalletError(state: String?): List<SessionEvent> {
+        val events = mutableListOf<SessionEvent>()
+        handleDirectPost(
+            verificationSession = this,
+            responseData = ErrorResponseDirectPost(
+                error = "access_denied",
+                errorDescription = "User denied",
+                state = state,
+            ),
+            updateSessionCallback = { session, event, block ->
+                events += event
+                session.block()
+            },
+            failSessionCallback = { session, event, updateSession ->
+                session.status = Verification2Session.VerificationSessionStatus.FAILED
+                updateSession(session, event) {}
+            },
+        )
+        return events
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -147,6 +147,22 @@ class Verifier2VPDirectPostHandlerParseTest {
     }
 
     @Test
+    fun walletErrorResponse_returnsErrorRedirectWhenConfigured() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(
+            expectedState = "expected-state",
+            redirects = Verification2Session.VerificationSessionRedirects(
+                errorRedirectUri = "https://verifier.example/error",
+            ),
+        )
+
+        val result = session.handleWalletErrorWithResponse(state = "expected-state")
+
+        assertEquals(mapOf("redirect_uri" to "https://verifier.example/error"), result.response)
+        assertEquals(listOf(SessionEvent.wallet_error_response_received), result.events)
+        assertEquals(Verification2Session.VerificationSessionStatus.FAILED, session.status)
+    }
+
+    @Test
     fun walletErrorResponse_secondPost_doesNotOverwriteTerminalSession() = kotlinx.coroutines.test.runTest {
         val session = directPostSession(expectedState = "expected-state")
 
@@ -197,7 +213,10 @@ class Verifier2VPDirectPostHandlerParseTest {
         assertEquals(null, session.failure, "invalid replay must not attach failure to terminal session")
     }
 
-    private fun directPostSession(expectedState: String) = Verification2Session(
+    private fun directPostSession(
+        expectedState: String,
+        redirects: Verification2Session.VerificationSessionRedirects? = null,
+    ) = Verification2Session(
         setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
         status = Verification2Session.VerificationSessionStatus.ACTIVE,
         authorizationRequest = AuthorizationRequest(
@@ -207,15 +226,27 @@ class Verifier2VPDirectPostHandlerParseTest {
         ),
         authorizationRequestUrl = null,
         requestMode = Verification2Session.RequestMode.REQUEST_URI,
+        redirects = redirects,
+    )
+
+    private data class WalletErrorHandleResult(
+        val response: Map<String, String>,
+        val events: List<SessionEvent>,
     )
 
     private suspend fun Verification2Session.handleWalletError(
         state: String?,
         error: String = "access_denied",
         errorDescription: String? = "User denied",
-    ): List<SessionEvent> {
+    ): List<SessionEvent> = handleWalletErrorWithResponse(state, error, errorDescription).events
+
+    private suspend fun Verification2Session.handleWalletErrorWithResponse(
+        state: String?,
+        error: String = "access_denied",
+        errorDescription: String? = "User denied",
+    ): WalletErrorHandleResult {
         val events = mutableListOf<SessionEvent>()
-        handleDirectPost(
+        val response = handleDirectPost(
             verificationSession = this,
             responseData = ErrorResponseDirectPost(
                 error = error,
@@ -231,6 +262,6 @@ class Verifier2VPDirectPostHandlerParseTest {
                 updateSession(session, event) {}
             },
         )
-        return events
+        return WalletErrorHandleResult(response = response, events = events)
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -26,14 +26,9 @@ import id.waltid.openid4vp.wallet.presentation.MdocPresenter
 import id.waltid.openid4vp.wallet.presentation.SdJwtVcPresenter
 import id.waltid.openid4vp.wallet.presentation.W3CPresenter
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.client.*
 import io.ktor.client.call.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
 import io.ktor.util.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -195,48 +190,34 @@ object WalletPresentFunctionality2 {
     ): Result<WalletPresentResult> = runCatching {
         val responseMode = authorizationRequest.responseMode ?: inferResponseMode(authorizationRequest)
         val errorParameters = buildErrorResponseParameters(authorizationRequest, error, errorDescription)
+        val redirectUri = authorizationRequest.redirectUri
+        val responseUri = authorizationRequest.responseUri
 
         when (responseMode) {
             OpenID4VPResponseMode.FRAGMENT -> {
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'fragment'."
-                }
-                WalletPresentResult(
-                    getUrl = "${authorizationRequest.redirectUri}#${errorParameters.formUrlEncode()}"
-                )
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'fragment'." }
+                WalletPresentResult(getUrl = "${redirectUri}#${errorParameters.formUrlEncode()}")
             }
 
             OpenID4VPResponseMode.QUERY -> {
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'query'."
-                }
-                WalletPresentResult(
-                    getUrl = URLBuilder(authorizationRequest.redirectUri!!).apply {
-                        parameters.appendAll(errorParameters)
-                    }.buildString()
-                )
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'query'." }
+                WalletPresentResult(getUrl = URLBuilder(redirectUri).apply { parameters.appendAll(errorParameters) }.buildString())
             }
 
             OpenID4VPResponseMode.FORM_POST -> {
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
-                }
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'." }
                 WalletPresentResult(
                     formPostHtml = buildFormPostHtml(
-                        actionUrl = authorizationRequest.redirectUri!!,
+                        actionUrl = redirectUri,
                         title = "Submitting Error Response...",
-                        fields = errorParameters.entries().flatMap { (name, values) ->
-                            values.map { name to it }
-                        },
+                        fields = errorParameters.entries().flatMap { (name, values) -> values.map { name to it } },
                     )
                 )
             }
 
             OpenID4VPResponseMode.DIRECT_POST, OpenID4VPResponseMode.DIRECT_POST_JWT -> {
-                require(authorizationRequest.responseUri != null) {
-                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'."
-                }
-                postFormResponse(authorizationRequest.responseUri!!, errorParameters)
+                require(responseUri != null) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'." }
+                postFormResponse(responseUri, errorParameters)
             }
 
             OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
@@ -547,21 +528,20 @@ object WalletPresentFunctionality2 {
 
             OpenID4VPResponseMode.FORM_POST -> {
                 // This mode also requires a redirect_uri to POST the form to.
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
-                }
+                val redirectUri = authorizationRequest.redirectUri
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'." }
 
                 val fields = buildList {
                     add("vp_token" to vpToken)
                     authorizationRequest.state?.let { add("state" to it) }
                 }
                 val htmlContent = buildFormPostHtml(
-                    actionUrl = authorizationRequest.redirectUri!!,
+                    actionUrl = redirectUri,
                     title = "Submitting Presentation...",
                     fields = fields,
                 )
 
-                log.trace { "Responding with self-submitting HTML form to post to: ${authorizationRequest.redirectUri}" }
+                log.trace { "Responding with self-submitting HTML form to post to: $redirectUri" }
 
                 // For a pure API, we return the HTML for the client to render in a WebView.
                 return Result.success(
@@ -573,7 +553,8 @@ object WalletPresentFunctionality2 {
 
             // authorizationRequest.responseUri
             OpenID4VPResponseMode.DIRECT_POST -> {
-                require(authorizationRequest.responseUri != null) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'." }
+                val responseUri = authorizationRequest.responseUri
+                requireNotNull(responseUri) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'." }
                 val parameters = ParametersBuilder().apply {
                     append("vp_token", vpToken)
 
@@ -582,17 +563,14 @@ object WalletPresentFunctionality2 {
                     }
                 }.build()
 
-                log.trace { "Submitting direct_post form to Verifier: ${authorizationRequest.responseUri}" }
-                return Result.success(
-                    postFormResponse(authorizationRequest.responseUri!!, parameters)
-                )
+                log.trace { "Submitting direct_post form to Verifier: $responseUri" }
+                return Result.success(postFormResponse(responseUri, parameters))
             }
 
             OpenID4VPResponseMode.DIRECT_POST_JWT -> {
                 // Encrypt the vp_token and state into a JWE, then POST response=<JWE_string>.
-                require(authorizationRequest.responseUri != null) {
-                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post.jwt'."
-                }
+                val responseUri = authorizationRequest.responseUri
+                requireNotNull(responseUri) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post.jwt'." }
 
                 // 1. Get Encryption Metadata
                 val clientMetadata = authorizationRequest.clientMetadata
@@ -630,10 +608,8 @@ object WalletPresentFunctionality2 {
                     append("response", jweString)
                 }.build()
 
-                log.trace { "Submitting direct_post.jwt (encrypted) to Verifier: ${authorizationRequest.responseUri}" }
-                return Result.success(
-                    postFormResponse(authorizationRequest.responseUri!!, parameters)
-                )
+                log.trace { "Submitting direct_post.jwt (encrypted) to Verifier: $responseUri" }
+                return Result.success(postFormResponse(responseUri, parameters))
 
             }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -154,20 +154,19 @@ object WalletPresentFunctionality2 {
      * future spec addition is needed before this enum is updated, use
      * [walletRejectHandling]'s String overload.
      */
-    @Suppress("EnumEntryName")
-    enum class Oid4vpErrorCode(val code: String) {
-        access_denied("access_denied"),
-        invalid_request("invalid_request"),
-        invalid_client("invalid_client"),
-        invalid_scope("invalid_scope"),
-        unauthorized_client("unauthorized_client"),
-        unsupported_response_type("unsupported_response_type"),
-        server_error("server_error"),
-        temporarily_unavailable("temporarily_unavailable"),
-        vp_formats_not_supported("vp_formats_not_supported"),
-        invalid_request_uri_method("invalid_request_uri_method"),
-        invalid_transaction_data("invalid_transaction_data"),
-        wallet_unavailable("wallet_unavailable"),
+    enum class OID4VPErrorCode(val code: String) {
+        ACCESS_DENIED("access_denied"),
+        INVALID_REQUEST("invalid_request"),
+        INVALID_CLIENT("invalid_client"),
+        INVALID_SCOPE("invalid_scope"),
+        UNAUTHORIZED_CLIENT("unauthorized_client"),
+        UNSUPPORTED_RESPONSE_TYPE("unsupported_response_type"),
+        SERVER_ERROR("server_error"),
+        TEMPORARILY_UNAVAILABLE("temporarily_unavailable"),
+        VP_FORMATS_NOT_SUPPORTED("vp_formats_not_supported"),
+        INVALID_REQUEST_URI_METHOD("invalid_request_uri_method"),
+        INVALID_TRANSACTION_DATA("invalid_transaction_data"),
+        WALLET_UNAVAILABLE("wallet_unavailable"),
     }
 
     /**
@@ -181,13 +180,13 @@ object WalletPresentFunctionality2 {
      */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,
-        error: Oid4vpErrorCode = Oid4vpErrorCode.access_denied,
+        error: OID4VPErrorCode = OID4VPErrorCode.ACCESS_DENIED,
         errorDescription: String? = null,
     ): Result<WalletPresentResult> = walletRejectHandling(authorizationRequest, error.code, errorDescription)
 
     /**
      * String overload of [walletRejectHandling] for forward-compatibility with error codes
-     * not yet in [Oid4vpErrorCode]. Prefer the typed variant.
+     * not yet in [OID4VPErrorCode]. Prefer the typed variant.
      */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -146,6 +146,110 @@ object WalletPresentFunctionality2 {
         val redirectTo: String? = null
     )
 
+    suspend fun walletRejectHandling(
+        authorizationRequest: AuthorizationRequest,
+        error: String = "access_denied",
+        errorDescription: String? = null,
+    ): Result<WalletPresentResult> = runCatching {
+        val responseMode = authorizationRequest.responseMode ?: inferResponseMode(authorizationRequest)
+        val errorParameters = buildErrorResponseParameters(authorizationRequest, error, errorDescription)
+
+        when (responseMode) {
+            OpenID4VPResponseMode.FRAGMENT -> {
+                require(authorizationRequest.redirectUri != null) {
+                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'fragment'."
+                }
+                WalletPresentResult(
+                    getUrl = "${authorizationRequest.redirectUri}#${errorParameters.formUrlEncode()}"
+                )
+            }
+
+            OpenID4VPResponseMode.QUERY -> {
+                require(authorizationRequest.redirectUri != null) {
+                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'query'."
+                }
+                WalletPresentResult(
+                    getUrl = URLBuilder(authorizationRequest.redirectUri!!).apply {
+                        parameters.appendAll(errorParameters)
+                    }.buildString()
+                )
+            }
+
+            OpenID4VPResponseMode.FORM_POST -> {
+                require(authorizationRequest.redirectUri != null) {
+                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
+                }
+                WalletPresentResult(
+                    formPostHtml = buildErrorResponseFormPostHtml(authorizationRequest.redirectUri!!, errorParameters)
+                )
+            }
+
+            OpenID4VPResponseMode.DIRECT_POST -> {
+                require(authorizationRequest.responseUri != null) {
+                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'."
+                }
+                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, errorParameters)
+                val responseBody = response.bodyAsText()
+                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }.getOrNull()
+
+                WalletPresentResult(
+                    transmissionSuccess = response.status.isSuccess(),
+                    verifierResponse = Json.parseToJsonElement(responseBody),
+                    redirectTo = responseBodyJson?.get("redirect_uri")?.jsonPrimitive?.content,
+                )
+            }
+
+            OpenID4VPResponseMode.DIRECT_POST_JWT ->
+                throw UnsupportedOperationException("OID4VP error responses for direct_post.jwt require JARM and are not supported yet.")
+
+            OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
+                throw UnsupportedOperationException("OID4VP error responses are not supported for DC API response modes.")
+
+            null -> throw IllegalArgumentException("Missing response mode from AuthorizationRequest")
+        }
+    }
+
+    private fun inferResponseMode(authorizationRequest: AuthorizationRequest): OpenID4VPResponseMode? {
+        val responseType = authorizationRequest.responseType?.responseType
+        return when {
+            responseType == null -> null
+            "vp_token" in responseType && "code" !in responseType -> OpenID4VPResponseMode.FRAGMENT
+            "code" in responseType -> OpenID4VPResponseMode.QUERY
+            else -> null
+        }
+    }
+
+    private fun buildErrorResponseParameters(
+        authorizationRequest: AuthorizationRequest,
+        error: String,
+        errorDescription: String?,
+    ): Parameters = ParametersBuilder().apply {
+        append("error", error)
+        errorDescription?.let { append("error_description", it) }
+        authorizationRequest.state?.let { append("state", it) }
+    }.build()
+
+    private fun buildErrorResponseFormPostHtml(
+        redirectUri: String,
+        parameters: Parameters,
+    ): String = buildString {
+        appendLine("<!DOCTYPE html>")
+        appendLine("<html>")
+        appendLine("<head><title>Submitting Error Response...</title></head>")
+        appendLine("<body onload=\"document.forms[0].submit()\">")
+        appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
+        appendLine("<form method=\"POST\" action=\"${redirectUri.encodeURLParameter()}\">")
+        parameters.entries().forEach { (name, values) ->
+            values.forEach { value ->
+                appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
+            }
+        }
+        appendLine("<input type=\"submit\" value=\"Continue\"/>")
+        appendLine("</form>")
+        appendLine("</body>")
+        appendLine("</html>")
+    }
+
     suspend fun walletPresentHandling(
         holderKey: Key,
         holderDid: String?,

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -174,8 +174,10 @@ object WalletPresentFunctionality2 {
      * Produce an OpenID4VP 1.0 §8.5 wallet rejection response for the given
      * [authorizationRequest]. The response is shaped according to the request's `response_mode`
      * and carries `error`, optional `error_description`, and the request's `state` (when
-     * present). For `direct_post`, the rejection is transmitted to the verifier's `response_uri`
-     * and the verifier's acknowledgement is returned.
+     * present). For `direct_post` and `direct_post.jwt`, the rejection is transmitted to the
+     * verifier's `response_uri` and the verifier's acknowledgement is returned. OpenID4VP 1.0
+     * permits an unencrypted error response for `direct_post.jwt` when the Wallet cannot generate
+     * the encrypted response.
      */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,
@@ -231,9 +233,9 @@ object WalletPresentFunctionality2 {
                 )
             }
 
-            OpenID4VPResponseMode.DIRECT_POST -> {
+            OpenID4VPResponseMode.DIRECT_POST, OpenID4VPResponseMode.DIRECT_POST_JWT -> {
                 require(authorizationRequest.responseUri != null) {
-                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'."
+                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'."
                 }
                 val response = webPostToken.sendForm(authorizationRequest.responseUri!!, errorParameters)
                 val responseBody = response.bodyAsText()
@@ -245,9 +247,6 @@ object WalletPresentFunctionality2 {
                     redirectTo = responseBodyJson?.get("redirect_uri")?.jsonPrimitive?.content,
                 )
             }
-
-            OpenID4VPResponseMode.DIRECT_POST_JWT ->
-                throw UnsupportedOperationException("OID4VP error responses for direct_post.jwt require JARM and are not supported yet.")
 
             OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
                 throw UnsupportedOperationException("OID4VP error responses are not supported for DC API response modes.")
@@ -291,7 +290,7 @@ object WalletPresentFunctionality2 {
         appendLine("<head><title>${title.escapeHTML()}</title></head>")
         appendLine("<body onload=\"document.forms[0].submit()\">")
         appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
-        appendLine("<form method=\"POST\" action=\"${actionUrl.encodeURLParameter()}\">")
+        appendLine("<form method=\"POST\" action=\"${actionUrl.escapeHTML()}\">")
         fields.forEach { (name, value) ->
             appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
         }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -146,9 +146,50 @@ object WalletPresentFunctionality2 {
         val redirectTo: String? = null
     )
 
+    /**
+     * OpenID4VP 1.0 §8.5 wallet-side error codes (with RFC 6749 §4.1.2.1 / §4.2.2.1 parents).
+     *
+     * The verifier side accepts any `error` string (permissive); this typed enum only steers
+     * wallet-side callers away from typos in the finite set that the spec enumerates. If a
+     * future spec addition is needed before this enum is updated, use
+     * [walletRejectHandling]'s String overload.
+     */
+    @Suppress("EnumEntryName")
+    enum class Oid4vpErrorCode(val code: String) {
+        access_denied("access_denied"),
+        invalid_request("invalid_request"),
+        invalid_client("invalid_client"),
+        invalid_scope("invalid_scope"),
+        unauthorized_client("unauthorized_client"),
+        unsupported_response_type("unsupported_response_type"),
+        server_error("server_error"),
+        temporarily_unavailable("temporarily_unavailable"),
+        vp_formats_not_supported("vp_formats_not_supported"),
+        invalid_request_uri_method("invalid_request_uri_method"),
+        invalid_transaction_data("invalid_transaction_data"),
+        wallet_unavailable("wallet_unavailable"),
+    }
+
+    /**
+     * Produce an OpenID4VP 1.0 §8.5 wallet rejection response for the given
+     * [authorizationRequest]. The response is shaped according to the request's `response_mode`
+     * and carries `error`, optional `error_description`, and the request's `state` (when
+     * present). For `direct_post`, the rejection is transmitted to the verifier's `response_uri`
+     * and the verifier's acknowledgement is returned.
+     */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,
-        error: String = "access_denied",
+        error: Oid4vpErrorCode = Oid4vpErrorCode.access_denied,
+        errorDescription: String? = null,
+    ): Result<WalletPresentResult> = walletRejectHandling(authorizationRequest, error.code, errorDescription)
+
+    /**
+     * String overload of [walletRejectHandling] for forward-compatibility with error codes
+     * not yet in [Oid4vpErrorCode]. Prefer the typed variant.
+     */
+    suspend fun walletRejectHandling(
+        authorizationRequest: AuthorizationRequest,
+        error: String,
         errorDescription: String? = null,
     ): Result<WalletPresentResult> = runCatching {
         val responseMode = authorizationRequest.responseMode ?: inferResponseMode(authorizationRequest)
@@ -180,7 +221,13 @@ object WalletPresentFunctionality2 {
                     "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
                 }
                 WalletPresentResult(
-                    formPostHtml = buildErrorResponseFormPostHtml(authorizationRequest.redirectUri!!, errorParameters)
+                    formPostHtml = buildFormPostHtml(
+                        actionUrl = authorizationRequest.redirectUri!!,
+                        title = "Submitting Error Response...",
+                        fields = errorParameters.entries().flatMap { (name, values) ->
+                            values.map { name to it }
+                        },
+                    )
                 )
             }
 
@@ -229,20 +276,24 @@ object WalletPresentFunctionality2 {
         authorizationRequest.state?.let { append("state", it) }
     }.build()
 
-    private fun buildErrorResponseFormPostHtml(
-        redirectUri: String,
-        parameters: Parameters,
+    /**
+     * Build a self-submitting `form_post` HTML page that POSTs [fields] to [actionUrl].
+     * Shared by [walletPresentHandling] (carrying `vp_token`) and [walletRejectHandling]
+     * (carrying `error` / `error_description` / `state`).
+     */
+    private fun buildFormPostHtml(
+        actionUrl: String,
+        title: String,
+        fields: List<Pair<String, String>>,
     ): String = buildString {
         appendLine("<!DOCTYPE html>")
         appendLine("<html>")
-        appendLine("<head><title>Submitting Error Response...</title></head>")
+        appendLine("<head><title>${title.escapeHTML()}</title></head>")
         appendLine("<body onload=\"document.forms[0].submit()\">")
         appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
-        appendLine("<form method=\"POST\" action=\"${redirectUri.encodeURLParameter()}\">")
-        parameters.entries().forEach { (name, values) ->
-            values.forEach { value ->
-                appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
-            }
+        appendLine("<form method=\"POST\" action=\"${actionUrl.encodeURLParameter()}\">")
+        fields.forEach { (name, value) ->
+            appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
         }
         appendLine("<input type=\"submit\" value=\"Continue\"/>")
         appendLine("</form>")
@@ -495,26 +546,15 @@ object WalletPresentFunctionality2 {
                     "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
                 }
 
-                // Build an HTML page with a self-submitting form.
-                val htmlContent = buildString {
-                    appendLine("<!DOCTYPE html>")
-                    appendLine("<html>")
-                    appendLine("<head><title>Submitting Presentation...</title></head>")
-                    // The body's onload attribute triggers the form submission automatically.
-                    appendLine("<body onload=\"document.forms[0].submit()\">")
-                    appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
-                    // The form action is the Verifier's redirect_uri.
-                    appendLine("<form method=\"POST\" action=\"${authorizationRequest.redirectUri!!.encodeURLParameter()}\">")
-                    // The vp_token and state are included as hidden input fields.
-                    appendLine("<input type=\"hidden\" name=\"vp_token\" value=\"${vpToken.escapeHTML()}\"/>")
-                    authorizationRequest.state?.let {
-                        appendLine("<input type=\"hidden\" name=\"state\" value=\"${it.escapeHTML()}\"/>")
-                    }
-                    appendLine("<input type=\"submit\" value=\"Continue\"/>")
-                    appendLine("</form>")
-                    appendLine("</body>")
-                    appendLine("</html>")
+                val fields = buildList {
+                    add("vp_token" to vpToken)
+                    authorizationRequest.state?.let { add("state" to it) }
                 }
+                val htmlContent = buildFormPostHtml(
+                    actionUrl = authorizationRequest.redirectUri!!,
+                    title = "Submitting Presentation...",
+                    fields = fields,
+                )
 
                 log.trace { "Responding with self-submitting HTML form to post to: ${authorizationRequest.redirectUri}" }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -237,15 +237,7 @@ object WalletPresentFunctionality2 {
                 require(authorizationRequest.responseUri != null) {
                     "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'."
                 }
-                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, errorParameters)
-                val responseBody = response.bodyAsText()
-                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }.getOrNull()
-
-                WalletPresentResult(
-                    transmissionSuccess = response.status.isSuccess(),
-                    verifierResponse = Json.parseToJsonElement(responseBody),
-                    redirectTo = responseBodyJson?.get("redirect_uri")?.jsonPrimitive?.content,
-                )
+                postFormResponse(authorizationRequest.responseUri!!, errorParameters)
             }
 
             OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
@@ -274,6 +266,21 @@ object WalletPresentFunctionality2 {
         errorDescription?.let { append("error_description", it) }
         authorizationRequest.state?.let { append("state", it) }
     }.build()
+
+    private suspend fun postFormResponse(
+        responseUri: String,
+        parameters: Parameters,
+    ): WalletPresentResult {
+        val response = webPostToken.sendForm(responseUri, parameters)
+        val responseBody = response.bodyAsText()
+        val responseBodyJson = Json.parseToJsonElement(responseBody).jsonObject
+
+        return WalletPresentResult(
+            transmissionSuccess = response.status.isSuccess(),
+            verifierResponse = responseBodyJson,
+            redirectTo = responseBodyJson["redirect_uri"]?.jsonPrimitive?.content,
+        )
+    }
 
     /**
      * Build a self-submitting `form_post` HTML page that POSTs [fields] to [actionUrl].
@@ -577,20 +584,8 @@ object WalletPresentFunctionality2 {
                 }.build()
 
                 log.trace { "Submitting direct_post form to Verifier: ${authorizationRequest.responseUri}" }
-                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, parameters)
-                log.trace { "Verifier direct_post response: $response" }
-
-                val responseBody = response.bodyAsText()
-                log.trace { "Verifier direct_post response body: $responseBody" }
-
-                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }
-
                 return Result.success(
-                    WalletPresentResult(
-                        transmissionSuccess = response.status.isSuccess(),
-                        verifierResponse = Json.parseToJsonElement(responseBody),
-                        redirectTo = responseBodyJson.getOrThrow()["redirect_uri"]?.jsonPrimitive?.content
-                    )
+                    postFormResponse(authorizationRequest.responseUri!!, parameters)
                 )
             }
 
@@ -637,20 +632,8 @@ object WalletPresentFunctionality2 {
                 }.build()
 
                 log.trace { "Submitting direct_post.jwt (encrypted) to Verifier: ${authorizationRequest.responseUri}" }
-                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, parameters)
-
-                log.trace { "Verifier direct_post.jwt response status: ${response.status}" }
-
-                // 7. Process Response (Same as direct_post)
-                val responseBody = response.bodyAsText()
-                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }
-
                 return Result.success(
-                    WalletPresentResult(
-                        transmissionSuccess = response.status.isSuccess(),
-                        verifierResponse = Json.parseToJsonElement(responseBody),
-                        redirectTo = responseBodyJson.getOrThrow()["redirect_uri"]?.jsonPrimitive?.content
-                    )
+                    postFormResponse(authorizationRequest.responseUri!!, parameters)
                 )
 
             }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -40,7 +40,7 @@ class WalletRejectHandlingTest {
                 responseMode = OpenID4VPResponseMode.FRAGMENT,
                 state = "state-123",
             ),
-            error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+            error = WalletPresentFunctionality2.OID4VPErrorCode.ACCESS_DENIED,
             errorDescription = "User denied",
         ).getOrThrow()
 
@@ -73,7 +73,7 @@ class WalletRejectHandlingTest {
                 responseMode = OpenID4VPResponseMode.QUERY,
                 state = "state-abc",
             ),
-            error = WalletPresentFunctionality2.Oid4vpErrorCode.invalid_request,
+            error = WalletPresentFunctionality2.OID4VPErrorCode.INVALID_REQUEST,
             errorDescription = "bad request",
         ).getOrThrow()
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -1,0 +1,30 @@
+package id.waltid.openid4vp.wallet
+
+import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalSerializationApi::class)
+class WalletRejectHandlingTest {
+
+    @Test
+    fun fragmentErrorResponse_includesErrorDescriptionAndState() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FRAGMENT,
+                state = "state-123",
+            ),
+            error = "access_denied",
+            errorDescription = "User denied",
+        ).getOrThrow()
+
+        assertEquals(
+            "https://wallet.example/callback#error=access_denied&error_description=User+denied&state=state-123",
+            result.getUrl,
+        )
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -100,6 +100,7 @@ class WalletRejectHandlingTest {
 
         val html = assertNotNull(result.formPostHtml)
         assertTrue("<form method=\"POST\"" in html)
+        assertTrue("action=\"https://wallet.example/callback\"" in html)
         assertTrue("name=\"error\" value=\"access_denied\"" in html)
         // error_description should be HTML-escaped
         assertTrue("name=\"error_description\" value=\"User &quot;denied&quot;\"" in html)
@@ -107,23 +108,6 @@ class WalletRejectHandlingTest {
         assertTrue("name=\"state\" value=\"state-&lt;123&gt;\"" in html)
         // auto-submit behavior present
         assertTrue("document.forms[0].submit()" in html)
-    }
-
-    // --- DIRECT_POST_JWT: explicitly unsupported ---------------------------
-
-    @Test
-    fun directPostJwt_isUnsupported() = runTest {
-        val result = WalletPresentFunctionality2.walletRejectHandling(
-            authorizationRequest = AuthorizationRequest(
-                responseUri = "https://verifier.example/response",
-                responseMode = OpenID4VPResponseMode.DIRECT_POST_JWT,
-                state = "s",
-            ),
-            error = "access_denied",
-        )
-
-        assertTrue(result.isFailure)
-        assertTrue(result.exceptionOrNull() is UnsupportedOperationException)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -6,9 +6,13 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalSerializationApi::class)
 class WalletRejectHandlingTest {
+
+    // --- FRAGMENT -----------------------------------------------------------
 
     @Test
     fun fragmentErrorResponse_includesErrorDescriptionAndState() = runTest {
@@ -26,5 +30,114 @@ class WalletRejectHandlingTest {
             "https://wallet.example/callback#error=access_denied&error_description=User+denied&state=state-123",
             result.getUrl,
         )
+    }
+
+    @Test
+    fun fragmentErrorResponse_typedEnum_producesSameUrl() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FRAGMENT,
+                state = "state-123",
+            ),
+            error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+            errorDescription = "User denied",
+        ).getOrThrow()
+
+        assertEquals(
+            "https://wallet.example/callback#error=access_denied&error_description=User+denied&state=state-123",
+            result.getUrl,
+        )
+    }
+
+    @Test
+    fun fragmentErrorResponse_omitsStateWhenRequestHasNone() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FRAGMENT,
+            ),
+            error = "access_denied",
+        ).getOrThrow()
+
+        assertEquals("https://wallet.example/callback#error=access_denied", result.getUrl)
+    }
+
+    // --- QUERY --------------------------------------------------------------
+
+    @Test
+    fun queryErrorResponse_appendsErrorParametersAsQueryString() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.QUERY,
+                state = "state-abc",
+            ),
+            error = WalletPresentFunctionality2.Oid4vpErrorCode.invalid_request,
+            errorDescription = "bad request",
+        ).getOrThrow()
+
+        val url = assertNotNull(result.getUrl)
+        assertTrue(url.startsWith("https://wallet.example/callback?"))
+        assertTrue("error=invalid_request" in url)
+        assertTrue("error_description=bad+request" in url || "error_description=bad%20request" in url)
+        assertTrue("state=state-abc" in url)
+    }
+
+    // --- FORM_POST ----------------------------------------------------------
+
+    @Test
+    fun formPostErrorResponse_generatesSelfSubmittingHtmlWithEscapedFields() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FORM_POST,
+                state = "state-<123>",
+            ),
+            error = "access_denied",
+            errorDescription = "User \"denied\"",
+        ).getOrThrow()
+
+        val html = assertNotNull(result.formPostHtml)
+        assertTrue("<form method=\"POST\"" in html)
+        assertTrue("name=\"error\" value=\"access_denied\"" in html)
+        // error_description should be HTML-escaped
+        assertTrue("name=\"error_description\" value=\"User &quot;denied&quot;\"" in html)
+        // state should be HTML-escaped
+        assertTrue("name=\"state\" value=\"state-&lt;123&gt;\"" in html)
+        // auto-submit behavior present
+        assertTrue("document.forms[0].submit()" in html)
+    }
+
+    // --- DIRECT_POST_JWT: explicitly unsupported ---------------------------
+
+    @Test
+    fun directPostJwt_isUnsupported() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                responseUri = "https://verifier.example/response",
+                responseMode = OpenID4VPResponseMode.DIRECT_POST_JWT,
+                state = "s",
+            ),
+            error = "access_denied",
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is UnsupportedOperationException)
+    }
+
+    @Test
+    fun dcApi_isUnsupported() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.DC_API,
+                state = "s",
+            ),
+            error = "access_denied",
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is UnsupportedOperationException)
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
@@ -27,7 +27,7 @@ class WalletRejectDirectPostHandlingJvmTest {
                     responseMode = OpenID4VPResponseMode.DIRECT_POST,
                     state = "state-123",
                 ),
-                error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+                error = WalletPresentFunctionality2.OID4VPErrorCode.ACCESS_DENIED,
                 errorDescription = "User denied",
             ).getOrThrow()
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
@@ -1,0 +1,81 @@
+package id.waltid.openid4vp.wallet
+
+import com.sun.net.httpserver.HttpServer
+import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalSerializationApi::class)
+class WalletRejectDirectPostHandlingJvmTest {
+
+    @Test
+    fun directPost_sendsErrorResponseToResponseUri() = runTest {
+        withRecordingServer { responseUri, receivedBody ->
+            val result = WalletPresentFunctionality2.walletRejectHandling(
+                authorizationRequest = AuthorizationRequest(
+                    responseUri = responseUri,
+                    responseMode = OpenID4VPResponseMode.DIRECT_POST,
+                    state = "state-123",
+                ),
+                error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+                errorDescription = "User denied",
+            ).getOrThrow()
+
+            assertEquals(true, result.transmissionSuccess)
+            assertEquals("acknowledged", result.verifierResponse?.jsonObjectValue("status"))
+            assertEquals("error=access_denied&error_description=User+denied&state=state-123", assertNotNull(receivedBody.get()))
+        }
+    }
+
+    @Test
+    fun directPostJwt_sendsPermittedUnencryptedErrorResponseToResponseUri() = runTest {
+        withRecordingServer { responseUri, receivedBody ->
+            val result = WalletPresentFunctionality2.walletRejectHandling(
+                authorizationRequest = AuthorizationRequest(
+                    responseUri = responseUri,
+                    responseMode = OpenID4VPResponseMode.DIRECT_POST_JWT,
+                    state = "state-456",
+                ),
+                error = "access_denied",
+            ).getOrThrow()
+
+            assertEquals(true, result.transmissionSuccess)
+            assertEquals("acknowledged", result.verifierResponse?.jsonObjectValue("status"))
+            assertEquals("error=access_denied&state=state-456", assertNotNull(receivedBody.get()))
+        }
+    }
+
+    private suspend fun withRecordingServer(
+        block: suspend (responseUri: String, receivedBody: AtomicReference<String?>) -> Unit,
+    ) {
+        val receivedBody = AtomicReference<String?>()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/response") { exchange ->
+            receivedBody.set(exchange.requestBody.readBytes().decodeToString())
+            val response = """{"status":"acknowledged"}""".toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { it.write(response) }
+        }
+
+        server.start()
+        try {
+            block("http://127.0.0.1:${server.address.port}/response", receivedBody)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    private fun JsonElement.jsonObjectValue(name: String): String? =
+        jsonObject[name]?.jsonPrimitive?.content
+}

--- a/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/w3c/W3CVerifier2IntegrationTest.kt
+++ b/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/w3c/W3CVerifier2IntegrationTest.kt
@@ -364,6 +364,14 @@ class W3CVerifier2IntegrationTest {
                 assertNotNull(info2.policyResults)
                 assertTrue { info2.policyResults!!.overallSuccess }
                 assertEquals(2, info2.policyResults!!.vcPolicies.size)
+                assertEquals(
+                    setOf("openbadge", "universitydegree"),
+                    info2.policyResults!!.vcPolicies.map { it.queryId }.toSet()
+                )
+                assertEquals(
+                    setOf(0),
+                    info2.policyResults!!.vcPolicies.map { it.credentialIndex }.toSet()
+                )
             }
         }
     }


### PR DESCRIPTION
## Tickets

- [WAL-976](https://linear.app/walt-new/issue/WAL-976) — Verifier2: `vc_policies` failures cannot be attributed to a specific credential
- [WAL-977](https://linear.app/walt-new/issue/WAL-977) — Verifier2: expose DCQL fulfillment failure structurally in webhook events

## Problem

- **WAL-976** — when a `vc_policies` check fails in Verifier2, consumers need to know which requested credential failed, especially when one query returns multiple credentials.
- **WAL-977** — when DCQL fulfillment fails, the verifier has useful detail server-side but the session/webhook payload lacked structured failure data.

Both asks are solved by adding structured failure detail to the session and by carrying credential attribution on policy results.

## Scope

- Adds optional `Verification2Session.failure` with `SessionFailure` subtypes:
  - `presentation_validation`
  - `dcql_fulfillment`
  - `vc_policy_violations`
  - `wallet_error_response` (defined here so the stacked WAL-965 PR can populate it)
- Adds optional `query_id` and `credential_index` fields to `CredentialPolicyResult`.
- Populates those fields for global `vc_policies` and `specific_vc_policies` results emitted by Verifier2.
- Preserves the existing `policy_results.vc_policies` and `policy_results.specific_vc_policies` shape; attribution is carried on each result entry rather than through a separate wrapper/list API.
- Adds `DcqlFulfillmentFailure(missingQueryIds, unsatisfiedSets, successfullyValidatedQueryIds)` and stores it under `failure.type = "dcql_fulfillment"`.
- Extends `DcqlFulfillmentException` with structured `details` while keeping `checkOverallDcqlFulfillment(...) : Result<Unit>` for existing callers.
- Populates `session.failure` before failure transitions for presentation validation, DCQL fulfillment, and VC policy violations.
- Extends `deletePII` coverage to the new failure payloads and attributed credential policy result fields.

## Schema

All additions are additive. Existing `status`, `statusReason`, `policy_results.vp_policies`, `policy_results.vc_policies`, and `policy_results.specific_vc_policies` remain available.

### VC policy violation

```json
{
  "event": "credential_policy_results_available",
  "session": {
    "status": "FAILED",
    "policy_results": {
      "vc_policies": [
        {
          "query_id": "pid",
          "credential_index": 1,
          "policy": {"id": "signature"},
          "success": false,
          "error": "Signature verification failed"
        }
      ]
    },
    "failure": {
      "type": "vc_policy_violations",
      "reason": "1 credential policy violation(s)",
      "violations": [
        {
          "query_id": "pid",
          "credential_index": 1,
          "policy": {"id": "signature"},
          "success": false,
          "error": "Signature verification failed"
        }
      ]
    }
  }
}
```

### DCQL fulfillment failure

```json
{
  "event": "dcql_fulfillment_check_failed",
  "session": {
    "status": "FAILED",
    "failure": {
      "type": "dcql_fulfillment",
      "reason": "DCQL Fulfillment Failed: 1 required CredentialSet(s) not satisfied ...",
      "failure": {
        "missing_query_ids": [],
        "unsatisfied_sets": [{ "options": [["pid"], ["mdl"]] }],
        "successfully_validated_query_ids": ["email"]
      }
    }
  }
}
```

## Compatibility

- New session fields are optional/additive.
- `CredentialPolicyResult` gains optional nullable attribution fields; existing consumers that ignore unknown fields keep working.
- No `SessionEvent` or `VerificationSessionStatus` values are renamed or removed.
- `checkOverallDcqlFulfillment(...) : Result<Unit>` is preserved; failures now carry structured details on the thrown `DcqlFulfillmentException`.
- Required credential-set failures now enumerate all unsatisfied required sets instead of stopping at the first one.

## Test evidence

Clean verification from the PR head against `main`:

```bash
./gradlew \
  :waltid-libraries:protocols:waltid-openid4vp-verifier:jvmTest \
  :waltid-services:waltid-verifier-api2:test \
  :waltid-libraries:protocols:waltid-openid4vp-verifier:compileKotlinJs \
  --no-build-cache --rerun-tasks
```

Result: `BUILD SUCCESSFUL`, `123 actionable tasks: 123 executed`.

Covered behavior:

- DCQL no-`credential_sets` missing IDs populate `missing_query_ids`.
- Unsatisfied required credential sets populate ordered `unsatisfied_sets`.
- Optional credential sets do not fail fulfillment.
- Legacy `checkOverallDcqlFulfillment(...)` still returns `Result.failure(Throwable)`.
- `SessionFailure` serializes with `type` discriminator and snake_case field names.
- Verifier-api2 tests exercise session creation, presentation response handling, and `/verification-session/{id}/info` serialization through a running test server.
- Verifier-api2 W3C session-info coverage asserts `query_id` and `credential_index` are emitted on credential policy results.

## Related

- Stacked code PR: [#1707](https://github.com/walt-id/waltid-identity/pull/1707) — WAL-965 wallet error response support.
- Docs PR: [walt-id/waltid-docs#277](https://github.com/walt-id/waltid-docs/pull/277).
