### PR TITLE
fix: restore issuer2 credential catalog

### DIFF
--- a/docker-compose/issuer-api2/config/credential-issuer-metadata.conf
+++ b/docker-compose/issuer-api2/config/credential-issuer-metadata.conf
@@ -49,6 +49,126 @@ credentialConfigurations = {
     }
   }
 
+  "BoardingPass_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "BoardingPass_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "BoardingPass"]
+    }
+  }
+
+  "DataspaceParticipantCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "DataspaceParticipantCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "DataspaceParticipantCredential"]
+    }
+  }
+
+  "EducationalID_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "EducationalID_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "EducationalID"]
+    }
+  }
+
+  "eID_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "eID_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "eID"]
+    }
+  }
+
+  "EmailVerificationCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "EmailVerificationCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "EmailVerificationCredential"]
+    }
+  }
+
+  "EnrollmentCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "EnrollmentCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "EnrollmentCredential"]
+    }
+  }
+
+  "ePassport_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "ePassport_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "ePassport"]
+    }
+  }
+
+  "GaiaXTermsAndConditions_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "GaiaXTermsAndConditions_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:Issuer"]
+    }
+  }
+
   "HotelReservation_jwt_vc_json" = {
     format = "jwt_vc_json"
     scope = "HotelReservation_jwt_vc_json"
@@ -61,6 +181,66 @@ credentialConfigurations = {
     }
     credential_definition = {
       type = ["VerifiableCredential", "HotelReservation"]
+    }
+  }
+
+  "IdentityCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "IdentityCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "IdentityCredential"]
+    }
+  }
+
+  "Iso18013DriversLicenseCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "Iso18013DriversLicenseCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "Iso18013DriversLicenseCredential"]
+    }
+  }
+
+  "KiwiAccessCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "KiwiAccessCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "KiwiAccessCredential"]
+    }
+  }
+
+  "KycChecksCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "KycChecksCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "KycChecksCredential"]
     }
   }
 
@@ -79,6 +259,111 @@ credentialConfigurations = {
     }
   }
 
+  "KycDataCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "KycDataCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "KycDataCredential"]
+    }
+  }
+
+  "LegalPerson_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalPerson_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:LegalPerson"]
+    }
+  }
+
+  "LegalRegistrationNumberEORI_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalRegistrationNumberEORI_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:EORI"]
+    }
+  }
+
+  "LegalRegistrationNumberLeiCode_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalRegistrationNumberLeiCode_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:LeiCode"]
+    }
+  }
+
+  "LegalRegistrationNumberVatId_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalRegistrationNumberVatId_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:VatID"]
+    }
+  }
+
+  "MortgageEligibility_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "MortgageEligibility_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "MortgageEligibility"]
+    }
+  }
+
+  "NaturalPersonVerifiableID_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "NaturalPersonVerifiableID_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "NaturalPersonVerifiableID"]
+    }
+  }
+
   "OpenBadgeCredential_jwt_vc_json" = {
     format = "jwt_vc_json"
     scope = "OpenBadgeCredential_jwt_vc_json"
@@ -94,6 +379,35 @@ credentialConfigurations = {
     }
   }
 
+  "PassportCh_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "PassportCh_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "PassportCh"]
+    }
+  }
+
+  "PhotoIDCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "PhotoIDCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "PhotoIDCredential"]
+    }
+  }
 
   "PND91Credential_jwt_vc_json" = {
     format = "jwt_vc_json"
@@ -122,6 +436,126 @@ credentialConfigurations = {
     }
     credential_definition = {
       type = ["VerifiableCredential", "ProofOfAddress"]
+    }
+  }
+
+  "TaxCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "TaxCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "TaxCredential"]
+    }
+  }
+
+  "TaxReceipt_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "TaxReceipt_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "TaxReceipt"]
+    }
+  }
+
+  "UniversityDegree_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "UniversityDegree_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "UniversityDegree"]
+    }
+  }
+
+  "VaccinationCertificate_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "VaccinationCertificate_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VaccinationCertificate"]
+    }
+  }
+
+  "VerifiableId_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "VerifiableId_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifiableId"]
+    }
+  }
+
+  "VerifiablePortableDocumentA1_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "VerifiablePortableDocumentA1_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifiablePortableDocumentA1"]
+    }
+  }
+
+  "Visa_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "Visa_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "Visa"]
+    }
+  }
+
+  "WalletHolderCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "WalletHolderCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "WalletHolderCredential"]
     }
   }
 

--- a/docker-compose/issuer-api2/config/issuer2-profiles.conf
+++ b/docker-compose/issuer-api2/config/issuer2-profiles.conf
@@ -109,6 +109,340 @@ profiles = {
     }
   }
 
