### PR TITLE
Skip EUDI integration tests due to expired backend certificate

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/EudiPublicBackendE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/EudiPublicBackendE2ETest.kt
@@ -19,12 +19,14 @@ import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForResource
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForStatus
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class EudiPublicBackendE2ETest {
 
+    @Ignore("EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168")
     @Test
     fun receiveAndPresentAgainstEudiPublicBackends() = runBlocking {
         val args = InstrumentationRegistry.getArguments()

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -82,7 +82,8 @@ final class MobileWalletIntegrationTests: XCTestCase {
         XCTAssertTrue(result.message.contains("Received"), "Message should confirm receipt: \(result.message)")
     }
 
-    func testReceiveAndPresentFullFlow() async throws {
+    // EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168
+    func skip_testReceiveAndPresentFullFlow() async throws {
         let controller = makeController()
 
         let bootstrapResult = try await controller.bootstrap()
@@ -113,7 +114,8 @@ final class MobileWalletIntegrationTests: XCTestCase {
         try await TestHelpers.waitForVerifierSuccess(transactionID: transaction.transactionId, timeoutSeconds: verifierPollingTimeout)
     }
 
-    func testCredentialPersistsAcrossControllerRecreation() async throws {
+    // EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168
+    func skip_testCredentialPersistsAcrossControllerRecreation() async throws {
         let controller1 = makeController()
 
         let bootstrapResult = try await controller1.bootstrap()

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -10,6 +10,7 @@ import id.walt.webdatafetching.WebDataFetchingConfiguration
 import id.walt.webdatafetching.config.HttpEngine
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
+import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -61,6 +62,7 @@ class MobileWalletIntegrationTest {
         assertTrue(credentialIds.isNotEmpty(), "Should receive at least one credential")
     }
 
+    @Ignore("EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168")
     @Test
     fun receiveAndPresentFullFlow() = runBlocking {
         val client = MobileWalletFactory(context).create(
@@ -83,6 +85,7 @@ class MobileWalletIntegrationTest {
         EudiTestBackend.waitForVerifierSuccess(transaction.transactionId)
     }
 
+    @Ignore("EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168")
     @Test
     fun credentialPersistsAcrossWalletRecreation() = runBlocking {
         val walletConfig = MobileWalletConfig(


### PR DESCRIPTION
## Summary

EUDI backend certificate expired on 2026-07-04, causing mobile wallet integration tests to fail. This PR disables the affected tests until the certificate is renewed.

## Changes

- iOS: Disabled `testReceiveAndPresentFullFlow` and `testCredentialPersistsAcrossControllerRecreation`
- Android: Disabled `receiveAndPresentFullFlow`, `credentialPersistsAcrossWalletRecreation` and `receiveAndPresentAgainstEudiPublicBackends`

## Reference

https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168