### PR TITLE
fail gracefully when ebsi gives 404

### DIFF
--- a/waltid-libraries/waltid-did/src/jvmTest/kotlin/resolvers/DidEbsiResolverTest.kt
+++ b/waltid-libraries/waltid-did/src/jvmTest/kotlin/resolvers/DidEbsiResolverTest.kt
@@ -6,8 +6,12 @@ import id.walt.did.dids.resolver.local.DidEbsiResolver
 import id.walt.did.dids.resolver.local.LocalResolverMethod
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
@@ -48,7 +52,13 @@ class DidEbsiResolverTest : DidResolverTestBase() {
     override fun `given a did String, when calling resolve, then the result is a valid did document`(
         did: String, key: JsonObject, resolverAssertion: resolverAssertion<DidDocument>
     ) {
-        super.`given a did String, when calling resolve, then the result is a valid did document`(did, key, resolverAssertion)
+        skipIfEbsiDidUnavailable {
+            super.`given a did String, when calling resolve, then the result is a valid did document`(
+                did,
+                key,
+                resolverAssertion
+            )
+        }
     }
 
 
@@ -60,8 +70,45 @@ class DidEbsiResolverTest : DidResolverTestBase() {
         key: JsonObject,
         resolverAssertion: resolverAssertion<Key>
     ) {
-        super.`given a did String, when calling resolveToKey, then the result is valid key`(did, key, resolverAssertion)
+        // Check availability upfront for resolveToKey since assertions may obscure the root cause
+        val resolveResult = runBlocking { resolver.resolve(did) }
+        checkEbsiDidAvailability(resolveResult)
+        
+        skipIfEbsiDidUnavailable {
+            super.`given a did String, when calling resolveToKey, then the result is valid key`(did, key, resolverAssertion)
+        }
     }
+
+    private fun checkEbsiDidAvailability(result: Result<DidDocument>) {
+        result.exceptionOrNull()?.let { ex ->
+            if (isEbsiDidUnavailable(ex)) {
+                // EBSI DIDs are externally hosted and may not always be available
+                Assumptions.abort<Unit>("Skipping test: EBSI DID resolver returned 404 or failed to resolve from both environments")
+            }
+        }
+    }
+
+    private fun skipIfEbsiDidUnavailable(block: () -> Unit) {
+        runCatching {
+            block()
+        }.onFailure { ex ->
+            if (isEbsiDidUnavailable(ex)) {
+                // EBSI DIDs are externally hosted and may not always be available
+                Assumptions.abort<Unit>("Skipping test: EBSI DID resolver returned 404 or failed to resolve from both environments")
+            } else {
+                throw ex
+            }
+        }
+    }
+
+    private fun isEbsiDidUnavailable(ex: Throwable): Boolean =
+        generateSequence(ex) { it.cause }.any { throwable ->
+            when (throwable) {
+                is ResponseException -> throwable.response.status == HttpStatusCode.NotFound
+                is IllegalStateException -> throwable.message?.contains("Failed to resolve EBSI DID") == true
+                else -> false
+            }
+        }
 
     companion object {
 
@@ -87,6 +134,7 @@ class DidEbsiResolverTest : DidResolverTestBase() {
         )
 
 
+        // EBSI DIDs are externally hosted and may not always be available.
         private val pilotEnvDidList: List<TestEntry> = listOf(
             TestEntry(
                 did = "did:ebsi:zfkNjYrzvx3bQn2SRyDZDMC",


### PR DESCRIPTION
ebsi dids are throwing 404, causing our tests to fail. Added a check so we can abort the tests if the external system is unavailable