### PR TITLE
fix logic for resolving multiple keys from did doc and add test

### DIFF
--- a/waltid-libraries/credentials/waltid-credential-key-resolver/build.gradle.kts
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/build.gradle.kts
@@ -33,9 +33,13 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(identityLibs.kotlinx.coroutines.test)
         }
         jvmTest.dependencies {
             implementation(identityLibs.slf4j.simple)
+            implementation(identityLibs.ktor.serialization.kotlinx.json)
+            implementation(identityLibs.ktor.server.content.negotiation)
+            implementation(identityLibs.ktor.server.netty)
         }
     }
 }

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
@@ -7,27 +7,57 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 object DidKeyResolver : BaseKeyResolver {
     private val log = KotlinLogging.logger { }
 
-    /**
-     * Resolves a key from a DID document.
-     * If [kid] is provided, attempts to match it against the keys in the DID document.
-     * Falls back to the first key if no match is found or [kid] is null.
-     */
     suspend fun resolveKeyFromDid(issuerId: String, kid: String? = null): Key {
         log.debug { "Resolving key via DID: $issuerId (kid=$kid)" }
         val keys = DidService.resolveToKeys(issuerId).getOrThrow()
 
         if (keys.isEmpty()) throw Exception("No valid key found in DID document for $issuerId")
 
-        if (kid != null) {
-            // Try to match by key ID — the DID key ID is typically the full DID fragment, e.g. did:example:123#key-1
-            val matched = keys.firstOrNull { it.getKeyId() == kid || kid.endsWith("#${it.getKeyId()}") }
+        if (!kid.isNullOrBlank()) {
+            val matched = findMatchingKey(keys, issuerId, kid)
             if (matched != null) {
                 log.debug { "Matched key by kid '$kid' in DID document for $issuerId" }
                 return matched
             }
-            log.debug { "No key with kid '$kid' found in DID document for $issuerId, falling back to first key" }
+            if (keys.size == 1) {
+                log.debug { "No key with kid '$kid' found in single-key DID document for $issuerId, using the only key" }
+                return keys.first()
+            }
+            throw NoSuchElementException("No key with kid '$kid' found in DID document for $issuerId")
         }
 
         return keys.first()
     }
+
+    /**
+     * Attempts to find a matching key using multiple matching strategies.
+     * This handles various kid formats that may be used in JWT headers:
+     * - Full DID URL with fragment: did:web:example.com#key-1
+     * - Just the fragment: key-1
+     * - Azure Key Vault URLs: https://vault.azure.net/keys/xxx
+     * - Full verification method ID: did:web:example.com#https://vault.azure.net/keys/xxx
+     */
+    private suspend fun findMatchingKey(keys: Set<Key>, issuerId: String, kid: String): Key? {
+        val kidCandidates = idCandidates(kid)
+        return keys.firstOrNull { key ->
+            val keyId = key.getKeyId()
+            idCandidates(keyId).any { it in kidCandidates } ||
+                (keyId == issuerId && removeFragment(kid) == issuerId)
+        }
+    }
+
+    private fun idCandidates(id: String): Set<String> =
+        setOfNotNull(id, extractFragment(id))
+
+    private fun extractFragment(didUrl: String): String? {
+        val fragmentIndex = didUrl.indexOf('#')
+        return if (fragmentIndex >= 0 && fragmentIndex < didUrl.length - 1) {
+            didUrl.substring(fragmentIndex + 1)
+        } else {
+            null
+        }
+    }
+
+    private fun removeFragment(didUrl: String): String =
+        didUrl.substringBefore('#')
 }

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/jvmTest/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolverKeyRotationTest.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/jvmTest/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolverKeyRotationTest.kt
@@ -1,0 +1,162 @@
+package id.walt.credentials.keyresolver.resolvers
+
+import id.walt.crypto.keys.Key
+import id.walt.did.dids.DidService
+import id.walt.did.dids.resolver.DidResolver
+import id.walt.did.dids.resolver.local.DidWebResolver
+import id.walt.webdatafetching.WebDataFetcher
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.NettyApplicationEngine
+import io.ktor.server.netty.Netty
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DidKeyResolverKeyRotationTest {
+
+    private var previousWebResolver: DidResolver? = null
+    private lateinit var server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration>
+
+    @BeforeTest
+    fun setup() {
+        DidWebResolver.enableHttps(false)
+        server = embeddedServer(Netty, port = DID_WEB_PORT) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+            routing {
+                get("/key-rotation/did.json") {
+                    call.respond(Json.decodeFromString<JsonObject>(keyRotationDidDocument))
+                }
+            }
+        }.start(wait = false)
+
+        previousWebResolver = DidService.resolverMethods["web"]
+        DidService.registerResolverForMethod("web", testDidWebResolver)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        previousWebResolver?.let {
+            DidService.registerResolverForMethod("web", it)
+        } ?: DidService.resolverMethods.remove("web")
+
+        server.stop()
+        DidWebResolver.enableHttps(true)
+    }
+
+    @Test
+    fun `resolves rotated old key by full verification method kid`() = runTest {
+        val key = DidKeyResolver.resolveKeyFromDid(KEY_ROTATION_DID, "$KEY_ROTATION_DID#$OLD_KEY_ID")
+
+        assertEquals("$KEY_ROTATION_DID#$OLD_KEY_ID", key.getKeyId())
+    }
+
+    @Test
+    fun `resolves rotated new key by full verification method kid even when it is not first`() = runTest {
+        val key = DidKeyResolver.resolveKeyFromDid(KEY_ROTATION_DID, "$KEY_ROTATION_DID#$NEW_KEY_ID")
+
+        assertEquals("$KEY_ROTATION_DID#$NEW_KEY_ID", key.getKeyId())
+    }
+
+    @Test
+    fun `resolves rotated key when jwt kid is the public key jwk kid`() = runTest {
+        val key = DidKeyResolver.resolveKeyFromDid(KEY_ROTATION_DID, OLD_KEY_ID)
+
+        assertEquals("$KEY_ROTATION_DID#$OLD_KEY_ID", key.getKeyId())
+    }
+
+    @Test
+    fun `fails instead of falling back to first key when supplied kid is unknown`() = runTest {
+        assertFailsWith<NoSuchElementException> {
+            DidKeyResolver.resolveKeyFromDid(KEY_ROTATION_DID, "https://vault.azure.net/keys/missing")
+        }
+    }
+
+    @Test
+    fun `keeps first key fallback when no kid is supplied`() = runTest {
+        val key = DidKeyResolver.resolveKeyFromDid(KEY_ROTATION_DID)
+
+        assertEquals("$KEY_ROTATION_DID#$OLD_KEY_ID", key.getKeyId())
+    }
+
+    private companion object {
+        const val DID_WEB_PORT = 18089
+        const val KEY_ROTATION_DID = "did:web:localhost%3A$DID_WEB_PORT:key-rotation"
+        const val OLD_KEY_ID = "https://vault.azure.net/keys/old-key-xxx"
+        const val NEW_KEY_ID = "https://vault.azure.net/keys/new-key-yyy"
+
+        val didWebResolver = DidWebResolver(WebDataFetcher(id = "did-key-resolver-key-rotation-test"))
+
+        val testDidWebResolver = object : DidResolver {
+            override val name: String = "key-rotation-test-did-web-resolver"
+
+            override suspend fun getSupportedMethods(): Result<Set<String>> = Result.success(setOf("web"))
+
+            override suspend fun resolve(did: String): Result<JsonObject> =
+                didWebResolver.resolve(did).map { it.toJsonObject() }
+
+            override suspend fun resolveToKey(did: String): Result<Key> =
+                didWebResolver.resolveToKey(did)
+
+            override suspend fun resolveToKeys(did: String): Result<Set<Key>> =
+                didWebResolver.resolveToKeys(did)
+        }
+
+        val keyRotationDidDocument = """
+            {
+              "assertionMethod": [
+                "$KEY_ROTATION_DID#$OLD_KEY_ID",
+                "$KEY_ROTATION_DID#$NEW_KEY_ID"
+              ],
+              "authentication": [
+                "$KEY_ROTATION_DID#$OLD_KEY_ID",
+                "$KEY_ROTATION_DID#$NEW_KEY_ID"
+              ],
+              "@context": "https://www.w3.org/ns/did/v1",
+              "id": "$KEY_ROTATION_DID",
+              "verificationMethod": [
+                {
+                  "controller": "$KEY_ROTATION_DID",
+                  "id": "$KEY_ROTATION_DID#$OLD_KEY_ID",
+                  "publicKeyJwk": {
+                    "alg": "EdDSA",
+                    "crv": "Ed25519",
+                    "kid": "$OLD_KEY_ID",
+                    "kty": "OKP",
+                    "use": "sig",
+                    "x": "qBDsYw3k62mUT8UmEx99Xz3yckiSRmTsL6aa21ZcAVM"
+                  },
+                  "type": "JsonWebKey2020"
+                },
+                {
+                  "controller": "$KEY_ROTATION_DID",
+                  "id": "$KEY_ROTATION_DID#$NEW_KEY_ID",
+                  "publicKeyJwk": {
+                    "alg": "ES256K",
+                    "crv": "secp256k1",
+                    "kid": "$NEW_KEY_ID",
+                    "kty": "EC",
+                    "use": "sig",
+                    "x": "eKx_FaLzPMT4ndwvImdV_pTv-JX1SQpJ8tDK6GLiYIE",
+                    "y": "-TzpGxGLPnXWMJWTqYvqn55Z8Xi-J_ZM40bjtjGaELs"
+                  },
+                  "type": "JsonWebKey2020"
+                }
+              ]
+            }
+        """.trimIndent()
+    }
+}

