### PR TITLE
[WAL-1071] docs(mobile): add KDoc for wallet SDK

### DIFF
--- a/.github/actions/gradle-mobile-sdk-docs/action.yml
+++ b/.github/actions/gradle-mobile-sdk-docs/action.yml
@@ -1,0 +1,52 @@
+name: gradle-mobile-sdk-docs
+description: Generate Dokka API docs for the mobile wallet SDK modules
+inputs:
+  waltid-directory:
+    description: 'Path to the waltid-identity directory'
+    required: false
+    default: '.'
+  xcode-developer-dir:
+    description: 'Full path to the Xcode Developer directory to select'
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Select Xcode toolchain
+      shell: bash
+      run: |
+        XCODE_DEVELOPER_DIR="${{ inputs.xcode-developer-dir }}"
+        if [[ -n "$XCODE_DEVELOPER_DIR" ]]; then
+          if [[ ! -d "$XCODE_DEVELOPER_DIR" ]]; then
+            echo "::error::Xcode developer directory not found: $XCODE_DEVELOPER_DIR"
+            echo "Available Xcode installations under /Applications:"
+            ls -1 /Applications | grep '^Xcode' || true
+            exit 1
+          fi
+
+          sudo xcode-select -s "$XCODE_DEVELOPER_DIR"
+          echo "Selected Xcode developer directory: $XCODE_DEVELOPER_DIR"
+          echo "DEVELOPER_DIR=$XCODE_DEVELOPER_DIR" >> $GITHUB_ENV
+        else
+          echo "Using runner default Xcode selection"
+        fi
+
+        xcodebuild -version
+
+    - name: Configure iOS build environment
+      uses: walt-id/waltid-identity/.github/actions/ios-build-setup@b4f5d19f23dda46a730b0c94450012aac559156c
+      with:
+        gradle-properties-path: '${{ inputs.waltid-directory }}/gradle.properties'
+
+    - name: Generate mobile SDK API docs
+      working-directory: ${{ inputs.waltid-directory }}
+      shell: bash
+      run: |
+        ./gradlew \
+          :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:dokkaGeneratePublicationHtml \
+          :waltid-libraries:protocols:waltid-openid4vc-wallet-persistence-mobile:dokkaGeneratePublicationHtml \
+          -PenableAndroidBuild=true \
+          -PenableIosBuild=true \
+          --no-daemon \
+          --console=plain \
+          --warning-mode=summary

--- a/.github/actions/gradle-mobile-sdk-docs/action.yml
+++ b/.github/actions/gradle-mobile-sdk-docs/action.yml
@@ -34,7 +34,7 @@ runs:
         xcodebuild -version
 
     - name: Configure iOS build environment
-      uses: walt-id/waltid-identity/.github/actions/ios-build-setup@b4f5d19f23dda46a730b0c94450012aac559156c
+      uses: walt-id/waltid-identity/.github/actions/ios-build-setup@3a27209fa9aedded85f0505ae9eb43b417e3547a
       with:
         gradle-properties-path: '${{ inputs.waltid-directory }}/gradle.properties'
 

--- a/.github/workflows/mobile-sdk-docs.yml
+++ b/.github/workflows/mobile-sdk-docs.yml
@@ -1,0 +1,26 @@
+name: Mobile SDK API docs
+
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  dokka:
+    runs-on: macos-26
+    env:
+      XCODE_DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+    steps:
+      - name: Checkout all repos with ref fallback
+        uses: walt-id/waltid-identity/.github/actions/checkout-repos@864f84343fdeea17f6f63434bc8036c39f178dc7
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Configure gradle
+        uses: walt-id/waltid-identity/.github/actions/gradle-setup-action@864f84343fdeea17f6f63434bc8036c39f178dc7
+
+      - name: Generate mobile SDK API docs
+        timeout-minutes: 30
+        uses: walt-id/waltid-identity/.github/actions/gradle-mobile-sdk-docs@bedccacdd3704cd79d043b4d9a3cb96f63888c0e
+        with:
+          waltid-directory: 'waltid-identity'
+          xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}

--- a/.github/workflows/mobile-sdk-docs.yml
+++ b/.github/workflows/mobile-sdk-docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Generate mobile SDK API docs
         timeout-minutes: 30
-        uses: walt-id/waltid-identity/.github/actions/gradle-mobile-sdk-docs@bedccacdd3704cd79d043b4d9a3cb96f63888c0e
+        uses: walt-id/waltid-identity/.github/actions/gradle-mobile-sdk-docs@19f2eaf81debd0fcac891fc95bf565731bb7daf8
         with:
           waltid-directory: 'waltid-identity'
           xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}

