### PR TITLE
move ebsi tests to java client due to tls 1.3 requirements

### DIFF
--- a/waltid-libraries/waltid-did/src/jvmTest/kotlin/resolvers/DidEbsiResolverTest.kt
+++ b/waltid-libraries/waltid-did/src/jvmTest/kotlin/resolvers/DidEbsiResolverTest.kt
@@ -5,7 +5,7 @@ import id.walt.did.dids.document.DidDocument
 import id.walt.did.dids.resolver.local.DidEbsiResolver
 import id.walt.did.dids.resolver.local.LocalResolverMethod
 import io.ktor.client.*
-import io.ktor.client.engine.cio.*
+import io.ktor.client.engine.java.*
 import io.ktor.client.plugins.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
@@ -16,34 +16,11 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import java.security.cert.X509Certificate
 import java.util.stream.Stream
-import javax.net.ssl.X509TrustManager
 
 class DidEbsiResolverTest : DidResolverTestBase() {
     override val resolver: LocalResolverMethod =
-        DidEbsiResolver(HttpClient(CIO) {
-            engine {
-                https {
-                    //disable https certificate verification
-                    trustManager = object : X509TrustManager {
-                        override fun checkClientTrusted(
-                            chain: Array<out X509Certificate?>?,
-                            authType: String?
-                        ) {
-                        }
-
-                        override fun checkServerTrusted(
-                            chain: Array<out X509Certificate?>?,
-                            authType: String?
-                        ) {
-                        }
-
-                        override fun getAcceptedIssuers(): Array<out X509Certificate?>? = null
-                    }
-                }
-            }
-        })
+        DidEbsiResolver(HttpClient(Java))
 
 
     // TODO: Include test in the scope of WAL-842
@@ -106,6 +83,9 @@ class DidEbsiResolverTest : DidResolverTestBase() {
             when (throwable) {
                 is ResponseException -> throwable.response.status == HttpStatusCode.NotFound
                 is IllegalStateException -> throwable.message?.contains("Failed to resolve EBSI DID") == true
+                is java.net.ConnectException -> true
+                is java.net.SocketTimeoutException -> true
+                is javax.net.ssl.SSLException -> true
                 else -> false
             }
         }


### PR DESCRIPTION
EBSI tests were throwing a TLS Exception as CIO does not support the cipher suite required by the EBSI server hosting the DIDs. This PR migrates the test file to use the native java http client which does have required support. Now tests pass