### PR TITLE
feat(verifier2): accept OID4VP 1.0 §8.5 wallet error response (WAL-965)

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
 
         jvmTest.dependencies {
             implementation("org.slf4j:slf4j-simple:2.0.17")
+            implementation(identityLibs.ktor.server.test.host)
         }
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionEvent.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/SessionEvent.kt
@@ -11,5 +11,6 @@ enum class SessionEvent {
     credential_policy_results_available,
     dcql_fulfillment_check_failed,
     presentation_validation_failed,
+    wallet_error_response_received,
     data_retention_purge
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -15,6 +15,8 @@ import id.walt.verifier2.data.DcApiAnnexCFlowSetup
 import id.walt.verifier2.data.SessionEvent
 import id.walt.verifier2.data.SessionFailure
 import id.walt.verifier2.data.Verification2Session
+import id.walt.verifier2.data.Verification2Session.VerificationSessionStatus.FAILED
+import id.walt.verifier2.data.Verification2Session.VerificationSessionStatus.SUCCESSFUL
 import id.walt.verifier2.data.Verifier2Response
 import id.walt.verifier2.utils.JsonUtils.parseAsJsonObject
 import id.walt.verifier2.verification2.PresentationVerificationEngine
@@ -230,7 +232,7 @@ object Verifier2VPDirectPostHandler {
 
     /**
      * Sealed (= limited option) interface to represent the different forms that
-     * a direct post response can come in.
+     * a direct post response can come in
      */
     sealed interface DirectPostResponse
 
@@ -357,15 +359,12 @@ object Verifier2VPDirectPostHandler {
     ): Map<String, String> {
         log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
 
-        val expectedState = session.authorizationRequest.state
-        if (expectedState != null && responseData.state != expectedState) {
-            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
-        }
+        session.authorizationRequest.state
+            ?.takeIf { it != responseData.state }
+            ?.let { Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError() }
 
-        if (session.status == Verification2Session.VerificationSessionStatus.SUCCESSFUL ||
-            session.status == Verification2Session.VerificationSessionStatus.FAILED
-        ) {
-            log.info { "Session ${session.id} is already terminal (${session.status}); ignoring wallet error response." }
+        if (session.status == SUCCESSFUL || session.status == FAILED) {
+            log.info { "Session ${session.id} already terminal (${session.status}); ignoring wallet error." }
             return mapOf(
                 "status" to "acknowledged",
                 "message" to "Session already terminal; wallet error response ignored.",
@@ -374,7 +373,7 @@ object Verifier2VPDirectPostHandler {
 
         updateSessionCallback(session, SessionEvent.wallet_error_response_received) {
             attempted = true
-            status = Verification2Session.VerificationSessionStatus.FAILED
+            status = FAILED
             statusReason = "Wallet returned OID4VP error: ${responseData.error}"
             failure = SessionFailure.WalletErrorResponse(
                 reason = "Wallet returned OID4VP error response per §8.5",
@@ -384,14 +383,12 @@ object Verifier2VPDirectPostHandler {
             )
         }
 
-        session.redirects?.errorRedirectUri?.let { errorRedirectUri ->
-            return mapOf("redirect_uri" to errorRedirectUri)
-        }
-
-        return mapOf(
-            "status" to "acknowledged",
-            "message" to "Wallet error response recorded.",
-        )
+        return session.redirects?.errorRedirectUri
+            ?.let { mapOf("redirect_uri" to it) }
+            ?: mapOf(
+                "status" to "acknowledged",
+                "message" to "Wallet error response recorded.",
+            )
     }
 
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -38,10 +38,12 @@ object Verifier2VPDirectPostHandler {
 
     suspend fun parseResponseBody(
         responseMode: OpenID4VPResponseMode?,
-        responseData: VpTokenDirectPostResponse,
+        responseData: DirectPostResponse,
         session: Verification2Session,
         ephemeralDecryptionKey: DirectSerializedKey?
     ): Pair<String, String?> = when (responseData) {
+        is ErrorResponseDirectPost -> error("Wallet error responses must be handled before parsing vp_token data")
+
         is DcApiJsonDirectPostResponse -> {
             if (session.setup is DcApiAnnexCFlowSetup) {
                 // Annex C handling
@@ -229,28 +231,17 @@ object Verifier2VPDirectPostHandler {
     /**
      * Sealed (= limited option) interface to represent the different forms that
      * a direct post response can come in.
-     *
-     * Split into two categories:
-     * - [VpTokenDirectPostResponse]: the wallet is attempting to deliver a `vp_token`
-     *   (cleartext, encrypted, or DC API).
-     * - [ErrorResponseDirectPost]: the wallet is rejecting the request per OID4VP §8.5.
-     *
-     * Keeping the two apart lets [parseResponseBody] accept only the vp_token variants
-     * and makes the wallet-error path a separate branch in [handleDirectPost].
      */
     sealed interface DirectPostResponse
 
-    /** Wallet attempts to deliver a `vp_token` (in any of the supported forms). */
-    sealed interface VpTokenDirectPostResponse : DirectPostResponse
-
     /** Custom DC API JSON Object structure */
-    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : VpTokenDirectPostResponse
+    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : DirectPostResponse
 
     /** Encrypted response (Data is in JWT String in URL parameter 'response') */
-    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : VpTokenDirectPostResponse
+    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : DirectPostResponse
 
     /** Cleartext response (Data is directly passed as strings in URL parameter 'vp_token' and 'state') */
-    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : VpTokenDirectPostResponse
+    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : DirectPostResponse
 
     /**
      * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
@@ -288,14 +279,13 @@ object Verifier2VPDirectPostHandler {
         val responseMode = session.authorizationRequest.responseMode
         val isAnnexC = verificationSession.setup is DcApiAnnexCFlowSetup
 
-        val vpTokenResponse: VpTokenDirectPostResponse = when (responseData) {
-            is ErrorResponseDirectPost -> return handleWalletErrorResponse(session, responseData, updateSessionCallback)
-            is VpTokenDirectPostResponse -> responseData
+        if (responseData is ErrorResponseDirectPost) {
+            return handleWalletErrorResponse(session, responseData, updateSessionCallback)
         }
 
         val (vpTokenString, receivedState) = parseResponseBody(
             responseMode = responseMode,
-            responseData = vpTokenResponse,
+            responseData = responseData,
             session = session,
             ephemeralDecryptionKey = session.ephemeralDecryptionKey
         )

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -367,6 +367,11 @@ object Verifier2VPDirectPostHandler {
     ): Map<String, String> {
         log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
 
+        val expectedState = session.authorizationRequest.state
+        if (expectedState != null && responseData.state != expectedState) {
+            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
+        }
+
         if (session.status == Verification2Session.VerificationSessionStatus.SUCCESSFUL ||
             session.status == Verification2Session.VerificationSessionStatus.FAILED
         ) {
@@ -375,11 +380,6 @@ object Verifier2VPDirectPostHandler {
                 "status" to "acknowledged",
                 "message" to "Session already terminal; wallet error response ignored.",
             )
-        }
-
-        val expectedState = session.authorizationRequest.state
-        if (expectedState != null && responseData.state != expectedState) {
-            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
         }
 
         updateSessionCallback(session, SessionEvent.wallet_error_response_received) {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -13,6 +13,7 @@ import id.walt.policies2.vc.policies.PolicyExecutionContext
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
 import id.walt.verifier2.data.DcApiAnnexCFlowSetup
 import id.walt.verifier2.data.SessionEvent
+import id.walt.verifier2.data.SessionFailure
 import id.walt.verifier2.data.Verification2Session
 import id.walt.verifier2.data.Verifier2Response
 import id.walt.verifier2.utils.JsonUtils.parseAsJsonObject
@@ -139,6 +140,9 @@ object Verifier2VPDirectPostHandler {
 
             responseData.vpToken to responseData.state
         }
+
+        is ErrorResponseDirectPost ->
+            error("parseResponseBody called with ErrorResponseDirectPost; handleDirectPost must short-circuit before this")
     }
 
     suspend fun RoutingCall.parseHttpRequestToDirectPostResponse(): DirectPostResponse {
@@ -151,7 +155,16 @@ object Verifier2VPDirectPostHandler {
                 log.trace { "Verification session data - body: $bodyText" }
                 val bodyJsonObject = bodyText.parseAsJsonObject("Could not parse provided body text as JSON object for DC API flow")
 
-                DcApiJsonDirectPostResponse(bodyJsonObject)
+                val errorCode = bodyJsonObject["error"]?.jsonPrimitive?.content
+                if (errorCode != null) {
+                    ErrorResponseDirectPost(
+                        error = errorCode,
+                        errorDescription = bodyJsonObject["error_description"]?.jsonPrimitive?.content,
+                        state = bodyJsonObject["state"]?.jsonPrimitive?.content,
+                    )
+                } else {
+                    DcApiJsonDirectPostResponse(bodyJsonObject)
+                }
             }
 
             else -> {
@@ -159,10 +172,17 @@ object Verifier2VPDirectPostHandler {
                 val responseString = urlParameters["response"]
                 val vpTokenString = urlParameters["vp_token"]
                 val receivedState = urlParameters["state"]
+                val errorCode = urlParameters["error"]
 
-                log.trace { "Verification session data: state = $receivedState, vp_token = $vpTokenString, response = $responseString" }
+                log.trace { "Verification session data: state = $receivedState, vp_token = $vpTokenString, response = $responseString, error = $errorCode" }
 
                 when {
+                    errorCode != null -> ErrorResponseDirectPost(
+                        error = errorCode,
+                        errorDescription = urlParameters["error_description"],
+                        state = receivedState,
+                    )
+
                     responseString != null -> EncryptedResponseStringDirectPostResponse(
                         responseParameter = responseString
                     )
@@ -225,6 +245,17 @@ object Verifier2VPDirectPostHandler {
     data class CleartextDirectPostResponse(val vpToken: String, val state: String) : DirectPostResponse
 
     /**
+     * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
+     * decline → `access_denied`). Body may arrive url-encoded or as JSON and always carries at
+     * least an `error` code; `error_description` and `state` are optional.
+     */
+    data class ErrorResponseDirectPost(
+        val error: String,
+        val errorDescription: String?,
+        val state: String?,
+    ) : DirectPostResponse
+
+    /**
      * Here the receiving of credentials through the Verifiers endpoints
      * (e.g. direct_post endpoint) is handled
      */
@@ -246,6 +277,32 @@ object Verifier2VPDirectPostHandler {
         val session = verificationSession
         val responseMode = session.authorizationRequest.responseMode
         val isAnnexC = verificationSession.setup is DcApiAnnexCFlowSetup
+
+        if (responseData is ErrorResponseDirectPost) {
+            log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
+
+            val expectedState = session.authorizationRequest.state
+            if (expectedState != null && responseData.state != null && responseData.state != expectedState) {
+                Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
+            }
+
+            session.updateSession(SessionEvent.wallet_error_response_received) {
+                attempted = true
+                status = Verification2Session.VerificationSessionStatus.FAILED
+                statusReason = "Wallet returned OID4VP error: ${responseData.error}"
+                failure = SessionFailure.WalletErrorResponse(
+                    reason = "Wallet returned OID4VP error response per §8.5",
+                    error = responseData.error,
+                    errorDescription = responseData.errorDescription,
+                    state = responseData.state,
+                )
+            }
+
+            return mapOf(
+                "status" to "acknowledged",
+                "message" to "Wallet error response recorded.",
+            )
+        }
 
         val (vpTokenString, receivedState) = parseResponseBody(
             responseMode = responseMode,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -38,7 +38,7 @@ object Verifier2VPDirectPostHandler {
 
     suspend fun parseResponseBody(
         responseMode: OpenID4VPResponseMode?,
-        responseData: DirectPostResponse,
+        responseData: VpTokenDirectPostResponse,
         session: Verification2Session,
         ephemeralDecryptionKey: DirectSerializedKey?
     ): Pair<String, String?> = when (responseData) {
@@ -140,9 +140,6 @@ object Verifier2VPDirectPostHandler {
 
             responseData.vpToken to responseData.state
         }
-
-        is ErrorResponseDirectPost ->
-            error("parseResponseBody called with ErrorResponseDirectPost; handleDirectPost must short-circuit before this")
     }
 
     suspend fun RoutingCall.parseHttpRequestToDirectPostResponse(): DirectPostResponse {
@@ -231,24 +228,36 @@ object Verifier2VPDirectPostHandler {
 
     /**
      * Sealed (= limited option) interface to represent the different forms that
-     * a direct post response can come in
+     * a direct post response can come in.
+     *
+     * Split into two categories:
+     * - [VpTokenDirectPostResponse]: the wallet is attempting to deliver a `vp_token`
+     *   (cleartext, encrypted, or DC API).
+     * - [ErrorResponseDirectPost]: the wallet is rejecting the request per OID4VP §8.5.
+     *
+     * Keeping the two apart lets [parseResponseBody] accept only the vp_token variants
+     * and makes the wallet-error path a separate branch in [handleDirectPost].
      */
     sealed interface DirectPostResponse
 
+    /** Wallet attempts to deliver a `vp_token` (in any of the supported forms). */
+    sealed interface VpTokenDirectPostResponse : DirectPostResponse
+
     /** Custom DC API JSON Object structure */
-    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : DirectPostResponse
+    data class DcApiJsonDirectPostResponse(val jsonBody: JsonObject) : VpTokenDirectPostResponse
 
     /** Encrypted response (Data is in JWT String in URL parameter 'response') */
-    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : DirectPostResponse
+    data class EncryptedResponseStringDirectPostResponse(val responseParameter: String) : VpTokenDirectPostResponse
 
     /** Cleartext response (Data is directly passed as strings in URL parameter 'vp_token' and 'state') */
-    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : DirectPostResponse
+    data class CleartextDirectPostResponse(val vpToken: String, val state: String) : VpTokenDirectPostResponse
 
     /**
      * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
      * decline → `access_denied`). Body may arrive url-encoded or as JSON and always carries at
-     * least an `error` code; `error_description` is optional. `state` is required when it was
-     * present in the Authorization Request.
+     * least an `error` code; `error_description` is optional. `state` is required whenever the
+     * Authorization Request included `state` — [handleDirectPost] rejects mismatched / absent
+     * state with `INVALID_STATE_PARAMETER` in that case.
      */
     data class ErrorResponseDirectPost(
         val error: String,
@@ -279,35 +288,14 @@ object Verifier2VPDirectPostHandler {
         val responseMode = session.authorizationRequest.responseMode
         val isAnnexC = verificationSession.setup is DcApiAnnexCFlowSetup
 
-        if (responseData is ErrorResponseDirectPost) {
-            log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
-
-            val expectedState = session.authorizationRequest.state
-            if (expectedState != null && responseData.state != expectedState) {
-                Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
-            }
-
-            session.updateSession(SessionEvent.wallet_error_response_received) {
-                attempted = true
-                status = Verification2Session.VerificationSessionStatus.FAILED
-                statusReason = "Wallet returned OID4VP error: ${responseData.error}"
-                failure = SessionFailure.WalletErrorResponse(
-                    reason = "Wallet returned OID4VP error response per §8.5",
-                    error = responseData.error,
-                    errorDescription = responseData.errorDescription,
-                    state = responseData.state,
-                )
-            }
-
-            return mapOf(
-                "status" to "acknowledged",
-                "message" to "Wallet error response recorded.",
-            )
+        val vpTokenResponse: VpTokenDirectPostResponse = when (responseData) {
+            is ErrorResponseDirectPost -> return handleWalletErrorResponse(session, responseData, updateSessionCallback)
+            is VpTokenDirectPostResponse -> responseData
         }
 
         val (vpTokenString, receivedState) = parseResponseBody(
             responseMode = responseMode,
-            responseData = responseData,
+            responseData = vpTokenResponse,
             session = session,
             ephemeralDecryptionKey = session.ephemeralDecryptionKey
         )
@@ -364,5 +352,52 @@ object Verifier2VPDirectPostHandler {
         Verifier2Response.Verifier2Error.MALFORMED_VP_TOKEN.throwAsError()
     }
 
+    /**
+     * Handles an OID4VP 1.0 §8.5 wallet error response. Validates `state` echo, marks the
+     * session as `FAILED` with a structured [SessionFailure.WalletErrorResponse], and emits
+     * [SessionEvent.wallet_error_response_received].
+     *
+     * Idempotent: if the session is already in a terminal state, the response is acknowledged
+     * without overwriting any existing outcome.
+     */
+    private suspend fun handleWalletErrorResponse(
+        session: Verification2Session,
+        responseData: ErrorResponseDirectPost,
+        updateSessionCallback: suspend (session: Verification2Session, event: SessionEvent, block: Verification2Session.() -> Unit) -> Unit,
+    ): Map<String, String> {
+        log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
+
+        if (session.status == Verification2Session.VerificationSessionStatus.SUCCESSFUL ||
+            session.status == Verification2Session.VerificationSessionStatus.FAILED
+        ) {
+            log.info { "Session ${session.id} is already terminal (${session.status}); ignoring wallet error response." }
+            return mapOf(
+                "status" to "acknowledged",
+                "message" to "Session already terminal; wallet error response ignored.",
+            )
+        }
+
+        val expectedState = session.authorizationRequest.state
+        if (expectedState != null && responseData.state != expectedState) {
+            Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
+        }
+
+        updateSessionCallback(session, SessionEvent.wallet_error_response_received) {
+            attempted = true
+            status = Verification2Session.VerificationSessionStatus.FAILED
+            statusReason = "Wallet returned OID4VP error: ${responseData.error}"
+            failure = SessionFailure.WalletErrorResponse(
+                reason = "Wallet returned OID4VP error response per §8.5",
+                error = responseData.error,
+                errorDescription = responseData.errorDescription,
+                state = responseData.state,
+            )
+        }
+
+        return mapOf(
+            "status" to "acknowledged",
+            "message" to "Wallet error response recorded.",
+        )
+    }
 
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -384,6 +384,10 @@ object Verifier2VPDirectPostHandler {
             )
         }
 
+        session.redirects?.errorRedirectUri?.let { errorRedirectUri ->
+            return mapOf("redirect_uri" to errorRedirectUri)
+        }
+
         return mapOf(
             "status" to "acknowledged",
             "message" to "Wallet error response recorded.",

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -247,7 +247,8 @@ object Verifier2VPDirectPostHandler {
     /**
      * OpenID4VP 1.0 §8.5 error response. Wallet rejects the presentation request (e.g. user
      * decline → `access_denied`). Body may arrive url-encoded or as JSON and always carries at
-     * least an `error` code; `error_description` and `state` are optional.
+     * least an `error` code; `error_description` is optional. `state` is required when it was
+     * present in the Authorization Request.
      */
     data class ErrorResponseDirectPost(
         val error: String,
@@ -282,7 +283,7 @@ object Verifier2VPDirectPostHandler {
             log.info { "Wallet returned OID4VP §8.5 error for session ${session.id}: error=${responseData.error}" }
 
             val expectedState = session.authorizationRequest.state
-            if (expectedState != null && responseData.state != null && responseData.state != expectedState) {
+            if (expectedState != null && responseData.state != expectedState) {
                 Verifier2Response.Verifier2Error.INVALID_STATE_PARAMETER.throwAsError()
             }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -185,6 +185,20 @@ class Verifier2VPDirectPostHandlerParseTest {
         assertEquals(null, session.failure, "must not attach failure to a SUCCESSFUL session")
     }
 
+    @Test
+    fun walletErrorResponse_onTerminalSession_stillRequiresMatchingState() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state").apply {
+            status = Verification2Session.VerificationSessionStatus.SUCCESSFUL
+        }
+
+        assertFailsWith<Throwable> {
+            session.handleWalletError(state = "wrong-state")
+        }
+
+        assertEquals(Verification2Session.VerificationSessionStatus.SUCCESSFUL, session.status)
+        assertEquals(null, session.failure, "invalid replay must not attach failure to terminal session")
+    }
+
     private fun directPostSession(expectedState: String) = Verification2Session(
         setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
         status = Verification2Session.VerificationSessionStatus.ACTIVE,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -22,7 +22,6 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
-import io.ktor.util.AttributeKey
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -35,7 +34,6 @@ import kotlin.test.assertNotNull
 class Verifier2VPDirectPostHandlerParseTest {
 
     private fun parse(contentType: ContentType, body: String): DirectPostResponse {
-        val captured = AttributeKey<DirectPostResponse>("captured-response")
         var parsedOut: DirectPostResponse? = null
 
         testApplication {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -1,0 +1,115 @@
+package id.walt.verifier2.handlers.vpresponse
+
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.CleartextDirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DcApiJsonDirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.EncryptedResponseStringDirectPostResponse
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.ErrorResponseDirectPost
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.parseHttpRequestToDirectPostResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.parseUrlEncodedParameters
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import io.ktor.util.AttributeKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertIs
+
+class Verifier2VPDirectPostHandlerParseTest {
+
+    private fun parse(contentType: ContentType, body: String): DirectPostResponse {
+        val captured = AttributeKey<DirectPostResponse>("captured-response")
+        var parsedOut: DirectPostResponse? = null
+
+        testApplication {
+            application {
+                routing {
+                    post("/test") {
+                        parsedOut = call.parseHttpRequestToDirectPostResponse()
+                        call.respond("ok")
+                    }
+                }
+            }
+            val response = client.post("/test") {
+                contentType(contentType)
+                setBody(body)
+            }
+            check(response.status.value == 200) { "setup call failed: ${response.status}" }
+        }
+
+        return parsedOut ?: error("parseHttpRequestToDirectPostResponse did not return")
+    }
+
+    @Test
+    fun urlEncoded_errorOnly_parsesToErrorResponseDirectPost() {
+        val body = "error=access_denied&error_description=User+denied&state=abc123"
+        val parsed = parse(ContentType.Application.FormUrlEncoded, body)
+
+        val errorResponse = assertIs<ErrorResponseDirectPost>(parsed)
+        assertEquals("access_denied", errorResponse.error)
+        assertEquals("User denied", errorResponse.errorDescription)
+        assertEquals("abc123", errorResponse.state)
+    }
+
+    @Test
+    fun urlEncoded_errorWithoutState_producesErrorResponseWithNullState() {
+        val parsed = parse(ContentType.Application.FormUrlEncoded, "error=access_denied")
+        val errorResponse = assertIs<ErrorResponseDirectPost>(parsed)
+        assertEquals("access_denied", errorResponse.error)
+        assertEquals(null, errorResponse.errorDescription)
+        assertEquals(null, errorResponse.state)
+    }
+
+    @Test
+    fun urlEncoded_vpTokenBody_stillRoutesToCleartextVariant() {
+        val parsed = parse(
+            ContentType.Application.FormUrlEncoded,
+            "vp_token=%7B%22pid%22%3A%5B%22ey...%22%5D%7D&state=abc",
+        )
+        val cleartext = assertIs<CleartextDirectPostResponse>(parsed)
+        assertEquals("abc", cleartext.state)
+    }
+
+    @Test
+    fun urlEncoded_responseBody_stillRoutesToEncryptedVariant() {
+        val parsed = parse(ContentType.Application.FormUrlEncoded, "response=eyAbc")
+        assertIs<EncryptedResponseStringDirectPostResponse>(parsed)
+    }
+
+    @Test
+    fun urlEncoded_emptyBody_stillThrows() {
+        assertFails {
+            parse(ContentType.Application.FormUrlEncoded, "")
+        }
+    }
+
+    @Test
+    fun json_withErrorField_routesToErrorResponseDirectPost() {
+        val body = """{"error":"access_denied","error_description":"User denied","state":"abc"}"""
+        val parsed = parse(ContentType.Application.Json, body)
+        val errorResponse = assertIs<ErrorResponseDirectPost>(parsed)
+        assertEquals("access_denied", errorResponse.error)
+        assertEquals("abc", errorResponse.state)
+    }
+
+    @Test
+    fun json_withoutErrorField_routesToDcApiJson() {
+        val body = """{"data":{"vp_token":{"pid":[]}}}"""
+        val parsed = parse(ContentType.Application.Json, body)
+        assertIs<DcApiJsonDirectPostResponse>(parsed)
+    }
+
+    @Test
+    fun urlEncoded_parsingRoundTrip_spaceEncoding() {
+        // Sanity check that `%20` and `+` both decode to space — the parser must preserve
+        // error_description exactly as the wallet sent it.
+        val params = "error=server_error&error_description=Internal%20server%20problem".parseUrlEncodedParameters()
+        assertEquals("Internal server problem", params["error_description"])
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -148,6 +148,43 @@ class Verifier2VPDirectPostHandlerParseTest {
         assertEquals("expected-state", failure.state)
     }
 
+    @Test
+    fun walletErrorResponse_secondPost_doesNotOverwriteTerminalSession() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state")
+
+        // First POST flips session to FAILED with access_denied
+        session.handleWalletError(state = "expected-state")
+        val failureAfterFirst = assertIs<SessionFailure.WalletErrorResponse>(assertNotNull(session.failure))
+        assertEquals("access_denied", failureAfterFirst.error)
+
+        // Second POST with a different error must not overwrite status/statusReason/failure
+        val events = session.handleWalletError(
+            state = "expected-state",
+            error = "invalid_request",
+            errorDescription = "overwrite attempt",
+        )
+
+        assertEquals(emptyList(), events, "No events should fire for a terminal session")
+        assertEquals(Verification2Session.VerificationSessionStatus.FAILED, session.status)
+        assertEquals("Wallet returned OID4VP error: access_denied", session.statusReason)
+
+        val failureAfterSecond = assertIs<SessionFailure.WalletErrorResponse>(assertNotNull(session.failure))
+        assertEquals("access_denied", failureAfterSecond.error, "original failure must be preserved")
+    }
+
+    @Test
+    fun walletErrorResponse_onSuccessfulSession_doesNotOverwrite() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state").apply {
+            status = Verification2Session.VerificationSessionStatus.SUCCESSFUL
+        }
+
+        val events = session.handleWalletError(state = "expected-state")
+
+        assertEquals(emptyList(), events)
+        assertEquals(Verification2Session.VerificationSessionStatus.SUCCESSFUL, session.status)
+        assertEquals(null, session.failure, "must not attach failure to a SUCCESSFUL session")
+    }
+
     private fun directPostSession(expectedState: String) = Verification2Session(
         setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
         status = Verification2Session.VerificationSessionStatus.ACTIVE,
@@ -160,13 +197,17 @@ class Verifier2VPDirectPostHandlerParseTest {
         requestMode = Verification2Session.RequestMode.REQUEST_URI,
     )
 
-    private suspend fun Verification2Session.handleWalletError(state: String?): List<SessionEvent> {
+    private suspend fun Verification2Session.handleWalletError(
+        state: String?,
+        error: String = "access_denied",
+        errorDescription: String? = "User denied",
+    ): List<SessionEvent> {
         val events = mutableListOf<SessionEvent>()
         handleDirectPost(
             verificationSession = this,
             responseData = ErrorResponseDirectPost(
-                error = "access_denied",
-                errorDescription = "User denied",
+                error = error,
+                errorDescription = errorDescription,
                 state = state,
             ),
             updateSessionCallback = { session, event, block ->

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -1,10 +1,17 @@
 package id.walt.verifier2.handlers.vpresponse
 
+import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import id.walt.verifier2.data.CrossDeviceFlowSetup
+import id.walt.verifier2.data.SessionEvent
+import id.walt.verifier2.data.SessionFailure
+import id.walt.verifier2.data.Verification2Session
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.CleartextDirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DcApiJsonDirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.DirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.EncryptedResponseStringDirectPostResponse
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.ErrorResponseDirectPost
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.handleDirectPost
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.parseHttpRequestToDirectPostResponse
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -16,11 +23,15 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.ktor.util.AttributeKey
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 
+@OptIn(ExperimentalSerializationApi::class)
 class Verifier2VPDirectPostHandlerParseTest {
 
     private fun parse(contentType: ContentType, body: String): DirectPostResponse {
@@ -111,5 +122,62 @@ class Verifier2VPDirectPostHandlerParseTest {
         // error_description exactly as the wallet sent it.
         val params = "error=server_error&error_description=Internal%20server%20problem".parseUrlEncodedParameters()
         assertEquals("Internal server problem", params["error_description"])
+    }
+
+    @Test
+    fun walletErrorResponse_missingExpectedState_isRejected() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state")
+
+        assertFailsWith<Throwable> {
+            session.handleWalletError(state = null)
+        }
+    }
+
+    @Test
+    fun walletErrorResponse_matchingState_recordsStructuredFailure() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(expectedState = "expected-state")
+        val events = session.handleWalletError(state = "expected-state")
+
+        assertEquals(listOf(SessionEvent.wallet_error_response_received), events)
+        assertEquals(Verification2Session.VerificationSessionStatus.FAILED, session.status)
+        assertEquals("Wallet returned OID4VP error: access_denied", session.statusReason)
+
+        val failure = assertIs<SessionFailure.WalletErrorResponse>(assertNotNull(session.failure))
+        assertEquals("access_denied", failure.error)
+        assertEquals("User denied", failure.errorDescription)
+        assertEquals("expected-state", failure.state)
+    }
+
+    private fun directPostSession(expectedState: String) = Verification2Session(
+        setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
+        status = Verification2Session.VerificationSessionStatus.ACTIVE,
+        authorizationRequest = AuthorizationRequest(
+            state = expectedState,
+            responseMode = OpenID4VPResponseMode.DIRECT_POST,
+            responseUri = "https://verifier.example/response",
+        ),
+        authorizationRequestUrl = null,
+        requestMode = Verification2Session.RequestMode.REQUEST_URI,
+    )
+
+    private suspend fun Verification2Session.handleWalletError(state: String?): List<SessionEvent> {
+        val events = mutableListOf<SessionEvent>()
+        handleDirectPost(
+            verificationSession = this,
+            responseData = ErrorResponseDirectPost(
+                error = "access_denied",
+                errorDescription = "User denied",
+                state = state,
+            ),
+            updateSessionCallback = { session, event, block ->
+                events += event
+                session.block()
+            },
+            failSessionCallback = { session, event, updateSession ->
+                session.status = Verification2Session.VerificationSessionStatus.FAILED
+                updateSession(session, event) {}
+            },
+        )
+        return events
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandlerParseTest.kt
@@ -147,6 +147,22 @@ class Verifier2VPDirectPostHandlerParseTest {
     }
 
     @Test
+    fun walletErrorResponse_returnsErrorRedirectWhenConfigured() = kotlinx.coroutines.test.runTest {
+        val session = directPostSession(
+            expectedState = "expected-state",
+            redirects = Verification2Session.VerificationSessionRedirects(
+                errorRedirectUri = "https://verifier.example/error",
+            ),
+        )
+
+        val result = session.handleWalletErrorWithResponse(state = "expected-state")
+
+        assertEquals(mapOf("redirect_uri" to "https://verifier.example/error"), result.response)
+        assertEquals(listOf(SessionEvent.wallet_error_response_received), result.events)
+        assertEquals(Verification2Session.VerificationSessionStatus.FAILED, session.status)
+    }
+
+    @Test
     fun walletErrorResponse_secondPost_doesNotOverwriteTerminalSession() = kotlinx.coroutines.test.runTest {
         val session = directPostSession(expectedState = "expected-state")
 
@@ -197,7 +213,10 @@ class Verifier2VPDirectPostHandlerParseTest {
         assertEquals(null, session.failure, "invalid replay must not attach failure to terminal session")
     }
 
-    private fun directPostSession(expectedState: String) = Verification2Session(
+    private fun directPostSession(
+        expectedState: String,
+        redirects: Verification2Session.VerificationSessionRedirects? = null,
+    ) = Verification2Session(
         setup = CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID,
         status = Verification2Session.VerificationSessionStatus.ACTIVE,
         authorizationRequest = AuthorizationRequest(
@@ -207,15 +226,27 @@ class Verifier2VPDirectPostHandlerParseTest {
         ),
         authorizationRequestUrl = null,
         requestMode = Verification2Session.RequestMode.REQUEST_URI,
+        redirects = redirects,
+    )
+
+    private data class WalletErrorHandleResult(
+        val response: Map<String, String>,
+        val events: List<SessionEvent>,
     )
 
     private suspend fun Verification2Session.handleWalletError(
         state: String?,
         error: String = "access_denied",
         errorDescription: String? = "User denied",
-    ): List<SessionEvent> {
+    ): List<SessionEvent> = handleWalletErrorWithResponse(state, error, errorDescription).events
+
+    private suspend fun Verification2Session.handleWalletErrorWithResponse(
+        state: String?,
+        error: String = "access_denied",
+        errorDescription: String? = "User denied",
+    ): WalletErrorHandleResult {
         val events = mutableListOf<SessionEvent>()
-        handleDirectPost(
+        val response = handleDirectPost(
             verificationSession = this,
             responseData = ErrorResponseDirectPost(
                 error = error,
@@ -231,6 +262,6 @@ class Verifier2VPDirectPostHandlerParseTest {
                 updateSession(session, event) {}
             },
         )
-        return events
+        return WalletErrorHandleResult(response = response, events = events)
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -26,14 +26,9 @@ import id.waltid.openid4vp.wallet.presentation.MdocPresenter
 import id.waltid.openid4vp.wallet.presentation.SdJwtVcPresenter
 import id.waltid.openid4vp.wallet.presentation.W3CPresenter
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.ktor.client.*
 import io.ktor.client.call.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
 import io.ktor.util.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -195,48 +190,34 @@ object WalletPresentFunctionality2 {
     ): Result<WalletPresentResult> = runCatching {
         val responseMode = authorizationRequest.responseMode ?: inferResponseMode(authorizationRequest)
         val errorParameters = buildErrorResponseParameters(authorizationRequest, error, errorDescription)
+        val redirectUri = authorizationRequest.redirectUri
+        val responseUri = authorizationRequest.responseUri
 
         when (responseMode) {
             OpenID4VPResponseMode.FRAGMENT -> {
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'fragment'."
-                }
-                WalletPresentResult(
-                    getUrl = "${authorizationRequest.redirectUri}#${errorParameters.formUrlEncode()}"
-                )
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'fragment'." }
+                WalletPresentResult(getUrl = "${redirectUri}#${errorParameters.formUrlEncode()}")
             }
 
             OpenID4VPResponseMode.QUERY -> {
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'query'."
-                }
-                WalletPresentResult(
-                    getUrl = URLBuilder(authorizationRequest.redirectUri!!).apply {
-                        parameters.appendAll(errorParameters)
-                    }.buildString()
-                )
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'query'." }
+                WalletPresentResult(getUrl = URLBuilder(redirectUri).apply { parameters.appendAll(errorParameters) }.buildString())
             }
 
             OpenID4VPResponseMode.FORM_POST -> {
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
-                }
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'." }
                 WalletPresentResult(
                     formPostHtml = buildFormPostHtml(
-                        actionUrl = authorizationRequest.redirectUri!!,
+                        actionUrl = redirectUri,
                         title = "Submitting Error Response...",
-                        fields = errorParameters.entries().flatMap { (name, values) ->
-                            values.map { name to it }
-                        },
+                        fields = errorParameters.entries().flatMap { (name, values) -> values.map { name to it } },
                     )
                 )
             }
 
             OpenID4VPResponseMode.DIRECT_POST, OpenID4VPResponseMode.DIRECT_POST_JWT -> {
-                require(authorizationRequest.responseUri != null) {
-                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'."
-                }
-                postFormResponse(authorizationRequest.responseUri!!, errorParameters)
+                require(responseUri != null) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'." }
+                postFormResponse(responseUri, errorParameters)
             }
 
             OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
@@ -547,21 +528,20 @@ object WalletPresentFunctionality2 {
 
             OpenID4VPResponseMode.FORM_POST -> {
                 // This mode also requires a redirect_uri to POST the form to.
-                require(authorizationRequest.redirectUri != null) {
-                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
-                }
+                val redirectUri = authorizationRequest.redirectUri
+                requireNotNull(redirectUri) { "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'." }
 
                 val fields = buildList {
                     add("vp_token" to vpToken)
                     authorizationRequest.state?.let { add("state" to it) }
                 }
                 val htmlContent = buildFormPostHtml(
-                    actionUrl = authorizationRequest.redirectUri!!,
+                    actionUrl = redirectUri,
                     title = "Submitting Presentation...",
                     fields = fields,
                 )
 
-                log.trace { "Responding with self-submitting HTML form to post to: ${authorizationRequest.redirectUri}" }
+                log.trace { "Responding with self-submitting HTML form to post to: $redirectUri" }
 
                 // For a pure API, we return the HTML for the client to render in a WebView.
                 return Result.success(
@@ -573,7 +553,8 @@ object WalletPresentFunctionality2 {
 
             // authorizationRequest.responseUri
             OpenID4VPResponseMode.DIRECT_POST -> {
-                require(authorizationRequest.responseUri != null) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'." }
+                val responseUri = authorizationRequest.responseUri
+                requireNotNull(responseUri) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'." }
                 val parameters = ParametersBuilder().apply {
                     append("vp_token", vpToken)
 
@@ -582,17 +563,14 @@ object WalletPresentFunctionality2 {
                     }
                 }.build()
 
-                log.trace { "Submitting direct_post form to Verifier: ${authorizationRequest.responseUri}" }
-                return Result.success(
-                    postFormResponse(authorizationRequest.responseUri!!, parameters)
-                )
+                log.trace { "Submitting direct_post form to Verifier: $responseUri" }
+                return Result.success(postFormResponse(responseUri, parameters))
             }
 
             OpenID4VPResponseMode.DIRECT_POST_JWT -> {
                 // Encrypt the vp_token and state into a JWE, then POST response=<JWE_string>.
-                require(authorizationRequest.responseUri != null) {
-                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post.jwt'."
-                }
+                val responseUri = authorizationRequest.responseUri
+                requireNotNull(responseUri) { "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post.jwt'." }
 
                 // 1. Get Encryption Metadata
                 val clientMetadata = authorizationRequest.clientMetadata
@@ -630,10 +608,8 @@ object WalletPresentFunctionality2 {
                     append("response", jweString)
                 }.build()
 
-                log.trace { "Submitting direct_post.jwt (encrypted) to Verifier: ${authorizationRequest.responseUri}" }
-                return Result.success(
-                    postFormResponse(authorizationRequest.responseUri!!, parameters)
-                )
+                log.trace { "Submitting direct_post.jwt (encrypted) to Verifier: $responseUri" }
+                return Result.success(postFormResponse(responseUri, parameters))
 
             }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -154,20 +154,19 @@ object WalletPresentFunctionality2 {
      * future spec addition is needed before this enum is updated, use
      * [walletRejectHandling]'s String overload.
      */
-    @Suppress("EnumEntryName")
-    enum class Oid4vpErrorCode(val code: String) {
-        access_denied("access_denied"),
-        invalid_request("invalid_request"),
-        invalid_client("invalid_client"),
-        invalid_scope("invalid_scope"),
-        unauthorized_client("unauthorized_client"),
-        unsupported_response_type("unsupported_response_type"),
-        server_error("server_error"),
-        temporarily_unavailable("temporarily_unavailable"),
-        vp_formats_not_supported("vp_formats_not_supported"),
-        invalid_request_uri_method("invalid_request_uri_method"),
-        invalid_transaction_data("invalid_transaction_data"),
-        wallet_unavailable("wallet_unavailable"),
+    enum class OID4VPErrorCode(val code: String) {
+        ACCESS_DENIED("access_denied"),
+        INVALID_REQUEST("invalid_request"),
+        INVALID_CLIENT("invalid_client"),
+        INVALID_SCOPE("invalid_scope"),
+        UNAUTHORIZED_CLIENT("unauthorized_client"),
+        UNSUPPORTED_RESPONSE_TYPE("unsupported_response_type"),
+        SERVER_ERROR("server_error"),
+        TEMPORARILY_UNAVAILABLE("temporarily_unavailable"),
+        VP_FORMATS_NOT_SUPPORTED("vp_formats_not_supported"),
+        INVALID_REQUEST_URI_METHOD("invalid_request_uri_method"),
+        INVALID_TRANSACTION_DATA("invalid_transaction_data"),
+        WALLET_UNAVAILABLE("wallet_unavailable"),
     }
 
     /**
@@ -181,13 +180,13 @@ object WalletPresentFunctionality2 {
      */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,
-        error: Oid4vpErrorCode = Oid4vpErrorCode.access_denied,
+        error: OID4VPErrorCode = OID4VPErrorCode.ACCESS_DENIED,
         errorDescription: String? = null,
     ): Result<WalletPresentResult> = walletRejectHandling(authorizationRequest, error.code, errorDescription)
 
     /**
      * String overload of [walletRejectHandling] for forward-compatibility with error codes
-     * not yet in [Oid4vpErrorCode]. Prefer the typed variant.
+     * not yet in [OID4VPErrorCode]. Prefer the typed variant.
      */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -146,6 +146,110 @@ object WalletPresentFunctionality2 {
         val redirectTo: String? = null
     )
 
+    suspend fun walletRejectHandling(
+        authorizationRequest: AuthorizationRequest,
+        error: String = "access_denied",
+        errorDescription: String? = null,
+    ): Result<WalletPresentResult> = runCatching {
+        val responseMode = authorizationRequest.responseMode ?: inferResponseMode(authorizationRequest)
+        val errorParameters = buildErrorResponseParameters(authorizationRequest, error, errorDescription)
+
+        when (responseMode) {
+            OpenID4VPResponseMode.FRAGMENT -> {
+                require(authorizationRequest.redirectUri != null) {
+                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'fragment'."
+                }
+                WalletPresentResult(
+                    getUrl = "${authorizationRequest.redirectUri}#${errorParameters.formUrlEncode()}"
+                )
+            }
+
+            OpenID4VPResponseMode.QUERY -> {
+                require(authorizationRequest.redirectUri != null) {
+                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'query'."
+                }
+                WalletPresentResult(
+                    getUrl = URLBuilder(authorizationRequest.redirectUri!!).apply {
+                        parameters.appendAll(errorParameters)
+                    }.buildString()
+                )
+            }
+
+            OpenID4VPResponseMode.FORM_POST -> {
+                require(authorizationRequest.redirectUri != null) {
+                    "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
+                }
+                WalletPresentResult(
+                    formPostHtml = buildErrorResponseFormPostHtml(authorizationRequest.redirectUri!!, errorParameters)
+                )
+            }
+
+            OpenID4VPResponseMode.DIRECT_POST -> {
+                require(authorizationRequest.responseUri != null) {
+                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'."
+                }
+                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, errorParameters)
+                val responseBody = response.bodyAsText()
+                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }.getOrNull()
+
+                WalletPresentResult(
+                    transmissionSuccess = response.status.isSuccess(),
+                    verifierResponse = Json.parseToJsonElement(responseBody),
+                    redirectTo = responseBodyJson?.get("redirect_uri")?.jsonPrimitive?.content,
+                )
+            }
+
+            OpenID4VPResponseMode.DIRECT_POST_JWT ->
+                throw UnsupportedOperationException("OID4VP error responses for direct_post.jwt require JARM and are not supported yet.")
+
+            OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
+                throw UnsupportedOperationException("OID4VP error responses are not supported for DC API response modes.")
+
+            null -> throw IllegalArgumentException("Missing response mode from AuthorizationRequest")
+        }
+    }
+
+    private fun inferResponseMode(authorizationRequest: AuthorizationRequest): OpenID4VPResponseMode? {
+        val responseType = authorizationRequest.responseType?.responseType
+        return when {
+            responseType == null -> null
+            "vp_token" in responseType && "code" !in responseType -> OpenID4VPResponseMode.FRAGMENT
+            "code" in responseType -> OpenID4VPResponseMode.QUERY
+            else -> null
+        }
+    }
+
+    private fun buildErrorResponseParameters(
+        authorizationRequest: AuthorizationRequest,
+        error: String,
+        errorDescription: String?,
+    ): Parameters = ParametersBuilder().apply {
+        append("error", error)
+        errorDescription?.let { append("error_description", it) }
+        authorizationRequest.state?.let { append("state", it) }
+    }.build()
+
+    private fun buildErrorResponseFormPostHtml(
+        redirectUri: String,
+        parameters: Parameters,
+    ): String = buildString {
+        appendLine("<!DOCTYPE html>")
+        appendLine("<html>")
+        appendLine("<head><title>Submitting Error Response...</title></head>")
+        appendLine("<body onload=\"document.forms[0].submit()\">")
+        appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
+        appendLine("<form method=\"POST\" action=\"${redirectUri.encodeURLParameter()}\">")
+        parameters.entries().forEach { (name, values) ->
+            values.forEach { value ->
+                appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
+            }
+        }
+        appendLine("<input type=\"submit\" value=\"Continue\"/>")
+        appendLine("</form>")
+        appendLine("</body>")
+        appendLine("</html>")
+    }
+
     suspend fun walletPresentHandling(
         holderKey: Key,
         holderDid: String?,

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -174,8 +174,10 @@ object WalletPresentFunctionality2 {
      * Produce an OpenID4VP 1.0 §8.5 wallet rejection response for the given
      * [authorizationRequest]. The response is shaped according to the request's `response_mode`
      * and carries `error`, optional `error_description`, and the request's `state` (when
-     * present). For `direct_post`, the rejection is transmitted to the verifier's `response_uri`
-     * and the verifier's acknowledgement is returned.
+     * present). For `direct_post` and `direct_post.jwt`, the rejection is transmitted to the
+     * verifier's `response_uri` and the verifier's acknowledgement is returned. OpenID4VP 1.0
+     * permits an unencrypted error response for `direct_post.jwt` when the Wallet cannot generate
+     * the encrypted response.
      */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,
@@ -231,9 +233,9 @@ object WalletPresentFunctionality2 {
                 )
             }
 
-            OpenID4VPResponseMode.DIRECT_POST -> {
+            OpenID4VPResponseMode.DIRECT_POST, OpenID4VPResponseMode.DIRECT_POST_JWT -> {
                 require(authorizationRequest.responseUri != null) {
-                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode 'direct_post'."
+                    "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'."
                 }
                 val response = webPostToken.sendForm(authorizationRequest.responseUri!!, errorParameters)
                 val responseBody = response.bodyAsText()
@@ -245,9 +247,6 @@ object WalletPresentFunctionality2 {
                     redirectTo = responseBodyJson?.get("redirect_uri")?.jsonPrimitive?.content,
                 )
             }
-
-            OpenID4VPResponseMode.DIRECT_POST_JWT ->
-                throw UnsupportedOperationException("OID4VP error responses for direct_post.jwt require JARM and are not supported yet.")
 
             OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
                 throw UnsupportedOperationException("OID4VP error responses are not supported for DC API response modes.")
@@ -291,7 +290,7 @@ object WalletPresentFunctionality2 {
         appendLine("<head><title>${title.escapeHTML()}</title></head>")
         appendLine("<body onload=\"document.forms[0].submit()\">")
         appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
-        appendLine("<form method=\"POST\" action=\"${actionUrl.encodeURLParameter()}\">")
+        appendLine("<form method=\"POST\" action=\"${actionUrl.escapeHTML()}\">")
         fields.forEach { (name, value) ->
             appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
         }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -146,9 +146,50 @@ object WalletPresentFunctionality2 {
         val redirectTo: String? = null
     )
 
+    /**
+     * OpenID4VP 1.0 §8.5 wallet-side error codes (with RFC 6749 §4.1.2.1 / §4.2.2.1 parents).
+     *
+     * The verifier side accepts any `error` string (permissive); this typed enum only steers
+     * wallet-side callers away from typos in the finite set that the spec enumerates. If a
+     * future spec addition is needed before this enum is updated, use
+     * [walletRejectHandling]'s String overload.
+     */
+    @Suppress("EnumEntryName")
+    enum class Oid4vpErrorCode(val code: String) {
+        access_denied("access_denied"),
+        invalid_request("invalid_request"),
+        invalid_client("invalid_client"),
+        invalid_scope("invalid_scope"),
+        unauthorized_client("unauthorized_client"),
+        unsupported_response_type("unsupported_response_type"),
+        server_error("server_error"),
+        temporarily_unavailable("temporarily_unavailable"),
+        vp_formats_not_supported("vp_formats_not_supported"),
+        invalid_request_uri_method("invalid_request_uri_method"),
+        invalid_transaction_data("invalid_transaction_data"),
+        wallet_unavailable("wallet_unavailable"),
+    }
+
+    /**
+     * Produce an OpenID4VP 1.0 §8.5 wallet rejection response for the given
+     * [authorizationRequest]. The response is shaped according to the request's `response_mode`
+     * and carries `error`, optional `error_description`, and the request's `state` (when
+     * present). For `direct_post`, the rejection is transmitted to the verifier's `response_uri`
+     * and the verifier's acknowledgement is returned.
+     */
     suspend fun walletRejectHandling(
         authorizationRequest: AuthorizationRequest,
-        error: String = "access_denied",
+        error: Oid4vpErrorCode = Oid4vpErrorCode.access_denied,
+        errorDescription: String? = null,
+    ): Result<WalletPresentResult> = walletRejectHandling(authorizationRequest, error.code, errorDescription)
+
+    /**
+     * String overload of [walletRejectHandling] for forward-compatibility with error codes
+     * not yet in [Oid4vpErrorCode]. Prefer the typed variant.
+     */
+    suspend fun walletRejectHandling(
+        authorizationRequest: AuthorizationRequest,
+        error: String,
         errorDescription: String? = null,
     ): Result<WalletPresentResult> = runCatching {
         val responseMode = authorizationRequest.responseMode ?: inferResponseMode(authorizationRequest)
@@ -180,7 +221,13 @@ object WalletPresentFunctionality2 {
                     "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
                 }
                 WalletPresentResult(
-                    formPostHtml = buildErrorResponseFormPostHtml(authorizationRequest.redirectUri!!, errorParameters)
+                    formPostHtml = buildFormPostHtml(
+                        actionUrl = authorizationRequest.redirectUri!!,
+                        title = "Submitting Error Response...",
+                        fields = errorParameters.entries().flatMap { (name, values) ->
+                            values.map { name to it }
+                        },
+                    )
                 )
             }
 
@@ -229,20 +276,24 @@ object WalletPresentFunctionality2 {
         authorizationRequest.state?.let { append("state", it) }
     }.build()
 
-    private fun buildErrorResponseFormPostHtml(
-        redirectUri: String,
-        parameters: Parameters,
+    /**
+     * Build a self-submitting `form_post` HTML page that POSTs [fields] to [actionUrl].
+     * Shared by [walletPresentHandling] (carrying `vp_token`) and [walletRejectHandling]
+     * (carrying `error` / `error_description` / `state`).
+     */
+    private fun buildFormPostHtml(
+        actionUrl: String,
+        title: String,
+        fields: List<Pair<String, String>>,
     ): String = buildString {
         appendLine("<!DOCTYPE html>")
         appendLine("<html>")
-        appendLine("<head><title>Submitting Error Response...</title></head>")
+        appendLine("<head><title>${title.escapeHTML()}</title></head>")
         appendLine("<body onload=\"document.forms[0].submit()\">")
         appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
-        appendLine("<form method=\"POST\" action=\"${redirectUri.encodeURLParameter()}\">")
-        parameters.entries().forEach { (name, values) ->
-            values.forEach { value ->
-                appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
-            }
+        appendLine("<form method=\"POST\" action=\"${actionUrl.encodeURLParameter()}\">")
+        fields.forEach { (name, value) ->
+            appendLine("<input type=\"hidden\" name=\"${name.escapeHTML()}\" value=\"${value.escapeHTML()}\"/>")
         }
         appendLine("<input type=\"submit\" value=\"Continue\"/>")
         appendLine("</form>")
@@ -495,26 +546,15 @@ object WalletPresentFunctionality2 {
                     "Invalid AuthorizationRequest: 'redirect_uri' is required for response_mode 'form_post'."
                 }
 
-                // Build an HTML page with a self-submitting form.
-                val htmlContent = buildString {
-                    appendLine("<!DOCTYPE html>")
-                    appendLine("<html>")
-                    appendLine("<head><title>Submitting Presentation...</title></head>")
-                    // The body's onload attribute triggers the form submission automatically.
-                    appendLine("<body onload=\"document.forms[0].submit()\">")
-                    appendLine("<noscript><p>Your browser does not support JavaScript. Please press the button below to continue.</p></noscript>")
-                    // The form action is the Verifier's redirect_uri.
-                    appendLine("<form method=\"POST\" action=\"${authorizationRequest.redirectUri!!.encodeURLParameter()}\">")
-                    // The vp_token and state are included as hidden input fields.
-                    appendLine("<input type=\"hidden\" name=\"vp_token\" value=\"${vpToken.escapeHTML()}\"/>")
-                    authorizationRequest.state?.let {
-                        appendLine("<input type=\"hidden\" name=\"state\" value=\"${it.escapeHTML()}\"/>")
-                    }
-                    appendLine("<input type=\"submit\" value=\"Continue\"/>")
-                    appendLine("</form>")
-                    appendLine("</body>")
-                    appendLine("</html>")
+                val fields = buildList {
+                    add("vp_token" to vpToken)
+                    authorizationRequest.state?.let { add("state" to it) }
                 }
+                val htmlContent = buildFormPostHtml(
+                    actionUrl = authorizationRequest.redirectUri!!,
+                    title = "Submitting Presentation...",
+                    fields = fields,
+                )
 
                 log.trace { "Responding with self-submitting HTML form to post to: ${authorizationRequest.redirectUri}" }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/WalletPresentFunctionality2.kt
@@ -237,15 +237,7 @@ object WalletPresentFunctionality2 {
                 require(authorizationRequest.responseUri != null) {
                     "Invalid AuthorizationRequest: 'response_uri' is required for response_mode '$responseMode'."
                 }
-                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, errorParameters)
-                val responseBody = response.bodyAsText()
-                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }.getOrNull()
-
-                WalletPresentResult(
-                    transmissionSuccess = response.status.isSuccess(),
-                    verifierResponse = Json.parseToJsonElement(responseBody),
-                    redirectTo = responseBodyJson?.get("redirect_uri")?.jsonPrimitive?.content,
-                )
+                postFormResponse(authorizationRequest.responseUri!!, errorParameters)
             }
 
             OpenID4VPResponseMode.DC_API, OpenID4VPResponseMode.DC_API_JWT ->
@@ -274,6 +266,21 @@ object WalletPresentFunctionality2 {
         errorDescription?.let { append("error_description", it) }
         authorizationRequest.state?.let { append("state", it) }
     }.build()
+
+    private suspend fun postFormResponse(
+        responseUri: String,
+        parameters: Parameters,
+    ): WalletPresentResult {
+        val response = webPostToken.sendForm(responseUri, parameters)
+        val responseBody = response.bodyAsText()
+        val responseBodyJson = Json.parseToJsonElement(responseBody).jsonObject
+
+        return WalletPresentResult(
+            transmissionSuccess = response.status.isSuccess(),
+            verifierResponse = responseBodyJson,
+            redirectTo = responseBodyJson["redirect_uri"]?.jsonPrimitive?.content,
+        )
+    }
 
     /**
      * Build a self-submitting `form_post` HTML page that POSTs [fields] to [actionUrl].
@@ -577,20 +584,8 @@ object WalletPresentFunctionality2 {
                 }.build()
 
                 log.trace { "Submitting direct_post form to Verifier: ${authorizationRequest.responseUri}" }
-                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, parameters)
-                log.trace { "Verifier direct_post response: $response" }
-
-                val responseBody = response.bodyAsText()
-                log.trace { "Verifier direct_post response body: $responseBody" }
-
-                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }
-
                 return Result.success(
-                    WalletPresentResult(
-                        transmissionSuccess = response.status.isSuccess(),
-                        verifierResponse = Json.parseToJsonElement(responseBody),
-                        redirectTo = responseBodyJson.getOrThrow()["redirect_uri"]?.jsonPrimitive?.content
-                    )
+                    postFormResponse(authorizationRequest.responseUri!!, parameters)
                 )
             }
 
@@ -637,20 +632,8 @@ object WalletPresentFunctionality2 {
                 }.build()
 
                 log.trace { "Submitting direct_post.jwt (encrypted) to Verifier: ${authorizationRequest.responseUri}" }
-                val response = webPostToken.sendForm(authorizationRequest.responseUri!!, parameters)
-
-                log.trace { "Verifier direct_post.jwt response status: ${response.status}" }
-
-                // 7. Process Response (Same as direct_post)
-                val responseBody = response.bodyAsText()
-                val responseBodyJson = runCatching { Json.decodeFromString<JsonObject>(responseBody) }
-
                 return Result.success(
-                    WalletPresentResult(
-                        transmissionSuccess = response.status.isSuccess(),
-                        verifierResponse = Json.parseToJsonElement(responseBody),
-                        redirectTo = responseBodyJson.getOrThrow()["redirect_uri"]?.jsonPrimitive?.content
-                    )
+                    postFormResponse(authorizationRequest.responseUri!!, parameters)
                 )
 
             }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -40,7 +40,7 @@ class WalletRejectHandlingTest {
                 responseMode = OpenID4VPResponseMode.FRAGMENT,
                 state = "state-123",
             ),
-            error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+            error = WalletPresentFunctionality2.OID4VPErrorCode.ACCESS_DENIED,
             errorDescription = "User denied",
         ).getOrThrow()
 
@@ -73,7 +73,7 @@ class WalletRejectHandlingTest {
                 responseMode = OpenID4VPResponseMode.QUERY,
                 state = "state-abc",
             ),
-            error = WalletPresentFunctionality2.Oid4vpErrorCode.invalid_request,
+            error = WalletPresentFunctionality2.OID4VPErrorCode.INVALID_REQUEST,
             errorDescription = "bad request",
         ).getOrThrow()
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -1,0 +1,30 @@
+package id.waltid.openid4vp.wallet
+
+import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalSerializationApi::class)
+class WalletRejectHandlingTest {
+
+    @Test
+    fun fragmentErrorResponse_includesErrorDescriptionAndState() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FRAGMENT,
+                state = "state-123",
+            ),
+            error = "access_denied",
+            errorDescription = "User denied",
+        ).getOrThrow()
+
+        assertEquals(
+            "https://wallet.example/callback#error=access_denied&error_description=User+denied&state=state-123",
+            result.getUrl,
+        )
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -100,6 +100,7 @@ class WalletRejectHandlingTest {
 
         val html = assertNotNull(result.formPostHtml)
         assertTrue("<form method=\"POST\"" in html)
+        assertTrue("action=\"https://wallet.example/callback\"" in html)
         assertTrue("name=\"error\" value=\"access_denied\"" in html)
         // error_description should be HTML-escaped
         assertTrue("name=\"error_description\" value=\"User &quot;denied&quot;\"" in html)
@@ -107,23 +108,6 @@ class WalletRejectHandlingTest {
         assertTrue("name=\"state\" value=\"state-&lt;123&gt;\"" in html)
         // auto-submit behavior present
         assertTrue("document.forms[0].submit()" in html)
-    }
-
-    // --- DIRECT_POST_JWT: explicitly unsupported ---------------------------
-
-    @Test
-    fun directPostJwt_isUnsupported() = runTest {
-        val result = WalletPresentFunctionality2.walletRejectHandling(
-            authorizationRequest = AuthorizationRequest(
-                responseUri = "https://verifier.example/response",
-                responseMode = OpenID4VPResponseMode.DIRECT_POST_JWT,
-                state = "s",
-            ),
-            error = "access_denied",
-        )
-
-        assertTrue(result.isFailure)
-        assertTrue(result.exceptionOrNull() is UnsupportedOperationException)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectHandlingTest.kt
@@ -6,9 +6,13 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalSerializationApi::class)
 class WalletRejectHandlingTest {
+
+    // --- FRAGMENT -----------------------------------------------------------
 
     @Test
     fun fragmentErrorResponse_includesErrorDescriptionAndState() = runTest {
@@ -26,5 +30,114 @@ class WalletRejectHandlingTest {
             "https://wallet.example/callback#error=access_denied&error_description=User+denied&state=state-123",
             result.getUrl,
         )
+    }
+
+    @Test
+    fun fragmentErrorResponse_typedEnum_producesSameUrl() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FRAGMENT,
+                state = "state-123",
+            ),
+            error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+            errorDescription = "User denied",
+        ).getOrThrow()
+
+        assertEquals(
+            "https://wallet.example/callback#error=access_denied&error_description=User+denied&state=state-123",
+            result.getUrl,
+        )
+    }
+
+    @Test
+    fun fragmentErrorResponse_omitsStateWhenRequestHasNone() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FRAGMENT,
+            ),
+            error = "access_denied",
+        ).getOrThrow()
+
+        assertEquals("https://wallet.example/callback#error=access_denied", result.getUrl)
+    }
+
+    // --- QUERY --------------------------------------------------------------
+
+    @Test
+    fun queryErrorResponse_appendsErrorParametersAsQueryString() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.QUERY,
+                state = "state-abc",
+            ),
+            error = WalletPresentFunctionality2.Oid4vpErrorCode.invalid_request,
+            errorDescription = "bad request",
+        ).getOrThrow()
+
+        val url = assertNotNull(result.getUrl)
+        assertTrue(url.startsWith("https://wallet.example/callback?"))
+        assertTrue("error=invalid_request" in url)
+        assertTrue("error_description=bad+request" in url || "error_description=bad%20request" in url)
+        assertTrue("state=state-abc" in url)
+    }
+
+    // --- FORM_POST ----------------------------------------------------------
+
+    @Test
+    fun formPostErrorResponse_generatesSelfSubmittingHtmlWithEscapedFields() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.FORM_POST,
+                state = "state-<123>",
+            ),
+            error = "access_denied",
+            errorDescription = "User \"denied\"",
+        ).getOrThrow()
+
+        val html = assertNotNull(result.formPostHtml)
+        assertTrue("<form method=\"POST\"" in html)
+        assertTrue("name=\"error\" value=\"access_denied\"" in html)
+        // error_description should be HTML-escaped
+        assertTrue("name=\"error_description\" value=\"User &quot;denied&quot;\"" in html)
+        // state should be HTML-escaped
+        assertTrue("name=\"state\" value=\"state-&lt;123&gt;\"" in html)
+        // auto-submit behavior present
+        assertTrue("document.forms[0].submit()" in html)
+    }
+
+    // --- DIRECT_POST_JWT: explicitly unsupported ---------------------------
+
+    @Test
+    fun directPostJwt_isUnsupported() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                responseUri = "https://verifier.example/response",
+                responseMode = OpenID4VPResponseMode.DIRECT_POST_JWT,
+                state = "s",
+            ),
+            error = "access_denied",
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is UnsupportedOperationException)
+    }
+
+    @Test
+    fun dcApi_isUnsupported() = runTest {
+        val result = WalletPresentFunctionality2.walletRejectHandling(
+            authorizationRequest = AuthorizationRequest(
+                redirectUri = "https://wallet.example/callback",
+                responseMode = OpenID4VPResponseMode.DC_API,
+                state = "s",
+            ),
+            error = "access_denied",
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is UnsupportedOperationException)
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
@@ -27,7 +27,7 @@ class WalletRejectDirectPostHandlingJvmTest {
                     responseMode = OpenID4VPResponseMode.DIRECT_POST,
                     state = "state-123",
                 ),
-                error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+                error = WalletPresentFunctionality2.OID4VPErrorCode.ACCESS_DENIED,
                 errorDescription = "User denied",
             ).getOrThrow()
 

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/WalletRejectDirectPostHandlingJvmTest.kt
@@ -1,0 +1,81 @@
+package id.waltid.openid4vp.wallet
+
+import com.sun.net.httpserver.HttpServer
+import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@OptIn(ExperimentalSerializationApi::class)
+class WalletRejectDirectPostHandlingJvmTest {
+
+    @Test
+    fun directPost_sendsErrorResponseToResponseUri() = runTest {
+        withRecordingServer { responseUri, receivedBody ->
+            val result = WalletPresentFunctionality2.walletRejectHandling(
+                authorizationRequest = AuthorizationRequest(
+                    responseUri = responseUri,
+                    responseMode = OpenID4VPResponseMode.DIRECT_POST,
+                    state = "state-123",
+                ),
+                error = WalletPresentFunctionality2.Oid4vpErrorCode.access_denied,
+                errorDescription = "User denied",
+            ).getOrThrow()
+
+            assertEquals(true, result.transmissionSuccess)
+            assertEquals("acknowledged", result.verifierResponse?.jsonObjectValue("status"))
+            assertEquals("error=access_denied&error_description=User+denied&state=state-123", assertNotNull(receivedBody.get()))
+        }
+    }
+
+    @Test
+    fun directPostJwt_sendsPermittedUnencryptedErrorResponseToResponseUri() = runTest {
+        withRecordingServer { responseUri, receivedBody ->
+            val result = WalletPresentFunctionality2.walletRejectHandling(
+                authorizationRequest = AuthorizationRequest(
+                    responseUri = responseUri,
+                    responseMode = OpenID4VPResponseMode.DIRECT_POST_JWT,
+                    state = "state-456",
+                ),
+                error = "access_denied",
+            ).getOrThrow()
+
+            assertEquals(true, result.transmissionSuccess)
+            assertEquals("acknowledged", result.verifierResponse?.jsonObjectValue("status"))
+            assertEquals("error=access_denied&state=state-456", assertNotNull(receivedBody.get()))
+        }
+    }
+
+    private suspend fun withRecordingServer(
+        block: suspend (responseUri: String, receivedBody: AtomicReference<String?>) -> Unit,
+    ) {
+        val receivedBody = AtomicReference<String?>()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/response") { exchange ->
+            receivedBody.set(exchange.requestBody.readBytes().decodeToString())
+            val response = """{"status":"acknowledged"}""".toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { it.write(response) }
+        }
+
+        server.start()
+        try {
+            block("http://127.0.0.1:${server.address.port}/response", receivedBody)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    private fun JsonElement.jsonObjectValue(name: String): String? =
+        jsonObject[name]?.jsonPrimitive?.content
+}


### PR DESCRIPTION
## Tickets

- [WAL-965](https://linear.app/walt-new/issue/WAL-965) — Support OIDC4VP Error response

## Problem

OpenID4VP 1.0 [§8.5](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-8.5) allows the wallet to return an OAuth-style error response, for example `error=access_denied`, instead of a `vp_token` when the user refuses a presentation request.

Verifier2 now distinguishes that protocol-level wallet rejection from malformed presentation input, stores it structurally on the session, and lets wallet SDK callers generate the corresponding rejection response.

## Scope

### Verifier side

- Adds `ErrorResponseDirectPost(error, errorDescription, state)` to the verifier direct-post response model.
- Parses `error` responses from both `application/x-www-form-urlencoded` and JSON bodies before the legacy missing-presentation error path.
- Short-circuits wallet error responses before VP-token parsing.
- Records `SessionFailure.WalletErrorResponse(...)`, marks the session `FAILED`, and emits `wallet_error_response_received`.
- Validates `state`: when the Authorization Request had one, the wallet error response must echo it; missing/mismatched state is rejected with `INVALID_STATE_PARAMETER`.
- Returns configured `redirects.errorRedirectUri` as `redirect_uri` for newly recorded `direct_post` wallet error responses.
- Preserves terminal-session idempotency: duplicate or late wallet-error POSTs against `FAILED` or `SUCCESSFUL` sessions are acknowledged with HTTP 200 and do not overwrite the existing outcome.

### Wallet side

- Adds `WalletPresentFunctionality2.walletRejectHandling(...)` for `fragment`, `query`, `form_post`, `direct_post`, and `direct_post.jwt` response modes.
- Keeps typed `WalletPresentFunctionality2.OID4VPErrorCode` for known §8.5 / RFC 6749 codes.
- Provides a `String` overload for forward compatibility with future or extension error codes.
- Shares form-post HTML generation and direct-post response parsing between presentation and rejection paths.
- For `direct_post.jwt`, sends the OpenID4VP-permitted unencrypted form-encoded error response to `response_uri` when the wallet cannot generate an encrypted response.

**Design note on status**: wallet errors map to `FAILED` with `failure.type = "wallet_error_response"` rather than introducing a new status enum value. This keeps strict enum consumers working; the discrimination lives in the structured `failure` object.

## Schema

```json
{
  "event": "wallet_error_response_received",
  "session": {
    "status": "FAILED",
    "statusReason": "Wallet returned OID4VP error: access_denied",
    "failure": {
      "type": "wallet_error_response",
      "reason": "Wallet returned OID4VP error response per §8.5",
      "error": "access_denied",
      "error_description": "User denied",
      "state": "abc123"
    }
  }
}
```

When `redirects.errorRedirectUri` is configured, the `direct_post` response body is:

```json
{
  "redirect_uri": "https://example.com/error"
}
```

## Compatibility

- Additive: `SessionFailure.WalletErrorResponse` is a subtype of the `SessionFailure` sealed class introduced by the target PR.
- New `SessionEvent.wallet_error_response_received` is appended to the enum.
- Legacy direct-post bodies (`vp_token=...`, `response=...`, DC API JSON) route to the existing variants unchanged.
- Strict state validation aligns with OAuth error-response rules inherited through OpenID4VP §8.5.
- `direct_post.jwt` wallet rejection uses the spec-permitted unencrypted error response fallback.

## Test evidence

Clean verification from the PR head against its target branch:

```bash
./gradlew \
  :waltid-libraries:protocols:waltid-openid4vp-verifier:jvmTest \
  :waltid-libraries:protocols:waltid-openid4vp-wallet:jvmTest \
  :waltid-services:waltid-verifier-api2:test \
  :waltid-libraries:protocols:waltid-openid4vp-verifier:compileKotlinJs \
  :waltid-libraries:protocols:waltid-openid4vp-wallet:compileKotlinJs \
  :waltid-libraries:protocols:waltid-openid4vp-verifier:compileCommonMainKotlinMetadata \
  :waltid-libraries:protocols:waltid-openid4vp-wallet:compileCommonMainKotlinMetadata \
  --no-build-cache --rerun-tasks
```

Result: `BUILD SUCCESSFUL`, `244 actionable tasks: 244 executed`.

Additional focused checks run while closing the final gap:

```bash
./gradlew :waltid-libraries:protocols:waltid-openid4vp-verifier:jvmTest \
  --tests 'id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandlerParseTest' \
  --no-build-cache --rerun-tasks

./gradlew :waltid-libraries:protocols:waltid-openid4vp-wallet:jvmTest \
  --tests 'id.waltid.openid4vp.wallet.WalletRejectDirectPostHandlingJvmTest' \
  --no-build-cache --rerun-tasks
```

Both focused checks passed.

Mobile-target note: these verifier/wallet protocol modules expose JVM, JS, and common metadata verification in the current repo shape. No Android, connected-device, or instrumentation Gradle tasks are present for `waltid-openid4vp-wallet`. Attempting iOS compilation with `-PenableIosBuild=true` currently fails during Gradle configuration before this module compiles because `/waltid-libraries/crypto/waltid-target-ios/build.gradle.kts` applies `org.jetbrains.kotlin.multiplatform` without a resolvable plugin version. The common metadata and JS checks above are the currently runnable shared-code compatibility checks for downstream mobile consumers.

Covered behavior:

- URL-encoded and JSON wallet error responses parse to `ErrorResponseDirectPost`.
- Missing/mismatched expected state is rejected.
- Matching state records structured `SessionFailure.WalletErrorResponse` and emits `wallet_error_response_received`.
- Configured `errorRedirectUri` is returned as `redirect_uri` for newly recorded `direct_post` wallet errors.
- Duplicate wallet error POSTs against terminal sessions do not overwrite status/reason/failure.
- Legacy URL-encoded `vp_token`, encrypted `response`, and DC API JSON bodies still route to existing variants.
- Wallet rejection helper covers `fragment`, `query`, `form_post`, `direct_post`, and `direct_post.jwt`.
- Typed `OID4VPErrorCode` and raw string overloads are both covered.
- Form-post HTML escaping and direct-post transmission/ack parsing are covered.
- Verifier-api2 tests exercise session creation, presentation response handling, and `/verification-session/{id}/info` serialization through a running test server.

## Related

- Stacks on: [#1706](https://github.com/walt-id/waltid-identity/pull/1706) — introduces structured `SessionFailure`. Must merge first.
- Docs: [walt-id/waltid-docs#277](https://github.com/walt-id/waltid-docs/pull/277).

## Rollout

Additive. Merge [#1706](https://github.com/walt-id/waltid-identity/pull/1706) first, then this PR.
