### PR TITLE
ci: verify current main conformance baseline

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
@@ -43,6 +43,7 @@ import kotlin.uuid.Uuid
 object VerificationSessionCreator {
 
     private val log = KotlinLogging.logger { }
+    private const val SELF_ISSUED_WALLET_AUDIENCE = "https://self-issued.me/v2"
 
     private suspend fun getKid(clientId: String?, key: Key): String {
         val prefix = "decentralized_identifier:"
@@ -206,6 +207,7 @@ object VerificationSessionCreator {
             scope = null,//OPTIONAL. OAuth 2.0 Scope value. Can be used for pre-defined DCQL queries or OpenID Connect scopes (e.g., "openid").
             state = state, // Opaque value used by the Verifier to maintain state between the request and callback.
             nonce = nonce, // String value used to mitigate replay attacks. Also used to establish holder binding.
+            aud = if (isSignedRequest) SELF_ISSUED_WALLET_AUDIENCE else null,
             responseMode = when {
                 isDcApi && isEncryptedResponse -> OpenID4VPResponseMode.DC_API_JWT // HAIP requires dc_api.jwt (encrypted)
                 isDcApi -> OpenID4VPResponseMode.DC_API

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
@@ -129,7 +129,7 @@ object VerificationSessionCreator {
                     "mso_mdoc" to JsonObject(
                         if (isDcApiHaip) mapOf(
                             "issuerauth_alg_values" to JsonArray(listOf(Cose.Algorithm.ES256, -9, -50).map { it.toJsonElement() }),
-                            "deviceauth_alg_values" to JsonArray(listOf(Cose.Algorithm.ES256, -9, -50, -65537).map { it.toJsonElement() })
+                            "deviceauth_alg_values" to JsonArray(listOf(Cose.Algorithm.ES256, -9, -50).map { it.toJsonElement() })
                             /*"alg_values_supported" to JsonArray(
                                 listOf(JsonPrimitive("ES256"))
                             )*/
@@ -146,7 +146,7 @@ object VerificationSessionCreator {
                     "mso_mdoc" to JsonObject(
                         mapOf(
                             "issuerauth_alg_values" to JsonArray(listOf(Cose.Algorithm.ES256, -9, -50).map { it.toJsonElement() }),
-                            "deviceauth_alg_values" to JsonArray(listOf(Cose.Algorithm.ES256, -9, -50, -65537).map { it.toJsonElement() })
+                            "deviceauth_alg_values" to JsonArray(listOf(Cose.Algorithm.ES256, -9, -50).map { it.toJsonElement() })
                         )
                     )
                 )

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorTest.kt
@@ -1,0 +1,39 @@
+package id.walt.verifier2.handlers.sessioncreation
+
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.verifier2.data.CrossDeviceFlowSetup
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalSerializationApi::class)
+class VerificationSessionCreatorTest {
+
+    @Test
+    fun signedAuthorizationRequestContainsWalletAudience() = runTest {
+        val setup = (CrossDeviceFlowSetup.EXAMPLE_SDJWT_PID as CrossDeviceFlowSetup).let {
+            it.copy(core = it.core.copy(signedRequest = true))
+        }
+        val key = JWKKey.generate(KeyType.secp256r1)
+
+        val session = VerificationSessionCreator.createVerificationSession(
+            setup = setup,
+            clientId = "x509_san_dns:test123",
+            urlPrefix = "https://verifier.example/verification-session",
+            urlHost = "https://wallet.example/authorize",
+            key = key,
+        )
+
+        val requestPayload = session.signedAuthorizationRequestJwt!!.split(".")[1]
+        val decodedPayload = Base64.getUrlDecoder().decode(requestPayload).decodeToString()
+        val payloadJson = Json.parseToJsonElement(decodedPayload).jsonObject
+
+        assertEquals("https://self-issued.me/v2", payloadJson["aud"]?.jsonPrimitive?.content)
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp/src/commonMain/kotlin/id/walt/verifier/openid/models/authorization/AuthorizationRequest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp/src/commonMain/kotlin/id/walt/verifier/openid/models/authorization/AuthorizationRequest.kt
@@ -72,6 +72,12 @@ data class AuthorizationRequest(
      */
     val nonce: String? = null,
 
+    /**
+     * REQUIRED in signed Authorization Request Objects.
+     * Identifies the Wallet as the intended recipient of the request.
+     */
+    val aud: String? = null,
+
     // JAR (RFC 9101) Parameters (Section 5)
     /**
      * OPTIONAL. The Authorization Request parameters are represented as a JWT [RFC7519].

--- a/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/MdlX509SanDnsRequestUriSignedDirectPost.kt
+++ b/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/MdlX509SanDnsRequestUriSignedDirectPost.kt
@@ -22,7 +22,7 @@ class MdlX509SanDnsRequestUriSignedDirectPost(
     val verifierKey =
         Json.decodeFromString<DirectSerializedKey>("""{"type":"jwk","jwk":{"kty":"EC","d":"AEb4k1BeTR9xt2NxYZggdzkFLLUkhyyWvyUOq3qSiwA","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}}""")
     val verifierCertificateChain =
-        listOf("MIIBVzCB/aADAgECAggNKZAvUrtimzAKBggqhkjOPQQDAjAfMR0wGwYDVQQDDBR2ZXJpZmllci5leGFtcGxlLmNvbTAeFw0yNTEwMTQwNjI0MjBaFw0yNjEwMTQwNjI0MjBaMB8xHTAbBgNVBAMMFHZlcmlmaWVyLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEG/TgBc0BkmMipiQ/6gkamIn3mmp7hcTrZuyrLTmknP1WRExl1dhdIx9/kAkuuceI3THkxXq7/y+sBzK0ZR7jPqMjMCEwHwYDVR0RBBgwFoIUdmVyaWZpZXIuZXhhbXBsZS5jb20wCgYIKoZIzj0EAwIDSQAwRgIhAOu0RGM6BjVQUepeLBogw+ZD3MQ9vFppbPIGMPjtn/qdAiEAttfdfyXHfzJ2tr+Pczyckzv3NlM43461cvP96sIzOQA=")
+        listOf("MIIBwjCCAWegAwIBAgIUZaaJWLxLPQCDu87JDIaHcN+UZTowCgYIKoZIzj0EAwIwKDEmMCQGA1UEAwwdd2FsdGlkIHRlc3QgcmVxdWVzdCBvYmplY3QgQ0EwHhcNMjYwNTIwMTE0OTQxWhcNMjcwNTIwMTE0OTQxWjASMRAwDgYDVQQDDAd0ZXN0MTIzMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEG/TgBc0BkmMipiQ/6gkamIn3mmp7hcTrZuyrLTmknP1WRExl1dhdIx9/kAkuuceI3THkxXq7/y+sBzK0ZR7jPqOBhDCBgTAJBgNVHRMEAjAAMAsGA1UdDwQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAjASBgNVHREECzAJggd0ZXN0MTIzMB0GA1UdDgQWBBSCJZ2bjB1VuLM8lvN8e/M4MYmLvzAfBgNVHSMEGDAWgBT5VqsOYyRZDSf3/l7pc+metuuv9zAKBggqhkjOPQQDAgNJADBGAiEA/8dLuFt2dPgyMRk+r3OEBER3lxwaDxN0aCQOcuNxTF8CIQDtuyP4EBiFf16o1bM+mJXCBEc20C1tpwX37KQDsuu50Q==")
 
     // DCQL
 

--- a/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/MdlX509SanDnsRequestUriSignedDirectPost.kt
+++ b/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/MdlX509SanDnsRequestUriSignedDirectPost.kt
@@ -70,7 +70,8 @@ class MdlX509SanDnsRequestUriSignedDirectPost(
                            "credential_format": "iso_mdl",
                            "client_id_prefix": "x509_san_dns",
                            "request_method": "request_uri_signed",
-                           "response_mode": "direct_post"
+                           "response_mode": "direct_post",
+                           "vp_profile": "plain_vp"
                          }""".trimIndent()
             )
         },

--- a/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/SdJwtVcX509SanDnsRequestUriSignedDirectPost.kt
+++ b/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/SdJwtVcX509SanDnsRequestUriSignedDirectPost.kt
@@ -22,7 +22,7 @@ class SdJwtVcX509SanDnsRequestUriSignedDirectPost(
     val verifierKey =
         Json.decodeFromString<DirectSerializedKey>("""{"type":"jwk","jwk":{"kty":"EC","d":"AEb4k1BeTR9xt2NxYZggdzkFLLUkhyyWvyUOq3qSiwA","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}}""")
     val verifierCertificateChain =
-        listOf("MIIBVzCB/aADAgECAggNKZAvUrtimzAKBggqhkjOPQQDAjAfMR0wGwYDVQQDDBR2ZXJpZmllci5leGFtcGxlLmNvbTAeFw0yNTEwMTQwNjI0MjBaFw0yNjEwMTQwNjI0MjBaMB8xHTAbBgNVBAMMFHZlcmlmaWVyLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEG/TgBc0BkmMipiQ/6gkamIn3mmp7hcTrZuyrLTmknP1WRExl1dhdIx9/kAkuuceI3THkxXq7/y+sBzK0ZR7jPqMjMCEwHwYDVR0RBBgwFoIUdmVyaWZpZXIuZXhhbXBsZS5jb20wCgYIKoZIzj0EAwIDSQAwRgIhAOu0RGM6BjVQUepeLBogw+ZD3MQ9vFppbPIGMPjtn/qdAiEAttfdfyXHfzJ2tr+Pczyckzv3NlM43461cvP96sIzOQA=")
+        listOf("MIIBwjCCAWegAwIBAgIUZaaJWLxLPQCDu87JDIaHcN+UZTowCgYIKoZIzj0EAwIwKDEmMCQGA1UEAwwdd2FsdGlkIHRlc3QgcmVxdWVzdCBvYmplY3QgQ0EwHhcNMjYwNTIwMTE0OTQxWhcNMjcwNTIwMTE0OTQxWjASMRAwDgYDVQQDDAd0ZXN0MTIzMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEG/TgBc0BkmMipiQ/6gkamIn3mmp7hcTrZuyrLTmknP1WRExl1dhdIx9/kAkuuceI3THkxXq7/y+sBzK0ZR7jPqOBhDCBgTAJBgNVHRMEAjAAMAsGA1UdDwQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAjASBgNVHREECzAJggd0ZXN0MTIzMB0GA1UdDgQWBBSCJZ2bjB1VuLM8lvN8e/M4MYmLvzAfBgNVHSMEGDAWgBT5VqsOYyRZDSf3/l7pc+metuuv9zAKBggqhkjOPQQDAgNJADBGAiEA/8dLuFt2dPgyMRk+r3OEBER3lxwaDxN0aCQOcuNxTF8CIQDtuyP4EBiFf16o1bM+mJXCBEc20C1tpwX37KQDsuu50Q==")
 
     // Wallet
     val signerCertificateChain = Json.encodeToString(

--- a/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/SdJwtVcX509SanDnsRequestUriSignedDirectPost.kt
+++ b/waltid-services/waltid-openid4vp-conformance-runners/src/main/kotlin/id/walt/openid4vp/conformance/testplans/plans/SdJwtVcX509SanDnsRequestUriSignedDirectPost.kt
@@ -79,7 +79,8 @@ class SdJwtVcX509SanDnsRequestUriSignedDirectPost(
                            "credential_format": "sd_jwt_vc",
                            "client_id_prefix": "x509_san_dns",
                            "request_method": "request_uri_signed",
-                           "response_mode": "direct_post"
+                           "response_mode": "direct_post",
+                           "vp_profile": "plain_vp"
                          }""".trimIndent()
             )
         },


### PR DESCRIPTION
Temporary draft PR to verify whether current main still passes the OpenID4VP conformance CI when rerun against today&apos;s live conformance server.\n\nFirst commit is intentionally empty so the initial CI run represents main without code changes. If it fails with the expected conformance variant error, the follow-up commit will add the vp_profile variant to verify the fix.