### PR TITLE
Fix Open API schema generation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ okio = "3.17.0"
 
 # Misc
 clikt = "5.1.0"
+smiley4-schema-kenerator = "2.7.2"
 
 [libraries]
 
@@ -237,6 +238,11 @@ jaywayjsonpath = { module = "com.jayway.jsonpath:json-path", version = "2.9.0" }
 ## Misc
 cache4k = { module = "io.github.reactivecircus.cache4k:cache4k", version.ref = "cache4k" }
 
+smiley4-schema-kenerator-core = { group = "io.github.smiley4", name = "schema-kenerator-core", version.ref = "smiley4-schema-kenerator" }
+smiley4-schema-kenerator-swagger = { group = "io.github.smiley4", name = "schema-kenerator-swagger", version.ref = "smiley4-schema-kenerator" }
+smiley4-schema-kenerator-serialization = { group = "io.github.smiley4", name = "schema-kenerator-serialization", version.ref = "smiley4-schema-kenerator" }
+smiley4-schema-kenerator-reflection = { group = "io.github.smiley4", name = "schema-kenerator-reflection", version.ref = "smiley4-schema-kenerator" }
+
 ## Testing
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
@@ -308,6 +314,13 @@ waltid-ktortesting = [
     "kotlinx-coroutines-test",
     "ktor-client-mock",
     "ktor-server-test-host"
+]
+
+smiley4-schema-kenerator = [
+    "smiley4-schema-kenerator-core",
+    "smiley4-schema-kenerator-swagger",
+    "smiley4-schema-kenerator-serialization",
+    "smiley4-schema-kenerator-reflection"
 ]
 
 [plugins]

