### PR TITLE
Add authorization details to TokenRequestBuilder

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/token/TokenRequestBuilder.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/token/TokenRequestBuilder.kt
@@ -1,6 +1,7 @@
 package id.waltid.openid4vci.wallet.token
 
 import id.walt.openid4vci.GrantType
+import id.walt.openid4vci.requests.authorization.AuthorizationDetail
 import id.waltid.openid4vci.wallet.oauth.ClientConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
@@ -9,6 +10,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 private val log = KotlinLogging.logger {}
 
@@ -36,6 +38,7 @@ class TokenRequestBuilder(
         val scope: String? = null,
         val c_nonce: String? = null,
         val c_nonce_expires_in: Long? = null,
+        val authorization_details: List<AuthorizationDetail>? = null
     )
 
     /**


### PR DESCRIPTION


* Added an optional `authorization_details` parameter of type `List<AuthorizationDetail>` to the `TokenRequestBuilder.RequestParameters` data class, allowing the inclusion of detailed authorization information in token requests.

