### PR TITLE
docs(mobile): add KDoc and DocC examples for SDK setup

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     // Buildconfig
     implementation(identityLibs.buildconfig.plugin)
 
+    // Documentation
+    implementation(identityLibs.dokka.gradle.plugin)
+
     // Gradle Shadow
     implementation(identityLibs.gradle.shadow)
 

--- a/build-logic/src/main/kotlin/waltid.mobile.sdk.documentation.gradle.kts
+++ b/build-logic/src/main/kotlin/waltid.mobile.sdk.documentation.gradle.kts
@@ -1,0 +1,23 @@
+import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
+
+plugins {
+    id("org.jetbrains.dokka")
+}
+
+dokka {
+    dokkaPublications.html {
+        moduleName.set(project.name)
+        moduleVersion.set(project.version.toString())
+        outputDirectory.set(layout.buildDirectory.dir("dokka/html"))
+        failOnWarning.set(true)
+        suppressObviousFunctions.set(true)
+        includes.from("README.md")
+    }
+
+    dokkaSourceSets.configureEach {
+        documentedVisibilities.set(setOf(VisibilityModifier.Public))
+        reportUndocumented.set(true)
+        skipDeprecated.set(false)
+        suppressGeneratedFiles.set(true)
+    }
+}

--- a/docs/mobile-wallet-development.md
+++ b/docs/mobile-wallet-development.md
@@ -105,6 +105,23 @@ From either platform scripts directory, create the mobile-only helper resources 
 
 This explicit preparation creates `issuer2-noattest` for non-attested issuance and `verifier2-mobile` for public verifier URLs. The normal test command validates existing resources and does not create them. The baseline organization, tenant, KMS, certificates, VICAL, trust registry, issuer2, verifier2, client attester, and mDL profile still come from quickstart. The iOS local Enterprise script runs `pod install` by default so the CocoaPods sandbox is in sync before Xcode starts.
 
+## Documentation checks
+
+The SDK-facing mobile modules use KDoc and Dokka for Kotlin API reference docs:
+
+```bash
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-persistence-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+```
+
+The iOS demo app also contains a DocC catalog with Swift integration examples. Use an installed
+arm64 simulator destination, for example:
+
+```bash
+cd waltid-applications/waltid-wallet-demo-ios/iosApp
+xcodebuild docbuild -workspace iosApp.xcworkspace -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES
+```
+
 ## Troubleshooting
 
 - **Android modules missing:** set `enableAndroidBuild=true` in `local.properties`, or pass `-PenableAndroidBuild=true`, then reload Gradle.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ gradle-shadow = "9.4.2"
 buildconfig = "6.0.10"
 compose-multiplatform = "1.11.1"
 compose-material3 = "1.11.0-alpha07"
+dokka = "2.2.0"
 
 # Plugins / Dependencies
 ktor = "3.5.0"
@@ -137,6 +138,7 @@ android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref
 jetbrains-compose = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
 mokkery-gradle-plugin = { module = "dev.mokkery:dev.mokkery.gradle.plugin", version.ref = "mokkery" }
 buildconfig-plugin = { module="com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin", version.ref="buildconfig" }
+dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 
 # Libraries
 
@@ -382,6 +384,7 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-m
 android-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-gradle" }
 android-application = { id = "com.android.application", version.ref = "android-gradle" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 shadow = { id = "com.gradleup.shadow", version.ref = "gradle-shadow" }
 versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A1000006AAAA000100000006 /* StatusBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000006AAAA000000000006 /* StatusBannerView.swift */; };
 		A1000007AAAA000100000007 /* CredentialCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000007AAAA000000000007 /* CredentialCardView.swift */; };
 		A1000008AAAA000100000008 /* WalletColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000008AAAA000000000008 /* WalletColors.swift */; };