--- a/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/resolver/local/DidWebResolver.kt
+++ b/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/resolver/local/DidWebResolver.kt
@@ -7,8 +7,10 @@ import id.walt.did.dids.document.DidDocument
 import id.walt.webdatafetching.WebDataFetcher
 import io.ktor.client.statement.*
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import love.forte.plugin.suspendtrans.annotation.JsPromise
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
 import love.forte.plugin.suspendtrans.annotation.JvmBlocking
@@ -62,21 +64,34 @@ class DidWebResolver(private val fetcher: WebDataFetcher) : LocalResolverMethod(
 
         val verificationArray = verificationMethod.jsonArray
 
-        val publicKeyJwks = verificationArray.mapNotNull { element ->
+        // Extract both the verification method ID and the public key JWK
+        val verificationMethodsWithJwks = verificationArray.mapNotNull { element ->
             runCatching {
                 val method = element.jsonObject
+                val verificationMethodId = method["id"]?.jsonPrimitive?.contentOrNull
                 val publicKeyJwk = method["publicKeyJwk"]?.jsonObject
                     ?: return@runCatching null
-                json.encodeToString(publicKeyJwk)
+                VerificationMethodWithJwk(
+                    verificationMethodId = verificationMethodId,
+                    publicKeyJwk = json.encodeToString(publicKeyJwk)
+                )
             }.getOrNull()
         }
 
-        if (publicKeyJwks.isEmpty()) {
+        if (verificationMethodsWithJwks.isEmpty()) {
             return Result.failure(IllegalStateException("No valid public key JWKs found in DID document for $did"))
         }
 
-        return tryConvertPublicKeyJwksToKeys(publicKeyJwks)
+        return tryConvertVerificationMethodsToKeys(verificationMethodsWithJwks)
     }
+
+    /**
+     * Data class to hold verification method ID and its associated JWK
+     */
+    private data class VerificationMethodWithJwk(
+        val verificationMethodId: String?,
+        val publicKeyJwk: String
+    )
 
     private fun resolveDidToUrl(did: String): String = DidUtils.identifierFromDid(did)?.let {
         val didParts = it.split(":")
@@ -114,6 +129,29 @@ class DidWebResolver(private val fetcher: WebDataFetcher) : LocalResolverMethod(
             val result = JWKKey.importJWK(publicKeyJwk)
             if (result.isSuccess) {
                 keys.add(result.getOrThrow())
+            }
+        }
+
+        return if (keys.isNotEmpty()) {
+            Result.success(keys)
+        } else {
+            Result.failure(NoSuchElementException("No keys could be imported from the DID document"))
+        }
+    }
+
+    private suspend fun tryConvertVerificationMethodsToKeys(verificationMethods: List<VerificationMethodWithJwk>): Result<Set<JWKKey>> {
+        val keys = mutableSetOf<JWKKey>()
+
+        for (vm in verificationMethods) {
+            val result = JWKKey.importJWK(vm.publicKeyJwk)
+            if (result.isSuccess) {
+                val importedKey = result.getOrThrow()
+                val keyWithVmId = if (vm.verificationMethodId != null) {
+                    JWKKey(importedKey.exportJWK(), vm.verificationMethodId)
+                } else {
+                    importedKey
+                }
+                keys.add(keyWithVmId)
             }
         }
 

--- a/waltid-libraries/waltid-did/src/jvmTest/kotlin/TestServer.kt
+++ b/waltid-libraries/waltid-did/src/jvmTest/kotlin/TestServer.kt
@@ -19,6 +19,9 @@ object TestServer {
 
     private const val DID_WEB_PORT_PLACEHOLDER = "<DID_WEB_PORT>"
 
+    @Volatile
+    private var serverStarted = false
+
     private val keyStoreFile = File(this.javaClass.classLoader.getResource("")!!.path.plus("keystore.jks"))
 
     private fun loadDidWebReferenceFile(fileName: String): String =
@@ -39,6 +42,23 @@ object TestServer {
     val server: EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration> by lazy {
         println("Initializing embedded webserver...")
         embeddedServer(Netty, applicationEnvironment(), { envConfig() }, module = { module() })
+    }
+
+    @Synchronized
+    fun ensureStarted() {
+        if (!serverStarted) {
+            println("Starting test web server...")
+            server.start()
+            serverStarted = true
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        if (serverStarted) {
+            server.stop()
+            serverStarted = false
+        }
     }
 
     private fun Application.module() {

--- a/waltid-libraries/waltid-did/src/jvmTest/kotlin/resolvers/DidWebResolverTest.kt
+++ b/waltid-libraries/waltid-did/src/jvmTest/kotlin/resolvers/DidWebResolverTest.kt
@@ -59,17 +59,13 @@ class DidWebResolverTest : DidResolverTestBase() {
         @JvmStatic
         @BeforeAll
         fun ensureServerStarted() {
-            if (!serverStarted) {
-                println("Starting test web server...")
-                TestServer.server.start()
-                serverStarted = true
-            }
+            TestServer.ensureStarted()
         }
 
         @JvmStatic
         @AfterAll
         fun stopServer() {
-            TestServer.server.stop()
+            TestServer.stop()
         }
 
         @JvmStatic


### PR DESCRIPTION
## Summary
This PR fixes DID key resolution for multi-key did:web documents, especially key rotation cases where older credentials must still verify against historical public keys.

Previously, verification could become order-dependent: if the JWT kid did not exactly match the imported key ID, resolution could fall back to the first key in the DID document. That meant rotating keys by appending a new key to verificationMethod could cause older or newer credentials to fail depending on key order.

## What Changed
DidWebResolver now preserves the DID document verification method id when importing publicKeyJwk entries. This means a key from:

```
{
  "id": "did:web:example.com#https://vault.azure.net/keys/old-key",
  "publicKeyJwk": {
    "kid": "https://vault.azure.net/keys/old-key"
  }
}
```
is resolved with the full verification method ID, not only the inner JWK kid or generated key ID.

DidKeyResolver now matches supplied JWT kid values against both full key IDs and DID URL fragments. This supports common formats such as:

- did:web:example.com#key-1
   - key-1
- did:web:example.com#https://vault.azure.net/keys/old-key
  - https://vault.azure.net/keys/old-key

For multi-key DID documents, an unknown kid now fails instead of falling back to the first key. This avoids accidentally verifying against the wrong key and removes the order-dependent behavior. Single-key DID fallback is preserved for compatibility.

## Tests
Added a production-path JVM test in waltid-credential-key-resolver using a mocked did:web document response. The test registers a mocked DID web resolver, serves a DID document containing old and new Azure Key Vault-style key IDs, and verifies that DidKeyResolver.resolveKeyFromDid(...) selects the correct key for both old and new kid values.

Also verifies that an unknown kid in a multi-key DID document fails rather than falling back to the first key.

ES regression test: https://github.com/walt-id/waltid-identity-enterprise/pull/522