### PR TITLE
supress logging for bitstring status

### DIFF
--- a/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/status/bit/BitValueReader.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies/src/commonMain/kotlin/id/walt/policies/policies/status/bit/BitValueReader.kt
@@ -20,18 +20,13 @@ class BitValueReader(
     ) = getBitValue(expansionAlgorithm(bitstring), idx, bitSize)
 
     private fun getBitValue(input: ByteArray, index: ULong, bitSize: Int): List<Char> {
-        logger.debug { "available bytes: ${bitmap(input)}" }
 
         // TODO: bitSize constraints
         val bitStartPosition = index * bitSize.toUInt()
-        logger.debug { "bitStartPosition overall: $bitStartPosition" }
 
         val byteStart = bitStartPosition / BITS_PER_BYTE_UNSIGNED
-        logger.debug { "skipping: $byteStart bytes" }
-        logger.debug { "available: ${input.size - byteStart.toInt()} bytes" }
 
         val bytesToRead = (bitSize - 1) / BITS_PER_BYTE_UNSIGNED.toInt() + 1
-        logger.debug { "readingNext: $bytesToRead bytes" }
 
         val startIndex = byteStart.toInt()
         val endIndex = minOf(startIndex + bytesToRead, input.size)
@@ -41,10 +36,8 @@ class BitValueReader(
     }
 
     private fun extractBitValue(bytes: ByteArray, index: ULong, bitSize: UInt): List<Char> {
-        logger.debug { "selected byte: ${bitmap(bytes)}" }
         val bits = bytes.toBitSequence()
         val bitStartPosition = index * bitSize % BITS_PER_BYTE_UNSIGNED
-        logger.debug { "bitStartPosition within byte: $bitStartPosition" }
         val bitSet = bits.drop(bitStartPosition.toInt()).iterator()
         val result = mutableListOf<Boolean>()
         var b = 0u

--- a/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/bit/BitValueReader.kt
+++ b/waltid-libraries/credentials/waltid-verification-policies2/src/commonMain/kotlin/id/walt/policies2/vc/policies/status/bit/BitValueReader.kt
@@ -20,18 +20,13 @@ class BitValueReader(
     ) = getBitValue(expansionAlgorithm(bitstring), idx, bitSize)
 
     private fun getBitValue(input: ByteArray, index: ULong, bitSize: Int): List<Char> {
-        logger.debug { "available bytes: ${bitmap(input)}" }
 
         // TODO: bitSize constraints
         val bitStartPosition = index * bitSize.toUInt()
-        logger.debug { "bitStartPosition overall: $bitStartPosition" }
 
         val byteStart = bitStartPosition / BITS_PER_BYTE_UNSIGNED
-        logger.debug { "skipping: $byteStart bytes" }
-        logger.debug { "available: ${input.size - byteStart.toInt()} bytes" }
 
         val bytesToRead = (bitSize - 1) / BITS_PER_BYTE_UNSIGNED.toInt() + 1
-        logger.debug { "readingNext: $bytesToRead bytes" }
 
         val startIndex = byteStart.toInt()
         val endIndex = minOf(startIndex + bytesToRead, input.size)
@@ -41,10 +36,8 @@ class BitValueReader(
     }
 
     private fun extractBitValue(bytes: ByteArray, index: ULong, bitSize: UInt): List<Char> {
-        logger.debug { "selected byte: ${bitmap(bytes)}" }
         val bits = bytes.toBitSequence()
         val bitStartPosition = index * bitSize % BITS_PER_BYTE_UNSIGNED
-        logger.debug { "bitStartPosition within byte: $bitStartPosition" }
         val bitSet = bits.drop(bitStartPosition.toInt()).iterator()
         val result = mutableListOf<Boolean>()
         var b = 0u

--- a/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/entrawallet/core/utils/Utils.kt
+++ b/waltid-libraries/waltid-core-wallet/src/jvmMain/java/id/walt/entrawallet/core/utils/Utils.kt
@@ -41,13 +41,9 @@ object BitstringUtils {
         inputStream.use { stream ->
             //TODO: bitSize constraints
             val bitStartPosition = index * bitSize.toUInt()
-            logger.debug { "bitStartPosition: $bitStartPosition" }
             val byteStart = bitStartPosition / 8u
-            logger.debug { "skipping: $byteStart bytes" }
             stream.skip(byteStart.toLong())
-            logger.debug { "available: ${stream.available()} bytes" }
             val bytesToRead = (bitSize - 1) / 8 + 1
-            logger.debug { "readingNext: $bytesToRead bytes" }
             extractBitValue(stream.readNBytes(bytesToRead), index, bitSize.toUInt())
         }
 

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/utils/Utils.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/utils/Utils.kt
@@ -42,26 +42,19 @@ object BitstringUtils {
         inputStream.use { stream ->
             if (stream.markSupported()) {
                 stream.mark(Int.MAX_VALUE)
-                logger.debug { "available bytes: ${bitmap(stream.readAllBytes())}" }
                 inputStream.reset()
             }
             //TODO: bitSize constraints
             val bitStartPosition = index * bitSize.toUInt()
-            logger.debug { "bitStartPosition overall: $bitStartPosition" }
             val byteStart = bitStartPosition / BITS_PER_BYTE_UNSIGNED
-            logger.debug { "skipping: $byteStart bytes" }
             stream.skip(byteStart.toLong())
-            logger.debug { "available: ${stream.available()} bytes" }
             val bytesToRead = (bitSize - 1) / BITS_PER_BYTE_UNSIGNED.toInt() + 1
-            logger.debug { "readingNext: $bytesToRead bytes" }
             extractBitValue(stream.readNBytes(bytesToRead), index, bitSize.toUInt())
         }
 
     private fun extractBitValue(bytes: ByteArray, index: ULong, bitSize: UInt): List<Char> {
-        logger.debug { "selected byte: ${bitmap(bytes)}" }
         val bits = bytes.toBitSequence()
         val bitStartPosition = index * bitSize % BITS_PER_BYTE_UNSIGNED
-        logger.debug { "bitStartPosition within byte: $bitStartPosition" }
         val bitSet = bits.drop(bitStartPosition.toInt()).iterator()
         val result = mutableListOf<Boolean>()
         var b = 0u

--- a/waltid-services/waltid-wallet-api/src/test/kotlin/id/walt/webwallet/utils/BitstringUtilsTest.kt
+++ b/waltid-services/waltid-wallet-api/src/test/kotlin/id/walt/webwallet/utils/BitstringUtilsTest.kt
@@ -7,14 +7,14 @@ class BitstringUtilsTest {
     private val bitString = hexToByteArray("A265")//0b10100010_01100101
 
     @Test
-    fun `test unit bitsize, no overflow`() {
+    fun validateUnitBitsizeNoOverflow() {
         val value = BitstringUtils.getBitValue(inputStream = bitString.inputStream(), index = 6UL, bitSize = 1)
         assertNotNull(value)
         assertEquals(expected = "1", actual = value.joinToString(""))
     }
 
     @Test
-    fun `test non-unit bitsize, no overflow`() {
+    fun validateNonUnitBitsizeNoOverflow() {
         val value = BitstringUtils.getBitValue(inputStream = bitString.inputStream(), index = 4UL, bitSize = 3)
         assertNotNull(value)
         assertEquals(expected = "010", actual = value.joinToString(""))
@@ -22,7 +22,7 @@ class BitstringUtilsTest {
 
     @Test
     @Ignore
-    fun `test unit bitsize, with overflow`() {
+    fun validateUnitBitsizeWithOverflow() {
         assertFailsWith<IllegalStateException> {
             BitstringUtils.getBitValue(
                 inputStream = bitString.inputStream(),
@@ -34,7 +34,7 @@ class BitstringUtilsTest {
 
     @Test
     @Ignore
-    fun `test non-unit bitsize, with overflow`() {
+    fun validateNonUnitBitsizeWithOverflow() {
         assertFailsWith<IllegalStateException> {
             BitstringUtils.getBitValue(
                 inputStream = bitString.inputStream(),


### PR DESCRIPTION
removes logging for now to stop the test logs from being so long, making debugging harder.
generally, we need to refactor the whole status list implementation to avoid these scenarios of code duplication but this will be taken up in another larger ticket