+		A1000009AAAA000100000009 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = A1000009AAAA000000000009 /* Documentation.docc */; };
 		B33B17EA2C2C394F001A32F7 /* iosAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33B17E92C2C394F001A32F7 /* iosAppApp.swift */; };
 		B33B17EC2C2C394F001A32F7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33B17EB2C2C394F001A32F7 /* ContentView.swift */; };
 		B33B17EE2C2C3957001A32F7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B33B17ED2C2C3957001A32F7 /* Assets.xcassets */; };
@@ -77,6 +78,7 @@
 		A1000006AAAA000000000006 /* StatusBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBannerView.swift; sourceTree = "<group>"; };
 		A1000007AAAA000000000007 /* CredentialCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialCardView.swift; sourceTree = "<group>"; };
 		A1000008AAAA000000000008 /* WalletColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletColors.swift; sourceTree = "<group>"; };
+		A1000009AAAA000000000009 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		B30E22802C2D8AD700D4781C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B33B17E62C2C394F001A32F7 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B33B17E92C2C394F001A32F7 /* iosAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosAppApp.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				A1000012AAAA000000000012 /* Components */,
 				A1000013AAAA000000000013 /* Theme */,
 				B33B17ED2C2C3957001A32F7 /* Assets.xcassets */,
+				A1000009AAAA000000000009 /* Documentation.docc */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -479,6 +482,7 @@
 				A1000006AAAA000100000006 /* StatusBannerView.swift in Sources */,
 				A1000007AAAA000100000007 /* CredentialCardView.swift in Sources */,
 				A1000008AAAA000100000008 /* WalletColors.swift in Sources */,