+  boardingPass = {
+    name = "BoardingPass"
+    credentialConfigurationId = "BoardingPass_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "BoardingPass"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "firstName" = "John"
+        "lastName" = "Doe"
+        "seat" = "1A"
+        "flight" = "LH123"
+        "date" = "09/01/2021"
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Airline"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  dataspaceParticipantCredential = {
+    name = "DataspaceParticipantCredential"
+    credentialConfigurationId = "DataspaceParticipantCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "DataspaceParticipantCredential"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "deltaDAO AG"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "type" = "DataspaceParticipant"
+        "dataspaceId" = "Pontus-X"
+        "legalName" = "deltaDAO AG"
+        "website" = "https://www.delta-dao.com"
+        "legalAddress" = {
+          "countryCode" = "DE"
+          "streetAddress" = "Katharinenstraße 30a"
+          "postalCode" = "20457"
+          "locality" = "Hamburg"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  educationalID = {
+    name = "EducationalID"
+    credentialConfigurationId = "EducationalID_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://europa.eu/schemas/v-id/2020/v1", "https://europa.eu/schemas/eidas/2020/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "EducationalID"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "identifier" = [
+          {
+            "schemeID" = "European Student Identifier"
+            "value" = "urn:schac:personalUniqueCode:int:esi:math.example.edu:xxxxxxxxxx"
+            "id" = "urn:schac:personalUniqueCode:int:esi:university.eu:firstlast@email.eu"
+          }
+        ]
+        "schacPersonalUniqueID" = "urn:schac:personalUniqueID:int:passport:{COUNTRY_CODE}:{PASSPORT_CODE}"
+        "commonName" = "Frist Last"
+        "displayName" = "Frist Last"
+        "firstName" = "Frist"
+        "familyName" = "Ferreira"
+        "dateOfBirth" = "19730429"
+        "schacHomeOrganization" = " "
+        "mail" = "first.last@university.eu"
+        "eduPersonPrincipalName" = "first.last@university.eu"
+        "eduPersonPrimaryAffiliation" = "student"
+        "schacPersonalUniqueCode" = "urn:schac:personalUniqueCode:int:esi:university.eu:firstlast@email.eu"
+        "eduPersonAffiliation" = [
+          {
+            "value" = "student, staff"
+          }
+        ]
+        "eduPersonScopedAffiliation" = [
+          {
+            "value" = "student@university.eu, staff@university.eu"
+          }
+        ]
+        "eduPersonAssurance" = [
+          {
+            "value" = "student, staff"
+          }
+        ]
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "issued" = "<timestamp>"
+    }
+  }
+
+  eID = {
+    name = "eID"
+    credentialConfigurationId = "eID_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "eID"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Department of Home Affairs, Cape Town"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "fullName" = "John Doe"
+        "firstName" = "John"
+        "lastName" = "Doe"
+        "nationality" = "ZAF"
+        "documentId" = "123456789"
+        "issuingCountry" = "ZAF"
+        "dateOfBirth" = "1990-04-15"
+        "sex" = "M"
+        "placeOfBirth" = {
+          "country" = "South Africa"
+          "city" = "Johannesburg"
+        }
+        "address" = "123 Kloof Street, Cape Town, 8001, South Africa"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  emailVerificationCredential = {
+    name = "EmailVerificationCredential"
+    credentialConfigurationId = "EmailVerificationCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/email/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "EmailVerificationCredential"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Christine Schmidt"
+        "email" = "user@example.com"
+        "emailVerified" = true
+        "verifiedAt" = "2025-05-12"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  enrollmentCredential = {
+    name = "EnrollmentCredential"
+    credentialConfigurationId = "EnrollmentCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "wiserID" = "10234567"
+        "name" = "Christine Schmidt"
+        "birthDate" = "1984-04-15"
+        "address" = {
+          "streetAddress" = "123 Main St"
+          "postalCode" = "82001"
+          "addressLocality" = "Cheyenne"
+          "addressRegion" = "WY"
+          "addressCountry" = "US"
+        }
+        "program" = "NA1-2024"
+        "enrollmentStatus" = "Enrolled"
+        "startDate" = "2024-09-01"
+        "expectedGraduationDate" = "2028-06-30"
+        "academicYear" = "2024/2025"
+        "currentSemester" = "Spring 2025"
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Eastern Wyoming College"
+      }
+      "type" = ["VerifiableCredential", "EnrollmentCredential"]
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  ePassport = {
+    name = "ePassport"
+    credentialConfigurationId = "ePassport_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "ePassport"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "fullName" = "John Doe"
+        "givenName" = "John"
+        "familyName" = "Doe"
+        "nationality" = "AUT"
+        "residency" = {
+          "country" = "Austria"
+          "countryCode" = "AT"
+          "city" = "Wien"
+        }
+        "passportNumber" = "P12345678"
+        "issuingCountry" = "AUT"
+        "dateOfBirth" = "1990-04-15"
+        "authority" = "Wien"
+        "sex" = "M"
+        "placeOfBirth" = {
+          "country" = "Austria"
+          "city" = "Graz"
+        }
+        "type" = "P"
+        "code" = "AUT"
+        "height" = "182 cm"
+        "eyeColor" = "Brown"
+        "issuanceDate" = "2021-06-15"
+        "expirationDate" = "2031-06-15"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  gaiaXTermsAndConditions = {
+    name = "GaiaXTermsAndConditions"
+    credentialConfigurationId = "GaiaXTermsAndConditions_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:Issuer"]
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "https://delta-dao.com/.well-known/2503_gx_TandC_deltaDAO.json"
+        "gaiaxTermsAndConditions" = "4bd7554097444c960292b4726c2efa1373485e8a5565d94d41195214c5e0ceb3"
+      }
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
   hotelReservation = {
     name = "HotelReservation"
     credentialConfigurationId = "HotelReservation_jwt_vc_json"
@@ -145,6 +479,238 @@ profiles = {
     }
   }
 
+  identityCredential = {
+    name = "IdentityCredential"
+    credentialConfigurationId = "IdentityCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "IdentityCredential"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "given_name" = "John"
+        "family_name" = "Doe"
+        "email" = "johndoe@example.com"
+        "phone_number" = "+1-202-555-0101"
+        "address" = {
+          "street_address" = "123 Main St"
+          "locality" = "Anytown"
+          "region" = "Anystate"
+          "country" = "US"
+        }
+        "birthdate" = "1940-01-01"
+        "is_over_18" = true
+        "is_over_21" = true
+        "is_over_65" = true
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Government of Anytown"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  iso18013DriversLicenseCredential = {
+    name = "Iso18013DriversLicenseCredential"
+    credentialConfigurationId = "Iso18013DriversLicenseCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/vdl/v1", "https://w3id.org/vdl/aamva/v1"]
+      "type" = ["VerifiableCredential", "Iso18013DriversLicenseCredential"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Utopia Department of Motor Vehicles"
+        "url" = "https://dmv.utopia.example/"
+        "image" = "https://dmv.utopia.example/logo.png"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "Utopia Driver's License"
+      "image" = "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUg...kSuQmCC"
+      "description" = "A license granting driving privileges in Utopia."
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "type" = "LicensedDriver"
+        "driversLicense" = {
+          "type" = "Iso18013DriversLicense"
+          "document_number" = "542426814"
+          "family_name" = "TURNER"
+          "given_name" = "SUSAN"
+          "portrait" = "data:image/jpeg;base64,/9j/4AAQSkZJR...RSClooooP/2Q=="
+          "birth_date" = "1998-08-28"
+          "issue_date" = "2023-01-15T10:00:00-07:00"
+          "expiry_date" = "2028-08-27T12:00:00-06:00"
+          "issuing_country" = "UA"
+          "issuing_authority" = "UADMV"
+          "driving_privileges" = [
+            {
+              "codes" = [
+                {
+                  "code" = "D"
+                }
+              ]
+              "vehicle_category_code" = "D"
+              "issue_date" = "2019-01-01"
+              "expiry_date" = "2027-01-01"
+            },
+            {
+              "codes" = [
+                {
+                  "code" = "C"
+                }
+              ]
+              "vehicle_category_code" = "C"
+              "issue_date" = "2019-01-01"
+              "expiry_date" = "2017-01-01"
+            }
+          ]
+          "un_distinguishing_sign" = "UTA"
+          "aamva_aka_suffix" = "1ST"
+          "sex" = 2
+          "aamva_family_name_truncation" = "N"
+          "aamva_given_name_truncation" = "N"
+        }
+      }
+    }
+    mapping = {
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  kiwiAccessCredential = {
+    name = "KiwiAccessCredential"
+    credentialConfigurationId = "KiwiAccessCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "KiwiAccessCredential"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Kiwi Access Authority"
+        "url" = "https://kiwiaccess.co.nz/"
+        "image" = "https://kiwiaccess.co.nz/wp-content/uploads/2018/10/Kiwi-Access-Logo-White.png"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "Kiwi Access Card"
+      "description" = "An official evidence of age and identity card for use across New Zealand."
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "card_number" = "KA123456789"
+        "full_name" = "SUSAN TURNER"
+        "birth_date" = "1998-08-28"
+        "issue_date" = "2023-01-15T10:00:00+13:00"
+        "expiry_date" = "2028-08-27T10:00:00+13:00"
+        "portrait" = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGYAAABmCAIAAAC2vXM1AAAABGdBTUEAALGPC/xhBQAACklpQ0NQc1JHQiBJRUM2MTk2Ni0yLjEAAEiJnVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQWaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28AAgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaOWJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHiwmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryMAgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0lYqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHiNLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYAQH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6cwR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBiewhi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1cQPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqOY4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hMWEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgohJZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSUEko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/pdLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Yb1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7OUndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsbdi97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxrPGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H08PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+Hvqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsGLww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjgR2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWYEpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1IreZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/PbFWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYji1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVkVe9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0IbwDa0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vzDoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+yCW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawto22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtdUV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3rO9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv9563Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+UPPR+mPHp9BP9z7nfP78L/eE8/stRzjPAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAJcEhZcwAACxMAAAsTAQCanBgAAEm9SURBVHicVf1psK5Xdh6GrWHvd/jmM91z7gzgAmig0WigB/bESRIlDqIlxVaislSlchx5UlR2rHK5XP6TpOKKKqUfqcSRGKnIOPEgUpStJhVapEh2i91kT+wBYDcaaMzAxR3PfL7pnfZea+XHfr8L5gKNukDfc8737XfttZ71PM9aH379q18CM0BARDMTiSqKRESEiABAxERkAGYqMYCZy3JEUolgQMwAYGCmqqamBgCEiEQAmL6tRFEVRAAARCJmU1VVQgIwNQMwBAQEADQzADQTEWVmYgIDVTUzRCByolFV058mQjMABEICADMFIEBDAEBCRFMFQABDRANQVTAzUDADQEQCMAA0MBVBRERQtfTCzMDAEEBVERGRDAHMHKTXa6CmBkZIwGBmZmoGiGRgZgYAKjH9BgEJ0RAB0UzTj7T+hAAQ1IzMiMhMRQSR0u/Tu1KB9DDUjJnIzEzTKZhZeg/MnhlC6NSEkAEBAABQVTD9IEhfhoiUfqqagBlRerlICBJDeuSqgulMVRARDAAxHWV6iGhAnkxVRNKDNTBEBEMwSw8biEDFzAj6pwCQnhYzAqqIqqbnYGaqoimKVAEAiVIsYB99BpYizRCJkJkcEQOCWvom6Zg5BZGZISKmA1VNZwFAKdzSN+6/FkFETS10rcRIzKoiUQCAmJ3zmyeBgP1Zq0YzQyJTjTGk958e7eZvQ2JE7t8xgJkaKAIgETH3oWebo0Mg59l5ME0PwKXrAI9iDwyZyDiF2ObxgkokJGRIh2iqBgYq6VYiIBKaICCYGREBgIqYKrEDRAJSFTMlJEBUVUAkIlUzMgBk55xz5LyGpmuqpl4ye5GI7IAg1qEcDoty0BGLxBQ4j6LeTCSmS6NmyuRS2DI7U1WIxM5UTft4B0JTBQNDw0epAYCQCNAY+zRjikT9jej/gUjk0pWydKVVAQwAmJ2ZEeGj999fO0MiVokqws6ZgZmmkzWR/vTBVBUxBcyHvxCJGVUNLMW8IQI7zvISEZanD+/dv310/4PTw/vVaiUSi+Fs+9LB7sHlg+tPDIbjw7vvhbaZ7uyNZ9tI6JwPqmYKZqL9bUJEAEJCMEAEJO5fg2l6g4gGSAQYzcyEkIldDJ2ZADoF7TO6pTsLpin9UH+9EBHApTAhYgBQFTNAAgQkIrWUR9E03REBMCROecQAmDlGNVNTUxV2fpM01QCJ2Yz6P4sIfRKxdIXZZ+PpVuyqu2++8vrL3zq8+/7p0YPlciVGMdULhdF4sru7+/RzL+SD8fe/8416vZrMpqPxdHvv0vXHP3LjqY/m5TB0rcUIYMwsqkSU7kFfu5CwDwh7FCmb4Nj8C5KZAhoiG/TvZvMIKGWJPpwBwAy/9pXfS6nxw6SaSk/K50hgFmMkRGROP8RU1NSxY/ZmJhIMgNkhkEhQFQBg5wlxk037TPfo8Yxn27FZv/ODb//wO3/03ls/auomH4zZ5wDQdt3pfDlfrUMUUyHE2XjIRMSuyHMJTb1eZI7LQfnYk89+7mf+jWu3no0iKpJeLxGqGfa1OpUd6CuYqRkQkaqoKjFvHv2jGEVVgVQokdIrZucR0VREVDUyO/z6H34pYYSUXEwNEVXVrI92FTEDZmZmABBVUDUAIiJ2iKAiiGSgKWWqKfaPjyBlGlVCTCHvsmIym737g299+Td/9e0fvWLkt/cOZrOZSmy7sFrXR2fnF6uq6SSImmoUBZPc8+7WbG9nmwnqupLQNvW6rZeXLh389M/9lc//7L8F5OpqBQDMTCkFW3+RTM1AESjBgPSOVIWIkQg38UHMZqYp20Kfx1WVML0bVBVAQGSX3kkPJtSQMNUjU1QViQGAmBmJUsQiInsPloq6AtCmqipSn0tSCdvcbmUEUDOD2e5BaJa/+6v/8Ku//ZtB4NLlx0bjMYJVVRVirOt6uV6HrmXCzBETAFBUA8jAtGk6MB0NJ97n1XoF7IHzk9Ozf/Frv3J69OAX/8bfLgejtq7SVUJEg75IoRogGibsyf3/PoQRfWpXM1NBZEQi4lSd+ywTI6aDMzJQl0I2FVsAQGTts2l/mS0l7B6IIBEDpuDv73mK5P4pqfbfPGVPFQMwFeJse2//zusv/6t/+is/euVPxjsHB1tbalbVNSOEtl1V66Zt6yasmi5EM4Agkn5y5nA2Goro/cMTAxwPhz7L2i4wOSjHqPHLv/0bKvGv/vv/uWaFxM5SETRNFwr6UEoAiKwHWggbuAOGSGQaMaHflHdU1JRSMQAAM0IyE1Pjv/W//psJMSAQs4sS0lmpCEAqOpoge/qRxCwSJXZInEpqj2FSasRNAPegB1SVfb61t//9r/3Or//S/+X48HBr/xoArqpKDYo8YzSNXVVVIRqgMaMjFNUQLUQNUc30YHdne7p1sVgigvfeeV83jYikHF8MRm+9+vJgUDzz4mfras3OmyluXltfA3sUhZvklW7J5iiJDDYAW9XAEoJhYkmlAMAMEA0AqIdzaiko0tUFBFWR9GXsACDGkKqMxJhOM4GJTYdEH5Z5TNCE0/1nn8229777pX/+xV/+v4piMZ7M5xfrpi3K4dZknHsnakGhKAdF7kE1RmuCdkGjqhogIiHFGMeDYlDmy9W6adsYopmt6rZpAxFHhWw4+61f+3+9/Ef/antvX2KXik3K//3jQzSzGLvUADAzkesBpkqf9S2hfyNkREKAdOESNlUTVTMDUpP+PRuoaY8h1AiJKEFkMLDUtRiomQIYIpmqaY+bH9Vv63tS3vQcPJlt//Abv/P//e9+CX0Rgc7Ol1UbRsPB9nScOY4xhiAGSM4je87KPMtyz5mj3LvMEzNmTLPRsCwLRhSRum66GH2e+yw7X7XLdYOIPht0gv/8v/0H9997vRiOYwj4YUcJiISEfWeYYCoYAhI7cj4VBJHQ953IiEBESKSmPYrETasLSn1vDJq+cULVaorMzC51GESUkKyqGgASE1MPQfoglfRSoM8afekYbe0e3X7jt3/tlw193cnpxXLVdKPxaGs8bOv10en5+WJFTIPhKMuLne3ZlZ1J6RBNzDSKEFrpaTTIL+3uXD04mE3GmfdlWQzL0pHbmU1m0/HpqltVDYCNZ7v37h391q/9Y8/EzscY+lZcoqlAeuDaI/YYgmpM54If4jWgPp2Zqvz/Q3F9lLbJAFTNUlkxldilZjLhM2bfXzaA/vKnpACIyIkh0B7LgaqqSsJAIjEfTqRZ/vav/qP5xVyQL5arTnQyHhbMDw+P7tw/XLfddDoZjYaOsWSI9fL45PR8WddtJLMhw4Bhbzx47PKlrcn44uwYpb15sL09GXjPjnFdNYOch2VxtgpV3XjP25f2vvf1P/zG739xurWb7lTKG7qBZanGpeOwvqUTAEzdNOIG9IOpaIJvqiIiKgoIqat16QgStQN9kkNAMFUBYHbELiEXlYhISISQulwzNDQ0eFQ2+58Hhs7no9Hoy7/+j9569fuQjR4en2e5H5UZmt47PG66eOnSpav7eyLRYsgsni3nDx6eLJZrBRx6f7C7ff3Kldl0WhZFWWRZljXtULr29PyswDgZD48lHp92bdtOSheiO543ReFHg2G9WnzpX/za0x//7HT3SrVaJIyJyGCqoIhMhAYMiACmIqmHT+1dwhxqMbXAiGCW+CVTU1BUMAN0iKQaVJUIiIh7esBMNeVGSOQHAhEjMRGpRNxgn4Q/NpgjlScFgMls+83vfvWP/+C3zRVHpxdZluXMbdOdNm1UuLK/tzcbLZfL6ahYn50c3nsYmu7SzvYLj93Y2t6ebe8MB8X+7s6VK1eYncawrisJ7XOPXXnjg/vff+2No/sPxpPhpdno/Qe1djIu3ZnI8dm6yLLZzt7dD+5+8/e/+Jf+5v8OzJAJUsPe16gUdELAmwomnHoskFReNyFoYLghNoSAEwuDiK5vt1P3mkgutdR6pMwOm+qDSKZRjfpq8CgkwRhJTZEQkdCoGI4XJ/e/+lu/WlX1RaVZluWOlnVbNUEBLu/NRjmtlnNH9vobP6JOnnv61ovPP3fr6Sdn29vD4RjAYuzYeSRCVVOcjor5xdnA2Y9//Omr25OvffcH948ejofllZ3JB8cXOcqkdPN1uFjWO7PBYDx6+Zt/8Mmf+Lndq09Uy7nPMpF0+0BNpBMzU3xEHBghIjGKaBRi7pvQ1CuoEPUYygBTX+FS375BWAAiuPlTCZEhkYmo9HxTirXUhdGGpLBN1kBEcpzl+R/+5m/cfe/tzjJ2wogXq7pqowLub49IZVVVcXVB6/YzH3/xL/78z9x66sl8MJJU4NBikEwzNBFRBdMoCt1oOKqRYuhu7m+Xn33+B28OX/rRmxbD7rg4nleFp2HhHpythrmbTCf3791/6Y9+9xf++t9WjaFLfWVEYkQS7foLqJr+SwwdezBIHAeBSd8w9SymPiImgB0YuNS+pm4/sW5mSsg9ISdGakiYyCVkh0CEmODFIy7JrGeiVaUcju688fIbL32zVdeKeML5ulm3EsUubQ0ZLEq3enB6a//S/+bf/Vuf+8JnweddVAU0EwMFU85yUB/rJZFDZJAIQACQeacSBCn37qlrl0Dj1/7ktdC0W6Nivu5Kj2uiO8eLJy5P88Hg5W999cXP/7nda7eq9aoHtSLOeXZeJQIikevbYSIweMTlpCRkYJsOFCDhKqDEstGjph+JUqoCQ1XpvyYlLMRNE9tz1moWY5AYEu+TkA6Y+SxH0O9/48snRw8FyAyqul3VoRPdmZSIINLNH5z++Iuf+Pt/77/6qT//ZxvjJqb4JspK8jm5nFyGxOQLdK7vOIjAjH3m85KYi3LgfXb9YO/FjzzmENeLdZm5Ltp04JaNHF9U5WB47/6Dt179Xp7ljhkAid2GTH6E/5GImTkRlhJjQpqQjoco/fk+kSegm7qonvXAxASrmaSam6oJs3c+26QtSpAV+h9sIiIxqvU5D4ic8/fefu32mz+sAjQhgOm86qLa/rRENJB2cXjxb/3Cz/6f/o//5fb+7tmiAnbkHLoCnSd2lA0wy5EdMKP35DwgIztMUNBlLst9lvksG4zHxHxld+czz95i1XpdZ47AbDrwJ4u2aWNUeOV73zg7vJNyYipKIkFiAOibPCY2AJGYemFJBbSni0VFEjAAME1xgwRgiXXo+Y2kvNijWqBmoD2h2FO/PVeXsj4iInHKbojonCfCt1976eTh/VYwRJmv6qiwOyliFAZZHi/+2l/5i//53/3fdjHMF2tyjElwyHIqhug8ssOU9RGQHbqcnCefI5ElGMmOnCfni3I4GI2Q6ObV/R977lYIoW07Myg9AOC86nwxfOuNN++88yo7Tq2Q9Q0YY0/ooGhUFSQkdn8K0CL1ZL30lwyAKJFrCpBIQQmElEIRAC1FqRmYxhBC16WzR7MUwElJIXLETIk/6Skntzw7Pnr/9fm6qZpWRZug2+NCRDMH5w8Xf/UXf/Y//Tv/3vn8oqobcg5TlWHf1ykis6AxSAi9dAJiaIZoSJZUMJE+QkzzPB+MR4b4xPXLV3ZnZ/MqQaMyw3UrzO7svH3j+98FjaqSxENEZOc+TO0iKRL6RjI1Roi9IoUE2LMghAip+TEgBOqFvcQyMqViDEj06M3YpnYk9hURDIiIkM0sxhBiAEJEuPv2D+69/86ihSaomg0Kr6plzueH87/8M1/4T/7Df+f87LRuA/kciJAydBmimfTahwElMNyXIjNQARUDBJ8hYQxtaBuVKDF0TTsYDMez2WAw+OjjVzPHZ4vGAAtPqrZsAuf80ne+eXzv3awcwIbMT4kJkdD6hk9EEsHQc8cbPoKYqVdjUxLsCRrqlageeygAOJ879kSpmaUPCYoUromZgyTzGgAkvGeqXbW888YPjo5P53VM3Vvu3WSY3b9z9hd+4tP/xd/926tqtVytqZdtUsug/YtRNQkgAZJom9QiUTPr1S+VhJg3Oi6ScwjgnS+Gg6effPwzzz3RtFK1wQDKjJpWkfP3P5j/6HvfdIRmmm6eSEw/0nCDNjdhsYk86UkZwNTPpINTVSDcKAWmarKh0gwBmB0ASgwxhkfSb/r+YJYKZU+qUC+sZ3lxenj3zjs/WnYoasPcKeDutLh/7/jm1YP/7D/+D4LparVinyETgAEROte3dghAaNDXHEDWGDUGVTMkTWy0iJhgEqetf2DOMTMTQJ75Z2/deOraztmia4MOc+cYq1Y6hbde/2G9PE8Cq5qaCpim7J7yPfUkWs/NfkiBQw/3EdBMVGM6VjIzQNoIrmimvRqemDnTXh1UkZ5p8gBgsmn0zWLXGZjPi7tvvnL88P55FXPPZrY9zBfzVdPB3/l3/9poNLi4mBM7dqlWMBgCoBHbpmSnyDdR6ToVTZI8MaPPIJW8dG9MH72ZrMi8c4ysMWbeP3F9fzrKV3UMorknQAgId26/e3TvPSKKEpKOAYCpGUxvVnsOAjcn9SgPaeJP1TTGoDEmYaRXhhMq2zBtAH8KuRhYQh6J/k00QJIINxyjIXK1OL//7quLql136piGhVOR128vfvoLn/jYM0+cnJ6aGfmMXYaIAAoWQRU1tboEBhY667kQQWYgRucQkHuGnsH6mpNulveeyaUKnh7feFgebI+j2qqJGaNnagQPH85PHnzgs1xi2MjjoCqJTzU1Uell6UdMX5+4LYEIkQgG7HN2TlWpF+dMY+xUBB7lKeuZCSbuc46aiohEEYkSe4kAAIl9Xpw9uP3gzvtVwKqNuaOM8d0HF4NR9pEnrrddFFEgR9TzUQiasgiyR3KmYhINUEJrsQXOkD06hy4jZkQ2NSCX6BlUMwXOcp+53jRhKiIE6ohy74aFqzttgnqPgDRfwdH9u4Sp9QEzVYuPpDjYaOCp+6EeM6FZz4mllE5E2Mejug+/DB/RRvRIkUv/B7NL1z4pb30xwA8FwSzPD++8fXp8tGpNDaYDd3hezRu5dTAuvOcElBP+M0Fw5DwiJ9RHABajxmgSpVkDOXaoMSIqONdjSQDtWiMysxCDIfrMmyJChwAiKiqmqhKjiCNCsnUrk9JlDtsW7t1+p14tnMs23FTf6VnK6Jp4W1ARIsOEy7jXjwAgobYUmIjo0hlDb7BIHoUU+EBEvQyYFE5VQgcbybunIRHBQEJ7eOfdtm1XDeWOTeJFFUdllnvano6ZqYuSgRF7zofsfApbZAaAWK3U1Lou1ivpGh7NRLq4PifnEcliMINQ14JILkO1fDTDGFUDMzVNPV8so0QzEAVCYIQ6iCMEs6YTRCSPH7z/3sXpw0s3nlnOz7DviKHXISUxppSa7541S7QNqCUOBA0SG02OiFwPgAAopSfoU1Rq0ZMvjIiTDmMbbJKuOiIk2n51fnxy730xt6zbQeHO1yE95NlkvLezrWaiiuTzckLOI6DL8uTjQIttrKXtYtvEtgYA7WprVtDV4jJTJbAYg4hm5dA5DpB1IgbYNh2Ass+Go+liVS+tAaRhWWTeJbowiAFaVHOI8/ny5P7t/RvPJPogHRYlNw0kS1LfEvaapgqCAoCaWhSixAhB8tw5U4Weets0m4qEvQJiGzuRqljPVSZUQWqCSGCaD4YfvPvK6eFdIx+k6YKuGjDEpguT0Wg2mcQYfT5A4ofvvbGanyP7ohyvlouLiwvVuDUaTifj8WRGzqkoNLXGlpi162K7AjUibmO4/cHtk9Pz88ViuVozYZZ5IvTes+NiMByORlW4KIo8z/Mg6piimna2aqT02LRw8uCuxI7Zq4RHCd6Sge8RYEI0Fe39K0Y9td3XQTMViYjgHoVMb0nso8l610GPUvqOkxLhbULkiF2C7N7708O79WoVhJtgauIZHVPbht2dndGgMPJN07z63W9ojNPpdtt1x0ev3Lt7/2S+ELHtyfjypZ3r16/evHnTsVO15ClSkdDUhnx2fvLm22+/d+f+2XzZdDHP/fZkNJ3Ntre3EeHo5GS+ur27f5BnOZqNymLdSpnhKOfzdWiCecIQ4fzksK1XgC5Zz0DNSFODa2qGRsTac9HJgJbUYSB2iVzrq6Sag00/1IffhhpRU9gYYMCQkJBTvUouO7Q+x2Fo1if3botY3UkdLajlXgDRO76yv+e8X7fx/ntvlcPp48+9MBiM1qcPh4N8a3trtV7XVV3VTS3x3sND1bi3szsaTV2Wq4HEULdxXc3feve9ew+Pstwf7G0XRT4ZD7dnk9Fo4vOcM79/9fKP3njr8OTs0v6ey3xR5AB4UcXckSMEgKggBhenx/Vq4cpJ4hGR0tHAxrjT/0q9TRLQkbB3T0HfURKSEbgeTHxoJcJHjEeieHAjokLv2OwRu0g0NV8OVmdHJ/ffR+YuBAXoFC7WMhuyAhZ5Rsyrxcl4a/f6E0+Cxm5xMszoqVuPd13XdO1yuTy7WJydz+t1tWqaqUQkdL4QCa3GdVO/f+fOw6PjCDabbR3sbu1Mhts7s9FgCGbL1frkYr6q2tnWFua5KjjCzLvccxXi+SpcNAoAdVBFODs5iaHJRtuhrdk5Qkyak4A8EoAQKbkLYaMRJCyPRD06AUMg18OTvsfqCaPElmgvPhEm21+f6xIHqYhkEJ3PHx7dW56fsPP3L9ZXhvn//i999jdeeffLr9+9vl0My9IM2BfMdHF4z6FZW797eHr3dPHe7TsIsD0q9iblaDrJfN52LTmfj0bFZBqbdb08Xywu7j44PF01V69fG2csTXMU8Ud3LgzAxWY6zAalb5qwbgIyu8wTYplng8zN67ho9db24Ond0R+9e7wMtpifLc9Pp/uPhbZO9w1RdSMwJsSuElMXoKKJzE+pCT5EcYgAjohTV2RqgAaGqjEBNGLsAXEv6HLS+TbKE7DzztHy4qSu6yh2WumfuzH8D//m/+K1X/rnv/vq3cs7s+lkTMxZUTTrlcQ2LM9++yvf/vKfvDfv9MazL9x953Ufq5985rHnb+zuHuxL0C5qMRiWs51YZcuTB6vV+uHZwpcj6tr5xfq92t5e28Ma3/nRD0oPA++fujz73HM3s8Gwa7qCIBsMJ+PR1rh4/6Rmg//kL3zyub3y8J9+9Y15t5g3FydHNxOsidFtzsFM1TAV/0Rqbfj51JMRbkgJ2PShtGEQex+a8x4QRYWYmf3GEdT/6b5pwkcsLIembterKCJRZwXePZ7/ky9+6WixmDi4frC3s7WVvAMIEpvl7/z+V37/e2994uf/zWu3rnbLBxAvrj92cOWzP7OsJBN9/OmPusFEVX0x9OWInVutqjrIZFhItWo02//8zy0JDu+9nbtw+fErNz76/Dffevivv/tqV68Y0ZnmBJPhcHsy8gSDnNah+52X3tagZcZB4OL0ocQQY1TVGGOyBiXxPLXoSMTOMTOxg0d+tBRetgkzQrdxCCggmIKRMrukikMyXpikSgq9Cypd8d6SphJX8zMJQQTEbDh0/9Pvf/WuwVOX893ZZFCUCFbmeXTw8OJ0ur3z7/3iMz/28z/9pWuXvvjf/dcH0/LPfOGnPv3U9bsn7x1c2X/805+49+4dENOm0rbSGNsgk9H4U5/86Nnrr6+74qc/9ymOq392+1We7Xzyoy88e7B3OcwPzw8v5su9g8FoUGbEmbfZZHRzJ8u8f+mt22eHc2K2GAXg5PBBW6/Z+RhaJtrwDglTCCA44h6dAQDoo8hICCQxQ2DgEkLb9PUKIkyc+s8NZw0bBAg9o9FzCYpIoGE5P1fVKFAHUKKnrx08Nhq/c/hgNhrkni3GYlDw9rZzz12+dqs+X4T3f/gzj1196j/6u1Ktr01yu/fm859+cXLt6upiUThCU6nW0lQqVpaD6aTtWnnmCz+DbVz/yVe+cGmy/9f/5vHp+TTP6tN716buscu3hpPpZDKcTkYazQtMBsVT+9NL4yEGgVE5X3X1qkOA0LbwqNwnDzT0xjzb6G+97G1GyR2EDBuB0lSSX9OpxARjEzpVEdxcur50GiaDa/LzmRkzp0vOzKvzh8v5GRKrRjC4u+yGg/LnfurzX/vBn5CnlDB8XhTloBxJ16wXDrs2ZHDx8avjGCdNVNjez4oC8i3GbpgThqgiptDWnQPbHg8fHp5Ntq7vH9zoVhcQ109c2d4q9P7RUaX13vWrV65eJkJEzLxbr2rPXGR+NshvXb10djqvLpaLIEGMPa0W5229zoezxC6w61NNLyeKGimie2SPBjVFAQBNDirm1Ce4ZGxL+hshSwxRzDmfjhFMtLd066Z9pUfBamZds27XiwRUhhkcNULl8NI0G7WrrpwiETORGiE675FGs4PrsQvoPfiBp9Ktl+38wo8n43FpVdMlK54hOR+6rlrVZZEXpVuefDAZ5oPhBKyMsRmyu1zku6Iuy4qcNUZNLFuIIJZnbjlfLs7n1y/vnZ8v77w7d4zs84uzk8Xp8ZWt/Xq9ZOcTxiQghQRLiZkflb7knksOUOyTWnKuqEuIAxSNDAmI3cYnZLb5TdLFDYyZk2SSYNtgVISubeoqlZgyY2ily0tXrV3E2c522zTjjKxrIWOXF0QMhlSwGalYe3EcV4tytjPe3eJ2FdpO2sCKjr2ZxqhtVBTJmD1KqM5Dyi+I3hfT2Y6GDgmcZzBt63rdtioxBCPEoiyPTxZP7O/GbNCI7ZWpSaRqPReJsMGVqoIu+1PDQn3O6hvHzS9ABOubBEBwlBBI6tbFkBxzMiUkGpnQPuSVknlIzcCM2TPz4uK0qVaOHWBP4K2ilb54/Nnn6WBvfjGfDQoXBDlCjMwOHQlYDKJd4wgH+1fKyQwlhLqKbQ1ISKhto13tTF2e1TG2dT0sC1bJXIJQjjhTyxGMCQGgWc/brtMQgtq66RjxxvWrJ3dPujpUAgDAROx81zbLs2NmTvZ1ACDk1O0Q9aHAzuOj+YfNMYiImTI7JlYVl7JSlJCkXVXhNH4kSeghZEwk3ub4N95QQlXpqpWIABJiP8rx1t1DX3x+OoqxHLRNHdquyHKNwtghMrsMRSjzjj1PZuQchKhtpcnMKZHYx3oR6oqJt0aj+xfnddtaiBiCR3RFkTIpICAaxNC1rYYYO+na0AVZ1s1wWK6bZnF6wU9cPlvXGzxEUeLFySGYMpGpbqyNAKmpZFKVNLSj/aQMYeqrN3UzKSm93xMSxieGnlzHDX/xodKXnAQARpRUAtAY6vlJ/w0RmAgAXnrj7Tvr+uDybnd+2hmuluvYNLFptW60aSxEVCWJ3nnncjRM7yFUq/piwUDeOWAnZr4cHOzuOuTjkzPV6LMczDBETKZUQOgChBjW8+rsbF3VVRubIEC0mi8e3P7g2WdurAFfu3MEAK43V9B6edE1NRKLihn0jiCkVADNLIawMZeRmYnKI6NrEisAoHciJ7ci2CPhAAxAQR/1m48MGcniiIjOezOo67qvwmqJoZyv4+9/5+XBzva1y/tttV7WTde0UlVhtQyrlVZLa1sCRiSQiKpM1C4vlienzigvyvzqk8Xjz+U7l6d7e6PxYFTki2V3er7IvCNTQrAYpK2lriTEZr2qF8umiXUbqqarg4hpu1595Nb1J5954qV37xyvQsbA6WKwD03dtfXGJqEqMQlsSbtMylsafuzDYGOosB7Pm6q6DQmZKKSopinRJa6yV6Yh2asIemYxzaiyqcTQIaKJRVMAKBx6sFfv3D85PXe5yx0vmrbtAiOqQOZLFSFyBoASzQQBY7WYP7xbDGZZ5larC7g49m1lGNu2unf/XhfCtcv76yrUdVMWZXoZKkGqtUpsYwzGkVzdhXXbtoLr5Wo6yLYvX3744Oi1uycKkLs0sWmOXdfWoa1dOcHNqMRGFwFCQOL0LFPFJITkYE0OvH5UEdKh9FK7JDgG0Aswj+YvTBR7BbQnh2IMIiKhkdCy85yYITAiuLqbf/tH771///CxS/tb01kbY9U00cDygYBJDCpB28raxmKUtl0e3W/qejidrOvVux/cufvOa/d+8Mcn77/15ptvvX77wbptr17ZQbB7Dx5aPwNioKbEbdc1behUqrZZN10VYqfKqCCKbfv+6eq1k2a7JEJkRiZEouX8Yn52nOUF2CYIkjpllnJUGhE0kURiJ/bRwDYDqoBIzkSTM3IjwiISqUSJkYiTNtzzi+TZOdl8MbGv5kdttUIkM2RCQiCA3cngg/r8H/yz3/rZz3zyx5556l99+6WLph0NIocOEQAZ2sa8gfMQTZpVV68xG7732svf/PJXvv368U/87OevXL6kMdw/Ov7qd1/Dphv99PPnqxpVb928Phg7ESE0Q4zIQds2xPWqqtsuAonqwPPVrb3JaPCV1+5EhdJTHc0zMhMiiurq/ARMDZN5FgAkDXalqaZ0MRERNFnEiCgJxmkMiwCgPxHoBX+DXtq3DYGhKR32HgADlQhgROS8X56f1OtFMuyZARM5QkJ79sbOy28/+Iv/2d/74r/6UhIh2hjVzEQsisZoMahElVDPzxXg0q1n2sjrZfP5F58+mI5Xq9Xrb73z+ptvzzKbFvi9779+vqiL0Xi1XnfVSmMXzWKMiigATV2v27Y1MzAivDhfPjg6/+Xf++4bDy72hilTAwE4JgBD9iIxtHVqotOURN8zm6qGGLtEvcJmOCcl935UHgDMXN9hKRgBfQhJksdKEcEw3WcQQERMc+MqohpBIzsvEpjJzAiM0Ji5cO7W5eFXX//gq6//k//bf/o3fvK5J9sQB0SGKTkSqEroNLRts8pme1mRf/QzP57luVnYu/HY+++/++Dhw/2Dg+lk3HYhdnL12rWt3d22i13XZew1dEGkqeuqqpdV3YgoIhGVhL/+gw/efnBhANMcc0eEEBQyR46566LEqDHE0G1aJQAzjdFSCJHbjH2kCXhIc0vpNMwwSbkuKb/YT5f0zfYjUzcCIoipKKBjRsQE59hnEjpRyfJys7cgmdkw954desK9Eo5rOFmssyJvujrE4DANnzjVaIChrf1st5xuh2qJvnzy05+u2yZUNSJ+5Nmn88Ho3fferep2XJazyaTwDryPTKwxinZt07btum7XTduJqAEjhhBP1206r8xRAroA5n2yEDuVuJyf95psGgEhSh13OjRmn8qiiiCRgpgFYoeUqYnGCAAOHzmTwIhoIykZAgIhJBcCO+zbV4TeKE+hqUEViJJVgpmYkYkAlMjnuSsyB3VcrivnnCGIaozR+yxIR2iogET5cELep0sVASnPPcJgUPpyMNmadqE5vbjwSOVoUA6G3mHQiFHNsAtd27Z10zQS0yw3IjQhSowAkDFmjJnDTowIPFEUSWU+hiBdQz7vM09CFQDoMwAQjUy8IcQMCFWVGExNYkw9gAMgSBgtsYyABr2wRIaaNE/4kFnEDcvYtVVbrxPBrRIRgXs4bQjgmTMmADifL9A5570BRDCL0YGyIwCjLEcmlahIJl0Xu2w4Kabb5d07Bbud/auL+aKJUpaFY8bcIxiitaEjok6k6domtArg2JlZnrl7p/N1ExwCM3qHpSdR8UzekaqZyqAcdE1Vr+bTS9dj6DbeE0CiPm2rKBEhb1ZwbEbIJSa1GBGdpVsF/SIOZE6zEWamyTcLsIm7vm/ojRXSSdd0bZeGnszUM1La8mFGBN4zANx9eLxuOp95NYsKyChgGgMQeueigcYoJlyWRT5woPH0aGtvvxhPyjybDQcRzAjbNjQhRGaP0Da1c6wIVQhxk6dJbVBkZ4sqKowzZEQmzB3VQbONwQJBu7ap18sYOmInTZ2gajqv3lZGaGqKQkR9viLozWVgaWwx7Ucwdn03kBJiKhPpmDYcd3LtJaM2SQyhrppqlSqVSHCESQRTM0LLHY0K5wAeHh+fL1eXZlshdEag2Pu5iCjEbtXUAaAYDbrDwwevvXXvlde0aR9/4fnhZHjnjbcOzxY4GY4vbRVbE0LM8gyJJERsaiYf+0lASrAKEQ7PFqk9IgRHmDnMPXcCUYUUc0eqEEOMbZNccSrSa2v96o6NUbBfWWAE3I/QgJkKCgGYs76dNCTQFFi9simIlOzyqcSmnjzxbRLa9eJMAYvBsAtd2qkCqEleT3k39zwt8O7h8r279564euViEXvUAsoEYnbvvbe+/vVvA2QD8Ot7x93FOvcZIN658wdVtbx7crEmHxAxc+PdqRuXmcOPPXvz6Scft0ZDDAagBkQoZoy4qtu37h4DgGP0DBlj7hxAMNMEs5kYADjLqvVSYtgAC0VEZpeiYTOJJdb7Eh/9QgBMzijHzMlR82gfDkLiY6HflpDcjh+a5g2Ipavb5Xk2GA2mO3VdFcXIoH+wakpEBEAIRe5Om/Dyj97+2S98FpKSbJigSWiq17//0ngyfe5jn2rvnoxuPDObTbZmW7FrH967X0mIhvPj4+P58u7p+clyGVtVguXFaZE/5Yvp0cPDuJmEB4DpuPz+O/fvnCxHHjKHw9zlngFh2QTP5Iic4zZEQi2Ksmuqrq37UQczQEymzN4cmrylxGl4ExB7CZxYVSCZpdLQfM+PJTqcEhVpgMjEmBYXAIgIGDiXS+jW6+XWwY0sL7omZFmqEpBnnPgMR+AIvKMM4Bsv/fD2Lx7tTCZN26QCzwYxxhd/7DPPfuJzo9lsfXbWztfdstGqy6G8OSoNsV2vT3OYzsrrT17SQd45G04HOQODAYGlgdvNaKP3/huvvgcAmaMi4yJjzywGUWyQoQF4pqpT0QBmTBTbOh9OIRqk2cpH1MOGc+a+nopZsiPjBrOkYeFE1JqpChA7dgAgMUgMifBFStDfEBAZVbuuXjdNIMS2WioAEnYBVDWlMwMQs8xR7nhc4Ku3L37vG9/9j/5Xf6luGzOREBTEe3/12vV2ddHVVRvCuqsjSxvPq/myXiyr5VoJqCxjlgfQOnbQycRKB9TVNXmvAMlXE9W2Z6NX3r338tsPcgYDyAgBzHPyi6Xmx5hw41NyTbWuFuf5cPpIYEp9+AY1QO8Yg81YP6FZGoowSGNivQbe375+DDUdrJpGCaq9XJICsF0vQtfko0nXdfOzk6IsEpdCG6MpWCIEIPfMjBnCr/7Pf/DqO7eHZQ4EXZSu7aLEuqnXy0W9vAhtHeq6WVzUsT1bn9+/OFxnBlvjWGaScR1i7LqCuWuaB4fHq3XdNW0bYlQTs+EgDzH++r9+GQDKjJjQOxSD0qM82tFksBESMS9HIca6rlRjYikQsLdRbpyxqhJClxZTYW9F0EcraajnLWRDY1ifx5jZeZ86c1URCbiZjpWui6EdjqflaBpDcC51BQgIjklVg2ieOTDwBGqwNeF3j1b/4+9+FZGZHXk2BDHsolRNs7w471YLpyEHG4Bd2t578slnHr96fW8y3RsOZrkfEgwcZ5lrQmzVFLFquybE1CQNy+K//73v3DtdOsIgVngsMzIFJhTD5DRlhiimBo4hzWlJwhkxRokqkn6TDOuwUWl7HEq8MRigGRCRSwSbqpoYsUs7HVQl7fyBNOhjqjGS8xtDvq6XC1+OGC3GoAaEKGkfWZKHe31ZEc0xMRGA3Hv48PD0BIxHZR4CAQEQp31y3ueZz3FElBXZeNtCaC5OurZSk7quB1lRdY2iraq6LAtyvFw1Uc05Hg+Hf/DyG1/74e3UGqpCwQRqngGRokZGwNQqggGAT7Z59uvFWQoFAgBiQExDrQmvppGmZA9CiYBkiZ5FBESXhkweDQAYECJJDDEaMSNAsn2z971lwYSZ26blrGirZZRogLBZNAYEgMiE/XhmSgtmALCoagfN0TyEOJiNMgbLi5KdY+SMvfe5L0YuHwI6oQbLkUMKbc05wlRpzau6AjXvXdfFdd1ExcznZxdn337lR7DR0RDBO2zFxoUDsBAF+7URvcHTwNpqvXNw/eL4XrNeOJ+lZTaYnrdB2tGWkrsE6ScAKDVFYKqwEQMQEJ3zav1+PXaenUuLRKA3pxmYEfsYQuzqYjTJi1G9Wo5nOwQmIlEUER2haupVQUTTXqwuGgCcLWoz29vOj07PHp4sQ5rbF005GVQtdLFtY13F1TI2tUo/Fhrqpmu6pm6DSNfF8/lq3Yqgf3h6eufu+2lFFCEYAiEyYRDLHUbpzatMSERNJ2aW+Xx+dpQmFJcnD7VfOGdJM0uTOdaP5KQxHUlvHBBEYqoJbiO5pXPDGAMgIFLiJ8Fss3UIkVk1xtA261XigZBdItNULYgScTIiYFoOAJAMpKkjW1bNYt3euHapC/H+0WpZd9cu2daoxIw1BjGwEJFai9qtlwampjF0y8V8XddtaNuua7qw7mIVQClbzE/n58cZgiJvgAKMs5RMkBHNgJkMjMAAIUj0jlyWNU3lvB+MtqrVYrR7pesaRGRyvUcdQuJwwIwADUAkGjiUqKbMDoCdJeABZAaE7FyfiHrqtS+nnPg2VSTn2rbt1out7R0N4eLkITtWQVVgh0YU1Qh7kUrNgkJiF6KCAYjCaDC8vAsPT5e37x/VO9tXdj1o5xBJIiiGpg4iQCiha9t2vjhfd2EdunWI606ryJ2Gan3R1Ks8y8hiEAXEIuO6jY57e2sUJSKyR+YuE7HMEYKFuiLmYjxdXZyycyRsoqltUhFK02xpAwlYfw4WkYCQAYiSid0g7bhLGogD7Me6mZ2BigipEaVmAl1WhKaS2JXj7Wq1bNuaCEH7+BeAKJp5XlemBqLQttHnbm8y2xrniU8CxEFZXNrSs8X6wclx28Wd8aBwjCKM2NVNF2KwGLuu67pl1azaro7aKLbCbay6ehVC6513TBJ6ZDObjfVi1YZA6JNQlpYsSUq0pqrWdjErBm1Try5OfTFUkRg6NNgEBCTw0E+7IBCQQZqlp40f1lRlA2XBqN9tSmYmltY3iIoCgGJMG/YMIHNZ21Sq4PMCAGOIYKj9UhjoRJiJEEKISNR1tcvcE0995PBs7h1nTMzOZ4RIeaFTQL+uzhcnF0vvkVGVVB1iVF1XVSfShRCiKXM062IXujp2laoxJ17aEKHI0vvhvd2d8+OHqlZ4RLCoGAHboEEIEZipbtsY43C2Nz873bs65KzcmInRUrNKJDEYGDEmF3LyVCCxShSJZETkHFiytxt7ZHaiEbRHwxKDiDjnkiKAaZ6GMHSdGrBzsavWq2XmXacWxDIHUSz3zkRaMUA+X7bPfPwzGdPdP3n14KOPjwYFPJrlwzIt23KOq7qtm7pugoSYJiOj9nXWQDS2QbquaxKSNoieycASa1g4AoCqaW9c262XF22IufdqgAQxmqhFSZs6yQCq1XKytdeFDolDW6kEUWPKkvqGRERONULfoIOlfXWWkJUCsYHRRuxQkSgSVSQJdkmC534HF9JGSI+hUwNfDLzPTx7caeoKiUENCRWgjTosfd1GMaibhsc7L37mp7oQAWBrUk5HAzHwWcbsvHPDQZmu82Q82pmNd6blZJzlOTgnjiNTR9iZNaGrQtf2QAI3owdITGRA49IBQNeFvUv709lW3cZ+/gEgbQloxbqYppegiwqI54f3zo4eJHEjpTB95IlFMIM0e2hgluRdiSKCxGoWu5BIcSakRHinWetHm0c21pUE2cw0Jql8vLUXQvf+G696nzl2XRTHHMSC6DinRdUS0umyvf7Mi0997JNt1wDAE5d3BkWmIgjo89J77x2PhgPPZCJ5lo0nk8loNCrLzBGjph06poZEjh31MyDKRIzoHBNRVNgZZQwQom7vHeweXO9ir0wmeKUGbbAQlRG6qFEpxHh2fLS+OJts7XVtkwYne/fchgvqkXj/txlYv8inJ9EMENPeGn5kDU0/L4oktuCRdzR2ncbonEekow/eenj3velsi03qLjrmVRO2hkVG2InVQc4795k/8xdvPvn0+XztAX7qYzdWXZr9NARzWc4+y/JsPB5nnk0FQbPMDwZlOSgHg3JQlN77jZbIaZ6KiTLvMu/60WGiQe4vFTAaFNlgcvmJZ4Zbs7pu1NKkAopBHa0JWmbkfHZ0umjr2hejk6MHSMzsYluriISgqiIR7NEqyp5OE9WEbxMuA9x0EohISLKR9VJ2AzME1NjFpgaiNOSnEq8+/fHzB+/90b/8p9PZzmSQX8yXRK4KKmofvT47WzYCfDivPvKpn/zMT/9cMd4qM/8TN/ytGwdNVEC0tMLLLMvyLC/zPBuNR3lZEhKYEpJ3ntkRgWfOMu99ZqYm0TFlzmXeuyxDIiaHiOx4NoD9ndlgtrO1e2n35kcWLcSoiDjI2RG00ea1EGKZ8bqTO3fuOe9Pjw7f+v63srwwohhClKBmaV+z9TvORDRavygr/VtiJc3FGKEXOy21nb1kboCMIqGen2pXl1v72WCUD8fMnKvcfvP7F0cPDvb3733wXivYCMyr7tnrWwR2supaARtd/al/498ejEchxJv7WzfiwhdDRERymykMMBPHjOVQVXM1730IXbWq0nqKVMzErO1qU3HOeaYsL5JCS4jMxEjMblDA5PrNye6V1fnh5etPzI/un57f2dsaOcZJ6eqgy9YWtY4LPlvRybwaP7iLRO++9v1bH/vUYLYHjhFQuoZ9LqrQD6WiiaaBBySCtN7XzFQ2yzp70Kew4c+IiYh8Vq4vjt575Y/v/Oil1emhGSxOH/7+P/mv29Xq2pXLJw/vNcHmjZ6tu+t7w2vbgw+Olmer9qzlz/3cX7359PNdXRvyzcefnI4GyM7nWdofoETI7LISiQkxHwyd92jiELPc55nP8yzzPpEAxDQoy0FZDMoyz5xzzrNPCqHzjojKcnD1yY8Op1t5MRiMJ0++8DnauvbwfNV1cZi72cAD4oN5x463hr6O8MHD09Vqparv/fB7jrkcjsA0hq6+OKnOjlJNkH7yvA+ytPUocZEOEZEZ+/UrG8ILzAzTVFM5mp7cf//tV//k4MZrg3Jw9vCDxcXZYDh8cPfevAoPLrp5q4/tj29dGn9wsn7neM3l9JN/9i9/7s//ZSAAiZTT/pMfq46+V62qndEsPpriJAYwlw9iU5GEPMsAsOs6gg4BmMk5550bFKVz3iQ4xz7LRQRADTDNtipRVy9nB49d/cgnM0dMBMi7l2+U49l7r3zn7O4boV0JOEewWMc7p3hju2yDnlVRtIJpef+Dd/jrvzvZPfA+W8/PQr26fOs5RDCJ6dvrh0ujevhKtKlEIo/2nFEaBwYEZqcSxzuXr9x67ugPf+fNl7+J2pXlEH12/+K8iny0jNHouevbBxN3uGjfOJFy/8nnP/X5H/vzf2UwGjdti0Shbcb7N+c8ODl6uHf1uiOOMUjbYpYTE2j0RQGIqmvvGMyDlYbIkdNej8pqFciGw6LIiFzbdlXTEIFnB95CjNVycem5L+zdeHp9es+AnM99MTjY2p1tX/rg3VvH996vlnMwHYTm+PgotO3uyFlBrcD5OhSLdXjt+1n+OjOJxL2DG6oa6jVlpUsJdENlPNrpBoiuV3M3066bpbJopiF0iAguv/nCT2TD8emddy4uLqpITSedHC4XhwOWW7uDMsf3z+K9tti79dGPffLz1z/y/HR7p2lbMzQARtu+/NiD2eUP3n/31kc/npVDVFPtYugIMnZkKuQ4K4YhdIatmZp5JkAwInbe5W3nssx7F7sQiRyziJljBYsxZMX4+nOfLUfDWA3EIK1SKgZjYnfrY5+++uTz3fKsqasiy86P7hzfv6Pr41yPQ92JhtPT9oLIWXQIT3zkI1cff8L5zP4Uy2gmJmaU5ufQUkfZDwsTJSSTgHKirFNAaleNJpOP/sRfWou7qPXkfHnywdvwxvfK2Z3Mmi7I/RYXk+H2ePfjn/7CMy9+ZjSZMLvVei2qIuqYh1t74ytPHr7+pbOzs72DkplUWc2iavoAiLQVAwGzcuiz3HedqIQutG2bxei4MlMi0v55M2J0zocoXTXfeezZ7VsvkmlZlgZAzhP7rBg472MI6MvRZLtbnQ3Gk5sfed5iWMzP5g/eO7v92vzoTrNetqo82du+/kT5+Edh6/JgOkjOFxFhx+l6Qu9Gd0kQd2l/EvbM5J+6tioOFQHUlQsbVFXRWCZgbuimNz4i2SBU67OTo9XJCRlcm+3uHlx9/NnntvYuqcS0EwjR0iqAtmuHV546fO0rx4dHo8l2MShT569EaUIFiJHNQpS27cuQiKlo7GIXfJYlY3QkSv02ERtSluWZyc5TLw53r2l1JhLB1PmcnTPTYjhRlfrsbDCelhmK2mBrz7HbvvYEffyz0jXL85NqcSYK+Xh7MJkB0rqrkcKEKi/nZgY2QE6+xt59kNYnOYl9S4Ub85BoJA1EFP10jcMGCgGOMXhSTxgz79zMkC+OjwbGl6eXZjt7O3uXnM+GoxGamloXohoQkXdeVUNTjy/fOpsdnJ+cHNzsOC+9yyR0MQTHzhGTgaggE6hIiCIxhi5GAWTnegOSGFmQGCIAFOUA2TXr+Xj7wF95Yblc7pT5PEoXIhKVwyGxizGOp9Oqqn2WDcaXz09PQog+y7z35FxeDgazHe/zlK+TRSKE0EVZxC7Pd/L22HdzRDaXp5kJSBvTkRwSiUQyQ6QYO5YWiVs/a7PtFoogyiCewZEjxLYLKqJmqjrZ2Tu4cZPZb29NZuPR6fk8poLCoAYhSlouU3fdoMj8+ObDvcfnF6+rKbJDVzgvbbUMCI6HvYgOwD5LcrXLHFCHJN58sktojBKiqZaDQT4cKSAsHgyf/smL7Y/MYjUZXTp2nsghofdZOZx0bQMA4+msDZKVo8G4894xMxIyJSrLNLYggRFEIxo4EOdAXd7ppXqwF5tjv7zrupVxLmIAwEym6vr9q2akAaxr3LQt9moowcxi69nleZGkrXVV101XFHmoK1Xd2b00nYwRLPdORYuiIGYDBEAPSBSg98KAqpbObT354uqP31jNl9PpDgBwPvIxqHSqmuy/GqUf7M4y6jn31ozBedIYQgwhOpeNxhN0Pq7nxc51eOHnvRtAJ12UQVkiMwIwe59551hVy8FQq5qYt7a2ibgLQQxGeS6qMYpjLjIvEoNgUWQiLoTAAA6lE+vyS52bFus7vjo0U3CFKhKaS74CskZcuciuVW7KRDmIGojPMp957xLpQ8TMrm7qpm6Hw9FkNHBMRNhFaYMgoWMOQQCBmYhQRUeTrWJkD+7dOT18EEaXcXJ18eCD/SvXs1xdljNMu+rCzNh5ZUeGFgU2ghhnXpjMDJlV4uLiwrtsujNzeR7aDjSsb/4Mb98YLI/HB1cGeXZ4+BCRERSIrF8eQnmehxAkxqwoQmgBIM8yZu5EmHmQ54iwXNbOe3Y+fVZA1wV2lKFy7DqkevpULHayxfsurg1yY+eYCELd8niRXVPOCxLHYMaq5omcYwQTNWQaFHlZ5CfndnJy5nIr8nSJzLNLtixRZQJm10UR0YMr1z64e+9HP3zlE5/8ZOnxfFXDzU93D74iiyMa32JCzgfsWEONzrOZWovozIT6zx9RACSfGcDq9CgjKvZ2s8EoRKHqoh1djpdfoHoZFf+HX/nHu9vTn/oLPz+dzU6PjgzAZ7mqMpLPMkobS1URaVjmeZYHUUQaDQrHfHZ+HkKcTCbeOxGFjZWCEZBylhAkNPnOIrMy3plCA2aOravLS/PsGoCNvCF6QoxqBJo7JsSqaZGJyUU1xzQdj5ez6fnZ+Xy53t2ahhg9c5DkY6Bk76vqav/y1aP7d/7jf/uvTK88/tn/5v/dNOHqwe5x/sKpg4vjN3eHuU0PyGVZXiin/i0EAHJMlCV1FhGIvcvLUC8d02g8A5cbUg5VK83tvc9RPrqyXb703e9+8R//EkB9/97dH//pP1NVlYpl3qe1eEWer4gQksmSi0HBRBKkyLx3brlaVXUzHg3zvNgsb+Asy1RVBIjAmK1rObTg8wveK+BkiK1raVKVNzLvc1IyjSGiQ0eYGnNRNTCJEjhm3ouaY9rZ2povVodHJ0WR51mWtCrv2QxSi1+Ug9DWf/+/+j80y7PLkxfOzs/3trdi1+Qoq8svvFLfzI6/c62tdPsKtICKhobsCMmQOSuJPXuf8gARQFcPhlPnirbtyngx7+z16efg2osldpmffO0rXxlcuXLp0s7//D/+0xDjn/vZX1gsFnXTlEVBzhmgc9x16dMJKJlTPHOZZ10X1uu1Y1eWg/QRJ0SMBsbW7yLr91cCsx8OPEm3WBcsFbXDK2WelQ7Fek5NxBCRibzjNECHCFE1fcwDIg2KYm93uw3h5PRcRFUT8YBRVVW7KAeXD774z37tre//4Omf/AWX5e9/8MF4PGTvt7d3Lo94wZM/Kn98jYOBNEQZuSysl+1qDmYQO0JyPvf5wPucESAE5rwY7+Sjrb0Bd+WlP8h/4uHep0e5u3n92re++c1vff2Pnnr6qcuXr370hU+89O0/fvvN12fbOyIxSkzmQkAKISJiWeQGGFSzzDHRulp3XRgOy6LI+88c6hey9uYlFVGJTRvSOs2iKMWP5jFzPh8QqaJjNEzaAQATAaEjajqLph6dmUVR70wNiGlna9a03fl8MRwMRsMBujTXaVH06vUb3/v2t37rN37jsec+dvPxJyaTrfsPju49ONrf3a4QY9fMcJ4//vztOt+qfjC5fFDXq259EVZLKo2cs7ZC56wDIEw7kpA9Gk55eV7s/R4+dyb2U9dn+wcHP3zllV/+f/7SeDLcPzjQGIej0WA4+vY3vjHd3nvm2We6NrRdxz7L8/z8/ByRiLgLscwz79yqquq6ds4NBgMijqL9gCUiM6GioCixBQkSY9uxybDIQ5s39YD/+t/6O6IISMwEpmkVFTMRYkilENAziyggZN6l9pOJM+9XdT1frvMiH5SFd248ne7s7n77m1//+3/v/8xZ9olPf+axJ5+5/vjjiHz3/iEiiCqxW9RhUnIzvHxx8uB6XivnoarSxg5il1Yjg0nv5iQnQCV0BPB77S23c/3pbffuO+9+/Q//4B/9P/7vEsNzz3/MM/ssGwyHly5fzfL8/fdvF4PhlatXs9zHLnjv5xcXg+GwyHNmLPPM1E7PzkOI4/E4L/LUXEdVBMyYKQ1NhuCYuq4Vw7SNazQcrBYXsWtcf7oAaiCijgABRY37pVXGmwl1EQ3R8oxAQUAHZXFt/9I7H9wLIVza2w1RvvO9737j69/45te+Nt3Z/dRnPn/56rWD/f1BWdjB/sMHD//4e99fLi6y3H/yE59sV8syH75TPF28+YcvPLFPxdBncUMKUWpBBBUJwGKGnZp9qXlCdx57bAj/za/82je+/vV6vdjd3f3ox57LMw9mzmd5UZaD4dUbj1/Ml6+88urDo+Onn3ryYH9/PJ4w83yxmI5HzrGBVVXVNDU7nxd5v+oHjBAdpyUqFkXapmF2TRfJZxpilmeqFmOkfr+DGZKJgmK6lyBq7JDZMcUuyd8bKhyBU5+KhNPx8Mr+XtuFf/nbv/O9737v8Pho/+DK3/h3/tb27u54NJyMhmbmHYMB7O9Ftft37d2332qefurKk4+tqtVguvMnR9e3P3jn4PqNwBkDbv5ClYhRyDOjUmy+Cx/hx1+8qct/9A//4Zd///cuXzm4fuP6lWvXtqYjDV0+GGZZUQ4GRVE6n+1dvrJ/5ep77777ne+8tLU1u3rt6sXZ6d6lfZ9lmaPQhWVVqekgy8q8QKI2iiNyjMkTGUNcrVZN2w6HTgwY2aTxrmiaBgDIeQcAjklNEbmL6hxmjjR2IRqz896LdlFUVJPHII0KSdQg4pn3d7dv3z985/a9rd39f/N/+dceu3mjbZqqacAEEWOUtGNiNCivXdnPi3w0HL32+lti+MxTj18du+PZzW/cP/wLxYPBweNAjgghsZ8ISAzsCmgezj7els+cvP7y/+df/Ob3vvOdq9eu7l+99tTTzwzLbHVxPphuDUfjPM/LwcD5jIicc4P9S3t7e4vl4v69B2+9/d5oPNjf38+cM4nrqm7bNnNZWRTEpAaO+4+EST7OtmtX6zUAiqghqZlznHlfr5YSA6M5YmZCjYqguXdt6DyzY667zhtk3hVZ1nSdAYhaTJ/8hWSWlBdwBJf3tn/xF3627mSYZ816SYgOevHOMROCiDBzmefb00nmnPP+zbfeuXPv/vPPPH15e/Ze9dwrR9/+zOhEp1cAmZgRjThTkSk0zfZTf/hg+K9/5x986ytfBsSDq5ev3Xz8+Y+/MBoOTg8fDIbDydZOkefOueGwdM6bGRMjE7KfjEeXDw7atmPH25MhmFZNW1UVIOZF4bPMzJKJDDbym5qtq7ptmuFwVLctAhFCVPPeOSZTBe9cssFCGpT2HGPsYsy9Zwwi0pl557z3iBKl/9UvLgYSszaIZx4Xvmvbs/N1VeeT0SD3Pk2nIxhC+gQfUrPJsHRMopeGo9HZ2dn3fvj6J569NRmOfri4cfnBu9eykWZDynLOXIwyxg5He7/y3Ytf/+J/357ee/yppw157+DKpz/1qWHp796+7bNse3uHnSvy3DnOs5wIY0wvj9IApmMaDgrHyIhdF9q2DTGmz4xh12/7MAPmfmaiC6Gpq7ZtRsMREwexdrXYmowRKYoAGAC61DZHUUBO1k5Jpiqk9NFzSMiESuQBDCCEAJlPNGTGjAAhRud4ZzJGgKoN89V6MiiZGBGI+3bPp3kV7xCxC1Lm2XA4nC9XR/P62q6fz66+fHG+c3IvO3jCAnozp2G8tfXLr4Rf/5df253kV5/7s8VgVA4GTz9xczwobt9+3wAO9g+GoyFhb1ko8jzEYGBM5J0jItvYttj5xFx0XRejjEejMs9pY5xIrQYBJKtA17USJZo6YocUurYsihDicrHs2o7Yu/QZeWZG/UQdARggMJGomJiIIqcBsDSKQ2lVrwEagHMOEZuuKzK/NR3zqm67rm66BEc8oEvzQ9B/qEaRZdOx1U1bFMV4NDpdrM4bvTobnvJzr1589+PFQ5tdAcMr0+xbp+X/9K0fPHEwvXnz5mS2XQ4Gj13ZzQjvP3zYdN3B5YO9nZ0owukDDpiI2CAm88HGhIBmkKznQSRGadqWEDLvnWeDNN6BzKiS5F0VkdCFjehrgOqdR+bQdV1TmWmWF2kXIyNiUzfALi/K0NaqxoSeOaikZrXfEwTmHq0qMSBEQ/DOiWrThTLz42HhGDeDxBZCNOO0IQwxZVsssgwRzSxE2ZmNTy/W58t6/9Kl9+3j5eFLt9xZOd0+sdlv/uBoe+iefeJjOzs7RZFvT0YZw8Pj0+W62prNdnd22bGlma+0MAPREaNP7HKSSo2IMschxrZtu7YT0Szz7H3agkHJKGZpxskkStO0bdMQpQ+spXVV5cyEJCGE0AKyy4r/HyznW757mleZAAAAAElFTkSuQmCC"
+        "issuing_country" = "NZ"
+        "issuing_authority" = "Kiwi Access Authority"
+        "sex" = "female"
+        "card_type" = "EvidenceOfAge"
+        "age_over_18" = true
+        "age_over_21" = true
+        "age_over_25" = true
+        "age_over_60" = false
+      }
+    }
+    mapping = {
+      "display" = "<display>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:1825d>"
+    }
+  }
+
+  kycChecksCredential = {
+    name = "KycChecksCredential"
+    credentialConfigurationId = "KycChecksCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "KycChecksCredential"]
+      "credentialSubject" = {
+        "type" = "KYC"
+        "result" = "SUCCESS"
+        "date" = "2023-07-10T14:45:10+02:00"
+        "checks" = [
+          {
+            "type" = "PEP"
+            "result" = "SUCCESS"
+            "date" = "2023-07-10T14:45:10+02:00"
+          },
+          {
+            "type" = "AML"
+            "result" = "SUCCESS"
+            "date" = "2023-07-10T14:45:10+02:00"
+          },
+          {
+            "type" = "KYC"
+            "result" = "SUCCESS"
+            "date" = "2023-07-10T14:45:10+02:00"
+          }
+        ]
+      }
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "image" = {
+          "id" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+          "type" = "Image"
+        }
+        "name" = "CH Authority"
+        "type" = "Profile"
+        "url" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "evidence" = {
+        "documentPresence" = "Digital"
+        "evidenceDocument" = "KYC"
+        "subjectPresence" = "Physical"
+        "type" = "DocumentVerification"
+        "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
 
   kycCredential = {
     name = "KycCredential"
@@ -207,6 +773,302 @@ profiles = {
     }
   }
 
+  kycDataCredential = {
+    name = "KycDataCredential"
+    credentialConfigurationId = "KycDataCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "KycDataCredential"]
+      "credentialSubject" = {
+        "identificationprocess" = {
+          "agentname" = "TROBOT"
+          "companyId" = "1234"
+          "result" = "SUCCESS"
+          "identificationTime" = "2023-07-10T14:45:10+02:00"
+          "identificationId" = "TST-ELXNG"
+          "transactionNumber" = "1234"
+          "type" = "APP"
+        }
+        "userData" = {
+          "dateOfBirth" = "1993-04-08"
+          "familyName" = "DOE"
+          "firstName" = "Jane"
+        }
+        "identificationdocument" = {
+          "type" = "IDCARD"
+          "country" = "DE"
+          "validuntil" = "2034-08-01"
+          "number" = "L01X00T27"
+          "dateissued" = "2021-08-31"
+        }
+        "performedKycChecks" = {
+          "livenessscreenshot" = true
+          "securityfeaturevideo" = true
+        }
+      }
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "image" = {
+          "id" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+          "type" = "Image"
+        }
+        "name" = "CH Authority"
+        "type" = "Profile"
+        "url" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "evidence" = {
+        "documentPresence" = "Digital"
+        "evidenceDocument" = "KYC"
+        "subjectPresence" = "Physical"
+        "type" = "DocumentVerification"
+        "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  legalPerson = {
+    name = "LegalPerson"
+    credentialConfigurationId = "LegalPerson_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:LegalPerson"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "Legal Person"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "type" = "gx:LegalPerson"
+        "gx:legalName" = "Example Org"
+        "gx:legalRegistrationNumber" = {
+          "id" = "https://example.org/gaiax-legal-registration-number/68a5bbea9518e7e2ac1cc75bcc8819a7edd5c4711e073ffa4bb260034dc6423c/data.json"
+        }
+        "gx:headquarterAddress" = {
+          "gx:countrySubdivisionCode" = "FR-75"
+        }
+        "gx:legalAddress" = {
+          "gx:countrySubdivisionCode" = "FR-75"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  legalRegistrationNumberEORI = {
+    name = "LegalRegistrationNumberEORI"
+    credentialConfigurationId = "LegalRegistrationNumberEORI_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:EORI"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "EORI Registration Number"
+      "description" = "Economic Operators Registration and Identification registration number"
+      "credentialSubject" = {
+        "id" = "https://example.org/subjects/123"
+        "type" = "gx:EORI"
+        "gx:eori" = "FR53740792600014"
+        "gx:country" = ""
+      }
+      "evidence" = {
+        "gx:evidenceOf" = "gx:EORI"
+        "gx:evidenceURL" = "https://ec.europa.eu/taxation_customs/dds2/eos/validation/services/validation"
+        "gx:executionDate" = "2025-09-17T09:16:14.928+00:00"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  legalRegistrationNumberLeiCode = {
+    name = "LegalRegistrationNumberLeiCode"
+    credentialConfigurationId = "LegalRegistrationNumberLeiCode_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1"]
+      "type" = ["VerifiableCredential", "gx:LeiCode"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "@context" = "https://registry.lab.gaia-x.eu/development/api/trusted-shape-registry/v1/shapes/jsonld/trustframework#"
+        "type" = "gx:legalRegistrationNumber"
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "gx:leiCode" = "391200FJBNU0YW987L26"
+        "gx:leiCode-countryCode" = "DE"
+      }
+      "evidence" = [
+        {
+          "gx:evidenceURL" = "https://api.gleif.org/api/v1/lei-records/"
+          "gx:executionDate" = "2025-02-23T16:42:16.058Z"
+          "gx:evidenceOf" = "gx:leiCode"
+        }
+      ]
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  legalRegistrationNumberVatId = {
+    name = "LegalRegistrationNumberVatId"
+    credentialConfigurationId = "LegalRegistrationNumberVatId_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:VatID"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "https://example.org/subjects/123"
+        "type" = "gx:VatID"
+        "gx:vatID" = "BE0762747721"
+        "gx:countryCode" = "BE"
+      }
+      "evidence" = {
+        "gx:evidenceOf" = "gx:VatID"
+        "gx:evidenceURL" = "http://ec.europa.eu/taxation_customs/vies/services/checkVatService"
+        "gx:executionDate" = "2025-09-17T09:11:13.643+00:00"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  mortgageEligibility = {
+    name = "MortgageEligibility"
+    credentialConfigurationId = "MortgageEligibility_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "MortgageEligibility"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "salutation" = ""
+        "familyName" = ""
+        "firstName" = ""
+        "emailAddress" = ""
+        "dateOfBirth" = ""
+        "purchasePrice" = ""
+        "totalIncome" = ""
+        "mortgageAmount" = ""
+        "additionalCollateral" = ""
+        "postCodeProperty" = ""
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "issued" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  naturalPersonVerifiableID = {
+    name = "NaturalPersonVerifiableID"
+    credentialConfigurationId = "NaturalPersonVerifiableID_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "NaturalPersonVerifiableID"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "familyName" = "Doe"
+        "firstName" = "Jane"
+        "dateOfBirth" = "1985-08-15"
+        "personalIdentifier" = "c02654b4-814e-46dd-ba17-0bd81a45057c"
+        "nameAndFamilyNameAtBirth" = "Jane Doe"
+        "placeOfBirth" = "Lille, France"
+        "currentAddress" = "1 Boulevard de la Liberté, 59800 Lille"
+        "gender" = "Female"
+      }
+      "credentialSchema" = {
+        "id" = "https://api-conformance.ebsi.eu/trusted-schemas-registry/v3/schemas/z22ZAMdQtNLwi51T2vdZXGGZaYyjrsuP1yzWyXZirCAHv"
+        "type" = "FullJsonSchemaValidator2021"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp-ebsi>"
+      "issued" = "<timestamp-ebsi>"
+      "expirationDate" = "<timestamp-ebsi-in:365d>"
+    }
+  }
 
   openBadgeCredential = {
     name = "OpenBadgeCredential"
@@ -255,6 +1117,121 @@ profiles = {
         "id" = "<subjectDid>"
       }
       "validFrom" = "<timestamp>"
+    }
+  }
+
+  passportCh = {
+    name = "PassportCh"
+    credentialConfigurationId = "PassportCh_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "PassportCh"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "image" = {
+          "id" = "https://img.freepik.com/premium-photo/swiss-flag-switzerland_469558-1774.jpg"
+          "type" = "Image"
+        }
+        "name" = "CH Authority"
+        "type" = "Profile"
+        "url" = "https://img.freepik.com/premium-photo/swiss-flag-switzerland_469558-1774.jpg"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "residence" = "Schweiz"
+        "canton" = "Zürich"
+        "address" = "Seestraße 1"
+        "passportNumber" = "C7648556"
+        "salutation" = ""
+        "familyName" = "DOE"
+        "givenName" = "Hans"
+        "birthName" = "Doe"
+        "dateOfBirth" = "1930-10-01"
+        "emailAddress" = ""
+        "placeOfBirth" = "Zug"
+        "height" = "179"
+        "gender" = "M"
+        "authority" = "Aarau AG"
+        "nationality" = "Schweiz"
+        "countryCode" = "CHE"
+        "passportPhoto" = "data:image/png;base64,iVBORw0KGgo...kJggg=="
+      }
+      "evidence" = {
+        "documentPresence" = "Physical"
+        "evidenceDocument" = "Passport"
+        "subjectPresence" = "Physical"
+        "type" = "DocumentVerification"
+        "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  photoIDCredential = {
+    name = "PhotoIDCredential"
+    credentialConfigurationId = "PhotoIDCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://domain.com/photoid.json"]
+      "id" = "urn:uuid:123"
+      "type" = ["VerifiableCredential", "PhotoIDCredential"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "iso23220" = {
+          "family_name_unicode" = "Doe"
+          "given_name_unicode" = "John"
+          "birth_date" = "1990-01-01"
+          "portrait" = "base64-image-data"
+          "issue_date" = "2025-01-01"
+          "expiry_date" = "2035-01-01"
+          "issuing_authority_unicode" = "Gov Authority"
+          "issuing_country" = "US"
+          "age_over_18" = true
+        }
+        "photoid" = {
+          "person_id" = "PID123456"
+          "birth_country" = "US"
+          "birth_state" = "CA"
+          "birth_city" = "Los Angeles"
+        }
+        "dtc" = {
+          "dtc_dg1" = "MRZDATA=="
+          "dtc_dg2" = "FACEIMAGE=="
+          "dtc_sod" = "SODDATA=="
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
     }
   }
 
@@ -385,6 +1362,514 @@ profiles = {
     }
   }
 
+  taxCredential = {
+    name = "TaxCredential"
+    credentialConfigurationId = "TaxCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "urn:uuid:4e7f3c21-5d8b-4f2a-9b11-1c2d3e4f5a67"
+      "type" = ["VerifiableCredential", "TaxCredential"]
+      "issuer" = "did:gov:US:irs"
+      "issuanceDate" = "2025-04-15T14:00:00Z"
+      "expirationDate" = "2026-04-14T23:59:59Z"
+      "evidence" = [
+        {
+          "type" = "TaxAssessmentRecord"
+          "assessmentReference" = "IRS-2024-5087321"
+          "assessedAt" = "2025-04-05"
+          "source" = "Internal Revenue Service Masterfile"
+        }
+      ]
+      "credentialSubject" = {
+        "id" = "did:wallet:us-7890abcd"
+        "person" = {
+          "givenName" = "John"
+          "familyName" = "Doe"
+          "dateOfBirth" = "1988-06-22"
+          "tin" = "US-98-7654321"
+          "taxResidency" = {
+            "countryCode" = "US"
+          }
+          "address" = {
+            "street" = "742 Evergreen Terrace"
+            "city" = "Springfield"
+            "postalCode" = "62704"
+            "countryCode" = "US"
+          }
+        }
+        "assessmentSummary" = {
+          "taxYear" = 2024
+          "filingStatus" = "single"
+          "incomeStabilityYears" = 4
+          "employmentStatus" = "employee"
+          "employerCount" = 1
+          "incomeBreakdown" = {
+            "employmentIncome" = {
+              "amount" = 87500
+              "currency" = "USD"
+            }
+            "selfEmploymentIncome" = {
+              "amount" = 4500
+              "currency" = "USD"
+            }
+            "capitalIncome" = {
+              "amount" = 2500
+              "currency" = "USD"
+            }
+          }
+          "grossIncomeTotal" = {
+            "amount" = 94500
+            "currency" = "USD"
+          }
+          "deductionsTotal" = {
+            "amount" = 12500
+            "currency" = "USD"
+          }
+          "taxableIncome" = {
+            "amount" = 82000
+            "currency" = "USD"
+          }
+          "taxDueTotal" = {
+            "amount" = 15200
+            "currency" = "USD"
+          }
+          "withholdingPaid" = {
+            "amount" = 15000
+            "currency" = "USD"
+          }
+          "balanceOrRefund" = {
+            "amount" = 200
+            "currency" = "USD"
+            "direction" = "owed"
+          }
+          "socialContributionsPaid" = {
+            "amount" = 3100
+            "currency" = "USD"
+          }
+        }
+        "clearance" = {
+          "status" = "inGoodStanding"
+          "asOf" = "2025-04-05"
+        }
+        "derivedForLending" = {
+          "annualNetIncomeEstimate" = {
+            "amount" = 67800
+            "currency" = "USD"
+          }
+          "monthlyNetIncomeEstimate" = {
+            "amount" = 5650
+            "currency" = "USD"
+          }
+          "incomeVerificationConfidence" = "taxAuthorityVerified"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+      "evidence" = [
+        {
+          "assessmentReference" = "<assessmentReference>"
+          "assessedAt" = "<date>"
+          "source" = "<source>"
+        }
+      ]
+    }
+  }
+
+  taxReceipt = {
+    name = "TaxReceipt"
+    credentialConfigurationId = "TaxReceipt_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "TaxReceipt"]
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "ReceiptId" = "string"
+        "VAT" = "string"
+      }
+      "evidence" = [
+        {
+          "documentPresence" = ["Physical"]
+          "evidenceDocument" = ["Passport"]
+          "subjectPresence" = "Physical"
+          "type" = ["DocumentVerification"]
+          "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+        }
+      ]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Tax Authority"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  universityDegree = {
+    name = "UniversityDegree"
+    credentialConfigurationId = "UniversityDegree_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"]
+      "id" = "http://example.gov/credentials/3732"
+      "type" = ["VerifiableCredential", "UniversityDegree"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "degree" = {
+          "type" = "BachelorDegree"
+          "name" = "Bachelor of Science and Arts"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  vaccinationCertificate = {
+    name = "VaccinationCertificate"
+    credentialConfigurationId = "VaccinationCertificate_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "credentialSchema" = {
+        "id" = "https://raw.githubusercontent.com/walt-id/waltid-ssikit-vclib/master/src/test/resources/schemas/VerifiableVaccinationCertificate.json"
+        "type" = "JsonSchemaValidator2018"
+      }
+      "credentialStatus" = {
+        "id" = "https://essif.europa.eu/status/covidvaccination#392ac7f6-399a-437b-a268-4691ead8f176"
+        "type" = "CredentialStatusList2020"
+      }
+      "credentialSubject" = {
+        "dateOfBirth" = "1993-04-08"
+        "familyName" = "DOE"
+        "givenNames" = "Jane"
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "personIdentifier" = "optional The type of identifier and identifier of the person, according to the policies applicable in each country. Examples are citizen ID and/or document number (ID- card/passport) or identifier within the health system/IIS/e-registry."
+        "personSex" = "optional"
+        "uniqueCertificateIdentifier" = "UVCI0904008084H"
+        "vaccinationProphylaxisInformation" = [
+          {
+            "administeringCentre" = "Name/code of administering centre or a health authority responsible for the vaccination event"
+            "batchNumber" = "optional 1234"
+            "countryOfVaccination" = "DE"
+            "dateOfVaccination" = "2021-02-12"
+            "diseaseOrAgentTargeted" = {
+              "code" = "840539006"
+              "system" = "2.16.840.1.113883. 6.96"
+              "version" = "2021-01-31"
+            }
+            "doseNumber" = "1"
+            "marketingAuthorizationHolder" = "Example Vaccine Manufacturing Company"
+            "nextVaccinationDate" = "optional - 2021-03-28"
+            "totalSeriesOfDoses" = "2"
+            "vaccineMedicinalProduct" = "VACCINE concentrate for dispersion for injection"
+            "vaccineOrProphylaxis" = "1119349007 COVID-19 example vaccine"
+          }
+        ]
+      }
+      "evidence" = {
+        "documentPresence" = ["Physical"]
+        "evidenceDocument" = ["Passport"]
+        "id" = "https://essif.europa.eu/tsr-va/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d5678"
+        "subjectPresence" = "Physical"
+        "type" = ["DocumentVerification"]
+        "verifier" = "did:ebsi:2962fb784df61baa267c8132497539f8c674b37c1244a7a"
+      }
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VaccinationCertificate"]
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  verifiableId = {
+    name = "VerifiableId"
+    credentialConfigurationId = "VerifiableId_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifiableId"]
+      "credentialSchema" = {
+        "id" = "https://api.preprod.ebsi.eu/trusted-schemas-registry/v1/schemas/0xb77f8516a965631b4f197ad54c65a9e2f9936ebfb76bae4906d33744dbcc60ba"
+        "type" = "FullJsonSchemaValidator2021"
+      }
+      "credentialSubject" = {
+        "currentAddress" = ["1 Boulevard de la Liberté, 59800 Lille"]
+        "dateOfBirth" = "1993-04-08"
+        "familyName" = "DOE"
+        "firstName" = "Jane"
+        "gender" = "FEMALE"
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "nameAndFamilyNameAtBirth" = "Jane DOE"
+        "personalIdentifier" = "0904008084H"
+        "placeOfBirth" = "LILLE, FRANCE"
+      }
+      "evidence" = [
+        {
+          "documentPresence" = ["Physical"]
+          "evidenceDocument" = ["Passport"]
+          "subjectPresence" = "Physical"
+          "type" = ["DocumentVerification"]
+          "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+        }
+      ]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "validFrom" = "2021-08-31T00:00:00Z"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  verifiablePortableDocumentA1 = {
+    name = "VerifiablePortableDocumentA1"
+    credentialConfigurationId = "VerifiablePortableDocumentA1_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifiablePortableDocumentA1"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "section1" = {
+          "personalIdentificationNumber" = "1"
+          "sex" = "01"
+          "surname" = "Jane"
+          "forenames" = "Doe"
+          "dateBirth" = "1985-08-15"
+          "nationalities" = ["BE"]
+          "stateOfResidenceAddress" = {
+            "streetNo" = "sss, nnn "
+            "postCode" = "ppp"
+            "town" = "ccc"
+            "countryCode" = "BE"
+          }
+          "stateOfStayAddress" = {
+            "streetNo" = "sss, nnn "
+            "postCode" = "ppp"
+            "town" = "ccc"
+            "countryCode" = "BE"
+          }
+        }
+        "section2" = {
+          "memberStateWhichLegislationApplies" = "DE"
+          "startingDate" = "2022-10-09"
+          "endingDate" = "2022-10-29"
+          "certificateForDurationActivity" = true
+          "determinationProvisional" = false
+          "transitionRulesApplyAsEC8832004" = false
+        }
+        "section3" = {
+          "postedEmployedPerson" = false
+          "employedTwoOrMoreStates" = false
+          "postedSelfEmployedPerson" = true
+          "selfEmployedTwoOrMoreStates" = true
+          "civilServant" = true
+          "contractStaff" = false
+          "mariner" = false
+          "employedAndSelfEmployed" = false
+          "civilAndEmployedSelfEmployed" = true
+          "flightCrewMember" = false
+          "exception" = false
+          "exceptionDescription" = ""
+          "workingInStateUnder21" = false
+        }
+        "section4" = {
+          "employee" = false
+          "selfEmployedActivity" = true
+          "nameBusinessName" = "1"
+          "registeredAddress" = {
+            "streetNo" = "1, 1 1"
+            "postCode" = "1"
+            "town" = "1"
+            "countryCode" = "DE"
+          }
+        }
+        "section5" = {
+          "noFixedAddress" = true
+        }
+        "section6" = {
+          "name" = "National Institute for the Social Security of the Self-employed (NISSE)"
+          "address" = {
+            "streetNo" = "Quai de Willebroeck 35"
+            "postCode" = "1000"
+            "town" = "Bruxelles"
+            "countryCode" = "BE"
+          }
+          "institutionID" = "NSSIE/INASTI/RSVZ"
+          "officeFaxNo" = ""
+          "officePhoneNo" = "0800 12 018"
+          "email" = "info@rsvz-inasti.fgov.be"
+          "date" = "2022-10-28"
+          "signature" = "Official signature"
+        }
+      }
+      "credentialSchema" = {
+        "id" = "https://api-conformance.ebsi.eu/trusted-schemas-registry/v3/schemas/z5qB8tydkn3Xk3VXb15SJ9dAWW6wky1YEoVdGzudWzhcW"
+        "type" = "FullJsonSchemaValidator2021"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp-ebsi>"
+      "issued" = "<timestamp-ebsi>"
+      "expirationDate" = "<timestamp-ebsi-in:365d>"
+    }
+  }
+
+  visa = {
+    name = "Visa"
+    credentialConfigurationId = "Visa_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "Visa"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "firstName" = "John"
+        "lastName" = "Doe"
+        "passportNumber" = "G7F2A04F7O"
+        "dateOfBirth" = "1980-01-01"
+        "gender" = "Male"
+        "nationality" = "US"
+        "visaType" = "Tourist"
+        "entryNumber" = "Single"
+        "visaValidity" = {
+          "start" = "2024-01-01"
+          "end" = "2024-06-30"
+        }
+        "purposeOfVisit" = "Tourism"
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Embassy of Wonderland"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  walletHolderCredential = {
+    name = "WalletHolderCredential"
+    credentialConfigurationId = "WalletHolderCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "ndid:context:walletHolder"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "WalletHolderCredential"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "walletHolderCredential" = {
+          "firstName" = "สมศักดิ์"
+          "lastName" = "มั่งมี"
+          "address" = "92/222 ซอยเสรีไทย  กรุงเทพมหานคร 10240 THAILAND"
+          "identifier" = "3199611153090"
+          "namespace" = "citizen_id"
+          "serviceID" = "001.cust_info_001"
+          "requestID" = "1f8ba8218162e354c028be342f507517e6bbceae9af3ff689551eea3981a0189"
+          "requestMessage" = "ท่านกำลังยืนยันตัวตนเพื่อใช้ตามวัตถุประสงค์ของ National Digital ID Wallet และประสงค์ให้ส่งข้อมูลจาก ธนาคารกรุงศรี (Transaction Ref: 31817034)"
+          "salt" = "tlVqHnQ8HfipI9r2WnL83QPH6Z01yBo0DQaQv7RyYSQ="
+          "aal" = 2.2
+          "ial" = 2.3
+          "idp" = "DC9E1ACB-D450-438F-9558-FE7672F3F3EB"
+        }
+      }
+      "credentialStatus" = {
+        "id" = "0x2ef196ba560d7d72f13d80f405841bc84cec229b70a0a05557c5388d215bb224"
+        "type" = "NDIDCredentialStatus2021"
+      }
+      "credentialSchema" = {
+        "id" = "ndid:schema:walletHolder"
+        "type" = "JsonSchemaValidator2018"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
 
   isoMdl = {
     name = "ISO 18013-5 Mobile Driving License"

--- a/waltid-services/waltid-issuer-api2/config/credential-issuer-metadata.conf
+++ b/waltid-services/waltid-issuer-api2/config/credential-issuer-metadata.conf
@@ -49,6 +49,126 @@ credentialConfigurations = {
     }
   }
 
+  "BoardingPass_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "BoardingPass_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "BoardingPass"]
+    }
+  }
+
+  "DataspaceParticipantCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "DataspaceParticipantCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "DataspaceParticipantCredential"]
+    }
+  }
+
+  "EducationalID_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "EducationalID_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "EducationalID"]
+    }
+  }
+
+  "eID_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "eID_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "eID"]
+    }
+  }
+
+  "EmailVerificationCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "EmailVerificationCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "EmailVerificationCredential"]
+    }
+  }
+
+  "EnrollmentCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "EnrollmentCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "EnrollmentCredential"]
+    }
+  }
+
+  "ePassport_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "ePassport_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "ePassport"]
+    }
+  }
+
+  "GaiaXTermsAndConditions_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "GaiaXTermsAndConditions_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:Issuer"]
+    }
+  }
+
   "HotelReservation_jwt_vc_json" = {
     format = "jwt_vc_json"
     scope = "HotelReservation_jwt_vc_json"
@@ -61,6 +181,66 @@ credentialConfigurations = {
     }
     credential_definition = {
       type = ["VerifiableCredential", "HotelReservation"]
+    }
+  }
+
+  "IdentityCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "IdentityCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "IdentityCredential"]
+    }
+  }
+
+  "Iso18013DriversLicenseCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "Iso18013DriversLicenseCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "Iso18013DriversLicenseCredential"]
+    }
+  }
+
+  "KiwiAccessCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "KiwiAccessCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "KiwiAccessCredential"]
+    }
+  }
+
+  "KycChecksCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "KycChecksCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "KycChecksCredential"]
     }
   }
 