--- a/waltid-services/waltid-service-commons/build.gradle.kts
+++ b/waltid-services/waltid-service-commons/build.gradle.kts
@@ -49,11 +49,7 @@ dependencies {
     api("io.github.smiley4:ktor-openapi:5.6.0")
     implementation("io.github.smiley4:ktor-swagger-ui:5.6.0")
     implementation("io.github.smiley4:ktor-redoc:5.6.0")
-
-    implementation("io.github.smiley4:schema-kenerator-core:2.6.0")
-    implementation("io.github.smiley4:schema-kenerator-swagger:2.6.0")
-    implementation("io.github.smiley4:schema-kenerator-serialization:2.6.0")
-    implementation("io.github.smiley4:schema-kenerator-reflection:2.6.0")
+    implementation(libs.bundles.smiley4.schema.kenerator)
 
     // Persistence
     api("io.github.reactivecircus.cache4k:cache4k:0.14.0")

--- a/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
+++ b/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
@@ -49,50 +49,8 @@ object OpenApiModule {
         install(OpenApi) {
 
             schemas {
-                val kotlinxGenerator = SchemaGenerator.kotlinx {
-                    explicitNullTypes = false
-                    customAnalyzer(ContextualSerializationTypeAnalyzerModule)
-                    customAnalyzer(FixSealedClassInheritanceModule)
-                    customGenerator(FixSealedClassInheritanceModule)
-                    customGenerator(FixJsonCustomParameters)
-                    overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
-                    overwrite(SchemaGenerator.TypeOverwrites.File())
-                    overwrite(SchemaGenerator.TypeOverwrites.Instant())
-                    overwrite(CustomTypeOverrides.KotlinxInstant())
-                    overwrite(CustomTypeOverrides.JsonArray())
-                    overwrite(CustomTypeOverrides.JsonObject())
-                    overwrite(CustomTypeOverrides.JsonElement())
-                    overwrite(CustomTypeOverrides.SdMap())
-                    overwrite(CustomTypeOverrides.QuickFixPolymorphic())
-                }
-                val reflectionGenerator = SchemaGenerator.reflection {
-                    explicitNullTypes = false
-                    customGenerator(FixJsonCustomParameters)
-                    overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
-                    overwrite(SchemaGenerator.TypeOverwrites.File())
-                    overwrite(SchemaGenerator.TypeOverwrites.Instant())
-                    overwrite(CustomTypeOverrides.KotlinxInstant())
-                    overwrite(CustomTypeOverrides.JsonArray())
-                    overwrite(CustomTypeOverrides.JsonObject())
-                    overwrite(CustomTypeOverrides.JsonElement())
-                    overwrite(CustomTypeOverrides.SdMap())
-                }
+                generator = createGenerator()
 
-                fun InitialTypeData.schemaName() =
-                    when (this) {
-                        is InitialKTypeData -> "${this.type} (KType)"
-                        is InitialSerialDescriptorTypeData -> "${this.type.serialName} (Serialname)"
-                        else -> error("Unknown data type $this")
-                    }
-
-                generator = { type ->
-                    runCatching {
-                        kotlinxGenerator.invoke(type)
-                    }.recoverCatching {
-                        logger.debug { "Failed kotlinx schema generation, trying reflection schema generation for: \"${type.schemaName()}\", due to: \"${it.message}\"." }
-                        reflectionGenerator.invoke(type)
-                    }.getOrThrow()
-                }
             }
 
             examples {
@@ -119,6 +77,7 @@ object OpenApiModule {
                     if (example is String && isStringType) {
                         example
                     } else if (example is JsonElement) {
+                        // support example encoding of JsonElement so examples can be created with buildJsonObject
                         Json.encodeToString(example).toStructuredJsonObject()
                     } else {
                         runCatching {
@@ -190,6 +149,54 @@ object OpenApiModule {
             }) {
                 call.respondRedirect("swagger")
             }
+        }
+    }
+
+    fun createGenerator(): GenericSchemaGenerator {
+        val kotlinxGenerator = SchemaGenerator.kotlinx {
+            explicitNullTypes = false
+            customAnalyzer(StripeNotAllowedCharactersAnalyzerModule)
+            customAnalyzer(ContextualSerializationTypeAnalyzerModule)
+            customAnalyzer(FixSealedClassInheritanceModule)
+            customGenerator(FixSealedClassInheritanceModule)
+            customGenerator(FixJsonCustomParameters)
+            overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
+            overwrite(SchemaGenerator.TypeOverwrites.File())
+            overwrite(SchemaGenerator.TypeOverwrites.Instant())
+            overwrite(CustomTypeOverrides.KotlinxInstant())
+            overwrite(CustomTypeOverrides.JsonArray())
+            overwrite(CustomTypeOverrides.JsonObject())
+            overwrite(CustomTypeOverrides.JsonElement())
+            overwrite(CustomTypeOverrides.SdMap())
+            overwrite(CustomTypeOverrides.QuickFixPolymorphic())
+        }
+        val reflectionGenerator = SchemaGenerator.reflection {
+            explicitNullTypes = false
+            customGenerator(FixJsonCustomParameters)
+            overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
+            overwrite(SchemaGenerator.TypeOverwrites.File())
+            overwrite(SchemaGenerator.TypeOverwrites.Instant())
+            overwrite(CustomTypeOverrides.KotlinxInstant())
+            overwrite(CustomTypeOverrides.JsonArray())
+            overwrite(CustomTypeOverrides.JsonObject())
+            overwrite(CustomTypeOverrides.JsonElement())
+            overwrite(CustomTypeOverrides.SdMap())
+        }
+
+        fun InitialTypeData.schemaName() =
+            when (this) {
+                is InitialKTypeData -> "${this.type} (KType)"
+                is InitialSerialDescriptorTypeData -> "${this.type.serialName} (Serialname)"
+                else -> error("Unknown data type $this")
+            }
+
+        return { type ->
+            runCatching {
+                kotlinxGenerator.invoke(type)
+            }.recoverCatching {
+                logger.debug { "Failed kotlinx schema generation, trying reflection schema generation for: \"${type.schemaName()}\", due to: \"${it.message}\"." }
+                reflectionGenerator.invoke(type)
+            }.getOrThrow()
         }
     }
 }
@@ -292,6 +299,44 @@ private object FixJsonCustomParameters : SwaggerSchemaGenerationModule {
         generated.required?.removeIf { it.equals("customParameters") }
         return generated
     }
+}
+
+
+private object StripeNotAllowedCharactersAnalyzerModule : SerializationTypeAnalyzerModule {
+
+    val notAllowedChars = Regex("/")
+
+    override fun applies(descriptor: SerialDescriptor): Boolean =
+        notAllowedChars.find(descriptor.serialName) != null
+
+    override fun analyze(context: SerializationTypeAnalyzerModule.Context): WrappedTypeData {
+        val newSerialName = context.descriptor.serialName.replace(notAllowedChars, "#")
+        val result = context.analyze(object : SerialDescriptor {
+            override val serialName: String
+                get() = newSerialName
+            override val kind: SerialKind
+                get() = context.descriptor.kind
+            override val elementsCount: Int
+                get() = context.descriptor.elementsCount
+
+            override fun getElementName(index: Int): String =
+                context.descriptor.getElementName(index)
+
+            override fun getElementIndex(name: String): Int =
+                context.descriptor.getElementIndex(name)
+
+            override fun getElementAnnotations(index: Int): List<Annotation> =
+                context.descriptor.getElementAnnotations(index)
+
+            override fun getElementDescriptor(index: Int): SerialDescriptor =
+                context.descriptor.getElementDescriptor(index)
+
+            override fun isElementOptional(index: Int): Boolean =
+                context.descriptor.isElementOptional(index)
+        })
+        return result
+    }
+
 }
 
 

--- a/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
+++ b/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
@@ -7,6 +7,7 @@ import id.walt.commons.config.statics.RunConfiguration
 import id.walt.commons.config.statics.ServiceConfig
 import io.github.smiley4.ktoropenapi.OpenApi
 import io.github.smiley4.ktoropenapi.config.*
+import io.github.smiley4.ktoropenapi.config.ExampleEncoder.toStructuredJsonObject
 import io.github.smiley4.ktoropenapi.config.descriptors.*
 import io.github.smiley4.ktoropenapi.get
 import io.github.smiley4.ktoropenapi.openApi
@@ -28,6 +29,9 @@ import io.swagger.v3.oas.models.media.Schema
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SealedSerializationApi
 import kotlinx.serialization.descriptors.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlin.reflect.KType
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Instant
 
@@ -42,88 +46,15 @@ object OpenApiModule {
     }
 
     // Module
-        fun Application.enable() {
+    fun Application.enable() {
         install(OpenApi) {
 
             schemas {
-                val kotlinxGenerator = SchemaGenerator.kotlinx {
-                    explicitNullTypes = false
-                    customAnalyzer(ContextualSerializationTypeAnalyzerModule)
-                    customAnalyzer(FixSealedClassInheritanceModule)
-                    customGenerator(FixSealedClassInheritanceModule)
-                    customGenerator(FixJsonCustomParameters)
-                    overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
-                    overwrite(SchemaGenerator.TypeOverwrites.File())
-                    overwrite(SchemaGenerator.TypeOverwrites.Instant())
-                    overwrite(CustomTypeOverrides.KotlinxInstant())
-                    overwrite(CustomTypeOverrides.JsonArray())
-                    overwrite(CustomTypeOverrides.JsonObject())
-                    overwrite(CustomTypeOverrides.JsonElement())
-                    overwrite(CustomTypeOverrides.SdMap())
-                    overwrite(CustomTypeOverrides.QuickFixPolymorphic())
-                }
-                val reflectionGenerator = SchemaGenerator.reflection {
-                    explicitNullTypes = false
-                    customGenerator(FixJsonCustomParameters)
-                    overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
-                    overwrite(SchemaGenerator.TypeOverwrites.File())
-                    overwrite(SchemaGenerator.TypeOverwrites.Instant())
-                    overwrite(CustomTypeOverrides.KotlinxInstant())
-                    overwrite(CustomTypeOverrides.JsonArray())
-                    overwrite(CustomTypeOverrides.JsonObject())
-                    overwrite(CustomTypeOverrides.JsonElement())
-                    overwrite(CustomTypeOverrides.SdMap())
-                }
-
-                fun InitialTypeData.schemaName() =
-                    when (this) {
-                        is InitialKTypeData -> "${this.type} (KType)"
-                        is InitialSerialDescriptorTypeData -> "${this.type.serialName} (Serialname)"
-                        else -> error("Unknown data type $this")
-                    }
-
-                generator = { type ->
-                    runCatching {
-                        kotlinxGenerator.invoke(type)
-                    }.recoverCatching {
-                        logger.debug { "Failed kotlinx schema generation, trying reflection schema generation for: \"${type.schemaName()}\", due to: \"${it.message}\"." }
-                        reflectionGenerator.invoke(type)
-                    }.getOrThrow()
-                }
+                generator = createOpenApiGenerator()
             }
 
             examples {
-                val kotlinxEncoder = ExampleEncoder.kotlinx()
-                val reflectionEncoder = ExampleEncoder.internal()
-
-                fun TypeDescriptor.typeName(): String = when (this) {
-                    is SwaggerTypeDescriptor -> "${schema.name} ${schema.type} (SwaggerType)"
-                    is KTypeDescriptor -> type.simpleName + "<" + type.arguments.joinToString { it.type?.simpleName.toString() } + "> (KType)"
-                    is SerialTypeDescriptor -> "${descriptor.serialName} (SerialType)"
-                    is AnyOfTypeDescriptor -> "Any of ${this.types.map { it.typeName() }} (AnyOfType)"
-                    is ArrayTypeDescriptor -> "Array of ${this.type.typeName()} (ArrayType)"
-                    is EmptyTypeDescriptor -> "Empty Type (EmptyType)"
-                    is RefTypeDescriptor -> "$schemaId (RefType)"
-                }
-
-                exampleEncoder = { type, example ->
-                    val isStringType = when (type) {
-                        is KTypeDescriptor -> type.type.classifier == String::class
-                        is SerialTypeDescriptor -> type.descriptor.serialName == "kotlin.String"
-                        else -> false
-                    }
-
-                    if (example is String && isStringType) {
-                        example
-                    } else {
-                        runCatching {
-                            kotlinxEncoder.invoke(type, example)
-                        }.recoverCatching {
-                            logger.debug { "Failed kotlinx example encoding, trying internal example encoder for: \"${type?.typeName()}\", due to: \"${it.message}\". Example in question: $example" }
-                            reflectionEncoder.invoke(type, example)
-                        }.getOrThrow()
-                    }
-                }
+                exampleEncoder = createOpenApiExampleEncoder()
             }
 
             info {
@@ -184,6 +115,88 @@ object OpenApiModule {
                 summary = "Redirect to swagger interface for API documentation"
             }) {
                 call.respondRedirect("swagger")
+            }
+        }
+    }
+
+    fun createOpenApiGenerator(): GenericSchemaGenerator {
+        val kotlinxGenerator = SchemaGenerator.kotlinx {
+            explicitNullTypes = false
+            customAnalyzer(ContextualSerializationTypeAnalyzerModule)
+            customAnalyzer(FixSealedClassInheritanceModule)
+            customGenerator(FixSealedClassInheritanceModule)
+            customGenerator(FixJsonCustomParameters)
+            overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
+            overwrite(SchemaGenerator.TypeOverwrites.File())
+            overwrite(SchemaGenerator.TypeOverwrites.Instant())
+            overwrite(CustomTypeOverrides.KotlinxInstant())
+            overwrite(CustomTypeOverrides.JsonArray())
+            overwrite(CustomTypeOverrides.JsonObject())
+            overwrite(CustomTypeOverrides.JsonElement())
+            overwrite(CustomTypeOverrides.SdMap())
+            overwrite(CustomTypeOverrides.QuickFixPolymorphic())
+        }
+        val reflectionGenerator = SchemaGenerator.reflection {
+            explicitNullTypes = false
+            customGenerator(FixJsonCustomParameters)
+            overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
+            overwrite(SchemaGenerator.TypeOverwrites.File())
+            overwrite(SchemaGenerator.TypeOverwrites.Instant())
+            overwrite(CustomTypeOverrides.KotlinxInstant())
+            overwrite(CustomTypeOverrides.JsonArray())
+            overwrite(CustomTypeOverrides.JsonObject())
+            overwrite(CustomTypeOverrides.JsonElement())
+            overwrite(CustomTypeOverrides.SdMap())
+        }
+
+        fun InitialTypeData.schemaName() =
+            when (this) {
+                is InitialKTypeData -> "${this.type} (KType)"
+                is InitialSerialDescriptorTypeData -> "${this.type.serialName} (Serialname)"
+                else -> error("Unknown data type $this")
+            }
+        return { type ->
+            runCatching {
+                kotlinxGenerator.invoke(type)
+            }.recoverCatching {
+                logger.debug { "Failed kotlinx schema generation, trying reflection schema generation for: \"${type.schemaName()}\", due to: \"${it.message}\"." }
+                reflectionGenerator.invoke(type)
+            }.getOrThrow()
+        }
+    }
+
+    fun createOpenApiExampleEncoder(): GenericExampleEncoder {
+        val kotlinxEncoder = ExampleEncoder.kotlinx()
+        val reflectionEncoder = ExampleEncoder.internal()
+
+        fun TypeDescriptor.typeName(): String = when (this) {
+            is SwaggerTypeDescriptor -> "${schema.name} ${schema.type} (SwaggerType)"
+            is KTypeDescriptor -> type.simpleName + "<" + type.arguments.joinToString { it.type?.simpleName.toString() } + "> (KType)"
+            is SerialTypeDescriptor -> "${descriptor.serialName} (SerialType)"
+            is AnyOfTypeDescriptor -> "Any of ${this.types.map { it.typeName() }} (AnyOfType)"
+            is ArrayTypeDescriptor -> "Array of ${this.type.typeName()} (ArrayType)"
+            is EmptyTypeDescriptor -> "Empty Type (EmptyType)"
+            is RefTypeDescriptor -> "$schemaId (RefType)"
+        }
+
+        return { type, example ->
+            val isStringType = when (type) {
+                is KTypeDescriptor -> type.type.classifier == String::class
+                is SerialTypeDescriptor -> type.descriptor.serialName == "kotlin.String"
+                else -> false
+            }
+
+            if (example is String && isStringType) {
+                example
+            } else if (example is JsonElement) {
+                Json.encodeToString(example).toStructuredJsonObject()
+            } else {
+                runCatching {
+                    kotlinxEncoder.invoke(type, example)
+                }.recoverCatching {
+                    logger.debug { "Failed kotlinx example encoding, trying internal example encoder for: \"${type?.typeName()}\", due to: \"${it.message}\". Example in question: $example" }
+                    reflectionEncoder.invoke(type, example)
+                }.getOrThrow()
             }
         }
     }
@@ -419,3 +432,24 @@ object CustomTypeOverrides {
         }
     }
 }
+
+class WrappedSchemeGenerator(
+    private val schemaGenerator: GenericSchemaGenerator,
+    private val exampleEncoder: GenericExampleEncoder,
+) {
+    fun generateSchema(type: KType): Unit {
+        val initialKType = InitialKTypeData(type, emptyList())
+        schemaGenerator.invoke(initialKType)
+    }
+
+    fun generateExample(type: KType, example: Any?): Unit {
+        exampleEncoder.invoke(KTypeDescriptor(type), example)
+    }
+
+}
+
+fun createOpenApiGenerator(): WrappedSchemeGenerator =
+    WrappedSchemeGenerator(
+        OpenApiModule.createOpenApiGenerator(),
+        OpenApiModule.createOpenApiExampleEncoder()
+    )

--- a/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
+++ b/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
@@ -155,7 +155,7 @@ object OpenApiModule {
     fun createGenerator(): GenericSchemaGenerator {
         val kotlinxGenerator = SchemaGenerator.kotlinx {
             explicitNullTypes = false
-            customAnalyzer(StripeNotAllowedCharactersAnalyzerModule)
+            customAnalyzer(StripNotAllowedCharactersAnalyzerModule)
             customAnalyzer(ContextualSerializationTypeAnalyzerModule)
             customAnalyzer(FixSealedClassInheritanceModule)
             customGenerator(FixSealedClassInheritanceModule)
@@ -302,7 +302,7 @@ private object FixJsonCustomParameters : SwaggerSchemaGenerationModule {
 }
 
 
-private object StripeNotAllowedCharactersAnalyzerModule : SerializationTypeAnalyzerModule {
+private object StripNotAllowedCharactersAnalyzerModule : SerializationTypeAnalyzerModule {
 
     val notAllowedChars = Regex("/")
 
@@ -310,7 +310,7 @@ private object StripeNotAllowedCharactersAnalyzerModule : SerializationTypeAnaly
         notAllowedChars.find(descriptor.serialName) != null
 
     override fun analyze(context: SerializationTypeAnalyzerModule.Context): WrappedTypeData {
-        val newSerialName = context.descriptor.serialName.replace(notAllowedChars, "#")
+        val newSerialName = context.descriptor.serialName.replace(notAllowedChars, ".")
         val result = context.analyze(object : SerialDescriptor {
             override val serialName: String
                 get() = newSerialName

--- a/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
+++ b/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/web/modules/OpenApiModule.kt
@@ -31,7 +31,6 @@ import kotlinx.serialization.SealedSerializationApi
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
-import kotlin.reflect.KType
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Instant
 
@@ -50,11 +49,86 @@ object OpenApiModule {
         install(OpenApi) {
 
             schemas {
-                generator = createOpenApiGenerator()
+                val kotlinxGenerator = SchemaGenerator.kotlinx {
+                    explicitNullTypes = false
+                    customAnalyzer(ContextualSerializationTypeAnalyzerModule)
+                    customAnalyzer(FixSealedClassInheritanceModule)
+                    customGenerator(FixSealedClassInheritanceModule)
+                    customGenerator(FixJsonCustomParameters)
+                    overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
+                    overwrite(SchemaGenerator.TypeOverwrites.File())
+                    overwrite(SchemaGenerator.TypeOverwrites.Instant())
+                    overwrite(CustomTypeOverrides.KotlinxInstant())
+                    overwrite(CustomTypeOverrides.JsonArray())
+                    overwrite(CustomTypeOverrides.JsonObject())
+                    overwrite(CustomTypeOverrides.JsonElement())
+                    overwrite(CustomTypeOverrides.SdMap())
+                    overwrite(CustomTypeOverrides.QuickFixPolymorphic())
+                }
+                val reflectionGenerator = SchemaGenerator.reflection {
+                    explicitNullTypes = false
+                    customGenerator(FixJsonCustomParameters)
+                    overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
+                    overwrite(SchemaGenerator.TypeOverwrites.File())
+                    overwrite(SchemaGenerator.TypeOverwrites.Instant())
+                    overwrite(CustomTypeOverrides.KotlinxInstant())
+                    overwrite(CustomTypeOverrides.JsonArray())
+                    overwrite(CustomTypeOverrides.JsonObject())
+                    overwrite(CustomTypeOverrides.JsonElement())
+                    overwrite(CustomTypeOverrides.SdMap())
+                }
+
+                fun InitialTypeData.schemaName() =
+                    when (this) {
+                        is InitialKTypeData -> "${this.type} (KType)"
+                        is InitialSerialDescriptorTypeData -> "${this.type.serialName} (Serialname)"
+                        else -> error("Unknown data type $this")
+                    }
+
+                generator = { type ->
+                    runCatching {
+                        kotlinxGenerator.invoke(type)
+                    }.recoverCatching {
+                        logger.debug { "Failed kotlinx schema generation, trying reflection schema generation for: \"${type.schemaName()}\", due to: \"${it.message}\"." }
+                        reflectionGenerator.invoke(type)
+                    }.getOrThrow()
+                }
             }
 
             examples {
-                exampleEncoder = createOpenApiExampleEncoder()
+                val kotlinxEncoder = ExampleEncoder.kotlinx()
+                val reflectionEncoder = ExampleEncoder.internal()
+
+                fun TypeDescriptor.typeName(): String = when (this) {
+                    is SwaggerTypeDescriptor -> "${schema.name} ${schema.type} (SwaggerType)"
+                    is KTypeDescriptor -> type.simpleName + "<" + type.arguments.joinToString { it.type?.simpleName.toString() } + "> (KType)"
+                    is SerialTypeDescriptor -> "${descriptor.serialName} (SerialType)"
+                    is AnyOfTypeDescriptor -> "Any of ${this.types.map { it.typeName() }} (AnyOfType)"
+                    is ArrayTypeDescriptor -> "Array of ${this.type.typeName()} (ArrayType)"
+                    is EmptyTypeDescriptor -> "Empty Type (EmptyType)"
+                    is RefTypeDescriptor -> "$schemaId (RefType)"
+                }
+
+                exampleEncoder = { type, example ->
+                    val isStringType = when (type) {
+                        is KTypeDescriptor -> type.type.classifier == String::class
+                        is SerialTypeDescriptor -> type.descriptor.serialName == "kotlin.String"
+                        else -> false
+                    }
+
+                    if (example is String && isStringType) {
+                        example
+                    } else if (example is JsonElement) {
+                        Json.encodeToString(example).toStructuredJsonObject()
+                    } else {
+                        runCatching {
+                            kotlinxEncoder.invoke(type, example)
+                        }.recoverCatching {
+                            logger.debug { "Failed kotlinx example encoding, trying internal example encoder for: \"${type?.typeName()}\", due to: \"${it.message}\". Example in question: $example" }
+                            reflectionEncoder.invoke(type, example)
+                        }.getOrThrow()
+                    }
+                }
             }
 
             info {
@@ -115,88 +189,6 @@ object OpenApiModule {
                 summary = "Redirect to swagger interface for API documentation"
             }) {
                 call.respondRedirect("swagger")
-            }
-        }
-    }
-
-    fun createOpenApiGenerator(): GenericSchemaGenerator {
-        val kotlinxGenerator = SchemaGenerator.kotlinx {
-            explicitNullTypes = false
-            customAnalyzer(ContextualSerializationTypeAnalyzerModule)
-            customAnalyzer(FixSealedClassInheritanceModule)
-            customGenerator(FixSealedClassInheritanceModule)
-            customGenerator(FixJsonCustomParameters)
-            overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
-            overwrite(SchemaGenerator.TypeOverwrites.File())
-            overwrite(SchemaGenerator.TypeOverwrites.Instant())
-            overwrite(CustomTypeOverrides.KotlinxInstant())
-            overwrite(CustomTypeOverrides.JsonArray())
-            overwrite(CustomTypeOverrides.JsonObject())
-            overwrite(CustomTypeOverrides.JsonElement())
-            overwrite(CustomTypeOverrides.SdMap())
-            overwrite(CustomTypeOverrides.QuickFixPolymorphic())
-        }
-        val reflectionGenerator = SchemaGenerator.reflection {
-            explicitNullTypes = false
-            customGenerator(FixJsonCustomParameters)
-            overwrite(SchemaGenerator.TypeOverwrites.KotlinUuid())
-            overwrite(SchemaGenerator.TypeOverwrites.File())
-            overwrite(SchemaGenerator.TypeOverwrites.Instant())
-            overwrite(CustomTypeOverrides.KotlinxInstant())
-            overwrite(CustomTypeOverrides.JsonArray())
-            overwrite(CustomTypeOverrides.JsonObject())
-            overwrite(CustomTypeOverrides.JsonElement())
-            overwrite(CustomTypeOverrides.SdMap())
-        }
-
-        fun InitialTypeData.schemaName() =
-            when (this) {
-                is InitialKTypeData -> "${this.type} (KType)"
-                is InitialSerialDescriptorTypeData -> "${this.type.serialName} (Serialname)"
-                else -> error("Unknown data type $this")
-            }
-        return { type ->
-            runCatching {
-                kotlinxGenerator.invoke(type)
-            }.recoverCatching {
-                logger.debug { "Failed kotlinx schema generation, trying reflection schema generation for: \"${type.schemaName()}\", due to: \"${it.message}\"." }
-                reflectionGenerator.invoke(type)
-            }.getOrThrow()
-        }
-    }
-
-    fun createOpenApiExampleEncoder(): GenericExampleEncoder {
-        val kotlinxEncoder = ExampleEncoder.kotlinx()
-        val reflectionEncoder = ExampleEncoder.internal()
-
-        fun TypeDescriptor.typeName(): String = when (this) {
-            is SwaggerTypeDescriptor -> "${schema.name} ${schema.type} (SwaggerType)"
-            is KTypeDescriptor -> type.simpleName + "<" + type.arguments.joinToString { it.type?.simpleName.toString() } + "> (KType)"
-            is SerialTypeDescriptor -> "${descriptor.serialName} (SerialType)"
-            is AnyOfTypeDescriptor -> "Any of ${this.types.map { it.typeName() }} (AnyOfType)"
-            is ArrayTypeDescriptor -> "Array of ${this.type.typeName()} (ArrayType)"
-            is EmptyTypeDescriptor -> "Empty Type (EmptyType)"
-            is RefTypeDescriptor -> "$schemaId (RefType)"
-        }
-
-        return { type, example ->
-            val isStringType = when (type) {
-                is KTypeDescriptor -> type.type.classifier == String::class
-                is SerialTypeDescriptor -> type.descriptor.serialName == "kotlin.String"
-                else -> false
-            }
-
-            if (example is String && isStringType) {
-                example
-            } else if (example is JsonElement) {
-                Json.encodeToString(example).toStructuredJsonObject()
-            } else {
-                runCatching {
-                    kotlinxEncoder.invoke(type, example)
-                }.recoverCatching {
-                    logger.debug { "Failed kotlinx example encoding, trying internal example encoder for: \"${type?.typeName()}\", due to: \"${it.message}\". Example in question: $example" }
-                    reflectionEncoder.invoke(type, example)
-                }.getOrThrow()
             }
         }
     }
@@ -432,24 +424,3 @@ object CustomTypeOverrides {
         }
     }
 }
-
-class WrappedSchemeGenerator(
-    private val schemaGenerator: GenericSchemaGenerator,
-    private val exampleEncoder: GenericExampleEncoder,
-) {
-    fun generateSchema(type: KType): Unit {
-        val initialKType = InitialKTypeData(type, emptyList())
-        schemaGenerator.invoke(initialKType)
-    }
-
-    fun generateExample(type: KType, example: Any?): Unit {
-        exampleEncoder.invoke(KTypeDescriptor(type), example)
-    }
-
-}
-
-fun createOpenApiGenerator(): WrappedSchemeGenerator =
-    WrappedSchemeGenerator(
-        OpenApiModule.createOpenApiGenerator(),
-        OpenApiModule.createOpenApiExampleEncoder()
-    )


### PR DESCRIPTION
## Description

Fix Open API Schema generation for  classes where the SerialName contains character "/"
Also support JsonElement for example rendering
Upgrade smiley4-schema-kenerator to latest version

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality

## Checklist

- [x] code cleanup and self-review
- [X] unit + e2e test coverage
- [ ] documentation updated accordingly

Depends on: https://github.com/walt-id/waltid-unified-build/pull/52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI schema generation now works more consistently across Kotlin serialization and reflection-based models.
  * Example values can now be built from JSON elements and displayed as structured JSON.

* **Bug Fixes**
  * Improved schema handling for serialized names containing `/`, reducing failures during API documentation generation.

* **Chores**
  * Updated dependency management to use a shared dependency bundle for schema generation libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->