+				A1000009AAAA000100000009 /* Documentation.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Documentation.docc/Documentation.md
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Documentation.docc/Documentation.md
@@ -1,0 +1,22 @@
+# ``iosApp``
+
+Use the walt.id mobile wallet SDK from a native iOS application.
+
+## Overview
+
+The iOS wallet demo shows the recommended Swift integration shape for the Kotlin
+Multiplatform wallet SDK:
+
+1. Keep platform UI and view-model state in Swift.
+2. Use a small shared bridge to hide Kotlin coroutine and optional-type details.
+3. Create the SDK wallet through `WalletDemoBridgeController`.
+4. Run wallet operations from Swift concurrency tasks.
+
+The bridge delegates to `MobileWalletFactory`, which wires the SDK to iOS
+Keychain/Secure Enclave storage and a native SQLDelight database.
+
+## Topics
+
+### Wallet SDK Integration
+
+- <doc:MobileWalletSDKIntegration>

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Documentation.docc/MobileWalletSDKIntegration.md
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Documentation.docc/MobileWalletSDKIntegration.md
@@ -1,0 +1,83 @@
+# Mobile Wallet SDK Integration
+
+Create a wallet, receive credentials, list stored credentials, and present to a
+verifier from Swift UI code.
+
+## Create the Bridge
+
+`WalletDemoBridgeController` is the demo app's Swift-facing wrapper around the
+Kotlin Multiplatform SDK. Keep one controller per persisted wallet identifier.
+
+```swift
+let controller = WalletDemoBridgeController(walletId: "default")
+```
+
+Use a stable wallet identifier when you want credentials, DIDs, and key
+references to persist across controller recreation and app launches.
+
+## Bootstrap the Wallet
+
+Bootstrap creates or reuses platform-backed signing material and a DID.
+
+```swift
+let result = try await controller.bootstrap()
+
+if result.success {
+    print("Wallet DID: \(result.message)")
+}
+```
+
+On iOS, the SDK factory uses Keychain/Secure Enclave key storage through the
+mobile persistence module.
+
+## Receive a Credential
+
+Pass an OpenID4VCI credential offer URL to the bridge.
+
+```swift
+let result = try await controller.receiveCredential(offerUrl)
+```
+
+The SDK stores accepted credentials in the mobile SQLDelight database and keeps
+signing key material in platform storage.
+
+## List Credentials
+
+Use the bridge from a Swift view model and publish the returned summaries to the
+UI.
+
+```swift
+let credentials = try await controller.listCredentials()
+```
+
+Each `BridgeCredential` is a display summary derived from the SDK credential
+metadata.
+
+## Present a Credential
+
+Pass an OpenID4VP authorization request URL to the bridge.
+
+```swift
+let result = try await controller.presentCredential(requestUrl)
+```
+
+The SDK selects matching credentials, creates the presentation response, and
+returns whether transmission to the verifier succeeded.
+
+## Configure Client Attestation
+
+Some enterprise issuer deployments require OAuth 2.0 client attestation. Provide
+the attester settings when creating the bridge.
+
+```swift
+let controller = WalletDemoBridgeController(
+    walletId: "default",
+    attestationBaseUrl: "https://enterprise.example.com",
+    attestationAttesterPath: "/client-attester",
+    attestationBearerToken: token,
+    attestationHostHeader: nil
+)
+```
+
+Use `attestationHostHeader` only for tunneled local enterprise setups where the
+public URL and upstream host differ.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -36,3 +36,13 @@ For local setup and platform build flags, see the [Mobile Wallet Development Gui
 
 - [Compose Wallet Demo](../../../waltid-applications/waltid-wallet-demo-compose/README.md)
 - [iOS Wallet Demo](../../../waltid-applications/waltid-wallet-demo-ios/README.md)
+
+## API documentation
+
+Generate the SDK facade API reference with Dokka:
+
+```bash
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+```
+
+The generated HTML is written to `build/dokka/html`. iOS integration examples are also documented in the iOS demo app's DocC catalog at `waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Documentation.docc`.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("waltid.mobile.library")
+    id("waltid.mobile.sdk.documentation")
 }
 
 group = "id.walt.protocols"

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -8,7 +8,18 @@ import id.walt.wallet2.persistence.stores.HardwareKeyStore
 import id.walt.wallet2.persistence.stores.SqlDelightCredentialStore
 import id.walt.wallet2.persistence.stores.SqlDelightDidStore
 
+/**
+ * Android [MobileWallet] factory backed by Android KeyStore and an app-private SQLDelight database.
+ *
+ * @param context Android context used to open the wallet database.
+ */
 actual class MobileWalletFactory(private val context: Context) {
+    /**
+     * Creates an Android mobile wallet for [config].
+     *
+     * The database is named from [MobileWalletConfig.walletId], and signing keys are created or loaded
+     * through Android KeyStore.
+     */
     actual fun create(config: MobileWalletConfig): MobileWallet {
         val driver = DriverFactory(context).createDriver("wallet_${config.walletId}")
         val db = WalletPersistenceDatabase(driver)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -19,11 +19,27 @@ import io.ktor.http.Url
 import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.json.JsonElement
 
+/**
+ * Result returned after a mobile wallet has been initialized with signing material and a DID.
+ *
+ * @property keyId Identifier of the persisted platform key used by the wallet.
+ * @property did Decentralized identifier registered for the persisted key.
+ */
 data class MobileWalletBootstrapResult(
     val keyId: String,
     val did: String,
 )
 
+/**
+ * Lightweight credential summary suitable for mobile UI lists.
+ *
+ * @property id Wallet-local credential identifier.
+ * @property format Credential format, such as `jwt_vc_json`, `vc+sd-jwt`, or `mso_mdoc`.
+ * @property issuer Issuer identifier extracted from the credential when available.
+ * @property subject Subject identifier extracted from the credential when available.
+ * @property label Optional display label stored with the credential.
+ * @property addedAt ISO-8601 timestamp string for when the credential was added, when known.
+ */
 data class MobileWalletCredential(
     val id: String,
     val format: String,
@@ -33,12 +49,30 @@ data class MobileWalletCredential(
     val addedAt: String?,
 )
 
+/**
+ * Result returned after attempting to answer an OpenID4VP presentation request.
+ *
+ * @property success `true` when the wallet transmitted the presentation successfully.
+ * @property redirectTo Optional verifier redirect URI returned by the presentation flow.
+ * @property verifierResponse Raw verifier response body, when the verifier returns structured JSON.
+ */
 data class MobileWalletPresentationResult(
     val success: Boolean,
     val redirectTo: String?,
     val verifierResponse: JsonElement? = null,
 )
 
+/**
+ * OAuth 2.0 client-attestation configuration used during mobile issuance.
+ *
+ * The wallet uses this configuration to request a client attestation JWT from the
+ * enterprise client-attester service and attach the resulting proof to token requests.
+ *
+ * @property enterpriseBaseUrl Base URL of the enterprise deployment that hosts the attester service.
+ * @property attesterPath Path to the attester endpoint, relative to [enterpriseBaseUrl].
+ * @property bearerToken Optional bearer token for protected attester endpoints.
+ * @property enterpriseHostHeader Optional `Host` header override for tunneled local enterprise tests.
+ */
 data class WalletAttestationConfig(
     val enterpriseBaseUrl: String,
     val attesterPath: String,
@@ -46,7 +80,14 @@ data class WalletAttestationConfig(
     val enterpriseHostHeader: String = "",
 )
 
-class MobileWallet(
+/**
+ * Android and iOS facade for the walt.id wallet SDK.
+ *
+ * Use [MobileWalletFactory] to create instances with the correct platform storage, key provider,
+ * and SQLDelight driver. The facade keeps the public mobile API intentionally small while delegating
+ * protocol work to the core wallet handlers.
+ */
+class MobileWallet internal constructor(
     walletId: String,
     private val keyStore: WalletKeyStore,
     private val didStore: WalletDidStore,
@@ -74,6 +115,16 @@ class MobileWallet(
         credentialStores = listOf(credentialStore),
     )
 
+    /**
+     * Initializes the wallet by creating or reusing platform-backed key material and a DID.
+     *
+     * If the wallet already contains persisted DIDs, the first persisted DID and key are reused.
+     *
+     * @param keyType Optional key type override. When omitted, [MobileWalletConfig.defaultKeyType] is used.
+     * @param didMethod DID method passed to [DidService.registerByKey], for example `key`.
+     * @return The key identifier and DID used by this wallet.
+     * @throws IllegalArgumentException When persisted DID state exists without a persisted key.
+     */
     suspend fun bootstrap(
         keyType: KeyType? = null,
         didMethod: String = "key",
@@ -110,6 +161,14 @@ class MobileWallet(
         )
     }
 
+    /**
+     * Receives credentials from an OpenID4VCI credential offer.
+     *
+     * @param offerUrl Credential offer URL, including `openid-credential-offer://` URLs.
+     * @param txCode Optional transaction code for pre-authorized offers.
+     * @param clientId Client identifier sent to the issuer.
+     * @return Wallet-local identifiers of the stored credentials.
+     */
     suspend fun receive(
         offerUrl: String,
         txCode: String? = null,
@@ -126,6 +185,11 @@ class MobileWallet(
             onEvent = onEvent,
         ).credentialIds
 
+    /**
+     * Lists all credentials currently stored in the mobile wallet.
+     *
+     * @return Credential summaries ordered by the underlying credential store.
+     */
     suspend fun credentials(): List<MobileWalletCredential> =
         wallet.streamAllCredentials().toList().map { credential ->
             val meta = credential.toMetadata()
@@ -139,6 +203,14 @@ class MobileWallet(
             )
         }
 
+    /**
+     * Presents matching wallet credentials to an OpenID4VP verifier request.
+     *
+     * @param requestUrl Authorization request URL received from the verifier.
+     * @param did Optional DID override for selecting the wallet DID used in the presentation.
+     * @param runPolicies Optional override for verifier policy execution in the core presentation handler.
+     * @return Transmission status, optional redirect, and optional verifier response details.
+     */
     suspend fun present(
         requestUrl: String,
         did: String? = null,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -4,6 +4,14 @@ import id.walt.crypto.keys.KeyType
 import id.walt.wallet2.data.WalletSessionEvent
 import kotlin.uuid.Uuid
 
+/**
+ * Configuration for creating a [MobileWallet].
+ *
+ * @property walletId Stable wallet identifier used for database naming and persisted wallet state.
+ * @property defaultKeyType Key type used by [MobileWallet.bootstrap] when no key type override is supplied.
+ * @property attestationConfig Optional client-attestation configuration for issuer deployments that require it.
+ * @property onEvent Optional callback for observing wallet issuance and presentation session events.
+ */
 data class MobileWalletConfig(
     val walletId: String = Uuid.random().toString(),
     val defaultKeyType: KeyType = KeyType.secp256r1,
@@ -11,6 +19,14 @@ data class MobileWalletConfig(
     val onEvent: suspend (WalletSessionEvent) -> Unit = {},
 )
 
+/**
+ * Platform factory that wires [MobileWallet] to Android or iOS storage and key infrastructure.
+ */
 expect class MobileWalletFactory {
+    /**
+     * Creates a mobile wallet instance for the current platform.
+     *
+     * @param config Wallet configuration. Defaults create a new wallet identifier and P-256 key material.
+     */
     fun create(config: MobileWalletConfig = MobileWalletConfig()): MobileWallet
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/IosWalletSecurityConfig.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/IosWalletSecurityConfig.kt
@@ -1,5 +1,10 @@
 package id.walt.wallet2.mobile
 
+/**
+ * iOS-specific security settings for [MobileWalletFactory].
+ *
+ * @property useSecureElement When `true`, supported keys are created in Secure Enclave where available.
+ */
 data class IosWalletSecurityConfig(
     val useSecureElement: Boolean = true,
 )

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -7,10 +7,22 @@ import id.walt.wallet2.persistence.stores.HardwareKeyStore
 import id.walt.wallet2.persistence.stores.SqlDelightCredentialStore
 import id.walt.wallet2.persistence.stores.SqlDelightDidStore
 
+/**
+ * iOS [MobileWallet] factory backed by Keychain/Secure Enclave and a native SQLDelight database.
+ */
 actual class MobileWalletFactory {
+    /**
+     * Creates an iOS mobile wallet using the default [IosWalletSecurityConfig].
+     */
     actual fun create(config: MobileWalletConfig): MobileWallet =
         create(config, IosWalletSecurityConfig())
 
+    /**
+     * Creates an iOS mobile wallet with explicit iOS security settings.
+     *
+     * @param config Shared wallet configuration.
+     * @param iosConfig iOS-specific key storage settings.
+     */
     fun create(
         config: MobileWalletConfig,
         iosConfig: IosWalletSecurityConfig,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/README.md
@@ -85,6 +85,16 @@ The mobile schema includes the following tables:
 
 Schema creation and migration are managed by SQLDelight on the target platform driver.
 
+## API documentation
+
+Generate the mobile persistence API reference with Dokka:
+
+```bash
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-persistence-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+```
+
+The generated HTML is written to `build/dokka/html`.
+
 ## Related Libraries
 
 - **[waltid-openid4vc-wallet](../waltid-openid4vc-wallet)** — Core wallet library (store interfaces)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("waltid.mobile.library")
+    id("waltid.mobile.sdk.documentation")
     alias(identityLibs.plugins.sqldelight)
 }
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
@@ -9,13 +9,25 @@ import id.walt.crypto.keys.KeyAlias
 import id.walt.crypto.keys.KeyType
 import kotlin.uuid.Uuid
 
+/**
+ * [PlatformKeyProvider] implementation backed by Android KeyStore.
+ */
 class AndroidPlatformKeyProvider : PlatformKeyProvider {
 
+    /**
+     * Android KeyStore-backed key types supported by this provider.
+     */
     override val supportedHardwareKeyTypes: Set<KeyType> =
         setOf(KeyType.secp256r1, KeyType.RSA)
 
+    /**
+     * Android KeyStore is treated as available for supported Android wallet builds.
+     */
     override val isHardwareBackingAvailable: Boolean = true
 
+    /**
+     * Generates an Android KeyStore key and returns its walt.id crypto wrapper.
+     */
     override suspend fun generateKey(keyType: KeyType, keyId: String?): Key {
         require(keyType in supportedHardwareKeyTypes) {
             "KeyType $keyType is not supported in Android KeyStore. Supported: $supportedHardwareKeyTypes"
@@ -27,9 +39,15 @@ class AndroidPlatformKeyProvider : PlatformKeyProvider {
         )
     }
 
+    /**
+     * Loads an Android KeyStore key by alias and expected key type.
+     */
     override suspend fun loadKey(keyId: String, keyType: KeyType): Key? =
         AndroidKeystoreLoader.load(type = keyType, keyId = keyId)
 
+    /**
+     * Deletes an Android KeyStore key by alias and expected key type.
+     */
     override suspend fun deleteKey(keyId: String, keyType: KeyType): Boolean = runCatching {
         AndroidKey(KeyAlias(keyId), keyType).deleteKey()
     }.getOrDefault(false)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
@@ -5,7 +5,15 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 
+/**
+ * Android SQLDelight driver factory for app-private SQLite wallet databases.
+ *
+ * @param context Android context used by [AndroidSqliteDriver].
+ */
 actual class DriverFactory(private val context: Context) {
+    /**
+     * Creates an Android SQLite driver for [databaseName].
+     */
     actual fun createDriver(databaseName: String): SqlDriver =
         AndroidSqliteDriver(WalletPersistenceDatabase.Schema, context, "$databaseName.db")
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/PlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/PlatformKeyProvider.kt
@@ -3,10 +3,44 @@ package id.walt.wallet2.persistence.keys
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
 
+/**
+ * Platform abstraction for creating, loading, and deleting mobile wallet signing keys.
+ */
 interface PlatformKeyProvider {
+    /**
+     * Creates a new platform-backed key.
+     *
+     * @param keyType Key type to create.
+     * @param keyId Optional platform key identifier. When omitted, the provider generates one.
+     * @return The created key.
+     */
     suspend fun generateKey(keyType: KeyType, keyId: String? = null): Key
+
+    /**
+     * Loads a previously generated key.
+     *
+     * @param keyId Platform key identifier.
+     * @param keyType Expected key type for the stored key.
+     * @return The loaded key, or `null` when the platform store has no matching key.
+     */
     suspend fun loadKey(keyId: String, keyType: KeyType): Key?
+
+    /**
+     * Deletes a key from the platform key store.
+     *
+     * @param keyId Platform key identifier.
+     * @param keyType Key type of the stored key.
+     * @return `true` when deletion succeeded or the platform reported success.
+     */
     suspend fun deleteKey(keyId: String, keyType: KeyType): Boolean
+
+    /**
+     * Key types that this provider can create with platform-backed storage.
+     */
     val supportedHardwareKeyTypes: Set<KeyType>
+
+    /**
+     * Whether the current device and provider can use hardware-backed storage.
+     */
     val isHardwareBackingAvailable: Boolean
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
@@ -2,6 +2,14 @@ package id.walt.wallet2.persistence.stores
 
 import app.cash.sqldelight.db.SqlDriver
 
+/**
+ * Platform factory for SQLDelight drivers used by the mobile wallet database.
+ */
 expect class DriverFactory {
+    /**
+     * Creates a SQLDelight driver for the named wallet database.
+     *
+     * @param databaseName Base database name. Platform implementations add the expected file extension.
+     */
     fun createDriver(databaseName: String): SqlDriver
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/HardwareKeyStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/HardwareKeyStore.kt
@@ -10,23 +10,40 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
 
+/**
+ * Wallet key store that persists key references in SQLDelight and key material in the platform store.
+ *
+ * @param keyProvider Platform key provider used to load and delete keys.
+ * @param queries SQLDelight queries for wallet persistence tables.
+ */
 class HardwareKeyStore(
     private val keyProvider: PlatformKeyProvider,
     private val queries: WalletPersistenceQueries,
 ) : WalletKeyStore {
 
+    /**
+     * Loads a wallet key by its wallet-local key identifier.
+     */
     override suspend fun getKey(keyId: String): Key? {
         val ref = queries.selectByKeyId(keyId).executeAsOneOrNull() ?: return null
         val keyType = KeyType.valueOf(ref.key_type)
         return keyProvider.loadKey(keyId, keyType)
     }
 
+    /**
+     * Streams all persisted key references.
+     */
     override suspend fun listKeys(): Flow<WalletKeyInfo> = flow {
         queries.selectAll().executeAsList().forEach { ref ->
             emit(WalletKeyInfo(keyId = ref.key_id, keyType = ref.key_type))
         }
     }
 
+    /**
+     * Persists a platform key reference for [key].
+     *
+     * The key material itself remains in the platform key store.
+     */
     override suspend fun addKey(key: Key): String {
         val keyId = key.getKeyId()
         queries.insert(
@@ -38,6 +55,9 @@ class HardwareKeyStore(
         return keyId
     }
 
+    /**
+     * Removes the platform key and its SQLDelight key reference.
+     */
     override suspend fun removeKey(keyId: String): Boolean {
         val ref = queries.selectByKeyId(keyId).executeAsOneOrNull() ?: return false
         val keyType = KeyType.valueOf(ref.key_type)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightCredentialStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightCredentialStore.kt
@@ -10,21 +10,35 @@ import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
 import kotlin.time.Instant
 
+/**
+ * SQLDelight-backed implementation of [WalletCredentialStore] for mobile wallets.
+ *
+ * @param queries SQLDelight queries for wallet persistence tables.
+ */
 class SqlDelightCredentialStore(
     private val queries: WalletPersistenceQueries,
 ) : WalletCredentialStore {
 
+    /**
+     * Loads a stored credential by wallet-local identifier.
+     */
     override suspend fun getCredential(id: String): StoredCredential? {
         val row = queries.selectCredentialById(id).executeAsOneOrNull() ?: return null
         return row.toStoredCredential()
     }
 
+    /**
+     * Streams all stored credentials from the mobile database.
+     */
     override suspend fun listCredentials(): Flow<StoredCredential> = flow {
         queries.selectAllCredentials().executeAsList().forEach { row ->
             emit(row.toStoredCredential())
         }
     }
 
+    /**
+     * Stores a credential and its display metadata.
+     */
     override suspend fun addCredential(entry: StoredCredential) {
         val rawString = entry.credential.signed ?: entry.credential.credentialData.toString()
         queries.insertCredential(
@@ -36,6 +50,9 @@ class SqlDelightCredentialStore(
         )
     }
 
+    /**
+     * Removes a credential by wallet-local identifier.
+     */
     override suspend fun removeCredential(id: String): Boolean {
         val exists = queries.selectCredentialById(id).executeAsOneOrNull() != null
         if (exists) queries.deleteCredentialById(id)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightDidStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightDidStore.kt
@@ -8,21 +8,35 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
+/**
+ * SQLDelight-backed implementation of [WalletDidStore] for mobile wallets.
+ *
+ * @param queries SQLDelight queries for wallet persistence tables.
+ */
 class SqlDelightDidStore(
     private val queries: WalletPersistenceQueries,
 ) : WalletDidStore {
 
+    /**
+     * Loads a DID document by DID.
+     */
     override suspend fun getDid(did: String): WalletDidEntry? {
         val row = queries.selectDidByDid(did).executeAsOneOrNull() ?: return null
         return WalletDidEntry(did = row.did, document = Json.decodeFromString<JsonObject>(row.document))
     }
 
+    /**
+     * Streams all DID documents stored in the mobile database.
+     */
     override suspend fun listDids(): Flow<WalletDidEntry> = flow {
         queries.selectAllDids().executeAsList().forEach { row ->
             emit(WalletDidEntry(did = row.did, document = Json.decodeFromString<JsonObject>(row.document)))
         }
     }
 
+    /**
+     * Stores or replaces a DID document.
+     */
     override suspend fun addDid(entry: WalletDidEntry) {
         queries.insertDid(
             did = entry.did,
@@ -30,6 +44,9 @@ class SqlDelightDidStore(
         )
     }
 
+    /**
+     * Removes a DID document by DID.
+     */
     override suspend fun removeDid(did: String): Boolean {
         val exists = queries.selectDidByDid(did).executeAsOneOrNull() != null
         if (exists) queries.deleteDidByDid(did)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
@@ -5,14 +5,28 @@ import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
 import kotlin.uuid.Uuid
 
+/**
+ * [PlatformKeyProvider] implementation backed by iOS Keychain and Secure Enclave.
+ *
+ * @param useSecureElement When `true`, P-256 keys are created in Secure Enclave where available.
+ */
 class IosPlatformKeyProvider(
     private val useSecureElement: Boolean = true,
 ) : PlatformKeyProvider {
 
+    /**
+     * iOS hardware-backed key types supported by this provider.
+     */
     override val supportedHardwareKeyTypes: Set<KeyType> = setOf(KeyType.secp256r1)
 
+    /**
+     * iOS Keychain/Secure Enclave storage is treated as available for supported iOS wallet builds.
+     */
     override val isHardwareBackingAvailable: Boolean = true
 
+    /**
+     * Generates an iOS key using Keychain or Secure Enclave according to [useSecureElement].
+     */
     override suspend fun generateKey(keyType: KeyType, keyId: String?): Key {
         val kid = keyId ?: Uuid.random().toString()
         val options = IosKey.Options(
@@ -23,6 +37,9 @@ class IosPlatformKeyProvider(
         return IosKey.create(options)
     }
 
+    /**
+     * Loads an iOS key by identifier and expected key type.
+     */
     override suspend fun loadKey(keyId: String, keyType: KeyType): Key? = runCatching {
         val options = IosKey.Options(
             kid = keyId,
@@ -32,6 +49,9 @@ class IosPlatformKeyProvider(
         IosKey.load(options)
     }.getOrNull()
 
+    /**
+     * Deletes an iOS key by identifier and expected key type.
+     */
     override suspend fun deleteKey(keyId: String, keyType: KeyType): Boolean = runCatching {
         IosKey.delete(keyId, keyType)
     }.isSuccess

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
@@ -4,7 +4,13 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 
+/**
+ * iOS SQLDelight driver factory for native SQLite wallet databases.
+ */
 actual class DriverFactory {
+    /**
+     * Creates a native SQLite driver for [databaseName].
+     */
     actual fun createDriver(databaseName: String): SqlDriver =
         NativeSqliteDriver(WalletPersistenceDatabase.Schema, "$databaseName.db")
 }


### PR DESCRIPTION
## Summary

Adds documentation coverage and generation setup for the new mobile-facing wallet SDK modules introduced in #1748.

- Adds KDoc for the public API surface in `waltid-openid4vc-wallet-mobile` and `waltid-openid4vc-wallet-persistence-mobile`.
- Tightens the `MobileWallet` constructor to `internal` so external consumers use `MobileWalletFactory`.
- Adds a shared Dokka convention plugin and applies it only to the two SDK-facing modules.
- Adds an iOS DocC catalog to the demo app with Swift integration examples.
- Documents the Dokka and DocC verification commands in the mobile development guide and module READMEs.