@@ -79,6 +259,111 @@ credentialConfigurations = {
     }
   }
 
+  "KycDataCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "KycDataCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "KycDataCredential"]
+    }
+  }
+
+  "LegalPerson_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalPerson_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:LegalPerson"]
+    }
+  }
+
+  "LegalRegistrationNumberEORI_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalRegistrationNumberEORI_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:EORI"]
+    }
+  }
+
+  "LegalRegistrationNumberLeiCode_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalRegistrationNumberLeiCode_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:LeiCode"]
+    }
+  }
+
+  "LegalRegistrationNumberVatId_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "LegalRegistrationNumberVatId_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "gx:VatID"]
+    }
+  }
+
+  "MortgageEligibility_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "MortgageEligibility_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "MortgageEligibility"]
+    }
+  }
+
+  "NaturalPersonVerifiableID_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "NaturalPersonVerifiableID_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "NaturalPersonVerifiableID"]
+    }
+  }
+
   "OpenBadgeCredential_jwt_vc_json" = {
     format = "jwt_vc_json"
     scope = "OpenBadgeCredential_jwt_vc_json"
@@ -94,6 +379,35 @@ credentialConfigurations = {
     }
   }
 
+  "PassportCh_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "PassportCh_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "PassportCh"]
+    }
+  }
+
+  "PhotoIDCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "PhotoIDCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "PhotoIDCredential"]
+    }
+  }
 
   "PND91Credential_jwt_vc_json" = {
     format = "jwt_vc_json"
@@ -122,6 +436,126 @@ credentialConfigurations = {
     }
     credential_definition = {
       type = ["VerifiableCredential", "ProofOfAddress"]
+    }
+  }
+
+  "TaxCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "TaxCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "TaxCredential"]
+    }
+  }
+
+  "TaxReceipt_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "TaxReceipt_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "TaxReceipt"]
+    }
+  }
+
+  "UniversityDegree_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "UniversityDegree_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "UniversityDegree"]
+    }
+  }
+
+  "VaccinationCertificate_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "VaccinationCertificate_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VaccinationCertificate"]
+    }
+  }
+
+  "VerifiableId_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "VerifiableId_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifiableId"]
+    }
+  }
+
+  "VerifiablePortableDocumentA1_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "VerifiablePortableDocumentA1_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "VerifiablePortableDocumentA1"]
+    }
+  }
+
+  "Visa_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "Visa_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "VerifiableAttestation", "Visa"]
+    }
+  }
+
+  "WalletHolderCredential_jwt_vc_json" = {
+    format = "jwt_vc_json"
+    scope = "WalletHolderCredential_jwt_vc_json"
+    credential_signing_alg_values_supported = ["ES256"]
+    cryptographic_binding_methods_supported = ["jwk", "did:key", "did:web", "did:jwk", "did:ebsi"]
+    proof_types_supported = {
+      jwt = {
+        proof_signing_alg_values_supported = ["ES256"]
+      }
+    }
+    credential_definition = {
+      type = ["VerifiableCredential", "WalletHolderCredential"]
     }
   }
 