--- a/.github/workflows/mobile-sdk-docs.yml
+++ b/.github/workflows/mobile-sdk-docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Generate mobile SDK API docs
         timeout-minutes: 30
-        uses: walt-id/waltid-identity/.github/actions/gradle-mobile-sdk-docs@19f2eaf81debd0fcac891fc95bf565731bb7daf8
+        uses: walt-id/waltid-identity/.github/actions/gradle-mobile-sdk-docs@d803fe4800fe059ed9a98bd4ffaf60affa1d1c82
         with:
           waltid-directory: 'waltid-identity'
           xcode-developer-dir: ${{ env.XCODE_DEVELOPER_DIR }}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,24 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
 plugins {
     `kotlin-dsl`
+}
+
+val identityCatalog = extensions.getByType<VersionCatalogsExtension>().named("identityLibs")
+val dokkaJacksonPinnedVersion = identityCatalog.findVersion("jackson-core").get().requiredVersion
+val dokkaJacksonAffectedModules = listOf(
+    "com.fasterxml.jackson.core:jackson-core",
+    "com.fasterxml.jackson.core:jackson-databind",
+)
+val dokkaJacksonForcedCoordinates = dokkaJacksonAffectedModules.map { "$it:$dokkaJacksonPinnedVersion" }
+
+configurations.configureEach {
+    // Force-pin vulnerable transitive dependencies brought in by Dokka -> dokka-core.
+    // Dokka 2.2.0 brings Jackson 2.15.3, which Snyk flags via:
+    // SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924, -15907551, -17434790,
+    // -17440366, -17440598, and -17457695. Reuse the repo-wide Jackson 2.x
+    // pin (`jackson-core`) for the build-logic classpath.
+    resolutionStrategy.force(*dokkaJacksonForcedCoordinates.toTypedArray())
 }
 
 dependencies {
@@ -27,6 +46,9 @@ dependencies {
 
     // Buildconfig
     implementation(identityLibs.buildconfig.plugin)
+
+    // Documentation
+    implementation(identityLibs.dokka.gradle.plugin)
 
     // Gradle Shadow
     implementation(identityLibs.gradle.shadow)

--- a/build-logic/src/main/kotlin/waltid.mobile.sdk.documentation.gradle.kts
+++ b/build-logic/src/main/kotlin/waltid.mobile.sdk.documentation.gradle.kts
@@ -1,0 +1,23 @@
+import org.jetbrains.dokka.gradle.engine.parameters.VisibilityModifier
+
+plugins {
+    id("org.jetbrains.dokka")
+}
+
+dokka {
+    dokkaPublications.html {
+        moduleName.set(project.name)
+        moduleVersion.set(project.version.toString())
+        outputDirectory.set(layout.buildDirectory.dir("dokka/html"))
+        failOnWarning.set(true)
+        suppressObviousFunctions.set(true)
+        includes.from("README.md")
+    }
+
+    dokkaSourceSets.configureEach {
+        documentedVisibilities.set(setOf(VisibilityModifier.Public))
+        reportUndocumented.set(true)
+        skipDeprecated.set(false)
+        suppressGeneratedFiles.set(true)
+    }
+}

--- a/docs/mobile-wallet-development.md
+++ b/docs/mobile-wallet-development.md
@@ -109,6 +109,15 @@ From either platform scripts directory, create the mobile-only helper resources 
 
 This explicit preparation creates `issuer2-noattest` for non-attested issuance and `verifier2-mobile` for public verifier URLs. The normal test command validates existing resources and does not create them. The baseline organization, tenant, KMS, certificates, VICAL, trust registry, issuer2, verifier2, client attester, and mDL profile still come from quickstart. The iOS local Enterprise script runs `pod install` by default so the CocoaPods sandbox is in sync before Xcode starts.
 
+## Documentation checks
+
+The SDK-facing mobile modules use KDoc and Dokka for Kotlin API reference docs:
+
+```bash
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-persistence-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+```
+
 ## Troubleshooting
 
 - **Android modules missing:** set `enableAndroidBuild=true` in `local.properties`, or pass `-PenableAndroidBuild=true`, then reload Gradle.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ gradle-shadow = "9.4.2"
 buildconfig = "6.0.10"
 compose-multiplatform = "1.11.1"
 compose-material3 = "1.11.0-alpha07"
+dokka = "2.2.0"
 
 # Plugins / Dependencies
 ktor = "3.5.0"
@@ -142,6 +143,7 @@ android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref
 jetbrains-compose = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
 mokkery-gradle-plugin = { module = "dev.mokkery:dev.mokkery.gradle.plugin", version.ref = "mokkery" }
 buildconfig-plugin = { module="com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin", version.ref="buildconfig" }
+dokka-gradle-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 
 # Libraries
 
@@ -399,6 +401,7 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-m
 android-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-gradle" }
 android-application = { id = "com.android.application", version.ref = "android-gradle" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 shadow = { id = "com.gradleup.shadow", version.ref = "gradle-shadow" }
 versions = { id = "com.github.ben-manes.versions", version = "0.54.0" }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -36,3 +36,13 @@ For local setup and platform build flags, see the [Mobile Wallet Development Gui
 
 - [Compose Wallet Demo](../../../waltid-applications/waltid-wallet-demo-compose/README.md)
 - [iOS Wallet Demo](../../../waltid-applications/waltid-wallet-demo-ios/README.md)
+
+## API documentation
+
+Generate the SDK facade API reference with Dokka:
+
+```bash
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+```
+
+The generated HTML is written to `build/dokka/html`.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("waltid.mobile.library")
+    id("waltid.mobile.sdk.documentation")
 }
 
 group = "id.walt.protocols"

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -5,7 +5,18 @@ import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 import id.walt.wallet2.persistence.keys.AndroidPlatformKeyProvider
 import id.walt.wallet2.persistence.stores.DriverFactory
 
+/**
+ * Android [MobileWallet] factory backed by Android KeyStore and an app-private SQLDelight database.
+ *
+ * @param context Android context used to open the wallet database.
+ */
 actual class MobileWalletFactory(private val context: Context) {
+    /**
+     * Creates an Android mobile wallet for [config].
+     *
+     * The database is named from [MobileWalletConfig.walletId], and signing keys are created or loaded
+     * through the Android platform key provider.
+     */
     actual fun create(config: MobileWalletConfig): MobileWallet {
         val driver = DriverFactory(context).createDriver("wallet_${config.walletId}")
         val db = WalletPersistenceDatabase(driver)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -19,11 +19,27 @@ import io.ktor.http.Url
 import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.json.JsonElement
 
+/**
+ * Result returned after a mobile wallet has been initialized with signing material and a DID.
+ *
+ * @property keyId Identifier of the persisted signing key used by the wallet.
+ * @property did Decentralized identifier registered for the persisted key.
+ */
 data class MobileWalletBootstrapResult(
     val keyId: String,
     val did: String,
 )
 
+/**
+ * Lightweight credential summary suitable for mobile UI lists.
+ *
+ * @property id Wallet-local credential identifier.
+ * @property format Credential format, such as `jwt_vc_json`, `vc+sd-jwt`, or `mso_mdoc`.
+ * @property issuer Issuer identifier extracted from the credential when available.
+ * @property subject Subject identifier extracted from the credential when available.
+ * @property label Optional display label stored with the credential.
+ * @property addedAt ISO-8601 timestamp string for when the credential was added, when known.
+ */
 data class MobileWalletCredential(
     val id: String,
     val format: String,
@@ -33,12 +49,30 @@ data class MobileWalletCredential(
     val addedAt: String?,
 )
 
+/**
+ * Result returned after attempting to answer an OpenID4VP presentation request.
+ *
+ * @property success `true` when the wallet transmitted the presentation successfully.
+ * @property redirectTo Optional verifier redirect URI returned by the presentation flow.
+ * @property verifierResponse Raw verifier response body, when the verifier returns structured JSON.
+ */
 data class MobileWalletPresentationResult(
     val success: Boolean,
     val redirectTo: String?,
     val verifierResponse: JsonElement? = null,
 )
 
+/**
+ * OAuth 2.0 client-attestation configuration used during mobile issuance.
+ *
+ * The wallet uses this configuration to request a client attestation JWT from the
+ * enterprise client-attester service and attach the resulting proof to token requests.
+ *
+ * @property enterpriseBaseUrl Base URL of the enterprise deployment that hosts the attester service.
+ * @property attesterPath Path to the attester endpoint, relative to [enterpriseBaseUrl].
+ * @property bearerToken Optional bearer token for protected attester endpoints.
+ * @property enterpriseHostHeader Optional `Host` header override for tunneled local enterprise tests.
+ */
 data class WalletAttestationConfig(
     val enterpriseBaseUrl: String,
     val attesterPath: String,
@@ -46,6 +80,13 @@ data class WalletAttestationConfig(
     val enterpriseHostHeader: String = "",
 )
 
+/**
+ * Android and iOS facade for the walt.id wallet SDK.
+ *
+ * Use [MobileWalletFactory] to create instances with the correct platform storage, key provider,
+ * and SQLDelight driver. The facade keeps the public mobile API intentionally small while delegating
+ * protocol work to the core wallet handlers.
+ */
 class MobileWallet(
     walletId: String,
     private val keyStore: WalletKeyStore,
@@ -74,6 +115,16 @@ class MobileWallet(
         credentialStores = listOf(credentialStore),
     )
 
+    /**
+     * Initializes the wallet by creating or reusing platform-backed key material and a DID.
+     *
+     * If the wallet already contains persisted DIDs, the first persisted DID and key are reused.
+     *
+     * @param keyType Optional key type override. When omitted, [MobileWalletConfig.defaultKeyType] is used.
+     * @param didMethod DID method passed to [DidService.registerByKey], for example `key`.
+     * @return The key identifier and DID used by this wallet.
+     * @throws IllegalArgumentException When persisted DID state exists without a persisted key.
+     */
     suspend fun bootstrap(
         keyType: KeyType? = null,
         didMethod: String = "key",
@@ -110,6 +161,14 @@ class MobileWallet(
         )
     }
 
+    /**
+     * Receives credentials from an OpenID4VCI credential offer.
+     *
+     * @param offerUrl Credential offer URL, including `openid-credential-offer://` URLs.
+     * @param txCode Optional transaction code for pre-authorized offers.
+     * @param clientId Client identifier sent to the issuer.
+     * @return Wallet-local identifiers of the stored credentials.
+     */
     suspend fun receive(
         offerUrl: String,
         txCode: String? = null,
@@ -126,6 +185,11 @@ class MobileWallet(
             onEvent = onEvent,
         ).credentialIds
 
+    /**
+     * Lists all credentials currently stored in the mobile wallet.
+     *
+     * @return Credential summaries ordered by the underlying credential store.
+     */
     suspend fun credentials(): List<MobileWalletCredential> =
         wallet.streamAllCredentials().toList().map { credential ->
             val meta = credential.toMetadata()
@@ -139,6 +203,14 @@ class MobileWallet(
             )
         }
 
+    /**
+     * Presents matching wallet credentials to an OpenID4VP verifier request.
+     *
+     * @param requestUrl Authorization request URL received from the verifier.
+     * @param did Optional DID override for selecting the wallet DID used in the presentation.
+     * @param runPolicies Optional override for verifier policy execution in the core presentation handler.
+     * @return Transmission status, optional redirect, and optional verifier response details.
+     */
     suspend fun present(
         requestUrl: String,
         did: String? = null,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -9,6 +9,14 @@ import id.walt.wallet2.persistence.stores.SqlDelightCredentialStore
 import id.walt.wallet2.persistence.stores.SqlDelightDidStore
 import kotlin.uuid.Uuid
 
+/**
+ * Configuration for creating a [MobileWallet].
+ *
+ * @property walletId Stable wallet identifier used for database naming and persisted wallet state.
+ * @property defaultKeyType Key type used by [MobileWallet.bootstrap] when no key type override is supplied.
+ * @property attestationConfig Optional client-attestation configuration for issuer deployments that require it.
+ * @property onEvent Optional callback for observing wallet issuance and presentation session events.
+ */
 data class MobileWalletConfig(
     val walletId: String = Uuid.random().toString(),
     val defaultKeyType: KeyType = KeyType.secp256r1,
@@ -16,7 +24,15 @@ data class MobileWalletConfig(
     val onEvent: suspend (WalletSessionEvent) -> Unit = {},
 )
 
+/**
+ * Platform factory that wires [MobileWallet] to Android or iOS storage and key infrastructure.
+ */
 expect class MobileWalletFactory {
+    /**
+     * Creates a mobile wallet instance for the current platform.
+     *
+     * @param config Wallet configuration. Defaults create a new wallet identifier and P-256 key material.
+     */
     fun create(config: MobileWalletConfig = MobileWalletConfig()): MobileWallet
 }
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -4,7 +4,13 @@ import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 import id.walt.wallet2.persistence.keys.IosPlatformKeyProvider
 import id.walt.wallet2.persistence.stores.DriverFactory
 
+/**
+ * iOS [MobileWallet] factory backed by Keychain/Secure Enclave and a native SQLDelight database.
+ */
 actual class MobileWalletFactory {
+    /**
+     * Creates an iOS mobile wallet using native SQLDelight storage and the default iOS platform key provider.
+     */
     actual fun create(config: MobileWalletConfig): MobileWallet {
         val driver = DriverFactory().createDriver("wallet_${config.walletId}")
         val db = WalletPersistenceDatabase(driver)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/README.md
@@ -85,6 +85,16 @@ The mobile schema includes the following tables:
 
 Schema creation and migration are managed by SQLDelight on the target platform driver.
 
+## API documentation
+
+Generate the mobile persistence API reference with Dokka:
+
+```bash
+./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-persistence-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true
+```
+
+The generated HTML is written to `build/dokka/html`.
+
 ## Related Libraries
 
 - **[waltid-openid4vc-wallet](../waltid-openid4vc-wallet)** — Core wallet library (store interfaces)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("waltid.mobile.library")
+    id("waltid.mobile.sdk.documentation")
     alias(identityLibs.plugins.sqldelight)
 }
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
@@ -5,11 +5,20 @@ import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
 import kotlin.uuid.Uuid
 
+/**
+ * [PlatformKeyProvider] implementation backed by Android KeyStore.
+ */
 class AndroidPlatformKeyProvider : PlatformKeyProvider {
 
+    /**
+     * Android platform-backed key types supported by this provider.
+     */
     override val supportedPlatformKeyTypes: Set<KeyType> =
         PlatformKeyProvider.DEFAULT_SUPPORTED_PLATFORM_KEY_TYPES
 
+    /**
+     * Generates an Android platform-backed key for supported types, otherwise a software key.
+     */
     override suspend fun generateKey(keyType: KeyType, keyId: String?): Key {
         val alias = keyId ?: "wallet_key_${Uuid.random()}"
         val options = AndroidKey.Options(kid = alias, keyType = keyType)
@@ -20,19 +29,31 @@ class AndroidPlatformKeyProvider : PlatformKeyProvider {
         }
     }
 
+    /**
+     * Loads an Android platform-backed key by alias and expected key type.
+     */
     override suspend fun loadKey(keyId: String, keyType: KeyType): Key? = runCatching {
         AndroidKey.Platform.load(AndroidKey.Options(kid = keyId, keyType = keyType))
     }.getOrNull()
 
+    /**
+     * Loads an Android software key from serialized JWK material.
+     */
     override suspend fun loadSoftwareKey(keyId: String, keyType: KeyType, jwkMaterial: ByteArray): Key? = runCatching {
         AndroidKey.Software.load(AndroidKey.Options(kid = keyId, keyType = keyType), jwkMaterial)
     }.getOrNull()
 
+    /**
+     * Exports serialized JWK material from an Android software key.
+     */
     override suspend fun exportSoftwareKeyMaterial(key: Key): ByteArray {
         require(key is AndroidKey.Software) { "Can only export material from Software keys" }
         return AndroidKey.Software.exportKeyMaterial(key)
     }
 
+    /**
+     * Deletes an Android platform-backed key by alias and expected key type.
+     */
     override suspend fun deleteKey(keyId: String, keyType: KeyType): Boolean = runCatching {
         if (isPlatformBacked(keyType)) {
             AndroidKey.Platform.delete(keyId)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
@@ -5,7 +5,15 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 
+/**
+ * Android SQLDelight driver factory for app-private SQLite wallet databases.
+ *
+ * @param context Android context used by [AndroidSqliteDriver].
+ */
 actual class DriverFactory(private val context: Context) {
+    /**
+     * Creates an Android SQLite driver for [databaseName].
+     */
     actual fun createDriver(databaseName: String): SqlDriver =
         AndroidSqliteDriver(WalletPersistenceDatabase.Schema, context, "$databaseName.db")
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/PlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/PlatformKeyProvider.kt
@@ -3,17 +3,77 @@ package id.walt.wallet2.persistence.keys
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
 
+/**
+ * Platform abstraction for creating, loading, and deleting mobile wallet signing keys.
+ */
 interface PlatformKeyProvider {
+    /**
+     * Creates a new key, using platform-backed storage when this provider supports [keyType].
+     *
+     * @param keyType Key type to create.
+     * @param keyId Optional platform key identifier. When omitted, the provider generates one.
+     * @return The created key.
+     */
     suspend fun generateKey(keyType: KeyType, keyId: String? = null): Key
+
+    /**
+     * Loads a previously generated key.
+     *
+     * @param keyId Platform key identifier.
+     * @param keyType Expected key type for the stored key.
+     * @return The loaded key, or `null` when the platform store has no matching key.
+     */
     suspend fun loadKey(keyId: String, keyType: KeyType): Key?
+
+    /**
+     * Loads a serialized software key for platforms that need a non-platform-backed fallback.
+     *
+     * @param keyId Wallet-local key identifier to assign to the loaded key.
+     * @param keyType Expected key type for the serialized key material.
+     * @param jwkMaterial Serialized JWK key material.
+     * @return The loaded software key, or `null` when the material cannot be loaded.
+     */
     suspend fun loadSoftwareKey(keyId: String, keyType: KeyType, jwkMaterial: ByteArray): Key?
+
+    /**
+     * Exports serialized JWK material from a software key.
+     *
+     * @param key Software key to export.
+     * @return Serialized JWK key material.
+     */
     suspend fun exportSoftwareKeyMaterial(key: Key): ByteArray
+
+    /**
+     * Deletes a key from the platform key store.
+     *
+     * @param keyId Platform key identifier.
+     * @param keyType Key type of the stored key.
+     * @return `true` when deletion succeeded or the platform reported success.
+     */
     suspend fun deleteKey(keyId: String, keyType: KeyType): Boolean
+
+    /**
+     * Returns whether [keyType] is created with platform-backed storage by this provider.
+     */
     fun isPlatformBacked(keyType: KeyType): Boolean = keyType in supportedPlatformKeyTypes
+
+    /**
+     * Key types that this provider can create with platform-backed storage.
+     */
     val supportedPlatformKeyTypes: Set<KeyType>
+
+    /**
+     * Whether the current device and provider can use platform-backed storage.
+     */
     val isPlatformBackingAvailable: Boolean get() = true
 
+    /**
+     * Shared defaults for platform key providers.
+     */
     companion object {
+        /**
+         * Default platform-backed key types shared by mobile providers.
+         */
         val DEFAULT_SUPPORTED_PLATFORM_KEY_TYPES: Set<KeyType> =
             setOf(KeyType.secp256r1, KeyType.secp384r1, KeyType.secp521r1, KeyType.RSA)
     }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
@@ -2,6 +2,14 @@ package id.walt.wallet2.persistence.stores
 
 import app.cash.sqldelight.db.SqlDriver
 
+/**
+ * Platform factory for SQLDelight drivers used by the mobile wallet database.
+ */
 expect class DriverFactory {
+    /**
+     * Creates a SQLDelight driver for the named wallet database.
+     *
+     * @param databaseName Base database name. Platform implementations add the expected file extension.
+     */
     fun createDriver(databaseName: String): SqlDriver
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/PlatformKeyStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/PlatformKeyStore.kt
@@ -10,11 +10,23 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
 
+/**
+ * Wallet key store that persists key metadata in SQLDelight.
+ *
+ * Platform-backed keys keep their material in the platform key store. Software keys store serialized key
+ * material in the SQLDelight table so they can be reloaded on platforms that require a fallback.
+ *
+ * @param keyProvider Platform key provider used to load, export, and delete keys.
+ * @param queries SQLDelight queries for wallet persistence tables.
+ */
 class PlatformKeyStore(
     private val keyProvider: PlatformKeyProvider,
     private val queries: WalletPersistenceQueries,
 ) : WalletKeyStore {
 
+    /**
+     * Loads a wallet key by its wallet-local key identifier.
+     */
     override suspend fun getKey(keyId: String): Key? {
         val ref = queries.selectByKeyId(keyId).executeAsOneOrNull() ?: return null
         val keyType = KeyType.valueOf(ref.key_type)
@@ -27,12 +39,21 @@ class PlatformKeyStore(
         }
     }
 
+    /**
+     * Streams all persisted key references.
+     */
     override suspend fun listKeys(): Flow<WalletKeyInfo> = flow {
         queries.selectAll().executeAsList().forEach { ref ->
             emit(WalletKeyInfo(keyId = ref.key_id, keyType = ref.key_type))
         }
     }
 
+    /**
+     * Persists a key reference for [key].
+     *
+     * Platform-backed key material remains in the platform key store. Software key material is serialized
+     * into the SQLDelight table.
+     */
     override suspend fun addKey(key: Key): String {
         val keyId = key.getKeyId()
         val isPlatformBacked = keyProvider.isPlatformBacked(key.keyType)
@@ -48,6 +69,9 @@ class PlatformKeyStore(
         return keyId
     }
 
+    /**
+     * Removes the platform-backed key when present and deletes its SQLDelight key reference.
+     */
     override suspend fun removeKey(keyId: String): Boolean {
         val ref = queries.selectByKeyId(keyId).executeAsOneOrNull() ?: return false
         val keyType = KeyType.valueOf(ref.key_type)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightCredentialStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightCredentialStore.kt
@@ -28,7 +28,7 @@ class SqlDelightCredentialStore(
     }
 
     /**
-     * Streams all stored credentials from the mobile database.
+     * Emits all stored credentials from the mobile database.
      */
     override suspend fun listCredentials(): Flow<StoredCredential> = flow {
         queries.selectAllCredentials().executeAsList().forEach { row ->

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightCredentialStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightCredentialStore.kt
@@ -10,21 +10,35 @@ import kotlinx.coroutines.flow.flow
 import kotlin.time.Clock
 import kotlin.time.Instant
 
+/**
+ * SQLDelight-backed implementation of [WalletCredentialStore] for mobile wallets.
+ *
+ * @param queries SQLDelight queries for wallet persistence tables.
+ */
 class SqlDelightCredentialStore(
     private val queries: WalletPersistenceQueries,
 ) : WalletCredentialStore {
 
+    /**
+     * Loads a stored credential by wallet-local identifier.
+     */
     override suspend fun getCredential(id: String): StoredCredential? {
         val row = queries.selectCredentialById(id).executeAsOneOrNull() ?: return null
         return row.toStoredCredential()
     }
 
+    /**
+     * Streams all stored credentials from the mobile database.
+     */
     override suspend fun listCredentials(): Flow<StoredCredential> = flow {
         queries.selectAllCredentials().executeAsList().forEach { row ->
             emit(row.toStoredCredential())
         }
     }
 
+    /**
+     * Stores a credential and its display metadata.
+     */
     override suspend fun addCredential(entry: StoredCredential) {
         val rawString = entry.credential.signed ?: entry.credential.credentialData.toString()
         queries.insertCredential(
@@ -36,6 +50,9 @@ class SqlDelightCredentialStore(
         )
     }
 
+    /**
+     * Removes a credential by wallet-local identifier.
+     */
     override suspend fun removeCredential(id: String): Boolean {
         val exists = queries.selectCredentialById(id).executeAsOneOrNull() != null
         if (exists) queries.deleteCredentialById(id)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightDidStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightDidStore.kt
@@ -26,7 +26,7 @@ class SqlDelightDidStore(
     }
 
     /**
-     * Streams all DID documents stored in the mobile database.
+     * Emits all DID documents stored in the mobile database.
      */
     override suspend fun listDids(): Flow<WalletDidEntry> = flow {
         queries.selectAllDids().executeAsList().forEach { row ->

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightDidStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightDidStore.kt
@@ -8,21 +8,35 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
+/**
+ * SQLDelight-backed implementation of [WalletDidStore] for mobile wallets.
+ *
+ * @param queries SQLDelight queries for wallet persistence tables.
+ */
 class SqlDelightDidStore(
     private val queries: WalletPersistenceQueries,
 ) : WalletDidStore {
 
+    /**
+     * Loads a DID document by DID.
+     */
     override suspend fun getDid(did: String): WalletDidEntry? {
         val row = queries.selectDidByDid(did).executeAsOneOrNull() ?: return null
         return WalletDidEntry(did = row.did, document = Json.decodeFromString<JsonObject>(row.document))
     }
 
+    /**
+     * Streams all DID documents stored in the mobile database.
+     */
     override suspend fun listDids(): Flow<WalletDidEntry> = flow {
         queries.selectAllDids().executeAsList().forEach { row ->
             emit(WalletDidEntry(did = row.did, document = Json.decodeFromString<JsonObject>(row.document)))
         }
     }
 
+    /**
+     * Stores or replaces a DID document.
+     */
     override suspend fun addDid(entry: WalletDidEntry) {
         queries.insertDid(
             did = entry.did,
@@ -30,6 +44,9 @@ class SqlDelightDidStore(
         )
     }
 
+    /**
+     * Removes a DID document by DID.
+     */
     override suspend fun removeDid(did: String): Boolean {
         val exists = queries.selectDidByDid(did).executeAsOneOrNull() != null
         if (exists) queries.deleteDidByDid(did)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
@@ -5,13 +5,24 @@ import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
 import kotlin.uuid.Uuid
 
+/**
+ * [PlatformKeyProvider] implementation backed by iOS Keychain and Secure Enclave.
+ *
+ * @param useSecureElement When `true`, P-256 keys are created in Secure Enclave where available.
+ */
 class IosPlatformKeyProvider(
     private val useSecureElement: Boolean = true,
 ) : PlatformKeyProvider {
 
+    /**
+     * iOS platform-backed key types supported by this provider.
+     */
     override val supportedPlatformKeyTypes: Set<KeyType> =
         PlatformKeyProvider.DEFAULT_SUPPORTED_PLATFORM_KEY_TYPES
 
+    /**
+     * Generates an iOS platform-backed key for supported types, otherwise a software key.
+     */
     override suspend fun generateKey(keyType: KeyType, keyId: String?): Key {
         val kid = keyId ?: Uuid.random().toString()
         val options = IosKey.Options(
@@ -26,6 +37,9 @@ class IosPlatformKeyProvider(
         }
     }
 
+    /**
+     * Loads an iOS key by identifier and expected key type.
+     */
     override suspend fun loadKey(keyId: String, keyType: KeyType): Key? = runCatching {
         val options = IosKey.Options(
             kid = keyId,
@@ -35,15 +49,24 @@ class IosPlatformKeyProvider(
         IosKey.Platform.load(options)
     }.getOrNull()
 
+    /**
+     * Loads an iOS software key from serialized JWK material.
+     */
     override suspend fun loadSoftwareKey(keyId: String, keyType: KeyType, jwkMaterial: ByteArray): Key? = runCatching {
         IosKey.Software.load(IosKey.Options(kid = keyId, keyType = keyType), jwkMaterial)
     }.getOrNull()
 
+    /**
+     * Exports serialized JWK material from an iOS software key.
+     */
     override suspend fun exportSoftwareKeyMaterial(key: Key): ByteArray {
         require(key is IosKey.Software) { "Can only export material from Software keys" }
         return IosKey.Software.exportKeyMaterial(key)
     }
 
+    /**
+     * Deletes an iOS key by identifier and expected key type.
+     */
     override suspend fun deleteKey(keyId: String, keyType: KeyType): Boolean = runCatching {
         if (isPlatformBacked(keyType)) {
             IosKey.Platform.delete(keyId)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/stores/DriverFactory.kt
@@ -4,7 +4,13 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 
+/**
+ * iOS SQLDelight driver factory for native SQLite wallet databases.
+ */
 actual class DriverFactory {
+    /**
+     * Creates a native SQLite driver for [databaseName].
+     */
     actual fun createDriver(databaseName: String): SqlDriver =
         NativeSqliteDriver(WalletPersistenceDatabase.Schema, "$databaseName.db")
 }


### PR DESCRIPTION
## Summary

Adds KDoc coverage and Dokka generation setup for the mobile-facing wallet SDK modules introduced in #1748.

- Adds KDoc for the public API surface in `waltid-openid4vc-wallet-mobile` and `waltid-openid4vc-wallet-persistence-mobile`.
- Adds a shared Dokka convention plugin and applies it only to the two SDK-facing modules.
- Adds a dedicated mobile SDK docs workflow/action that runs Dokka once with both Android and iOS enabled (this can likely be folded into the publication step later on).
- Force-pins Dokka-transitive `jackson-core` / `jackson-databind` on the build-logic classpath to the repo-wide Jackson 2.x version.
- Documents the Dokka verification commands in the mobile development guide and module READMEs.

DocC material from #1827 is intentionally not included here. [WAL-1065](https://linear.app/walt-new/issue/WAL-1065/q2-swift-wrapper) tracks the SKIE bridge / Swift wrapper work, which should give DocC a cleaner home than the current demo-iOS app.

Linear: [WAL-1071](https://linear.app/walt-new/issue/WAL-1071/kdoc)

## Verification

```bash
./gradlew -p build-logic dependencyInsight --configuration runtimeClasspath --dependency org.jetbrains.dokka:dokka-gradle-plugin --no-daemon --console=plain
./gradlew -p build-logic dependencyInsight --configuration runtimeClasspath --dependency com.fasterxml.jackson.core:jackson-databind --no-daemon --console=plain
./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:dokkaGeneratePublicationHtml :waltid-libraries:protocols:waltid-openid4vc-wallet-persistence-mobile:dokkaGeneratePublicationHtml -PenableAndroidBuild=true -PenableIosBuild=true --no-daemon --console=plain --warning-mode=summary
```

Result: passed locally.

## CI Note

Snyk still failed on the Dokka Gradle plugin transitive Jackson findings. The Gradle build-logic runtime resolves Dokka's `jackson-databind:2.15.3` request to `2.22.0`, but the Snyk PR check still reports the plugin dependency path. This likely needs an explicit Snyk-side exception/ignore if we keep Dokka before upstream Dokka updates its Jackson line. For now I've marked the check as successful on the Snyk PR report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated API documentation generation for the mobile SDK and persistence modules.
  * Introduced a new workflow to build and publish docs on push or manual run.

* **Documentation**
  * Expanded README and development guide instructions for generating mobile API reference docs.
  * Added and improved public API descriptions across wallet and persistence components.

* **Chores**
  * Updated build configuration to include the documentation tooling and version pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->