--- a/waltid-services/waltid-issuer-api2/config/issuer2-profiles.conf
+++ b/waltid-services/waltid-issuer-api2/config/issuer2-profiles.conf
@@ -109,6 +109,340 @@ profiles = {
     }
   }
 
+  boardingPass = {
+    name = "BoardingPass"
+    credentialConfigurationId = "BoardingPass_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "BoardingPass"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "firstName" = "John"
+        "lastName" = "Doe"
+        "seat" = "1A"
+        "flight" = "LH123"
+        "date" = "09/01/2021"
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Airline"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  dataspaceParticipantCredential = {
+    name = "DataspaceParticipantCredential"
+    credentialConfigurationId = "DataspaceParticipantCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "DataspaceParticipantCredential"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "deltaDAO AG"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "type" = "DataspaceParticipant"
+        "dataspaceId" = "Pontus-X"
+        "legalName" = "deltaDAO AG"
+        "website" = "https://www.delta-dao.com"
+        "legalAddress" = {
+          "countryCode" = "DE"
+          "streetAddress" = "Katharinenstraße 30a"
+          "postalCode" = "20457"
+          "locality" = "Hamburg"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  educationalID = {
+    name = "EducationalID"
+    credentialConfigurationId = "EducationalID_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://europa.eu/schemas/v-id/2020/v1", "https://europa.eu/schemas/eidas/2020/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "EducationalID"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "identifier" = [
+          {
+            "schemeID" = "European Student Identifier"
+            "value" = "urn:schac:personalUniqueCode:int:esi:math.example.edu:xxxxxxxxxx"
+            "id" = "urn:schac:personalUniqueCode:int:esi:university.eu:firstlast@email.eu"
+          }
+        ]
+        "schacPersonalUniqueID" = "urn:schac:personalUniqueID:int:passport:{COUNTRY_CODE}:{PASSPORT_CODE}"
+        "commonName" = "Frist Last"
+        "displayName" = "Frist Last"
+        "firstName" = "Frist"
+        "familyName" = "Ferreira"
+        "dateOfBirth" = "19730429"
+        "schacHomeOrganization" = " "
+        "mail" = "first.last@university.eu"
+        "eduPersonPrincipalName" = "first.last@university.eu"
+        "eduPersonPrimaryAffiliation" = "student"
+        "schacPersonalUniqueCode" = "urn:schac:personalUniqueCode:int:esi:university.eu:firstlast@email.eu"
+        "eduPersonAffiliation" = [
+          {
+            "value" = "student, staff"
+          }
+        ]
+        "eduPersonScopedAffiliation" = [
+          {
+            "value" = "student@university.eu, staff@university.eu"
+          }
+        ]
+        "eduPersonAssurance" = [
+          {
+            "value" = "student, staff"
+          }
+        ]
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "issued" = "<timestamp>"
+    }
+  }
+
+  eID = {
+    name = "eID"
+    credentialConfigurationId = "eID_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "eID"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Department of Home Affairs, Cape Town"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "fullName" = "John Doe"
+        "firstName" = "John"
+        "lastName" = "Doe"
+        "nationality" = "ZAF"
+        "documentId" = "123456789"
+        "issuingCountry" = "ZAF"
+        "dateOfBirth" = "1990-04-15"
+        "sex" = "M"
+        "placeOfBirth" = {
+          "country" = "South Africa"
+          "city" = "Johannesburg"
+        }
+        "address" = "123 Kloof Street, Cape Town, 8001, South Africa"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  emailVerificationCredential = {
+    name = "EmailVerificationCredential"
+    credentialConfigurationId = "EmailVerificationCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/email/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "EmailVerificationCredential"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Christine Schmidt"
+        "email" = "user@example.com"
+        "emailVerified" = true
+        "verifiedAt" = "2025-05-12"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  enrollmentCredential = {
+    name = "EnrollmentCredential"
+    credentialConfigurationId = "EnrollmentCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "wiserID" = "10234567"
+        "name" = "Christine Schmidt"
+        "birthDate" = "1984-04-15"
+        "address" = {
+          "streetAddress" = "123 Main St"
+          "postalCode" = "82001"
+          "addressLocality" = "Cheyenne"
+          "addressRegion" = "WY"
+          "addressCountry" = "US"
+        }
+        "program" = "NA1-2024"
+        "enrollmentStatus" = "Enrolled"
+        "startDate" = "2024-09-01"
+        "expectedGraduationDate" = "2028-06-30"
+        "academicYear" = "2024/2025"
+        "currentSemester" = "Spring 2025"
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Eastern Wyoming College"
+      }
+      "type" = ["VerifiableCredential", "EnrollmentCredential"]
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  ePassport = {
+    name = "ePassport"
+    credentialConfigurationId = "ePassport_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "ePassport"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "fullName" = "John Doe"
+        "givenName" = "John"
+        "familyName" = "Doe"
+        "nationality" = "AUT"
+        "residency" = {
+          "country" = "Austria"
+          "countryCode" = "AT"
+          "city" = "Wien"
+        }
+        "passportNumber" = "P12345678"
+        "issuingCountry" = "AUT"
+        "dateOfBirth" = "1990-04-15"
+        "authority" = "Wien"
+        "sex" = "M"
+        "placeOfBirth" = {
+          "country" = "Austria"
+          "city" = "Graz"
+        }
+        "type" = "P"
+        "code" = "AUT"
+        "height" = "182 cm"
+        "eyeColor" = "Brown"
+        "issuanceDate" = "2021-06-15"
+        "expirationDate" = "2031-06-15"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  gaiaXTermsAndConditions = {
+    name = "GaiaXTermsAndConditions"
+    credentialConfigurationId = "GaiaXTermsAndConditions_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:Issuer"]
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "https://delta-dao.com/.well-known/2503_gx_TandC_deltaDAO.json"
+        "gaiaxTermsAndConditions" = "4bd7554097444c960292b4726c2efa1373485e8a5565d94d41195214c5e0ceb3"
+      }
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
   hotelReservation = {
     name = "HotelReservation"
     credentialConfigurationId = "HotelReservation_jwt_vc_json"
@@ -145,6 +479,238 @@ profiles = {
     }
   }
 
+  identityCredential = {
+    name = "IdentityCredential"
+    credentialConfigurationId = "IdentityCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "IdentityCredential"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "given_name" = "John"
+        "family_name" = "Doe"
+        "email" = "johndoe@example.com"
+        "phone_number" = "+1-202-555-0101"
+        "address" = {
+          "street_address" = "123 Main St"
+          "locality" = "Anytown"
+          "region" = "Anystate"
+          "country" = "US"
+        }
+        "birthdate" = "1940-01-01"
+        "is_over_18" = true
+        "is_over_21" = true
+        "is_over_65" = true
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Government of Anytown"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  iso18013DriversLicenseCredential = {
+    name = "Iso18013DriversLicenseCredential"
+    credentialConfigurationId = "Iso18013DriversLicenseCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/vdl/v1", "https://w3id.org/vdl/aamva/v1"]
+      "type" = ["VerifiableCredential", "Iso18013DriversLicenseCredential"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Utopia Department of Motor Vehicles"
+        "url" = "https://dmv.utopia.example/"
+        "image" = "https://dmv.utopia.example/logo.png"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "Utopia Driver's License"
+      "image" = "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUg...kSuQmCC"
+      "description" = "A license granting driving privileges in Utopia."
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "type" = "LicensedDriver"
+        "driversLicense" = {
+          "type" = "Iso18013DriversLicense"
+          "document_number" = "542426814"
+          "family_name" = "TURNER"
+          "given_name" = "SUSAN"
+          "portrait" = "data:image/jpeg;base64,/9j/4AAQSkZJR...RSClooooP/2Q=="
+          "birth_date" = "1998-08-28"
+          "issue_date" = "2023-01-15T10:00:00-07:00"
+          "expiry_date" = "2028-08-27T12:00:00-06:00"
+          "issuing_country" = "UA"
+          "issuing_authority" = "UADMV"
+          "driving_privileges" = [
+            {
+              "codes" = [
+                {
+                  "code" = "D"
+                }
+              ]
+              "vehicle_category_code" = "D"
+              "issue_date" = "2019-01-01"
+              "expiry_date" = "2027-01-01"
+            },
+            {
+              "codes" = [
+                {
+                  "code" = "C"
+                }
+              ]
+              "vehicle_category_code" = "C"
+              "issue_date" = "2019-01-01"
+              "expiry_date" = "2017-01-01"
+            }
+          ]
+          "un_distinguishing_sign" = "UTA"
+          "aamva_aka_suffix" = "1ST"
+          "sex" = 2
+          "aamva_family_name_truncation" = "N"
+          "aamva_given_name_truncation" = "N"
+        }
+      }
+    }
+    mapping = {
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  kiwiAccessCredential = {
+    name = "KiwiAccessCredential"
+    credentialConfigurationId = "KiwiAccessCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "KiwiAccessCredential"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Kiwi Access Authority"
+        "url" = "https://kiwiaccess.co.nz/"
+        "image" = "https://kiwiaccess.co.nz/wp-content/uploads/2018/10/Kiwi-Access-Logo-White.png"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "Kiwi Access Card"
+      "description" = "An official evidence of age and identity card for use across New Zealand."
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "card_number" = "KA123456789"
+        "full_name" = "SUSAN TURNER"
+        "birth_date" = "1998-08-28"
+        "issue_date" = "2023-01-15T10:00:00+13:00"
+        "expiry_date" = "2028-08-27T10:00:00+13:00"
+        "portrait" = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGYAAABmCAIAAAC2vXM1AAAABGdBTUEAALGPC/xhBQAACklpQ0NQc1JHQiBJRUM2MTk2Ni0yLjEAAEiJnVN3WJP3Fj7f92UPVkLY8LGXbIEAIiOsCMgQWaIQkgBhhBASQMWFiApWFBURnEhVxILVCkidiOKgKLhnQYqIWotVXDjuH9yntX167+3t+9f7vOec5/zOec8PgBESJpHmomoAOVKFPDrYH49PSMTJvYACFUjgBCAQ5svCZwXFAADwA3l4fnSwP/wBr28AAgBw1S4kEsfh/4O6UCZXACCRAOAiEucLAZBSAMguVMgUAMgYALBTs2QKAJQAAGx5fEIiAKoNAOz0ST4FANipk9wXANiiHKkIAI0BAJkoRyQCQLsAYFWBUiwCwMIAoKxAIi4EwK4BgFm2MkcCgL0FAHaOWJAPQGAAgJlCLMwAIDgCAEMeE80DIEwDoDDSv+CpX3CFuEgBAMDLlc2XS9IzFLiV0Bp38vDg4iHiwmyxQmEXKRBmCeQinJebIxNI5wNMzgwAABr50cH+OD+Q5+bk4eZm52zv9MWi/mvwbyI+IfHf/ryMAgQAEE7P79pf5eXWA3DHAbB1v2upWwDaVgBo3/ldM9sJoFoK0Hr5i3k4/EAenqFQyDwdHAoLC+0lYqG9MOOLPv8z4W/gi372/EAe/tt68ABxmkCZrcCjg/1xYW52rlKO58sEQjFu9+cj/seFf/2OKdHiNLFcLBWK8ViJuFAiTcd5uVKRRCHJleIS6X8y8R+W/QmTdw0ArIZPwE62B7XLbMB+7gECiw5Y0nYAQH7zLYwaC5EAEGc0Mnn3AACTv/mPQCsBAM2XpOMAALzoGFyolBdMxggAAESggSqwQQcMwRSswA6cwR28wBcCYQZEQAwkwDwQQgbkgBwKoRiWQRlUwDrYBLWwAxqgEZrhELTBMTgN5+ASXIHrcBcGYBiewhi8hgkEQcgIE2EhOogRYo7YIs4IF5mOBCJhSDSSgKQg6YgUUSLFyHKkAqlCapFdSCPyLXIUOY1cQPqQ28ggMor8irxHMZSBslED1AJ1QLmoHxqKxqBz0XQ0D12AlqJr0Rq0Hj2AtqKn0UvodXQAfYqOY4DRMQ5mjNlhXIyHRWCJWBomxxZj5Vg1Vo81Yx1YN3YVG8CeYe8IJAKLgBPsCF6EEMJsgpCQR1hMWEOoJewjtBK6CFcJg4Qxwicik6hPtCV6EvnEeGI6sZBYRqwm7iEeIZ4lXicOE1+TSCQOyZLkTgohJZAySQtJa0jbSC2kU6Q+0hBpnEwm65Btyd7kCLKArCCXkbeQD5BPkvvJw+S3FDrFiOJMCaIkUqSUEko1ZT/lBKWfMkKZoKpRzame1AiqiDqfWkltoHZQL1OHqRM0dZolzZsWQ8ukLaPV0JppZ2n3aC/pdLoJ3YMeRZfQl9Jr6Afp5+mD9HcMDYYNg8dIYigZaxl7GacYtxkvmUymBdOXmchUMNcyG5lnmA+Yb1VYKvYqfBWRyhKVOpVWlX6V56pUVXNVP9V5qgtUq1UPq15WfaZGVbNQ46kJ1Bar1akdVbupNq7OUndSj1DPUV+jvl/9gvpjDbKGhUaghkijVGO3xhmNIRbGMmXxWELWclYD6yxrmE1iW7L57Ex2Bfsbdi97TFNDc6pmrGaRZp3mcc0BDsax4PA52ZxKziHODc57LQMtPy2x1mqtZq1+rTfaetq+2mLtcu0W7eva73VwnUCdLJ31Om0693UJuja6UbqFutt1z+o+02PreekJ9cr1Dund0Uf1bfSj9Rfq79bv0R83MDQINpAZbDE4Y/DMkGPoa5hpuNHwhOGoEctoupHEaKPRSaMnuCbuh2fjNXgXPmasbxxirDTeZdxrPGFiaTLbpMSkxeS+Kc2Ua5pmutG003TMzMgs3KzYrMnsjjnVnGueYb7ZvNv8jYWlRZzFSos2i8eW2pZ8ywWWTZb3rJhWPlZ5VvVW16xJ1lzrLOtt1ldsUBtXmwybOpvLtqitm63Edptt3xTiFI8p0in1U27aMez87ArsmuwG7Tn2YfYl9m32zx3MHBId1jt0O3xydHXMdmxwvOuk4TTDqcSpw+lXZxtnoXOd8zUXpkuQyxKXdpcXU22niqdun3rLleUa7rrStdP1o5u7m9yt2W3U3cw9xX2r+00umxvJXcM970H08PdY4nHM452nm6fC85DnL152Xlle+70eT7OcJp7WMG3I28Rb4L3Le2A6Pj1l+s7pAz7GPgKfep+Hvqa+It89viN+1n6Zfgf8nvs7+sv9j/i/4XnyFvFOBWABwQHlAb2BGoGzA2sDHwSZBKUHNQWNBbsGLww+FUIMCQ1ZH3KTb8AX8hv5YzPcZyya0RXKCJ0VWhv6MMwmTB7WEY6GzwjfEH5vpvlM6cy2CIjgR2yIuB9pGZkX+X0UKSoyqi7qUbRTdHF09yzWrORZ+2e9jvGPqYy5O9tqtnJ2Z6xqbFJsY+ybuIC4qriBeIf4RfGXEnQTJAntieTE2MQ9ieNzAudsmjOc5JpUlnRjruXcorkX5unOy553PFk1WZB8OIWYEpeyP+WDIEJQLxhP5aduTR0T8oSbhU9FvqKNolGxt7hKPJLmnVaV9jjdO31D+miGT0Z1xjMJT1IreZEZkrkj801WRNberM/ZcdktOZSclJyjUg1plrQr1zC3KLdPZisrkw3keeZtyhuTh8r35CP5c/PbFWyFTNGjtFKuUA4WTC+oK3hbGFt4uEi9SFrUM99m/ur5IwuCFny9kLBQuLCz2Lh4WfHgIr9FuxYji1MXdy4xXVK6ZHhp8NJ9y2jLspb9UOJYUlXyannc8o5Sg9KlpUMrglc0lamUycturvRauWMVYZVkVe9ql9VbVn8qF5VfrHCsqK74sEa45uJXTl/VfPV5bdra3kq3yu3rSOuk626s91m/r0q9akHV0IbwDa0b8Y3lG19tSt50oXpq9Y7NtM3KzQM1YTXtW8y2rNvyoTaj9nqdf13LVv2tq7e+2Sba1r/dd3vzDoMdFTve75TsvLUreFdrvUV99W7S7oLdjxpiG7q/5n7duEd3T8Wej3ulewf2Re/ranRvbNyvv7+yCW1SNo0eSDpw5ZuAb9qb7Zp3tXBaKg7CQeXBJ9+mfHvjUOihzsPcw83fmX+39QjrSHkr0jq/dawto22gPaG97+iMo50dXh1Hvrf/fu8x42N1xzWPV56gnSg98fnkgpPjp2Snnp1OPz3Umdx590z8mWtdUV29Z0PPnj8XdO5Mt1/3yfPe549d8Lxw9CL3Ytslt0utPa49R35w/eFIr1tv62X3y+1XPK509E3rO9Hv03/6asDVc9f41y5dn3m978bsG7duJt0cuCW69fh29u0XdwruTNxdeo94r/y+2v3qB/oP6n+0/rFlwG3g+GDAYM/DWQ/vDgmHnv6U/9OH4dJHzEfVI0YjjY+dHx8bDRq98mTOk+GnsqcTz8p+Vv9563Or59/94vtLz1j82PAL+YvPv655qfNy76uprzrHI8cfvM55PfGm/K3O233vuO+638e9H5ko/ED+UPPR+mPHp9BP9z7nfP78L/eE8/stRzjPAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAJcEhZcwAACxMAAAsTAQCanBgAAEm9SURBVHicVf1psK5Xdh6GrWHvd/jmM91z7gzgAmig0WigB/bESRIlDqIlxVaislSlchx5UlR2rHK5XP6TpOKKKqUfqcSRGKnIOPEgUpStJhVapEh2i91kT+wBYDcaaMzAxR3PfL7pnfZea+XHfr8L5gKNukDfc8737XfttZ71PM9aH379q18CM0BARDMTiSqKRESEiABAxERkAGYqMYCZy3JEUolgQMwAYGCmqqamBgCEiEQAmL6tRFEVRAAARCJmU1VVQgIwNQMwBAQEADQzADQTEWVmYgIDVTUzRCByolFV058mQjMABEICADMFIEBDAEBCRFMFQABDRANQVTAzUDADQEQCMAA0MBVBRERQtfTCzMDAEEBVERGRDAHMHKTXa6CmBkZIwGBmZmoGiGRgZgYAKjH9BgEJ0RAB0UzTj7T+hAAQ1IzMiMhMRQSR0u/Tu1KB9DDUjJnIzEzTKZhZeg/MnhlC6NSEkAEBAABQVTD9IEhfhoiUfqqagBlRerlICBJDeuSqgulMVRARDAAxHWV6iGhAnkxVRNKDNTBEBEMwSw8biEDFzAj6pwCQnhYzAqqIqqbnYGaqoimKVAEAiVIsYB99BpYizRCJkJkcEQOCWvom6Zg5BZGZISKmA1VNZwFAKdzSN+6/FkFETS10rcRIzKoiUQCAmJ3zmyeBgP1Zq0YzQyJTjTGk958e7eZvQ2JE7t8xgJkaKAIgETH3oWebo0Mg59l5ME0PwKXrAI9iDwyZyDiF2ObxgkokJGRIh2iqBgYq6VYiIBKaICCYGREBgIqYKrEDRAJSFTMlJEBUVUAkIlUzMgBk55xz5LyGpmuqpl4ye5GI7IAg1qEcDoty0BGLxBQ4j6LeTCSmS6NmyuRS2DI7U1WIxM5UTft4B0JTBQNDw0epAYCQCNAY+zRjikT9jej/gUjk0pWydKVVAQwAmJ2ZEeGj999fO0MiVokqws6ZgZmmkzWR/vTBVBUxBcyHvxCJGVUNLMW8IQI7zvISEZanD+/dv310/4PTw/vVaiUSi+Fs+9LB7sHlg+tPDIbjw7vvhbaZ7uyNZ9tI6JwPqmYKZqL9bUJEAEJCMEAEJO5fg2l6g4gGSAQYzcyEkIldDJ2ZADoF7TO6pTsLpin9UH+9EBHApTAhYgBQFTNAAgQkIrWUR9E03REBMCROecQAmDlGNVNTUxV2fpM01QCJ2Yz6P4sIfRKxdIXZZ+PpVuyqu2++8vrL3zq8+/7p0YPlciVGMdULhdF4sru7+/RzL+SD8fe/8416vZrMpqPxdHvv0vXHP3LjqY/m5TB0rcUIYMwsqkSU7kFfu5CwDwh7FCmb4Nj8C5KZAhoiG/TvZvMIKGWJPpwBwAy/9pXfS6nxw6SaSk/K50hgFmMkRGROP8RU1NSxY/ZmJhIMgNkhkEhQFQBg5wlxk037TPfo8Yxn27FZv/ODb//wO3/03ls/auomH4zZ5wDQdt3pfDlfrUMUUyHE2XjIRMSuyHMJTb1eZI7LQfnYk89+7mf+jWu3no0iKpJeLxGqGfa1OpUd6CuYqRkQkaqoKjFvHv2jGEVVgVQokdIrZucR0VREVDUyO/z6H34pYYSUXEwNEVXVrI92FTEDZmZmABBVUDUAIiJ2iKAiiGSgKWWqKfaPjyBlGlVCTCHvsmIym737g299+Td/9e0fvWLkt/cOZrOZSmy7sFrXR2fnF6uq6SSImmoUBZPc8+7WbG9nmwnqupLQNvW6rZeXLh389M/9lc//7L8F5OpqBQDMTCkFW3+RTM1AESjBgPSOVIWIkQg38UHMZqYp20Kfx1WVML0bVBVAQGSX3kkPJtSQMNUjU1QViQGAmBmJUsQiInsPloq6AtCmqipSn0tSCdvcbmUEUDOD2e5BaJa/+6v/8Ku//ZtB4NLlx0bjMYJVVRVirOt6uV6HrmXCzBETAFBUA8jAtGk6MB0NJ97n1XoF7IHzk9Ozf/Frv3J69OAX/8bfLgejtq7SVUJEg75IoRogGibsyf3/PoQRfWpXM1NBZEQi4lSd+ywTI6aDMzJQl0I2FVsAQGTts2l/mS0l7B6IIBEDpuDv73mK5P4pqfbfPGVPFQMwFeJse2//zusv/6t/+is/euVPxjsHB1tbalbVNSOEtl1V66Zt6yasmi5EM4Agkn5y5nA2Goro/cMTAxwPhz7L2i4wOSjHqPHLv/0bKvGv/vv/uWaFxM5SETRNFwr6UEoAiKwHWggbuAOGSGQaMaHflHdU1JRSMQAAM0IyE1Pjv/W//psJMSAQs4sS0lmpCEAqOpoge/qRxCwSJXZInEpqj2FSasRNAPegB1SVfb61t//9r/3Or//S/+X48HBr/xoArqpKDYo8YzSNXVVVIRqgMaMjFNUQLUQNUc30YHdne7p1sVgigvfeeV83jYikHF8MRm+9+vJgUDzz4mfras3OmyluXltfA3sUhZvklW7J5iiJDDYAW9XAEoJhYkmlAMAMEA0AqIdzaiko0tUFBFWR9GXsACDGkKqMxJhOM4GJTYdEH5Z5TNCE0/1nn8229777pX/+xV/+v4piMZ7M5xfrpi3K4dZknHsnakGhKAdF7kE1RmuCdkGjqhogIiHFGMeDYlDmy9W6adsYopmt6rZpAxFHhWw4+61f+3+9/Ef/antvX2KXik3K//3jQzSzGLvUADAzkesBpkqf9S2hfyNkREKAdOESNlUTVTMDUpP+PRuoaY8h1AiJKEFkMLDUtRiomQIYIpmqaY+bH9Vv63tS3vQcPJlt//Abv/P//e9+CX0Rgc7Ol1UbRsPB9nScOY4xhiAGSM4je87KPMtyz5mj3LvMEzNmTLPRsCwLRhSRum66GH2e+yw7X7XLdYOIPht0gv/8v/0H9997vRiOYwj4YUcJiISEfWeYYCoYAhI7cj4VBJHQ953IiEBESKSmPYrETasLSn1vDJq+cULVaorMzC51GESUkKyqGgASE1MPQfoglfRSoM8afekYbe0e3X7jt3/tlw193cnpxXLVdKPxaGs8bOv10en5+WJFTIPhKMuLne3ZlZ1J6RBNzDSKEFrpaTTIL+3uXD04mE3GmfdlWQzL0pHbmU1m0/HpqltVDYCNZ7v37h391q/9Y8/EzscY+lZcoqlAeuDaI/YYgmpM54If4jWgPp2Zqvz/Q3F9lLbJAFTNUlkxldilZjLhM2bfXzaA/vKnpACIyIkh0B7LgaqqSsJAIjEfTqRZ/vav/qP5xVyQL5arTnQyHhbMDw+P7tw/XLfddDoZjYaOsWSI9fL45PR8WddtJLMhw4Bhbzx47PKlrcn44uwYpb15sL09GXjPjnFdNYOch2VxtgpV3XjP25f2vvf1P/zG739xurWb7lTKG7qBZanGpeOwvqUTAEzdNOIG9IOpaIJvqiIiKgoIqat16QgStQN9kkNAMFUBYHbELiEXlYhISISQulwzNDQ0eFQ2+58Hhs7no9Hoy7/+j9569fuQjR4en2e5H5UZmt47PG66eOnSpav7eyLRYsgsni3nDx6eLJZrBRx6f7C7ff3Kldl0WhZFWWRZljXtULr29PyswDgZD48lHp92bdtOSheiO543ReFHg2G9WnzpX/za0x//7HT3SrVaJIyJyGCqoIhMhAYMiACmIqmHT+1dwhxqMbXAiGCW+CVTU1BUMAN0iKQaVJUIiIh7esBMNeVGSOQHAhEjMRGpRNxgn4Q/NpgjlScFgMls+83vfvWP/+C3zRVHpxdZluXMbdOdNm1UuLK/tzcbLZfL6ahYn50c3nsYmu7SzvYLj93Y2t6ebe8MB8X+7s6VK1eYncawrisJ7XOPXXnjg/vff+2No/sPxpPhpdno/Qe1djIu3ZnI8dm6yLLZzt7dD+5+8/e/+Jf+5v8OzJAJUsPe16gUdELAmwomnHoskFReNyFoYLghNoSAEwuDiK5vt1P3mkgutdR6pMwOm+qDSKZRjfpq8CgkwRhJTZEQkdCoGI4XJ/e/+lu/WlX1RaVZluWOlnVbNUEBLu/NRjmtlnNH9vobP6JOnnv61ovPP3fr6Sdn29vD4RjAYuzYeSRCVVOcjor5xdnA2Y9//Omr25OvffcH948ejofllZ3JB8cXOcqkdPN1uFjWO7PBYDx6+Zt/8Mmf+Lndq09Uy7nPMpF0+0BNpBMzU3xEHBghIjGKaBRi7pvQ1CuoEPUYygBTX+FS375BWAAiuPlTCZEhkYmo9HxTirXUhdGGpLBN1kBEcpzl+R/+5m/cfe/tzjJ2wogXq7pqowLub49IZVVVcXVB6/YzH3/xL/78z9x66sl8MJJU4NBikEwzNBFRBdMoCt1oOKqRYuhu7m+Xn33+B28OX/rRmxbD7rg4nleFp2HhHpythrmbTCf3791/6Y9+9xf++t9WjaFLfWVEYkQS7foLqJr+SwwdezBIHAeBSd8w9SymPiImgB0YuNS+pm4/sW5mSsg9ISdGakiYyCVkh0CEmODFIy7JrGeiVaUcju688fIbL32zVdeKeML5ulm3EsUubQ0ZLEq3enB6a//S/+bf/Vuf+8JnweddVAU0EwMFU85yUB/rJZFDZJAIQACQeacSBCn37qlrl0Dj1/7ktdC0W6Nivu5Kj2uiO8eLJy5P88Hg5W999cXP/7nda7eq9aoHtSLOeXZeJQIikevbYSIweMTlpCRkYJsOFCDhKqDEstGjph+JUqoCQ1XpvyYlLMRNE9tz1moWY5AYEu+TkA6Y+SxH0O9/48snRw8FyAyqul3VoRPdmZSIINLNH5z++Iuf+Pt/77/6qT//ZxvjJqb4JspK8jm5nFyGxOQLdK7vOIjAjH3m85KYi3LgfXb9YO/FjzzmENeLdZm5Ltp04JaNHF9U5WB47/6Dt179Xp7ljhkAid2GTH6E/5GImTkRlhJjQpqQjoco/fk+kSegm7qonvXAxASrmaSam6oJs3c+26QtSpAV+h9sIiIxqvU5D4ic8/fefu32mz+sAjQhgOm86qLa/rRENJB2cXjxb/3Cz/6f/o//5fb+7tmiAnbkHLoCnSd2lA0wy5EdMKP35DwgIztMUNBlLst9lvksG4zHxHxld+czz95i1XpdZ47AbDrwJ4u2aWNUeOV73zg7vJNyYipKIkFiAOibPCY2AJGYemFJBbSni0VFEjAAME1xgwRgiXXo+Y2kvNijWqBmoD2h2FO/PVeXsj4iInHKbojonCfCt1976eTh/VYwRJmv6qiwOyliFAZZHi/+2l/5i//53/3fdjHMF2tyjElwyHIqhug8ssOU9RGQHbqcnCefI5ElGMmOnCfni3I4GI2Q6ObV/R977lYIoW07Myg9AOC86nwxfOuNN++88yo7Tq2Q9Q0YY0/ooGhUFSQkdn8K0CL1ZL30lwyAKJFrCpBIQQmElEIRAC1FqRmYxhBC16WzR7MUwElJIXLETIk/6Skntzw7Pnr/9fm6qZpWRZug2+NCRDMH5w8Xf/UXf/Y//Tv/3vn8oqobcg5TlWHf1ykis6AxSAi9dAJiaIZoSJZUMJE+QkzzPB+MR4b4xPXLV3ZnZ/MqQaMyw3UrzO7svH3j+98FjaqSxENEZOc+TO0iKRL6RjI1Roi9IoUE2LMghAip+TEgBOqFvcQyMqViDEj06M3YpnYk9hURDIiIkM0sxhBiAEJEuPv2D+69/86ihSaomg0Kr6plzueH87/8M1/4T/7Df+f87LRuA/kciJAydBmimfTahwElMNyXIjNQARUDBJ8hYQxtaBuVKDF0TTsYDMez2WAw+OjjVzPHZ4vGAAtPqrZsAuf80ne+eXzv3awcwIbMT4kJkdD6hk9EEsHQc8cbPoKYqVdjUxLsCRrqlageeygAOJ879kSpmaUPCYoUromZgyTzGgAkvGeqXbW888YPjo5P53VM3Vvu3WSY3b9z9hd+4tP/xd/926tqtVytqZdtUsug/YtRNQkgAZJom9QiUTPr1S+VhJg3Oi6ScwjgnS+Gg6effPwzzz3RtFK1wQDKjJpWkfP3P5j/6HvfdIRmmm6eSEw/0nCDNjdhsYk86UkZwNTPpINTVSDcKAWmarKh0gwBmB0ASgwxhkfSb/r+YJYKZU+qUC+sZ3lxenj3zjs/WnYoasPcKeDutLh/7/jm1YP/7D/+D4LparVinyETgAEROte3dghAaNDXHEDWGDUGVTMkTWy0iJhgEqetf2DOMTMTQJ75Z2/deOraztmia4MOc+cYq1Y6hbde/2G9PE8Cq5qaCpim7J7yPfUkWs/NfkiBQw/3EdBMVGM6VjIzQNoIrmimvRqemDnTXh1UkZ5p8gBgsmn0zWLXGZjPi7tvvnL88P55FXPPZrY9zBfzVdPB3/l3/9poNLi4mBM7dqlWMBgCoBHbpmSnyDdR6ToVTZI8MaPPIJW8dG9MH72ZrMi8c4ysMWbeP3F9fzrKV3UMorknQAgId26/e3TvPSKKEpKOAYCpGUxvVnsOAjcn9SgPaeJP1TTGoDEmYaRXhhMq2zBtAH8KuRhYQh6J/k00QJIINxyjIXK1OL//7quLql136piGhVOR128vfvoLn/jYM0+cnJ6aGfmMXYaIAAoWQRU1tboEBhY667kQQWYgRucQkHuGnsH6mpNulveeyaUKnh7feFgebI+j2qqJGaNnagQPH85PHnzgs1xi2MjjoCqJTzU1Uell6UdMX5+4LYEIkQgG7HN2TlWpF+dMY+xUBB7lKeuZCSbuc46aiohEEYkSe4kAAIl9Xpw9uP3gzvtVwKqNuaOM8d0HF4NR9pEnrrddFFEgR9TzUQiasgiyR3KmYhINUEJrsQXOkD06hy4jZkQ2NSCX6BlUMwXOcp+53jRhKiIE6ohy74aFqzttgnqPgDRfwdH9u4Sp9QEzVYuPpDjYaOCp+6EeM6FZz4mllE5E2Mejug+/DB/RRvRIkUv/B7NL1z4pb30xwA8FwSzPD++8fXp8tGpNDaYDd3hezRu5dTAuvOcElBP+M0Fw5DwiJ9RHABajxmgSpVkDOXaoMSIqONdjSQDtWiMysxCDIfrMmyJChwAiKiqmqhKjiCNCsnUrk9JlDtsW7t1+p14tnMs23FTf6VnK6Jp4W1ARIsOEy7jXjwAgobYUmIjo0hlDb7BIHoUU+EBEvQyYFE5VQgcbybunIRHBQEJ7eOfdtm1XDeWOTeJFFUdllnvano6ZqYuSgRF7zofsfApbZAaAWK3U1Lou1ivpGh7NRLq4PifnEcliMINQ14JILkO1fDTDGFUDMzVNPV8so0QzEAVCYIQ6iCMEs6YTRCSPH7z/3sXpw0s3nlnOz7DviKHXISUxppSa7541S7QNqCUOBA0SG02OiFwPgAAopSfoU1Rq0ZMvjIiTDmMbbJKuOiIk2n51fnxy730xt6zbQeHO1yE95NlkvLezrWaiiuTzckLOI6DL8uTjQIttrKXtYtvEtgYA7WprVtDV4jJTJbAYg4hm5dA5DpB1IgbYNh2Ass+Go+liVS+tAaRhWWTeJbowiAFaVHOI8/ny5P7t/RvPJPogHRYlNw0kS1LfEvaapgqCAoCaWhSixAhB8tw5U4Weets0m4qEvQJiGzuRqljPVSZUQWqCSGCaD4YfvPvK6eFdIx+k6YKuGjDEpguT0Wg2mcQYfT5A4ofvvbGanyP7ohyvlouLiwvVuDUaTifj8WRGzqkoNLXGlpi162K7AjUibmO4/cHtk9Pz88ViuVozYZZ5IvTes+NiMByORlW4KIo8z/Mg6piimna2aqT02LRw8uCuxI7Zq4RHCd6Sge8RYEI0Fe39K0Y9td3XQTMViYjgHoVMb0nso8l610GPUvqOkxLhbULkiF2C7N7708O79WoVhJtgauIZHVPbht2dndGgMPJN07z63W9ojNPpdtt1x0ev3Lt7/2S+ELHtyfjypZ3r16/evHnTsVO15ClSkdDUhnx2fvLm22+/d+f+2XzZdDHP/fZkNJ3Ntre3EeHo5GS+ur27f5BnOZqNymLdSpnhKOfzdWiCecIQ4fzksK1XgC5Zz0DNSFODa2qGRsTac9HJgJbUYSB2iVzrq6Sag00/1IffhhpRU9gYYMCQkJBTvUouO7Q+x2Fo1if3botY3UkdLajlXgDRO76yv+e8X7fx/ntvlcPp48+9MBiM1qcPh4N8a3trtV7XVV3VTS3x3sND1bi3szsaTV2Wq4HEULdxXc3feve9ew+Pstwf7G0XRT4ZD7dnk9Fo4vOcM79/9fKP3njr8OTs0v6ey3xR5AB4UcXckSMEgKggBhenx/Vq4cpJ4hGR0tHAxrjT/0q9TRLQkbB3T0HfURKSEbgeTHxoJcJHjEeieHAjokLv2OwRu0g0NV8OVmdHJ/ffR+YuBAXoFC7WMhuyAhZ5Rsyrxcl4a/f6E0+Cxm5xMszoqVuPd13XdO1yuTy7WJydz+t1tWqaqUQkdL4QCa3GdVO/f+fOw6PjCDabbR3sbu1Mhts7s9FgCGbL1frkYr6q2tnWFua5KjjCzLvccxXi+SpcNAoAdVBFODs5iaHJRtuhrdk5Qkyak4A8EoAQKbkLYaMRJCyPRD06AUMg18OTvsfqCaPElmgvPhEm21+f6xIHqYhkEJ3PHx7dW56fsPP3L9ZXhvn//i999jdeeffLr9+9vl0My9IM2BfMdHF4z6FZW797eHr3dPHe7TsIsD0q9iblaDrJfN52LTmfj0bFZBqbdb08Xywu7j44PF01V69fG2csTXMU8Ud3LgzAxWY6zAalb5qwbgIyu8wTYplng8zN67ho9db24Ond0R+9e7wMtpifLc9Pp/uPhbZO9w1RdSMwJsSuElMXoKKJzE+pCT5EcYgAjohTV2RqgAaGqjEBNGLsAXEv6HLS+TbKE7DzztHy4qSu6yh2WumfuzH8D//m/+K1X/rnv/vq3cs7s+lkTMxZUTTrlcQ2LM9++yvf/vKfvDfv9MazL9x953Ufq5985rHnb+zuHuxL0C5qMRiWs51YZcuTB6vV+uHZwpcj6tr5xfq92t5e28Ma3/nRD0oPA++fujz73HM3s8Gwa7qCIBsMJ+PR1rh4/6Rmg//kL3zyub3y8J9+9Y15t5g3FydHNxOsidFtzsFM1TAV/0Rqbfj51JMRbkgJ2PShtGEQex+a8x4QRYWYmf3GEdT/6b5pwkcsLIembterKCJRZwXePZ7/ky9+6WixmDi4frC3s7WVvAMIEpvl7/z+V37/e2994uf/zWu3rnbLBxAvrj92cOWzP7OsJBN9/OmPusFEVX0x9OWInVutqjrIZFhItWo02//8zy0JDu+9nbtw+fErNz76/Dffevivv/tqV68Y0ZnmBJPhcHsy8gSDnNah+52X3tagZcZB4OL0ocQQY1TVGGOyBiXxPLXoSMTOMTOxg0d+tBRetgkzQrdxCCggmIKRMrukikMyXpikSgq9Cypd8d6SphJX8zMJQQTEbDh0/9Pvf/WuwVOX893ZZFCUCFbmeXTw8OJ0ur3z7/3iMz/28z/9pWuXvvjf/dcH0/LPfOGnPv3U9bsn7x1c2X/805+49+4dENOm0rbSGNsgk9H4U5/86Nnrr6+74qc/9ymOq392+1We7Xzyoy88e7B3OcwPzw8v5su9g8FoUGbEmbfZZHRzJ8u8f+mt22eHc2K2GAXg5PBBW6/Z+RhaJtrwDglTCCA44h6dAQDoo8hICCQxQ2DgEkLb9PUKIkyc+s8NZw0bBAg9o9FzCYpIoGE5P1fVKFAHUKKnrx08Nhq/c/hgNhrkni3GYlDw9rZzz12+dqs+X4T3f/gzj1196j/6u1Ktr01yu/fm859+cXLt6upiUThCU6nW0lQqVpaD6aTtWnnmCz+DbVz/yVe+cGmy/9f/5vHp+TTP6tN716buscu3hpPpZDKcTkYazQtMBsVT+9NL4yEGgVE5X3X1qkOA0LbwqNwnDzT0xjzb6G+97G1GyR2EDBuB0lSSX9OpxARjEzpVEdxcur50GiaDa/LzmRkzp0vOzKvzh8v5GRKrRjC4u+yGg/LnfurzX/vBn5CnlDB8XhTloBxJ16wXDrs2ZHDx8avjGCdNVNjez4oC8i3GbpgThqgiptDWnQPbHg8fHp5Ntq7vH9zoVhcQ109c2d4q9P7RUaX13vWrV65eJkJEzLxbr2rPXGR+NshvXb10djqvLpaLIEGMPa0W5229zoezxC6w61NNLyeKGimie2SPBjVFAQBNDirm1Ce4ZGxL+hshSwxRzDmfjhFMtLd066Z9pUfBamZds27XiwRUhhkcNULl8NI0G7WrrpwiETORGiE675FGs4PrsQvoPfiBp9Ktl+38wo8n43FpVdMlK54hOR+6rlrVZZEXpVuefDAZ5oPhBKyMsRmyu1zku6Iuy4qcNUZNLFuIIJZnbjlfLs7n1y/vnZ8v77w7d4zs84uzk8Xp8ZWt/Xq9ZOcTxiQghQRLiZkflb7knksOUOyTWnKuqEuIAxSNDAmI3cYnZLb5TdLFDYyZk2SSYNtgVISubeoqlZgyY2ily0tXrV3E2c522zTjjKxrIWOXF0QMhlSwGalYe3EcV4tytjPe3eJ2FdpO2sCKjr2ZxqhtVBTJmD1KqM5Dyi+I3hfT2Y6GDgmcZzBt63rdtioxBCPEoiyPTxZP7O/GbNCI7ZWpSaRqPReJsMGVqoIu+1PDQn3O6hvHzS9ABOubBEBwlBBI6tbFkBxzMiUkGpnQPuSVknlIzcCM2TPz4uK0qVaOHWBP4K2ilb54/Nnn6WBvfjGfDQoXBDlCjMwOHQlYDKJd4wgH+1fKyQwlhLqKbQ1ISKhto13tTF2e1TG2dT0sC1bJXIJQjjhTyxGMCQGgWc/brtMQgtq66RjxxvWrJ3dPujpUAgDAROx81zbLs2NmTvZ1ACDk1O0Q9aHAzuOj+YfNMYiImTI7JlYVl7JSlJCkXVXhNH4kSeghZEwk3ub4N95QQlXpqpWIABJiP8rx1t1DX3x+OoqxHLRNHdquyHKNwtghMrsMRSjzjj1PZuQchKhtpcnMKZHYx3oR6oqJt0aj+xfnddtaiBiCR3RFkTIpICAaxNC1rYYYO+na0AVZ1s1wWK6bZnF6wU9cPlvXGzxEUeLFySGYMpGpbqyNAKmpZFKVNLSj/aQMYeqrN3UzKSm93xMSxieGnlzHDX/xodKXnAQARpRUAtAY6vlJ/w0RmAgAXnrj7Tvr+uDybnd+2hmuluvYNLFptW60aSxEVCWJ3nnncjRM7yFUq/piwUDeOWAnZr4cHOzuOuTjkzPV6LMczDBETKZUQOgChBjW8+rsbF3VVRubIEC0mi8e3P7g2WdurAFfu3MEAK43V9B6edE1NRKLihn0jiCkVADNLIawMZeRmYnKI6NrEisAoHciJ7ci2CPhAAxAQR/1m48MGcniiIjOezOo67qvwmqJoZyv4+9/5+XBzva1y/tttV7WTde0UlVhtQyrlVZLa1sCRiSQiKpM1C4vlienzigvyvzqk8Xjz+U7l6d7e6PxYFTki2V3er7IvCNTQrAYpK2lriTEZr2qF8umiXUbqqarg4hpu1595Nb1J5954qV37xyvQsbA6WKwD03dtfXGJqEqMQlsSbtMylsafuzDYGOosB7Pm6q6DQmZKKSopinRJa6yV6Yh2asIemYxzaiyqcTQIaKJRVMAKBx6sFfv3D85PXe5yx0vmrbtAiOqQOZLFSFyBoASzQQBY7WYP7xbDGZZ5larC7g49m1lGNu2unf/XhfCtcv76yrUdVMWZXoZKkGqtUpsYwzGkVzdhXXbtoLr5Wo6yLYvX3744Oi1uycKkLs0sWmOXdfWoa1dOcHNqMRGFwFCQOL0LFPFJITkYE0OvH5UEdKh9FK7JDgG0Aswj+YvTBR7BbQnh2IMIiKhkdCy85yYITAiuLqbf/tH771///CxS/tb01kbY9U00cDygYBJDCpB28raxmKUtl0e3W/qejidrOvVux/cufvOa/d+8Mcn77/15ptvvX77wbptr17ZQbB7Dx5aPwNioKbEbdc1behUqrZZN10VYqfKqCCKbfv+6eq1k2a7JEJkRiZEouX8Yn52nOUF2CYIkjpllnJUGhE0kURiJ/bRwDYDqoBIzkSTM3IjwiISqUSJkYiTNtzzi+TZOdl8MbGv5kdttUIkM2RCQiCA3cngg/r8H/yz3/rZz3zyx5556l99+6WLph0NIocOEQAZ2sa8gfMQTZpVV68xG7732svf/PJXvv368U/87OevXL6kMdw/Ov7qd1/Dphv99PPnqxpVb928Phg7ESE0Q4zIQds2xPWqqtsuAonqwPPVrb3JaPCV1+5EhdJTHc0zMhMiiurq/ARMDZN5FgAkDXalqaZ0MRERNFnEiCgJxmkMiwCgPxHoBX+DXtq3DYGhKR32HgADlQhgROS8X56f1OtFMuyZARM5QkJ79sbOy28/+Iv/2d/74r/6UhIh2hjVzEQsisZoMahElVDPzxXg0q1n2sjrZfP5F58+mI5Xq9Xrb73z+ptvzzKbFvi9779+vqiL0Xi1XnfVSmMXzWKMiigATV2v27Y1MzAivDhfPjg6/+Xf++4bDy72hilTAwE4JgBD9iIxtHVqotOURN8zm6qGGLtEvcJmOCcl935UHgDMXN9hKRgBfQhJksdKEcEw3WcQQERMc+MqohpBIzsvEpjJzAiM0Ji5cO7W5eFXX//gq6//k//bf/o3fvK5J9sQB0SGKTkSqEroNLRts8pme1mRf/QzP57luVnYu/HY+++/++Dhw/2Dg+lk3HYhdnL12rWt3d22i13XZew1dEGkqeuqqpdV3YgoIhGVhL/+gw/efnBhANMcc0eEEBQyR46566LEqDHE0G1aJQAzjdFSCJHbjH2kCXhIc0vpNMwwSbkuKb/YT5f0zfYjUzcCIoipKKBjRsQE59hnEjpRyfJys7cgmdkw954desK9Eo5rOFmssyJvujrE4DANnzjVaIChrf1st5xuh2qJvnzy05+u2yZUNSJ+5Nmn88Ho3fferep2XJazyaTwDryPTKwxinZt07btum7XTduJqAEjhhBP1206r8xRAroA5n2yEDuVuJyf95psGgEhSh13OjRmn8qiiiCRgpgFYoeUqYnGCAAOHzmTwIhoIykZAgIhJBcCO+zbV4TeKE+hqUEViJJVgpmYkYkAlMjnuSsyB3VcrivnnCGIaozR+yxIR2iogET5cELep0sVASnPPcJgUPpyMNmadqE5vbjwSOVoUA6G3mHQiFHNsAtd27Z10zQS0yw3IjQhSowAkDFmjJnDTowIPFEUSWU+hiBdQz7vM09CFQDoMwAQjUy8IcQMCFWVGExNYkw9gAMgSBgtsYyABr2wRIaaNE/4kFnEDcvYtVVbrxPBrRIRgXs4bQjgmTMmADifL9A5570BRDCL0YGyIwCjLEcmlahIJl0Xu2w4Kabb5d07Bbud/auL+aKJUpaFY8bcIxiitaEjok6k6domtArg2JlZnrl7p/N1ExwCM3qHpSdR8UzekaqZyqAcdE1Vr+bTS9dj6DbeE0CiPm2rKBEhb1ZwbEbIJSa1GBGdpVsF/SIOZE6zEWamyTcLsIm7vm/ojRXSSdd0bZeGnszUM1La8mFGBN4zANx9eLxuOp95NYsKyChgGgMQeueigcYoJlyWRT5woPH0aGtvvxhPyjybDQcRzAjbNjQhRGaP0Da1c6wIVQhxk6dJbVBkZ4sqKowzZEQmzB3VQbONwQJBu7ap18sYOmInTZ2gajqv3lZGaGqKQkR9viLozWVgaWwx7Ucwdn03kBJiKhPpmDYcd3LtJaM2SQyhrppqlSqVSHCESQRTM0LLHY0K5wAeHh+fL1eXZlshdEag2Pu5iCjEbtXUAaAYDbrDwwevvXXvlde0aR9/4fnhZHjnjbcOzxY4GY4vbRVbE0LM8gyJJERsaiYf+0lASrAKEQ7PFqk9IgRHmDnMPXcCUYUUc0eqEEOMbZNccSrSa2v96o6NUbBfWWAE3I/QgJkKCgGYs76dNCTQFFi9simIlOzyqcSmnjzxbRLa9eJMAYvBsAtd2qkCqEleT3k39zwt8O7h8r279564euViEXvUAsoEYnbvvbe+/vVvA2QD8Ot7x93FOvcZIN658wdVtbx7crEmHxAxc+PdqRuXmcOPPXvz6Scft0ZDDAagBkQoZoy4qtu37h4DgGP0DBlj7hxAMNMEs5kYADjLqvVSYtgAC0VEZpeiYTOJJdb7Eh/9QgBMzijHzMlR82gfDkLiY6HflpDcjh+a5g2Ipavb5Xk2GA2mO3VdFcXIoH+wakpEBEAIRe5Om/Dyj97+2S98FpKSbJigSWiq17//0ngyfe5jn2rvnoxuPDObTbZmW7FrH967X0mIhvPj4+P58u7p+clyGVtVguXFaZE/5Yvp0cPDuJmEB4DpuPz+O/fvnCxHHjKHw9zlngFh2QTP5Iic4zZEQi2Ksmuqrq37UQczQEymzN4cmrylxGl4ExB7CZxYVSCZpdLQfM+PJTqcEhVpgMjEmBYXAIgIGDiXS+jW6+XWwY0sL7omZFmqEpBnnPgMR+AIvKMM4Bsv/fD2Lx7tTCZN26QCzwYxxhd/7DPPfuJzo9lsfXbWztfdstGqy6G8OSoNsV2vT3OYzsrrT17SQd45G04HOQODAYGlgdvNaKP3/huvvgcAmaMi4yJjzywGUWyQoQF4pqpT0QBmTBTbOh9OIRqk2cpH1MOGc+a+nopZsiPjBrOkYeFE1JqpChA7dgAgMUgMifBFStDfEBAZVbuuXjdNIMS2WioAEnYBVDWlMwMQs8xR7nhc4Ku3L37vG9/9j/5Xf6luGzOREBTEe3/12vV2ddHVVRvCuqsjSxvPq/myXiyr5VoJqCxjlgfQOnbQycRKB9TVNXmvAMlXE9W2Z6NX3r338tsPcgYDyAgBzHPyi6Xmx5hw41NyTbWuFuf5cPpIYEp9+AY1QO8Yg81YP6FZGoowSGNivQbe375+DDUdrJpGCaq9XJICsF0vQtfko0nXdfOzk6IsEpdCG6MpWCIEIPfMjBnCr/7Pf/DqO7eHZQ4EXZSu7aLEuqnXy0W9vAhtHeq6WVzUsT1bn9+/OFxnBlvjWGaScR1i7LqCuWuaB4fHq3XdNW0bYlQTs+EgDzH++r9+GQDKjJjQOxSD0qM82tFksBESMS9HIca6rlRjYikQsLdRbpyxqhJClxZTYW9F0EcraajnLWRDY1ifx5jZeZ86c1URCbiZjpWui6EdjqflaBpDcC51BQgIjklVg2ieOTDwBGqwNeF3j1b/4+9+FZGZHXk2BDHsolRNs7w471YLpyEHG4Bd2t578slnHr96fW8y3RsOZrkfEgwcZ5lrQmzVFLFquybE1CQNy+K//73v3DtdOsIgVngsMzIFJhTD5DRlhiimBo4hzWlJwhkxRokqkn6TDOuwUWl7HEq8MRigGRCRSwSbqpoYsUs7HVQl7fyBNOhjqjGS8xtDvq6XC1+OGC3GoAaEKGkfWZKHe31ZEc0xMRGA3Hv48PD0BIxHZR4CAQEQp31y3ueZz3FElBXZeNtCaC5OurZSk7quB1lRdY2iraq6LAtyvFw1Uc05Hg+Hf/DyG1/74e3UGqpCwQRqngGRokZGwNQqggGAT7Z59uvFWQoFAgBiQExDrQmvppGmZA9CiYBkiZ5FBESXhkweDQAYECJJDDEaMSNAsn2z971lwYSZ26blrGirZZRogLBZNAYEgMiE/XhmSgtmALCoagfN0TyEOJiNMgbLi5KdY+SMvfe5L0YuHwI6oQbLkUMKbc05wlRpzau6AjXvXdfFdd1ExcznZxdn337lR7DR0RDBO2zFxoUDsBAF+7URvcHTwNpqvXNw/eL4XrNeOJ+lZTaYnrdB2tGWkrsE6ScAKDVFYKqwEQMQEJ3zav1+PXaenUuLRKA3pxmYEfsYQuzqYjTJi1G9Wo5nOwQmIlEUER2haupVQUTTXqwuGgCcLWoz29vOj07PHp4sQ5rbF005GVQtdLFtY13F1TI2tUo/Fhrqpmu6pm6DSNfF8/lq3Yqgf3h6eufu+2lFFCEYAiEyYRDLHUbpzatMSERNJ2aW+Xx+dpQmFJcnD7VfOGdJM0uTOdaP5KQxHUlvHBBEYqoJbiO5pXPDGAMgIFLiJ8Fss3UIkVk1xtA261XigZBdItNULYgScTIiYFoOAJAMpKkjW1bNYt3euHapC/H+0WpZd9cu2daoxIw1BjGwEJFai9qtlwampjF0y8V8XddtaNuua7qw7mIVQClbzE/n58cZgiJvgAKMs5RMkBHNgJkMjMAAIUj0jlyWNU3lvB+MtqrVYrR7pesaRGRyvUcdQuJwwIwADUAkGjiUqKbMDoCdJeABZAaE7FyfiHrqtS+nnPg2VSTn2rbt1out7R0N4eLkITtWQVVgh0YU1Qh7kUrNgkJiF6KCAYjCaDC8vAsPT5e37x/VO9tXdj1o5xBJIiiGpg4iQCiha9t2vjhfd2EdunWI606ryJ2Gan3R1Ks8y8hiEAXEIuO6jY57e2sUJSKyR+YuE7HMEYKFuiLmYjxdXZyycyRsoqltUhFK02xpAwlYfw4WkYCQAYiSid0g7bhLGogD7Me6mZ2BigipEaVmAl1WhKaS2JXj7Wq1bNuaCEH7+BeAKJp5XlemBqLQttHnbm8y2xrniU8CxEFZXNrSs8X6wclx28Wd8aBwjCKM2NVNF2KwGLuu67pl1azaro7aKLbCbay6ehVC6513TBJ6ZDObjfVi1YZA6JNQlpYsSUq0pqrWdjErBm1Try5OfTFUkRg6NNgEBCTw0E+7IBCQQZqlp40f1lRlA2XBqN9tSmYmltY3iIoCgGJMG/YMIHNZ21Sq4PMCAGOIYKj9UhjoRJiJEEKISNR1tcvcE0995PBs7h1nTMzOZ4RIeaFTQL+uzhcnF0vvkVGVVB1iVF1XVSfShRCiKXM062IXujp2laoxJ17aEKHI0vvhvd2d8+OHqlZ4RLCoGAHboEEIEZipbtsY43C2Nz873bs65KzcmInRUrNKJDEYGDEmF3LyVCCxShSJZETkHFiytxt7ZHaiEbRHwxKDiDjnkiKAaZ6GMHSdGrBzsavWq2XmXacWxDIHUSz3zkRaMUA+X7bPfPwzGdPdP3n14KOPjwYFPJrlwzIt23KOq7qtm7pugoSYJiOj9nXWQDS2QbquaxKSNoieycASa1g4AoCqaW9c262XF22IufdqgAQxmqhFSZs6yQCq1XKytdeFDolDW6kEUWPKkvqGRERONULfoIOlfXWWkJUCsYHRRuxQkSgSVSQJdkmC534HF9JGSI+hUwNfDLzPTx7caeoKiUENCRWgjTosfd1GMaibhsc7L37mp7oQAWBrUk5HAzHwWcbsvHPDQZmu82Q82pmNd6blZJzlOTgnjiNTR9iZNaGrQtf2QAI3owdITGRA49IBQNeFvUv709lW3cZ+/gEgbQloxbqYppegiwqI54f3zo4eJHEjpTB95IlFMIM0e2hgluRdiSKCxGoWu5BIcSakRHinWetHm0c21pUE2cw0Jql8vLUXQvf+G696nzl2XRTHHMSC6DinRdUS0umyvf7Mi0997JNt1wDAE5d3BkWmIgjo89J77x2PhgPPZCJ5lo0nk8loNCrLzBGjph06poZEjh31MyDKRIzoHBNRVNgZZQwQom7vHeweXO9ir0wmeKUGbbAQlRG6qFEpxHh2fLS+OJts7XVtkwYne/fchgvqkXj/txlYv8inJ9EMENPeGn5kDU0/L4oktuCRdzR2ncbonEekow/eenj3velsi03qLjrmVRO2hkVG2InVQc4795k/8xdvPvn0+XztAX7qYzdWXZr9NARzWc4+y/JsPB5nnk0FQbPMDwZlOSgHg3JQlN77jZbIaZ6KiTLvMu/60WGiQe4vFTAaFNlgcvmJZ4Zbs7pu1NKkAopBHa0JWmbkfHZ0umjr2hejk6MHSMzsYluriISgqiIR7NEqyp5OE9WEbxMuA9x0EohISLKR9VJ2AzME1NjFpgaiNOSnEq8+/fHzB+/90b/8p9PZzmSQX8yXRK4KKmofvT47WzYCfDivPvKpn/zMT/9cMd4qM/8TN/ytGwdNVEC0tMLLLMvyLC/zPBuNR3lZEhKYEpJ3ntkRgWfOMu99ZqYm0TFlzmXeuyxDIiaHiOx4NoD9ndlgtrO1e2n35kcWLcSoiDjI2RG00ea1EGKZ8bqTO3fuOe9Pjw7f+v63srwwohhClKBmaV+z9TvORDRavygr/VtiJc3FGKEXOy21nb1kboCMIqGen2pXl1v72WCUD8fMnKvcfvP7F0cPDvb3733wXivYCMyr7tnrWwR2supaARtd/al/498ejEchxJv7WzfiwhdDRERymykMMBPHjOVQVXM1730IXbWq0nqKVMzErO1qU3HOeaYsL5JCS4jMxEjMblDA5PrNye6V1fnh5etPzI/un57f2dsaOcZJ6eqgy9YWtY4LPlvRybwaP7iLRO++9v1bH/vUYLYHjhFQuoZ9LqrQD6WiiaaBBySCtN7XzFQ2yzp70Kew4c+IiYh8Vq4vjt575Y/v/Oil1emhGSxOH/7+P/mv29Xq2pXLJw/vNcHmjZ6tu+t7w2vbgw+Olmer9qzlz/3cX7359PNdXRvyzcefnI4GyM7nWdofoETI7LISiQkxHwyd92jiELPc55nP8yzzPpEAxDQoy0FZDMoyz5xzzrNPCqHzjojKcnD1yY8Op1t5MRiMJ0++8DnauvbwfNV1cZi72cAD4oN5x463hr6O8MHD09Vqparv/fB7jrkcjsA0hq6+OKnOjlJNkH7yvA+ytPUocZEOEZEZ+/UrG8ILzAzTVFM5mp7cf//tV//k4MZrg3Jw9vCDxcXZYDh8cPfevAoPLrp5q4/tj29dGn9wsn7neM3l9JN/9i9/7s//ZSAAiZTT/pMfq46+V62qndEsPpriJAYwlw9iU5GEPMsAsOs6gg4BmMk5550bFKVz3iQ4xz7LRQRADTDNtipRVy9nB49d/cgnM0dMBMi7l2+U49l7r3zn7O4boV0JOEewWMc7p3hju2yDnlVRtIJpef+Dd/jrvzvZPfA+W8/PQr26fOs5RDCJ6dvrh0ujevhKtKlEIo/2nFEaBwYEZqcSxzuXr9x67ugPf+fNl7+J2pXlEH12/+K8iny0jNHouevbBxN3uGjfOJFy/8nnP/X5H/vzf2UwGjdti0Shbcb7N+c8ODl6uHf1uiOOMUjbYpYTE2j0RQGIqmvvGMyDlYbIkdNej8pqFciGw6LIiFzbdlXTEIFnB95CjNVycem5L+zdeHp9es+AnM99MTjY2p1tX/rg3VvH996vlnMwHYTm+PgotO3uyFlBrcD5OhSLdXjt+1n+OjOJxL2DG6oa6jVlpUsJdENlPNrpBoiuV3M3066bpbJopiF0iAguv/nCT2TD8emddy4uLqpITSedHC4XhwOWW7uDMsf3z+K9tti79dGPffLz1z/y/HR7p2lbMzQARtu+/NiD2eUP3n/31kc/npVDVFPtYugIMnZkKuQ4K4YhdIatmZp5JkAwInbe5W3nssx7F7sQiRyziJljBYsxZMX4+nOfLUfDWA3EIK1SKgZjYnfrY5+++uTz3fKsqasiy86P7hzfv6Pr41yPQ92JhtPT9oLIWXQIT3zkI1cff8L5zP4Uy2gmJmaU5ufQUkfZDwsTJSSTgHKirFNAaleNJpOP/sRfWou7qPXkfHnywdvwxvfK2Z3Mmi7I/RYXk+H2ePfjn/7CMy9+ZjSZMLvVei2qIuqYh1t74ytPHr7+pbOzs72DkplUWc2iavoAiLQVAwGzcuiz3HedqIQutG2bxei4MlMi0v55M2J0zocoXTXfeezZ7VsvkmlZlgZAzhP7rBg472MI6MvRZLtbnQ3Gk5sfed5iWMzP5g/eO7v92vzoTrNetqo82du+/kT5+Edh6/JgOkjOFxFhx+l6Qu9Gd0kQd2l/EvbM5J+6tioOFQHUlQsbVFXRWCZgbuimNz4i2SBU67OTo9XJCRlcm+3uHlx9/NnntvYuqcS0EwjR0iqAtmuHV546fO0rx4dHo8l2MShT569EaUIFiJHNQpS27cuQiKlo7GIXfJYlY3QkSv02ERtSluWZyc5TLw53r2l1JhLB1PmcnTPTYjhRlfrsbDCelhmK2mBrz7HbvvYEffyz0jXL85NqcSYK+Xh7MJkB0rqrkcKEKi/nZgY2QE6+xt59kNYnOYl9S4Ub85BoJA1EFP10jcMGCgGOMXhSTxgz79zMkC+OjwbGl6eXZjt7O3uXnM+GoxGamloXohoQkXdeVUNTjy/fOpsdnJ+cHNzsOC+9yyR0MQTHzhGTgaggE6hIiCIxhi5GAWTnegOSGFmQGCIAFOUA2TXr+Xj7wF95Yblc7pT5PEoXIhKVwyGxizGOp9Oqqn2WDcaXz09PQog+y7z35FxeDgazHe/zlK+TRSKE0EVZxC7Pd/L22HdzRDaXp5kJSBvTkRwSiUQyQ6QYO5YWiVs/a7PtFoogyiCewZEjxLYLKqJmqjrZ2Tu4cZPZb29NZuPR6fk8poLCoAYhSlouU3fdoMj8+ObDvcfnF6+rKbJDVzgvbbUMCI6HvYgOwD5LcrXLHFCHJN58sktojBKiqZaDQT4cKSAsHgyf/smL7Y/MYjUZXTp2nsghofdZOZx0bQMA4+msDZKVo8G4894xMxIyJSrLNLYggRFEIxo4EOdAXd7ppXqwF5tjv7zrupVxLmIAwEym6vr9q2akAaxr3LQt9moowcxi69nleZGkrXVV101XFHmoK1Xd2b00nYwRLPdORYuiIGYDBEAPSBSg98KAqpbObT354uqP31jNl9PpDgBwPvIxqHSqmuy/GqUf7M4y6jn31ozBedIYQgwhOpeNxhN0Pq7nxc51eOHnvRtAJ12UQVkiMwIwe59551hVy8FQq5qYt7a2ibgLQQxGeS6qMYpjLjIvEoNgUWQiLoTAAA6lE+vyS52bFus7vjo0U3CFKhKaS74CskZcuciuVW7KRDmIGojPMp957xLpQ8TMrm7qpm6Hw9FkNHBMRNhFaYMgoWMOQQCBmYhQRUeTrWJkD+7dOT18EEaXcXJ18eCD/SvXs1xdljNMu+rCzNh5ZUeGFgU2ghhnXpjMDJlV4uLiwrtsujNzeR7aDjSsb/4Mb98YLI/HB1cGeXZ4+BCRERSIrF8eQnmehxAkxqwoQmgBIM8yZu5EmHmQ54iwXNbOe3Y+fVZA1wV2lKFy7DqkevpULHayxfsurg1yY+eYCELd8niRXVPOCxLHYMaq5omcYwQTNWQaFHlZ5CfndnJy5nIr8nSJzLNLtixRZQJm10UR0YMr1z64e+9HP3zlE5/8ZOnxfFXDzU93D74iiyMa32JCzgfsWEONzrOZWovozIT6zx9RACSfGcDq9CgjKvZ2s8EoRKHqoh1djpdfoHoZFf+HX/nHu9vTn/oLPz+dzU6PjgzAZ7mqMpLPMkobS1URaVjmeZYHUUQaDQrHfHZ+HkKcTCbeOxGFjZWCEZBylhAkNPnOIrMy3plCA2aOravLS/PsGoCNvCF6QoxqBJo7JsSqaZGJyUU1xzQdj5ez6fnZ+Xy53t2ahhg9c5DkY6Bk76vqav/y1aP7d/7jf/uvTK88/tn/5v/dNOHqwe5x/sKpg4vjN3eHuU0PyGVZXiin/i0EAHJMlCV1FhGIvcvLUC8d02g8A5cbUg5VK83tvc9RPrqyXb703e9+8R//EkB9/97dH//pP1NVlYpl3qe1eEWer4gQksmSi0HBRBKkyLx3brlaVXUzHg3zvNgsb+Asy1RVBIjAmK1rObTg8wveK+BkiK1raVKVNzLvc1IyjSGiQ0eYGnNRNTCJEjhm3ouaY9rZ2povVodHJ0WR51mWtCrv2QxSi1+Ug9DWf/+/+j80y7PLkxfOzs/3trdi1+Qoq8svvFLfzI6/c62tdPsKtICKhobsCMmQOSuJPXuf8gARQFcPhlPnirbtyngx7+z16efg2osldpmffO0rXxlcuXLp0s7//D/+0xDjn/vZX1gsFnXTlEVBzhmgc9x16dMJKJlTPHOZZ10X1uu1Y1eWg/QRJ0SMBsbW7yLr91cCsx8OPEm3WBcsFbXDK2WelQ7Fek5NxBCRibzjNECHCFE1fcwDIg2KYm93uw3h5PRcRFUT8YBRVVW7KAeXD774z37tre//4Omf/AWX5e9/8MF4PGTvt7d3Lo94wZM/Kn98jYOBNEQZuSysl+1qDmYQO0JyPvf5wPucESAE5rwY7+Sjrb0Bd+WlP8h/4uHep0e5u3n92re++c1vff2Pnnr6qcuXr370hU+89O0/fvvN12fbOyIxSkzmQkAKISJiWeQGGFSzzDHRulp3XRgOy6LI+88c6hey9uYlFVGJTRvSOs2iKMWP5jFzPh8QqaJjNEzaAQATAaEjajqLph6dmUVR70wNiGlna9a03fl8MRwMRsMBujTXaVH06vUb3/v2t37rN37jsec+dvPxJyaTrfsPju49ONrf3a4QY9fMcJ4//vztOt+qfjC5fFDXq259EVZLKo2cs7ZC56wDIEw7kpA9Gk55eV7s/R4+dyb2U9dn+wcHP3zllV/+f/7SeDLcPzjQGIej0WA4+vY3vjHd3nvm2We6NrRdxz7L8/z8/ByRiLgLscwz79yqquq6ds4NBgMijqL9gCUiM6GioCixBQkSY9uxybDIQ5s39YD/+t/6O6IISMwEpmkVFTMRYkilENAziyggZN6l9pOJM+9XdT1frvMiH5SFd248ne7s7n77m1//+3/v/8xZ9olPf+axJ5+5/vjjiHz3/iEiiCqxW9RhUnIzvHxx8uB6XivnoarSxg5il1Yjg0nv5iQnQCV0BPB77S23c/3pbffuO+9+/Q//4B/9P/7vEsNzz3/MM/ssGwyHly5fzfL8/fdvF4PhlatXs9zHLnjv5xcXg+GwyHNmLPPM1E7PzkOI4/E4L/LUXEdVBMyYKQ1NhuCYuq4Vw7SNazQcrBYXsWtcf7oAaiCijgABRY37pVXGmwl1EQ3R8oxAQUAHZXFt/9I7H9wLIVza2w1RvvO9737j69/45te+Nt3Z/dRnPn/56rWD/f1BWdjB/sMHD//4e99fLi6y3H/yE59sV8syH75TPF28+YcvPLFPxdBncUMKUWpBBBUJwGKGnZp9qXlCdx57bAj/za/82je+/vV6vdjd3f3ox57LMw9mzmd5UZaD4dUbj1/Ml6+88urDo+Onn3ryYH9/PJ4w83yxmI5HzrGBVVXVNDU7nxd5v+oHjBAdpyUqFkXapmF2TRfJZxpilmeqFmOkfr+DGZKJgmK6lyBq7JDZMcUuyd8bKhyBU5+KhNPx8Mr+XtuFf/nbv/O9737v8Pho/+DK3/h3/tb27u54NJyMhmbmHYMB7O9Ftft37d2332qefurKk4+tqtVguvMnR9e3P3jn4PqNwBkDbv5ClYhRyDOjUmy+Cx/hx1+8qct/9A//4Zd///cuXzm4fuP6lWvXtqYjDV0+GGZZUQ4GRVE6n+1dvrJ/5ep77777ne+8tLU1u3rt6sXZ6d6lfZ9lmaPQhWVVqekgy8q8QKI2iiNyjMkTGUNcrVZN2w6HTgwY2aTxrmiaBgDIeQcAjklNEbmL6hxmjjR2IRqz896LdlFUVJPHII0KSdQg4pn3d7dv3z985/a9rd39f/N/+dceu3mjbZqqacAEEWOUtGNiNCivXdnPi3w0HL32+lti+MxTj18du+PZzW/cP/wLxYPBweNAjgghsZ8ISAzsCmgezj7els+cvP7y/+df/Ob3vvOdq9eu7l+99tTTzwzLbHVxPphuDUfjPM/LwcD5jIicc4P9S3t7e4vl4v69B2+9/d5oPNjf38+cM4nrqm7bNnNZWRTEpAaO+4+EST7OtmtX6zUAiqghqZlznHlfr5YSA6M5YmZCjYqguXdt6DyzY667zhtk3hVZ1nSdAYhaTJ/8hWSWlBdwBJf3tn/xF3627mSYZ816SYgOevHOMROCiDBzmefb00nmnPP+zbfeuXPv/vPPPH15e/Ze9dwrR9/+zOhEp1cAmZgRjThTkSk0zfZTf/hg+K9/5x986ytfBsSDq5ev3Xz8+Y+/MBoOTg8fDIbDydZOkefOueGwdM6bGRMjE7KfjEeXDw7atmPH25MhmFZNW1UVIOZF4bPMzJKJDDbym5qtq7ptmuFwVLctAhFCVPPeOSZTBe9cssFCGpT2HGPsYsy9Zwwi0pl557z3iBKl/9UvLgYSszaIZx4Xvmvbs/N1VeeT0SD3Pk2nIxhC+gQfUrPJsHRMopeGo9HZ2dn3fvj6J569NRmOfri4cfnBu9eykWZDynLOXIwyxg5He7/y3Ytf/+J/357ee/yppw157+DKpz/1qWHp796+7bNse3uHnSvy3DnOs5wIY0wvj9IApmMaDgrHyIhdF9q2DTGmz4xh12/7MAPmfmaiC6Gpq7ZtRsMREwexdrXYmowRKYoAGAC61DZHUUBO1k5Jpiqk9NFzSMiESuQBDCCEAJlPNGTGjAAhRud4ZzJGgKoN89V6MiiZGBGI+3bPp3kV7xCxC1Lm2XA4nC9XR/P62q6fz66+fHG+c3IvO3jCAnozp2G8tfXLr4Rf/5df253kV5/7s8VgVA4GTz9xczwobt9+3wAO9g+GoyFhb1ko8jzEYGBM5J0jItvYttj5xFx0XRejjEejMs9pY5xIrQYBJKtA17USJZo6YocUurYsihDicrHs2o7Yu/QZeWZG/UQdARggMJGomJiIIqcBsDSKQ2lVrwEagHMOEZuuKzK/NR3zqm67rm66BEc8oEvzQ9B/qEaRZdOx1U1bFMV4NDpdrM4bvTobnvJzr1589+PFQ5tdAcMr0+xbp+X/9K0fPHEwvXnz5mS2XQ4Gj13ZzQjvP3zYdN3B5YO9nZ0owukDDpiI2CAm88HGhIBmkKznQSRGadqWEDLvnWeDNN6BzKiS5F0VkdCFjehrgOqdR+bQdV1TmWmWF2kXIyNiUzfALi/K0NaqxoSeOaikZrXfEwTmHq0qMSBEQ/DOiWrThTLz42HhGDeDxBZCNOO0IQwxZVsssgwRzSxE2ZmNTy/W58t6/9Kl9+3j5eFLt9xZOd0+sdlv/uBoe+iefeJjOzs7RZFvT0YZw8Pj0+W62prNdnd22bGlma+0MAPREaNP7HKSSo2IMschxrZtu7YT0Szz7H3agkHJKGZpxskkStO0bdMQpQ+spXVV5cyEJCGE0AKyy4r/HyznW757mleZAAAAAElFTkSuQmCC"
+        "issuing_country" = "NZ"
+        "issuing_authority" = "Kiwi Access Authority"
+        "sex" = "female"
+        "card_type" = "EvidenceOfAge"
+        "age_over_18" = true
+        "age_over_21" = true
+        "age_over_25" = true
+        "age_over_60" = false
+      }
+    }
+    mapping = {
+      "display" = "<display>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:1825d>"
+    }
+  }
+
+  kycChecksCredential = {
+    name = "KycChecksCredential"
+    credentialConfigurationId = "KycChecksCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "KycChecksCredential"]
+      "credentialSubject" = {
+        "type" = "KYC"
+        "result" = "SUCCESS"
+        "date" = "2023-07-10T14:45:10+02:00"
+        "checks" = [
+          {
+            "type" = "PEP"
+            "result" = "SUCCESS"
+            "date" = "2023-07-10T14:45:10+02:00"
+          },
+          {
+            "type" = "AML"
+            "result" = "SUCCESS"
+            "date" = "2023-07-10T14:45:10+02:00"
+          },
+          {
+            "type" = "KYC"
+            "result" = "SUCCESS"
+            "date" = "2023-07-10T14:45:10+02:00"
+          }
+        ]
+      }
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "image" = {
+          "id" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+          "type" = "Image"
+        }
+        "name" = "CH Authority"
+        "type" = "Profile"
+        "url" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "evidence" = {
+        "documentPresence" = "Digital"
+        "evidenceDocument" = "KYC"
+        "subjectPresence" = "Physical"
+        "type" = "DocumentVerification"
+        "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
 
   kycCredential = {
     name = "KycCredential"
@@ -207,6 +773,302 @@ profiles = {
     }
   }
 
+  kycDataCredential = {
+    name = "KycDataCredential"
+    credentialConfigurationId = "KycDataCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "KycDataCredential"]
+      "credentialSubject" = {
+        "identificationprocess" = {
+          "agentname" = "TROBOT"
+          "companyId" = "1234"
+          "result" = "SUCCESS"
+          "identificationTime" = "2023-07-10T14:45:10+02:00"
+          "identificationId" = "TST-ELXNG"
+          "transactionNumber" = "1234"
+          "type" = "APP"
+        }
+        "userData" = {
+          "dateOfBirth" = "1993-04-08"
+          "familyName" = "DOE"
+          "firstName" = "Jane"
+        }
+        "identificationdocument" = {
+          "type" = "IDCARD"
+          "country" = "DE"
+          "validuntil" = "2034-08-01"
+          "number" = "L01X00T27"
+          "dateissued" = "2021-08-31"
+        }
+        "performedKycChecks" = {
+          "livenessscreenshot" = true
+          "securityfeaturevideo" = true
+        }
+      }
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "image" = {
+          "id" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+          "type" = "Image"
+        }
+        "name" = "CH Authority"
+        "type" = "Profile"
+        "url" = "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/1660296169313-K159K9WX8J8PPJE005HV/Walt+Bot_Logo.png?format=100w"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "evidence" = {
+        "documentPresence" = "Digital"
+        "evidenceDocument" = "KYC"
+        "subjectPresence" = "Physical"
+        "type" = "DocumentVerification"
+        "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  legalPerson = {
+    name = "LegalPerson"
+    credentialConfigurationId = "LegalPerson_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:LegalPerson"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "Legal Person"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "type" = "gx:LegalPerson"
+        "gx:legalName" = "Example Org"
+        "gx:legalRegistrationNumber" = {
+          "id" = "https://example.org/gaiax-legal-registration-number/68a5bbea9518e7e2ac1cc75bcc8819a7edd5c4711e073ffa4bb260034dc6423c/data.json"
+        }
+        "gx:headquarterAddress" = {
+          "gx:countrySubdivisionCode" = "FR-75"
+        }
+        "gx:legalAddress" = {
+          "gx:countrySubdivisionCode" = "FR-75"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  legalRegistrationNumberEORI = {
+    name = "LegalRegistrationNumberEORI"
+    credentialConfigurationId = "LegalRegistrationNumberEORI_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:EORI"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "name" = "EORI Registration Number"
+      "description" = "Economic Operators Registration and Identification registration number"
+      "credentialSubject" = {
+        "id" = "https://example.org/subjects/123"
+        "type" = "gx:EORI"
+        "gx:eori" = "FR53740792600014"
+        "gx:country" = ""
+      }
+      "evidence" = {
+        "gx:evidenceOf" = "gx:EORI"
+        "gx:evidenceURL" = "https://ec.europa.eu/taxation_customs/dds2/eos/validation/services/validation"
+        "gx:executionDate" = "2025-09-17T09:16:14.928+00:00"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  legalRegistrationNumberLeiCode = {
+    name = "LegalRegistrationNumberLeiCode"
+    credentialConfigurationId = "LegalRegistrationNumberLeiCode_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1"]
+      "type" = ["VerifiableCredential", "gx:LeiCode"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "@context" = "https://registry.lab.gaia-x.eu/development/api/trusted-shape-registry/v1/shapes/jsonld/trustframework#"
+        "type" = "gx:legalRegistrationNumber"
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "gx:leiCode" = "391200FJBNU0YW987L26"
+        "gx:leiCode-countryCode" = "DE"
+      }
+      "evidence" = [
+        {
+          "gx:evidenceURL" = "https://api.gleif.org/api/v1/lei-records/"
+          "gx:executionDate" = "2025-02-23T16:42:16.058Z"
+          "gx:evidenceOf" = "gx:leiCode"
+        }
+      ]
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  legalRegistrationNumberVatId = {
+    name = "LegalRegistrationNumberVatId"
+    credentialConfigurationId = "LegalRegistrationNumberVatId_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/ns/credentials/v2", "https://w3id.org/gaia-x/development#"]
+      "type" = ["VerifiableCredential", "gx:VatID"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "https://example.org/subjects/123"
+        "type" = "gx:VatID"
+        "gx:vatID" = "BE0762747721"
+        "gx:countryCode" = "BE"
+      }
+      "evidence" = {
+        "gx:evidenceOf" = "gx:VatID"
+        "gx:evidenceURL" = "http://ec.europa.eu/taxation_customs/vies/services/checkVatService"
+        "gx:executionDate" = "2025-09-17T09:11:13.643+00:00"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  mortgageEligibility = {
+    name = "MortgageEligibility"
+    credentialConfigurationId = "MortgageEligibility_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "MortgageEligibility"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "salutation" = ""
+        "familyName" = ""
+        "firstName" = ""
+        "emailAddress" = ""
+        "dateOfBirth" = ""
+        "purchasePrice" = ""
+        "totalIncome" = ""
+        "mortgageAmount" = ""
+        "additionalCollateral" = ""
+        "postCodeProperty" = ""
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "issued" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  naturalPersonVerifiableID = {
+    name = "NaturalPersonVerifiableID"
+    credentialConfigurationId = "NaturalPersonVerifiableID_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "NaturalPersonVerifiableID"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "familyName" = "Doe"
+        "firstName" = "Jane"
+        "dateOfBirth" = "1985-08-15"
+        "personalIdentifier" = "c02654b4-814e-46dd-ba17-0bd81a45057c"
+        "nameAndFamilyNameAtBirth" = "Jane Doe"
+        "placeOfBirth" = "Lille, France"
+        "currentAddress" = "1 Boulevard de la Liberté, 59800 Lille"
+        "gender" = "Female"
+      }
+      "credentialSchema" = {
+        "id" = "https://api-conformance.ebsi.eu/trusted-schemas-registry/v3/schemas/z22ZAMdQtNLwi51T2vdZXGGZaYyjrsuP1yzWyXZirCAHv"
+        "type" = "FullJsonSchemaValidator2021"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp-ebsi>"
+      "issued" = "<timestamp-ebsi>"
+      "expirationDate" = "<timestamp-ebsi-in:365d>"
+    }
+  }
 
   openBadgeCredential = {
     name = "OpenBadgeCredential"
@@ -255,6 +1117,121 @@ profiles = {
         "id" = "<subjectDid>"
       }
       "validFrom" = "<timestamp>"
+    }
+  }
+
+  passportCh = {
+    name = "PassportCh"
+    credentialConfigurationId = "PassportCh_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifableId", "PassportCh"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "image" = {
+          "id" = "https://img.freepik.com/premium-photo/swiss-flag-switzerland_469558-1774.jpg"
+          "type" = "Image"
+        }
+        "name" = "CH Authority"
+        "type" = "Profile"
+        "url" = "https://img.freepik.com/premium-photo/swiss-flag-switzerland_469558-1774.jpg"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "residence" = "Schweiz"
+        "canton" = "Zürich"
+        "address" = "Seestraße 1"
+        "passportNumber" = "C7648556"
+        "salutation" = ""
+        "familyName" = "DOE"
+        "givenName" = "Hans"
+        "birthName" = "Doe"
+        "dateOfBirth" = "1930-10-01"
+        "emailAddress" = ""
+        "placeOfBirth" = "Zug"
+        "height" = "179"
+        "gender" = "M"
+        "authority" = "Aarau AG"
+        "nationality" = "Schweiz"
+        "countryCode" = "CHE"
+        "passportPhoto" = "data:image/png;base64,iVBORw0KGgo...kJggg=="
+      }
+      "evidence" = {
+        "documentPresence" = "Physical"
+        "evidenceDocument" = "Passport"
+        "subjectPresence" = "Physical"
+        "type" = "DocumentVerification"
+        "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  photoIDCredential = {
+    name = "PhotoIDCredential"
+    credentialConfigurationId = "PhotoIDCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://domain.com/photoid.json"]
+      "id" = "urn:uuid:123"
+      "type" = ["VerifiableCredential", "PhotoIDCredential"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "iso23220" = {
+          "family_name_unicode" = "Doe"
+          "given_name_unicode" = "John"
+          "birth_date" = "1990-01-01"
+          "portrait" = "base64-image-data"
+          "issue_date" = "2025-01-01"
+          "expiry_date" = "2035-01-01"
+          "issuing_authority_unicode" = "Gov Authority"
+          "issuing_country" = "US"
+          "age_over_18" = true
+        }
+        "photoid" = {
+          "person_id" = "PID123456"
+          "birth_country" = "US"
+          "birth_state" = "CA"
+          "birth_city" = "Los Angeles"
+        }
+        "dtc" = {
+          "dtc_dg1" = "MRZDATA=="
+          "dtc_dg2" = "FACEIMAGE=="
+          "dtc_sod" = "SODDATA=="
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
     }
   }
 
@@ -385,6 +1362,514 @@ profiles = {
     }
   }
 
+  taxCredential = {
+    name = "TaxCredential"
+    credentialConfigurationId = "TaxCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "urn:uuid:4e7f3c21-5d8b-4f2a-9b11-1c2d3e4f5a67"
+      "type" = ["VerifiableCredential", "TaxCredential"]
+      "issuer" = "did:gov:US:irs"
+      "issuanceDate" = "2025-04-15T14:00:00Z"
+      "expirationDate" = "2026-04-14T23:59:59Z"
+      "evidence" = [
+        {
+          "type" = "TaxAssessmentRecord"
+          "assessmentReference" = "IRS-2024-5087321"
+          "assessedAt" = "2025-04-05"
+          "source" = "Internal Revenue Service Masterfile"
+        }
+      ]
+      "credentialSubject" = {
+        "id" = "did:wallet:us-7890abcd"
+        "person" = {
+          "givenName" = "John"
+          "familyName" = "Doe"
+          "dateOfBirth" = "1988-06-22"
+          "tin" = "US-98-7654321"
+          "taxResidency" = {
+            "countryCode" = "US"
+          }
+          "address" = {
+            "street" = "742 Evergreen Terrace"
+            "city" = "Springfield"
+            "postalCode" = "62704"
+            "countryCode" = "US"
+          }
+        }
+        "assessmentSummary" = {
+          "taxYear" = 2024
+          "filingStatus" = "single"
+          "incomeStabilityYears" = 4
+          "employmentStatus" = "employee"
+          "employerCount" = 1
+          "incomeBreakdown" = {
+            "employmentIncome" = {
+              "amount" = 87500
+              "currency" = "USD"
+            }
+            "selfEmploymentIncome" = {
+              "amount" = 4500
+              "currency" = "USD"
+            }
+            "capitalIncome" = {
+              "amount" = 2500
+              "currency" = "USD"
+            }
+          }
+          "grossIncomeTotal" = {
+            "amount" = 94500
+            "currency" = "USD"
+          }
+          "deductionsTotal" = {
+            "amount" = 12500
+            "currency" = "USD"
+          }
+          "taxableIncome" = {
+            "amount" = 82000
+            "currency" = "USD"
+          }
+          "taxDueTotal" = {
+            "amount" = 15200
+            "currency" = "USD"
+          }
+          "withholdingPaid" = {
+            "amount" = 15000
+            "currency" = "USD"
+          }
+          "balanceOrRefund" = {
+            "amount" = 200
+            "currency" = "USD"
+            "direction" = "owed"
+          }
+          "socialContributionsPaid" = {
+            "amount" = 3100
+            "currency" = "USD"
+          }
+        }
+        "clearance" = {
+          "status" = "inGoodStanding"
+          "asOf" = "2025-04-05"
+        }
+        "derivedForLending" = {
+          "annualNetIncomeEstimate" = {
+            "amount" = 67800
+            "currency" = "USD"
+          }
+          "monthlyNetIncomeEstimate" = {
+            "amount" = 5650
+            "currency" = "USD"
+          }
+          "incomeVerificationConfidence" = "taxAuthorityVerified"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+      "evidence" = [
+        {
+          "assessmentReference" = "<assessmentReference>"
+          "assessedAt" = "<date>"
+          "source" = "<source>"
+        }
+      ]
+    }
+  }
+
+  taxReceipt = {
+    name = "TaxReceipt"
+    credentialConfigurationId = "TaxReceipt_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "TaxReceipt"]
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "ReceiptId" = "string"
+        "VAT" = "string"
+      }
+      "evidence" = [
+        {
+          "documentPresence" = ["Physical"]
+          "evidenceDocument" = ["Passport"]
+          "subjectPresence" = "Physical"
+          "type" = ["DocumentVerification"]
+          "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+        }
+      ]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Tax Authority"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  universityDegree = {
+    name = "UniversityDegree"
+    credentialConfigurationId = "UniversityDegree_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"]
+      "id" = "http://example.gov/credentials/3732"
+      "type" = ["VerifiableCredential", "UniversityDegree"]
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "degree" = {
+          "type" = "BachelorDegree"
+          "name" = "Bachelor of Science and Arts"
+        }
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  vaccinationCertificate = {
+    name = "VaccinationCertificate"
+    credentialConfigurationId = "VaccinationCertificate_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "credentialSchema" = {
+        "id" = "https://raw.githubusercontent.com/walt-id/waltid-ssikit-vclib/master/src/test/resources/schemas/VerifiableVaccinationCertificate.json"
+        "type" = "JsonSchemaValidator2018"
+      }
+      "credentialStatus" = {
+        "id" = "https://essif.europa.eu/status/covidvaccination#392ac7f6-399a-437b-a268-4691ead8f176"
+        "type" = "CredentialStatusList2020"
+      }
+      "credentialSubject" = {
+        "dateOfBirth" = "1993-04-08"
+        "familyName" = "DOE"
+        "givenNames" = "Jane"
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "personIdentifier" = "optional The type of identifier and identifier of the person, according to the policies applicable in each country. Examples are citizen ID and/or document number (ID- card/passport) or identifier within the health system/IIS/e-registry."
+        "personSex" = "optional"
+        "uniqueCertificateIdentifier" = "UVCI0904008084H"
+        "vaccinationProphylaxisInformation" = [
+          {
+            "administeringCentre" = "Name/code of administering centre or a health authority responsible for the vaccination event"
+            "batchNumber" = "optional 1234"
+            "countryOfVaccination" = "DE"
+            "dateOfVaccination" = "2021-02-12"
+            "diseaseOrAgentTargeted" = {
+              "code" = "840539006"
+              "system" = "2.16.840.1.113883. 6.96"
+              "version" = "2021-01-31"
+            }
+            "doseNumber" = "1"
+            "marketingAuthorizationHolder" = "Example Vaccine Manufacturing Company"
+            "nextVaccinationDate" = "optional - 2021-03-28"
+            "totalSeriesOfDoses" = "2"
+            "vaccineMedicinalProduct" = "VACCINE concentrate for dispersion for injection"
+            "vaccineOrProphylaxis" = "1119349007 COVID-19 example vaccine"
+          }
+        ]
+      }
+      "evidence" = {
+        "documentPresence" = ["Physical"]
+        "evidenceDocument" = ["Passport"]
+        "id" = "https://essif.europa.eu/tsr-va/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d5678"
+        "subjectPresence" = "Physical"
+        "type" = ["DocumentVerification"]
+        "verifier" = "did:ebsi:2962fb784df61baa267c8132497539f8c674b37c1244a7a"
+      }
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VaccinationCertificate"]
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  verifiableId = {
+    name = "VerifiableId"
+    credentialConfigurationId = "VerifiableId_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifiableId"]
+      "credentialSchema" = {
+        "id" = "https://api.preprod.ebsi.eu/trusted-schemas-registry/v1/schemas/0xb77f8516a965631b4f197ad54c65a9e2f9936ebfb76bae4906d33744dbcc60ba"
+        "type" = "FullJsonSchemaValidator2021"
+      }
+      "credentialSubject" = {
+        "currentAddress" = ["1 Boulevard de la Liberté, 59800 Lille"]
+        "dateOfBirth" = "1993-04-08"
+        "familyName" = "DOE"
+        "firstName" = "Jane"
+        "gender" = "FEMALE"
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "nameAndFamilyNameAtBirth" = "Jane DOE"
+        "personalIdentifier" = "0904008084H"
+        "placeOfBirth" = "LILLE, FRANCE"
+      }
+      "evidence" = [
+        {
+          "documentPresence" = ["Physical"]
+          "evidenceDocument" = ["Passport"]
+          "subjectPresence" = "Physical"
+          "type" = ["DocumentVerification"]
+          "verifier" = "did:ebsi:2A9BZ9SUe6BatacSpvs1V5CdjHvLpQ7bEsi2Jb6LdHKnQxaN"
+        }
+      ]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "2021-08-31T00:00:00Z"
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "validFrom" = "2021-08-31T00:00:00Z"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
+
+  verifiablePortableDocumentA1 = {
+    name = "VerifiablePortableDocumentA1"
+    credentialConfigurationId = "VerifiablePortableDocumentA1_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "VerifiablePortableDocumentA1"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issued" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "section1" = {
+          "personalIdentificationNumber" = "1"
+          "sex" = "01"
+          "surname" = "Jane"
+          "forenames" = "Doe"
+          "dateBirth" = "1985-08-15"
+          "nationalities" = ["BE"]
+          "stateOfResidenceAddress" = {
+            "streetNo" = "sss, nnn "
+            "postCode" = "ppp"
+            "town" = "ccc"
+            "countryCode" = "BE"
+          }
+          "stateOfStayAddress" = {
+            "streetNo" = "sss, nnn "
+            "postCode" = "ppp"
+            "town" = "ccc"
+            "countryCode" = "BE"
+          }
+        }
+        "section2" = {
+          "memberStateWhichLegislationApplies" = "DE"
+          "startingDate" = "2022-10-09"
+          "endingDate" = "2022-10-29"
+          "certificateForDurationActivity" = true
+          "determinationProvisional" = false
+          "transitionRulesApplyAsEC8832004" = false
+        }
+        "section3" = {
+          "postedEmployedPerson" = false
+          "employedTwoOrMoreStates" = false
+          "postedSelfEmployedPerson" = true
+          "selfEmployedTwoOrMoreStates" = true
+          "civilServant" = true
+          "contractStaff" = false
+          "mariner" = false
+          "employedAndSelfEmployed" = false
+          "civilAndEmployedSelfEmployed" = true
+          "flightCrewMember" = false
+          "exception" = false
+          "exceptionDescription" = ""
+          "workingInStateUnder21" = false
+        }
+        "section4" = {
+          "employee" = false
+          "selfEmployedActivity" = true
+          "nameBusinessName" = "1"
+          "registeredAddress" = {
+            "streetNo" = "1, 1 1"
+            "postCode" = "1"
+            "town" = "1"
+            "countryCode" = "DE"
+          }
+        }
+        "section5" = {
+          "noFixedAddress" = true
+        }
+        "section6" = {
+          "name" = "National Institute for the Social Security of the Self-employed (NISSE)"
+          "address" = {
+            "streetNo" = "Quai de Willebroeck 35"
+            "postCode" = "1000"
+            "town" = "Bruxelles"
+            "countryCode" = "BE"
+          }
+          "institutionID" = "NSSIE/INASTI/RSVZ"
+          "officeFaxNo" = ""
+          "officePhoneNo" = "0800 12 018"
+          "email" = "info@rsvz-inasti.fgov.be"
+          "date" = "2022-10-28"
+          "signature" = "Official signature"
+        }
+      }
+      "credentialSchema" = {
+        "id" = "https://api-conformance.ebsi.eu/trusted-schemas-registry/v3/schemas/z5qB8tydkn3Xk3VXb15SJ9dAWW6wky1YEoVdGzudWzhcW"
+        "type" = "FullJsonSchemaValidator2021"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp-ebsi>"
+      "issued" = "<timestamp-ebsi>"
+      "expirationDate" = "<timestamp-ebsi-in:365d>"
+    }
+  }
+
+  visa = {
+    name = "Visa"
+    credentialConfigurationId = "Visa_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1"]
+      "type" = ["VerifiableCredential", "VerifiableAttestation", "Visa"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "firstName" = "John"
+        "lastName" = "Doe"
+        "passportNumber" = "G7F2A04F7O"
+        "dateOfBirth" = "1980-01-01"
+        "gender" = "Male"
+        "nationality" = "US"
+        "visaType" = "Tourist"
+        "entryNumber" = "Single"
+        "visaValidity" = {
+          "start" = "2024-01-01"
+          "end" = "2024-06-30"
+        }
+        "purposeOfVisit" = "Tourism"
+      }
+      "issuer" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "name" = "Embassy of Wonderland"
+      }
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "expirationDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = {
+        "id" = "<issuerDid>"
+      }
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+      "expirationDate" = "<timestamp-in:365d>"
+    }
+  }
+
+  walletHolderCredential = {
+    name = "WalletHolderCredential"
+    credentialConfigurationId = "WalletHolderCredential_jwt_vc_json"
+    issuerKey = ${defaultIssuerKey}
+    issuerDid = ${defaultIssuerDid}
+    credentialData = {
+      "@context" = ["https://www.w3.org/2018/credentials/v1", "ndid:context:walletHolder"]
+      "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "type" = ["VerifiableCredential", "WalletHolderCredential"]
+      "issuer" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "issuanceDate" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+      "credentialSubject" = {
+        "id" = "THIS WILL BE REPLACED WITH DYNAMIC DATA FUNCTION"
+        "walletHolderCredential" = {
+          "firstName" = "สมศักดิ์"
+          "lastName" = "มั่งมี"
+          "address" = "92/222 ซอยเสรีไทย  กรุงเทพมหานคร 10240 THAILAND"
+          "identifier" = "3199611153090"
+          "namespace" = "citizen_id"
+          "serviceID" = "001.cust_info_001"
+          "requestID" = "1f8ba8218162e354c028be342f507517e6bbceae9af3ff689551eea3981a0189"
+          "requestMessage" = "ท่านกำลังยืนยันตัวตนเพื่อใช้ตามวัตถุประสงค์ของ National Digital ID Wallet และประสงค์ให้ส่งข้อมูลจาก ธนาคารกรุงศรี (Transaction Ref: 31817034)"
+          "salt" = "tlVqHnQ8HfipI9r2WnL83QPH6Z01yBo0DQaQv7RyYSQ="
+          "aal" = 2.2
+          "ial" = 2.3
+          "idp" = "DC9E1ACB-D450-438F-9558-FE7672F3F3EB"
+        }
+      }
+      "credentialStatus" = {
+        "id" = "0x2ef196ba560d7d72f13d80f405841bc84cec229b70a0a05557c5388d215bb224"
+        "type" = "NDIDCredentialStatus2021"
+      }
+      "credentialSchema" = {
+        "id" = "ndid:schema:walletHolder"
+        "type" = "JsonSchemaValidator2018"
+      }
+    }
+    mapping = {
+      "id" = "<uuid>"
+      "issuer" = "<issuerDid>"
+      "credentialSubject" = {
+        "id" = "<subjectDid>"
+      }
+      "issuanceDate" = "<timestamp>"
+    }
+  }
 
   isoMdl = {
     name = "ISO 18013-5 Mobile Driving License"


### PR DESCRIPTION
## Summary

Restores the issuer2 credential metadata and profile configs removed in #1822 for both the default service config and the matching docker-compose copy.

## Why

`main` CI is failing in `:waltid-services:waltid-issuer-api2:test` because the default issuer2 config no longer includes expected profiles such as `universityDegree`.