### PR TITLE
[WAL-1085] Expose Swift DID and key store overrides

### DIFF
--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -131,6 +131,33 @@ final class MobileWalletIntegrationTests: XCTestCase {
         try await wallet.deleteLocalData()
     }
 
+    func testProvidedDatabaseKeyProviderBootstrapsAcrossRecreationAndDeletesProviderKey() async throws {
+        let provider = RecordingWalletDatabaseKeyProvider()
+        let persistence = WalletPersistence(databaseKey: .provided(provider))
+        let wallet1 = try await makeWallet(persistence: persistence)
+
+        let first = try await wallet1.bootstrap()
+
+        let wallet2 = try await makeWallet(persistence: persistence)
+        let second = try await wallet2.bootstrap()
+        let requestedKeys = await provider.requestedKeys
+
+        XCTAssertEqual(second.did, first.did, "Provided database key should reopen encrypted wallet state")
+        XCTAssertEqual(second.keyID, first.keyID, "Provided database key should preserve platform key references")
+        XCTAssertEqual(
+            requestedKeys,
+            [
+                "\(testWalletId):wallet_\(testWalletId)",
+                "\(testWalletId):wallet_\(testWalletId)"
+            ]
+        )
+
+        try await wallet2.deleteLocalData()
+        let deletedKeys = await provider.deletedKeys
+
+        XCTAssertEqual(deletedKeys, ["\(testWalletId):wallet_\(testWalletId)"])
+    }
+
     func testReceiveCredentialFromEudi() async throws {
         let wallet = try await makeWallet()
         _ = try await wallet.bootstrap()
@@ -228,5 +255,23 @@ private actor RecordingWalletCredentialStore: WalletCredentialStore {
 
     func removeCredential(id: String) async throws -> Bool {
         false
+    }
+}
+
+private actor RecordingWalletDatabaseKeyProvider: WalletDatabaseKeyProvider {
+    private let key = WalletDatabaseKey(
+        keyID: "ios-unit-test-provider-key",
+        material: Data((0..<32).map { UInt8($0 + 1) })
+    )
+    private(set) var requestedKeys: [String] = []
+    private(set) var deletedKeys: [String] = []
+
+    func databaseKey(walletID: String, databaseName: String) async throws -> WalletDatabaseKey {
+        requestedKeys.append("\(walletID):\(databaseName)")
+        return key
+    }
+
+    func deleteDatabaseKey(walletID: String, databaseName: String) async throws {
+        deletedKeys.append("\(walletID):\(databaseName)")
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -224,7 +224,13 @@ data class WalletBridgeStoredKey(
     val keyType: String,
     val algorithm: String? = null,
     val serializedKeyJson: String,
-)
+) {
+    /**
+     * Text representation that redacts serialized key material.
+     */
+    override fun toString(): String =
+        "WalletBridgeStoredKey(keyId=$keyId, keyType=$keyType, algorithm=$algorithm, serializedKeyJson=<redacted>)"
+}
 
 /**
  * Atomic Swift-facing key store and generator override.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -1,10 +1,19 @@
 package id.walt.wallet2.mobile.swiftinterop
 
 import id.walt.credentials.CredentialParser
+import id.walt.crypto.keys.Key
+import id.walt.crypto.keys.KeyManager
+import id.walt.crypto.keys.KeySerialization
+import id.walt.crypto.keys.KeyType
 import id.walt.wallet2.data.StoredCredential
 import id.walt.wallet2.data.WalletCredentialStore
+import id.walt.wallet2.data.WalletDidEntry
+import id.walt.wallet2.data.WalletDidStore
+import id.walt.wallet2.data.WalletKeyInfo
+import id.walt.wallet2.data.WalletKeyStore
 import id.walt.wallet2.mobile.MobileWalletConfig
 import id.walt.wallet2.mobile.MobileWalletDatabaseKey
+import id.walt.wallet2.mobile.MobileWalletKeys
 import id.walt.wallet2.mobile.MobileWalletKeyType
 import id.walt.wallet2.mobile.MobileWalletPersistence
 import id.walt.wallet2.mobile.MobileWalletStores
@@ -16,6 +25,9 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import kotlin.time.Instant
 
 /**
@@ -69,9 +81,13 @@ enum class WalletBridgeDatabaseKeyConfiguration {
  * Optional Swift-provided store overrides exposed to the bridge.
  *
  * @property credentials Optional Swift-provided credential store.
+ * @property dids Optional Swift-provided DID document store.
+ * @property keys Optional atomic Swift-provided key store and key generator.
  */
 data class WalletBridgeStores(
     val credentials: WalletBridgeCredentialStore? = null,
+    val dids: WalletBridgeDidStore? = null,
+    val keys: WalletBridgeKeys? = null,
 )
 
 /**
@@ -144,12 +160,130 @@ interface WalletBridgeCredentialStore {
     suspend fun removeCredential(id: String): Boolean
 }
 
+/**
+ * DID document entry exchanged with Swift custom DID stores.
+ *
+ * @property did Stable DID string.
+ * @property documentJson Serialized DID document JSON object.
+ */
+data class WalletBridgeStoredDid(
+    val did: String,
+    val documentJson: String,
+)
+
+/**
+ * Swift-facing DID document store override.
+ */
+interface WalletBridgeDidStore {
+    /**
+     * Returns a stored DID document by DID string.
+     */
+    suspend fun getDid(did: String): WalletBridgeStoredDid?
+
+    /**
+     * Lists all DID documents in this store.
+     */
+    suspend fun listDids(): List<WalletBridgeStoredDid>
+
+    /**
+     * Adds or replaces a DID document entry.
+     */
+    suspend fun addDid(entry: WalletBridgeStoredDid)
+
+    /**
+     * Removes a DID document by DID string.
+     *
+     * @return `true` when a DID existed and was removed.
+     */
+    suspend fun removeDid(did: String): Boolean
+}
+
+/**
+ * Key metadata exchanged with Swift custom key stores.
+ *
+ * @property keyId Stable wallet-local key identifier.
+ * @property keyType Wallet key type name.
+ * @property algorithm Optional signing algorithm label supplied by Swift.
+ */
+data class WalletBridgeKeyInfo(
+    val keyId: String,
+    val keyType: String,
+    val algorithm: String? = null,
+)
+
+/**
+ * Serialized signing key exchanged with Swift custom key stores.
+ *
+ * @property keyId Stable wallet-local key identifier.
+ * @property keyType Wallet key type name.
+ * @property algorithm Optional signing algorithm label supplied by Swift.
+ * @property serializedKeyJson walt.id serialized key JSON payload.
+ */
+data class WalletBridgeStoredKey(
+    val keyId: String,
+    val keyType: String,
+    val algorithm: String? = null,
+    val serializedKeyJson: String,
+)
+
+/**
+ * Atomic Swift-facing key store and generator override.
+ *
+ * KMP requires the store and generator together so generated signing keys are persisted into the same
+ * app-owned key domain.
+ */
+data class WalletBridgeKeys(
+    val store: WalletBridgeKeyStore,
+    val generate: WalletBridgeKeyGenerator,
+)
+
+/**
+ * Swift-facing signing-key store override.
+ */
+interface WalletBridgeKeyStore {
+    /**
+     * Returns a serialized signing key by wallet-local identifier.
+     */
+    suspend fun getKey(keyId: String): WalletBridgeStoredKey?
+
+    /**
+     * Lists stored signing-key metadata.
+     */
+    suspend fun listKeys(): List<WalletBridgeKeyInfo>
+
+    /**
+     * Adds or replaces a serialized signing key entry.
+     *
+     * @return Stable wallet-local key identifier for the stored key.
+     */
+    suspend fun addKey(entry: WalletBridgeStoredKey): String
+
+    /**
+     * Removes a signing key by wallet-local identifier.
+     *
+     * @return `true` when a key existed and was removed.
+     */
+    suspend fun removeKey(keyId: String): Boolean
+}
+
+/**
+ * Swift-facing signing-key generator override.
+ */
+interface WalletBridgeKeyGenerator {
+    /**
+     * Generates a serialized signing key for [keyType].
+     */
+    suspend fun generateKey(keyType: MobileWalletKeyType): WalletBridgeStoredKey
+}
+
 private fun WalletBridgePersistence.toMobileWalletPersistence(
     databaseKeyProvider: WalletBridgeDatabaseEncryptionKeyProvider?,
 ): MobileWalletPersistence = MobileWalletPersistence(
     databaseKey = databaseKey.toMobileWalletDatabaseKey(databaseKeyProvider),
     stores = MobileWalletStores(
         credentials = stores.credentials?.let(::BridgeCredentialStore),
+        dids = stores.dids?.let(::BridgeDidStore),
+        keys = stores.keys?.toMobileWalletKeys(),
     ),
 )
 
@@ -201,6 +335,44 @@ private class BridgeCredentialStore(
         bridgeStore.removeCredential(id)
 }
 
+private class BridgeDidStore(
+    private val bridgeStore: WalletBridgeDidStore,
+) : WalletDidStore {
+    override suspend fun getDid(did: String): WalletDidEntry? =
+        bridgeStore.getDid(did)?.toWalletDidEntry()
+
+    override suspend fun listDids(): Flow<WalletDidEntry> =
+        bridgeStore.listDids().map { it.toWalletDidEntry() }.asFlow()
+
+    override suspend fun addDid(entry: WalletDidEntry) {
+        bridgeStore.addDid(entry.toBridgeStoredDid())
+    }
+
+    override suspend fun removeDid(did: String): Boolean =
+        bridgeStore.removeDid(did)
+}
+
+private class BridgeKeyStore(
+    private val bridgeStore: WalletBridgeKeyStore,
+) : WalletKeyStore {
+    override suspend fun getKey(keyId: String): Key? =
+        bridgeStore.getKey(keyId)?.toKey()
+
+    override suspend fun listKeys(): Flow<WalletKeyInfo> =
+        bridgeStore.listKeys().map { it.toWalletKeyInfo() }.asFlow()
+
+    override suspend fun addKey(key: Key): String =
+        bridgeStore.addKey(key.toBridgeStoredKey())
+
+    override suspend fun removeKey(keyId: String): Boolean =
+        bridgeStore.removeKey(keyId)
+}
+
+private fun WalletBridgeKeys.toMobileWalletKeys() = MobileWalletKeys(
+    store = BridgeKeyStore(store),
+    generate = { keyType -> generate.generateKey(keyType.toMobileWalletKeyType()).toKey() },
+)
+
 private suspend fun WalletBridgeStoredCredential.toStoredCredential(): StoredCredential {
     val (_, credential) = CredentialParser.detectAndParse(serializedCredential)
     return StoredCredential(
@@ -218,6 +390,43 @@ private fun StoredCredential.toBridgeStoredCredential() = WalletBridgeStoredCred
     label = label,
     addedAt = addedAt?.toString(),
 )
+
+private fun WalletBridgeStoredDid.toWalletDidEntry() = WalletDidEntry(
+    did = did,
+    document = Json.parseToJsonElement(documentJson).jsonObject,
+)
+
+private fun WalletDidEntry.toBridgeStoredDid() = WalletBridgeStoredDid(
+    did = did,
+    documentJson = Json.encodeToString(JsonObject.serializer(), document),
+)
+
+private fun WalletBridgeKeyInfo.toWalletKeyInfo() = WalletKeyInfo(
+    keyId = keyId,
+    keyType = keyType,
+    algorithm = algorithm,
+)
+
+private suspend fun WalletBridgeStoredKey.toKey(): Key =
+    KeyManager.resolveSerializedKey(serializedKeyJson)
+
+private suspend fun Key.toBridgeStoredKey() = WalletBridgeStoredKey(
+    keyId = getKeyId(),
+    keyType = keyType.name,
+    algorithm = null,
+    serializedKeyJson = KeySerialization.serializeKey(this),
+)
+
+private fun KeyType.toMobileWalletKeyType(): MobileWalletKeyType = when (this) {
+    KeyType.Ed25519 -> MobileWalletKeyType.Ed25519
+    KeyType.secp256k1 -> MobileWalletKeyType.secp256k1
+    KeyType.secp256r1 -> MobileWalletKeyType.secp256r1
+    KeyType.secp384r1 -> MobileWalletKeyType.secp384r1
+    KeyType.secp521r1 -> MobileWalletKeyType.secp521r1
+    KeyType.RSA -> MobileWalletKeyType.RSA
+    KeyType.RSA3072 -> MobileWalletKeyType.RSA3072
+    KeyType.RSA4096 -> MobileWalletKeyType.RSA4096
+}
 
 /**
  * Coarse error category for Swift bridge failures.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -231,6 +231,9 @@ data class WalletBridgeStoredKey(
  *
  * KMP requires the store and generator together so generated signing keys are persisted into the same
  * app-owned key domain.
+ *
+ * @property store Swift-provided signing-key store.
+ * @property generate Swift-provided signing-key generator.
  */
 data class WalletBridgeKeys(
     val store: WalletBridgeKeyStore,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/MobileWalletPersistenceIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/MobileWalletPersistenceIntegrationTest.kt
@@ -42,21 +42,21 @@ class MobileWalletPersistenceIntegrationTest {
     }
 
     @Test
-    fun customIosCredentialStoreRoutesWithProvidedDatabaseKey() = runTest {
+    fun customIosCredentialStoreRoutesWithoutReplacingDidOrKeyStores() = runTest {
         val walletId = "ios-custom-credential-store-${Uuid.random()}"
         val databaseName = "wallet_$walletId"
-        val provider = RecordingDatabaseKeyProvider(
+        val credentialStore = RecordingCredentialStore()
+        val databaseKeyProvider = RecordingDatabaseKeyProvider(
             DatabaseEncryptionKey(
                 keyId = "provided-key",
-                material = ByteArray(32) { index -> (index + 9).toByte() },
+                material = ByteArray(32) { index -> (index + 7).toByte() },
             )
         )
-        val credentialStore = RecordingCredentialStore()
         val factory = MobileWalletFactory()
         val config = MobileWalletConfig(
             walletId = walletId,
             persistence = MobileWalletPersistence(
-                databaseKey = MobileWalletDatabaseKey.Provided(provider),
+                databaseKey = MobileWalletDatabaseKey.Provided(databaseKeyProvider),
                 stores = MobileWalletStores(credentials = credentialStore),
             ),
         )
@@ -65,11 +65,11 @@ class MobileWalletPersistenceIntegrationTest {
         // Swift integration tests cover managed Keychain persistence with this store shape.
         val wallet = factory.create(config)
         assertEquals(emptyList(), wallet.credentials())
+        assertEquals(listOf("$walletId:$databaseName"), databaseKeyProvider.requestedKeys)
         assertEquals(1, credentialStore.listCredentialsCalls)
-        assertEquals(listOf("$walletId:$databaseName"), provider.requestedKeys)
 
         wallet.deleteWallet()
-        assertEquals(listOf("$walletId:$databaseName"), provider.deletedKeys)
+        assertEquals(listOf("$walletId:$databaseName"), databaseKeyProvider.deletedKeys)
     }
 
     private class RecordingDatabaseKeyProvider(

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 
 class WalletSdkBridgeTest {
 
@@ -225,8 +226,50 @@ class WalletSdkBridgeTest {
         )
 
         assertIs<WalletBridgeResult.Success<WalletSdkBridge>>(result)
-        val credentialStore = capturedConfig?.persistence?.stores?.credentials
+        val persistence = capturedConfig?.persistence
+        assertIs<MobileWalletDatabaseKey.Managed>(persistence?.databaseKey)
+        assertNull(persistence?.stores?.dids)
+        assertNull(persistence?.stores?.keys)
+        val credentialStore = persistence?.stores?.credentials
         assertEquals(true, credentialStore?.removeCredential("credential-1"))
+        assertEquals(listOf("credential-1"), bridgeCredentialStore.removedCredentialIds)
+    }
+
+    @Test
+    fun factoryCombinesSwiftDatabaseKeyProviderAndCredentialStoreOverride() = runTest {
+        var capturedConfig: MobileWalletConfig? = null
+        val bridgeKeyProvider = RecordingBridgeDatabaseKeyProvider(
+            WalletBridgeDatabaseEncryptionKey(
+                keyId = "swift-key",
+                material = byteArrayOf(4, 5, 6),
+            )
+        )
+        val bridgeCredentialStore = RecordingBridgeCredentialStore()
+        val factory = WalletSdkBridgeFactory.forOperationsFactory { config ->
+            capturedConfig = config
+            FakeWalletSdkBridgeOperations()
+        }
+
+        val result = factory.create(
+            WalletBridgeConfiguration(
+                walletId = "swift-combined-wallet",
+                persistence = WalletBridgePersistence(
+                    databaseKey = WalletBridgeDatabaseKeyConfiguration.Provided,
+                    stores = WalletBridgeStores(credentials = bridgeCredentialStore),
+                ),
+                databaseKeyProvider = bridgeKeyProvider,
+            )
+        )
+
+        assertIs<WalletBridgeResult.Success<WalletSdkBridge>>(result)
+        val persistence = capturedConfig?.persistence
+        val databaseKey = assertIs<MobileWalletDatabaseKey.Provided>(persistence?.databaseKey)
+        val key = databaseKey.provider.getOrCreateKey("swift-combined-wallet", "wallet_swift-combined-wallet")
+
+        assertEquals(DatabaseEncryptionKey("swift-key", byteArrayOf(4, 5, 6)), key)
+        assertNull(persistence?.stores?.dids)
+        assertNull(persistence?.stores?.keys)
+        assertEquals(true, persistence?.stores?.credentials?.removeCredential("credential-1"))
         assertEquals(listOf("credential-1"), bridgeCredentialStore.removedCredentialIds)
     }
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 
@@ -62,6 +63,22 @@ class WalletSdkBridgeTest {
         }
 
         assertEquals("cancelled", cancellation.message)
+    }
+
+    @Test
+    fun storedKeyStringRepresentationRedactsSerializedKeyJson() {
+        val key = WalletBridgeStoredKey(
+            keyId = "key-1",
+            keyType = "secp256r1",
+            algorithm = "ES256",
+            serializedKeyJson = """{"type":"jwk","jwk":{"kid":"key-1","d":"secret"}}""",
+        )
+
+        assertEquals(
+            "WalletBridgeStoredKey(keyId=key-1, keyType=secp256r1, algorithm=ES256, serializedKeyJson=<redacted>)",
+            key.toString(),
+        )
+        assertFalse(key.toString().contains("secret"))
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -1,6 +1,9 @@
 package id.walt.wallet2.mobile.swiftinterop
 
+import id.walt.crypto.keys.KeyManager
 import id.walt.crypto.keys.KeyType
+import id.walt.wallet2.data.WalletDidEntry
+import id.walt.wallet2.data.WalletKeyInfo
 import id.walt.wallet2.mobile.MobileWalletEvent
 import id.walt.wallet2.mobile.MobileWalletEventPhase
 import id.walt.wallet2.mobile.MobileWalletEventStatus
@@ -16,8 +19,11 @@ import id.walt.wallet2.mobile.WalletAttestationConfig
 import id.walt.wallet2.mobile.toKeyType
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -236,6 +242,78 @@ class WalletSdkBridgeTest {
     }
 
     @Test
+    fun factoryMapsSwiftDidAndKeyStoreOverridesToMobileWalletConfig() = runTest {
+        var capturedConfig: MobileWalletConfig? = null
+        val generatedKey = KeyManager.resolveSerializedKey(ED25519_SERIALIZED_KEY)
+        val generatedBridgeKey = WalletBridgeStoredKey(
+            keyId = generatedKey.getKeyId(),
+            keyType = "Ed25519",
+            algorithm = "EdDSA",
+            serializedKeyJson = ED25519_SERIALIZED_KEY,
+        )
+        val storedBridgeKey = WalletBridgeStoredKey(
+            keyId = P256_KEY_ID,
+            keyType = "secp256r1",
+            algorithm = "ES256",
+            serializedKeyJson = P256_SERIALIZED_KEY,
+        )
+        val bridgeDidStore = RecordingBridgeDidStore(
+            WalletBridgeStoredDid(
+                did = "did:key:swift",
+                documentJson = """{"id":"did:key:swift"}""",
+            )
+        )
+        val bridgeKeyStore = RecordingBridgeKeyStore(storedBridgeKey)
+        val bridgeKeyGenerator = RecordingBridgeKeyGenerator(generatedBridgeKey)
+        val factory = WalletSdkBridgeFactory.forOperationsFactory { config ->
+            capturedConfig = config
+            FakeWalletSdkBridgeOperations()
+        }
+
+        val result = factory.create(
+            WalletBridgeConfiguration(
+                walletId = "swift-full-store-wallet",
+                persistence = WalletBridgePersistence(
+                    stores = WalletBridgeStores(
+                        dids = bridgeDidStore,
+                        keys = WalletBridgeKeys(
+                            store = bridgeKeyStore,
+                            generate = bridgeKeyGenerator,
+                        ),
+                    ),
+                ),
+            )
+        )
+
+        assertIs<WalletBridgeResult.Success<WalletSdkBridge>>(result)
+        val persistence = requireNotNull(capturedConfig).persistence
+        assertIs<MobileWalletDatabaseKey.Managed>(persistence.databaseKey)
+
+        val didStore = requireNotNull(persistence.stores.dids)
+        assertEquals(
+            WalletDidEntry("did:key:swift", Json.parseToJsonElement("""{"id":"did:key:swift"}""").jsonObject),
+            didStore.getDid("did:key:swift"),
+        )
+        didStore.addDid(WalletDidEntry("did:key:new", Json.parseToJsonElement("""{"id":"did:key:new"}""").jsonObject))
+        assertEquals(listOf("did:key:new"), bridgeDidStore.addedDids.map { it.did })
+        assertEquals("""{"id":"did:key:new"}""", bridgeDidStore.addedDids.single().documentJson)
+        assertEquals(true, didStore.removeDid("did:key:swift"))
+        assertEquals(listOf("did:key:swift"), bridgeDidStore.removedDids)
+
+        val keys = requireNotNull(persistence.stores.keys)
+        assertEquals(listOf(WalletKeyInfo(P256_KEY_ID, "secp256r1", "ES256")), keys.store.listKeys().toList())
+        assertEquals(P256_KEY_ID, keys.store.getKey(P256_KEY_ID)?.getKeyId())
+        assertEquals(P256_KEY_ID, keys.store.addKey(generatedKey))
+        assertEquals(generatedBridgeKey.keyId, bridgeKeyStore.addedKeys.single().keyId)
+        assertEquals(true, keys.store.removeKey(P256_KEY_ID))
+        assertEquals(listOf(P256_KEY_ID), bridgeKeyStore.removedKeyIds)
+
+        val generated = keys.generate(KeyType.Ed25519)
+        assertEquals(generatedBridgeKey.keyId, generated.getKeyId())
+        assertEquals(listOf(MobileWalletKeyType.Ed25519), bridgeKeyGenerator.requestedTypes)
+    }
+
+    @Test
     fun factoryCombinesSwiftDatabaseKeyProviderAndCredentialStoreOverride() = runTest {
         var capturedConfig: MobileWalletConfig? = null
         val bridgeKeyProvider = RecordingBridgeDatabaseKeyProvider(
@@ -413,5 +491,71 @@ class WalletSdkBridgeTest {
             removedCredentialIds += id
             return true
         }
+    }
+
+    private class RecordingBridgeDidStore(
+        private val did: WalletBridgeStoredDid,
+    ) : WalletBridgeDidStore {
+        val addedDids = mutableListOf<WalletBridgeStoredDid>()
+        val removedDids = mutableListOf<String>()
+
+        override suspend fun getDid(did: String): WalletBridgeStoredDid? =
+            this.did.takeIf { it.did == did }
+
+        override suspend fun listDids(): List<WalletBridgeStoredDid> =
+            listOf(did)
+
+        override suspend fun addDid(entry: WalletBridgeStoredDid) {
+            addedDids += entry
+        }
+
+        override suspend fun removeDid(did: String): Boolean {
+            removedDids += did
+            return true
+        }
+    }
+
+    private class RecordingBridgeKeyStore(
+        private val key: WalletBridgeStoredKey,
+    ) : WalletBridgeKeyStore {
+        val addedKeys = mutableListOf<WalletBridgeStoredKey>()
+        val removedKeyIds = mutableListOf<String>()
+
+        override suspend fun getKey(keyId: String): WalletBridgeStoredKey? =
+            key.takeIf { it.keyId == keyId }
+
+        override suspend fun listKeys(): List<WalletBridgeKeyInfo> =
+            listOf(WalletBridgeKeyInfo(key.keyId, key.keyType, key.algorithm))
+
+        override suspend fun addKey(entry: WalletBridgeStoredKey): String {
+            addedKeys += entry
+            return key.keyId
+        }
+
+        override suspend fun removeKey(keyId: String): Boolean {
+            removedKeyIds += keyId
+            return true
+        }
+    }
+
+    private class RecordingBridgeKeyGenerator(
+        private val key: WalletBridgeStoredKey,
+    ) : WalletBridgeKeyGenerator {
+        val requestedTypes = mutableListOf<MobileWalletKeyType>()
+
+        override suspend fun generateKey(keyType: MobileWalletKeyType): WalletBridgeStoredKey {
+            requestedTypes += keyType
+            return key
+        }
+    }
+
+    private companion object {
+        private const val ED25519_SERIALIZED_KEY =
+            """{"type":"jwk","jwk":{"kty":"OKP","d":"lPR4XjW-9_rI4hLjvdjmjoGC6ozblm9juDv4OHYdm5M","crv":"Ed25519","kid":"sryFIxLJ7aIqTsXo0QCnNUR9TG6jmHOQa9CFhxg5OIA","x":"LRHvL7I9utgSl47JksY0-uY21TlIxp_queROJJzknNM"}}"""
+
+        private const val P256_KEY_ID = "_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug"
+
+        private const val P256_SERIALIZED_KEY =
+            """{"type":"jwk","jwk":{"kty":"EC","d":"AEb4k1BeTR9xt2NxYZggdzkFLLUkhyyWvyUOq3qSiwA","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}}"""
     }
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
@@ -128,7 +128,77 @@ let wallet = try await Wallet(
 )
 ```
 
-Provided database keys and custom credential stores can be combined when an app owns both database-key recovery and credential durability:
+Apps that own more wallet durability can also provide DID and signing-key stores. Signing-key overrides are configured through `WalletKeys` so the app-owned `WalletKeyStore` and generator are supplied atomically:
+
+```swift
+actor AppDidStore: WalletDidStore {
+    private var entries: [String: StoredDid] = [:]
+
+    func did(id: String) async throws -> StoredDid? {
+        entries[id]
+    }
+
+    func dids() async throws -> [StoredDid] {
+        Array(entries.values)
+    }
+
+    func addDid(_ did: StoredDid) async throws {
+        entries[did.id] = did
+    }
+
+    func removeDid(id: String) async throws -> Bool {
+        entries.removeValue(forKey: id) != nil
+    }
+}
+
+actor AppKeyStore: WalletKeyStore {
+    private var entries: [String: StoredKey] = [:]
+
+    func key(id: String) async throws -> StoredKey? {
+        entries[id]
+    }
+
+    func keys() async throws -> [WalletKeyInfo] {
+        entries.values.map {
+            WalletKeyInfo(keyID: $0.keyID, keyType: $0.keyType, algorithm: $0.algorithm)
+        }
+    }
+
+    func addKey(_ key: StoredKey) async throws -> String {
+        entries[key.id] = key
+        return key.keyID
+    }
+
+    func removeKey(id: String) async throws -> Bool {
+        entries.removeValue(forKey: id) != nil
+    }
+
+    func generateKey(type: WalletKeyType) async throws -> StoredKey {
+        try await createSerializedWalletKey(type: type)
+    }
+}
+
+let keyStore = AppKeyStore()
+
+let wallet = try await Wallet(
+    configuration: WalletConfiguration(
+        walletID: "consumer-wallet",
+        persistence: WalletPersistence(
+            stores: WalletStores(
+                credentials: AppCredentialStore(),
+                dids: AppDidStore(),
+                keys: WalletKeys(store: keyStore) { keyType in
+                    try await keyStore.generateKey(type: keyType)
+                }
+            )
+        )
+    )
+)
+```
+
+`StoredKey.serializedKeyJSON` is a walt.id serialized key payload and may contain private signing material. Treat it like a secret and store it only in app-owned secure storage.
+
+Provided database keys and custom stores can be combined when an app owns both database-key recovery and wallet-record durability:
 
 ```swift
 let wallet = try await Wallet(
@@ -136,15 +206,19 @@ let wallet = try await Wallet(
         walletID: "consumer-wallet",
         persistence: WalletPersistence(
             databaseKey: .provided(KMSDatabaseKeyProvider()),
-            stores: WalletStores(credentials: AppCredentialStore())
+            stores: WalletStores(
+                credentials: AppCredentialStore(),
+                dids: AppDidStore(),
+                keys: WalletKeys(store: keyStore) { keyType in
+                    try await keyStore.generateKey(type: keyType)
+                }
+            )
         )
     )
 )
 ```
 
-The Swift facade intentionally exposes credential-store overrides first. Kotlin Multiplatform still supports full credential, DID, and key store overrides through `MobileWalletStores`; Swift key/DID store parity needs public Swift signing-key and DID-document models, defined deletion semantics for app-owned stores, and typed error behavior before those overrides become public Swift API.
-
-Call `try await wallet.deleteLocalData()` to remove local material for that wallet: stored wallet records, platform signing keys referenced by the wallet, encrypted database files and sidecars, and the configured database key. Local development databases created before encrypted persistence may fail to open; reset the app by calling `deleteLocalData()`, uninstalling the app, or deleting local app data.
+Call `try await wallet.deleteLocalData()` to remove local material for that wallet. The active credential, DID, and key stores receive their remove calls; the SDK then removes encrypted database files and sidecars plus the configured database key. Local development databases created before encrypted persistence may fail to open; reset the app by calling `deleteLocalData()`, uninstalling the app, or deleting local app data.
 
 ## Native iOS Consumer
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
@@ -128,7 +128,21 @@ let wallet = try await Wallet(
 )
 ```
 
-The Swift facade intentionally exposes credential-store overrides first. Kotlin Multiplatform still supports full credential, DID, and key store overrides through `MobileWalletStores`; Swift key/DID store parity needs public Swift signing-key and DID-document models and is tracked separately.
+Provided database keys and custom credential stores can be combined when an app owns both database-key recovery and credential durability:
+
+```swift
+let wallet = try await Wallet(
+    configuration: WalletConfiguration(
+        walletID: "consumer-wallet",
+        persistence: WalletPersistence(
+            databaseKey: .provided(KMSDatabaseKeyProvider()),
+            stores: WalletStores(credentials: AppCredentialStore())
+        )
+    )
+)
+```
+
+The Swift facade intentionally exposes credential-store overrides first. Kotlin Multiplatform still supports full credential, DID, and key store overrides through `MobileWalletStores`; Swift key/DID store parity needs public Swift signing-key and DID-document models, defined deletion semantics for app-owned stores, and typed error behavior before those overrides become public Swift API.
 
 Call `try await wallet.deleteLocalData()` to remove local material for that wallet: stored wallet records, platform signing keys referenced by the wallet, encrypted database files and sidecars, and the configured database key. Local development databases created before encrypted persistence may fail to open; reset the app by calling `deleteLocalData()`, uninstalling the app, or deleting local app data.
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
@@ -27,6 +27,11 @@ Apps that own database-key recovery can pass ``WalletPersistence`` with
 ``WalletDatabaseKeyConfiguration/provided(_:)`` and a
 ``WalletDatabaseKeyProvider`` implementation.
 
+Apps can also pass ``WalletStores`` with a ``WalletCredentialStore`` when they
+own credential durability. The Swift facade intentionally exposes credential
+store overrides only; DID storage and signing-key storage stay SDK-managed for
+now.
+
 > Important: Keep Kotlin Multiplatform and generated bridge symbols behind
 > `WalletSDK`. Native iOS consumers should import this Swift package and work
 > with Swift-owned types.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
@@ -27,10 +27,30 @@ Apps that own database-key recovery can pass ``WalletPersistence`` with
 ``WalletDatabaseKeyConfiguration/provided(_:)`` and a
 ``WalletDatabaseKeyProvider`` implementation.
 
-Apps can also pass ``WalletStores`` with a ``WalletCredentialStore`` when they
-own credential durability. The Swift facade intentionally exposes credential
-store overrides only; DID storage and signing-key storage stay SDK-managed for
-now.
+Apps can also pass ``WalletStores`` when they own credential, DID, or signing-key
+durability. Credential and DID stores can be supplied independently. Signing-key
+stores use ``WalletKeys`` so the app-owned ``WalletKeyStore`` and key generator
+are configured atomically.
+
+```swift
+let wallet = try await Wallet(
+    configuration: WalletConfiguration(
+        walletID: "consumer-wallet",
+        persistence: WalletPersistence(
+            stores: WalletStores(
+                credentials: AppCredentialStore(),
+                dids: AppDidStore(),
+                keys: WalletKeys(store: AppKeyStore()) { keyType in
+                    try await generateSerializedWalletKey(type: keyType)
+                }
+            )
+        )
+    )
+)
+```
+
+``StoredKey`` contains walt.id serialized key JSON and may include private key
+material. Keep those entries in app-owned secure storage.
 
 > Important: Keep Kotlin Multiplatform and generated bridge symbols behind
 > `WalletSDK`. Native iOS consumers should import this Swift package and work

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/WalletSDK.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/WalletSDK.md
@@ -64,15 +64,32 @@ let wallet = try await Wallet(
 ``WalletDatabaseKey`` descriptions redact raw key material, but apps should still
 avoid logging, serializing, or otherwise exposing the `material` bytes.
 
-Use ``WalletStores`` with ``WalletCredentialStore`` to override credential
-storage while keeping the managed encrypted database key, DID store, and
-platform signing-key store.
+Use ``WalletStores`` when an app owns credential, DID, or signing-key
+durability. Store overrides are independent except for signing keys:
+``WalletKeys`` keeps the ``WalletKeyStore`` and its generator together so newly
+generated keys are persisted into the same app-owned key domain.
 
-Provided database keys and custom credential stores can be combined when an app
-owns both database-key recovery and credential durability. Swift currently keeps
-DID document storage and signing-key storage managed by the SDK; those store
-overrides remain Kotlin Multiplatform-only until Swift has stable public models,
-deletion semantics, and typed errors for app-owned DID and key stores.
+```swift
+let wallet = try await Wallet(
+    configuration: WalletConfiguration(
+        walletID: "consumer-wallet",
+        persistence: WalletPersistence(
+            stores: WalletStores(
+                credentials: AppCredentialStore(),
+                dids: AppDidStore(),
+                keys: WalletKeys(store: AppKeyStore()) { keyType in
+                    try await generateSerializedWalletKey(type: keyType)
+                }
+            )
+        )
+    )
+)
+```
+
+Provided database keys and custom stores can be combined when an app owns both
+database-key recovery and wallet-record durability. ``StoredKey`` carries
+walt.id serialized key JSON and may contain private signing material, so apps
+should keep it in app-owned secure storage and avoid logging it.
 
 Use ``Wallet/deleteLocalData()`` to reset local data for the wallet.
 This removes wallet records, platform signing keys referenced by the wallet,
@@ -101,12 +118,18 @@ reset; plaintext-to-encrypted migration is not performed.
 - ``WalletDatabaseKey``
 - ``WalletStores``
 - ``WalletCredentialStore``
+- ``WalletDidStore``
+- ``WalletKeyStore``
+- ``WalletKeys``
 - ``WalletAttestationConfiguration``
 
 ### Wallet Data
 
 - ``Credential``
 - ``StoredCredential``
+- ``StoredDid``
+- ``StoredKey``
+- ``WalletKeyInfo``
 - ``WalletBootstrapResult``
 - ``PresentationResult``
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/WalletSDK.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/WalletSDK.md
@@ -68,6 +68,12 @@ Use ``WalletStores`` with ``WalletCredentialStore`` to override credential
 storage while keeping the managed encrypted database key, DID store, and
 platform signing-key store.
 
+Provided database keys and custom credential stores can be combined when an app
+owns both database-key recovery and credential durability. Swift currently keeps
+DID document storage and signing-key storage managed by the SDK; those store
+overrides remain Kotlin Multiplatform-only until Swift has stable public models,
+deletion semantics, and typed errors for app-owned DID and key stores.
+
 Use ``Wallet/deleteLocalData()`` to reset local data for the wallet.
 This removes wallet records, platform signing keys referenced by the wallet,
 encrypted database files and sidecars, and managed database keys. When using

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -184,7 +184,14 @@ private extension WalletDatabaseKeyConfiguration {
 private extension WalletStores {
     func toKMPStores() -> WalletBridgeStores {
         WalletBridgeStores(
-            credentials: credentials.map { KMPWalletCredentialStoreAdapter(store: $0) }
+            credentials: credentials.map { KMPWalletCredentialStoreAdapter(store: $0) },
+            dids: dids.map { KMPWalletDidStoreAdapter(store: $0) },
+            keys: keys.map { keyOverride in
+                WalletBridgeKeys(
+                    store: KMPWalletKeyStoreAdapter(store: keyOverride.store),
+                    generate: KMPWalletKeyGeneratorAdapter(generate: keyOverride.generate)
+                )
+            }
         )
     }
 }
@@ -233,6 +240,66 @@ private final class KMPWalletCredentialStoreAdapter: WalletBridgeCredentialStore
     }
 }
 
+private final class KMPWalletDidStoreAdapter: WalletBridgeDidStore, @unchecked Sendable {
+    private let store: any WalletDidStore
+
+    init(store: any WalletDidStore) {
+        self.store = store
+    }
+
+    func __getDid(did: String) async throws -> WalletBridgeStoredDid? {
+        try await store.did(id: did)?.toKMPStoredDid()
+    }
+
+    func __listDids() async throws -> [WalletBridgeStoredDid] {
+        try await store.dids().map { $0.toKMPStoredDid() }
+    }
+
+    func __addDid(entry: WalletBridgeStoredDid) async throws {
+        try await store.addDid(entry.toSwiftStoredDid())
+    }
+
+    func __removeDid(did: String) async throws -> KotlinBoolean {
+        KotlinBoolean(bool: try await store.removeDid(id: did))
+    }
+}
+
+private final class KMPWalletKeyStoreAdapter: WalletBridgeKeyStore, @unchecked Sendable {
+    private let store: any WalletKeyStore
+
+    init(store: any WalletKeyStore) {
+        self.store = store
+    }
+
+    func __getKey(keyId: String) async throws -> WalletBridgeStoredKey? {
+        try await store.key(id: keyId)?.toKMPStoredKey()
+    }
+
+    func __listKeys() async throws -> [WalletBridgeKeyInfo] {
+        try await store.keys().map { $0.toKMPKeyInfo() }
+    }
+
+    func __addKey(entry: WalletBridgeStoredKey) async throws -> String {
+        try await store.addKey(entry.toSwiftStoredKey())
+    }
+
+    func __removeKey(keyId: String) async throws -> KotlinBoolean {
+        KotlinBoolean(bool: try await store.removeKey(id: keyId))
+    }
+}
+
+private final class KMPWalletKeyGeneratorAdapter: WalletBridgeKeyGenerator, @unchecked Sendable {
+    private let generate: @Sendable (WalletKeyType) async throws -> StoredKey
+
+    init(generate: @escaping @Sendable (WalletKeyType) async throws -> StoredKey) {
+        self.generate = generate
+    }
+
+    func __generateKey(keyType: MobileWalletKeyType) async throws -> WalletBridgeStoredKey {
+        try await generate(keyType.toSwiftKeyType()).toKMPStoredKey()
+    }
+}
+
 private extension StoredCredential {
     func toKMPStoredCredential() -> WalletBridgeStoredCredential {
         WalletBridgeStoredCredential(
@@ -253,6 +320,56 @@ private extension WalletBridgeStoredCredential {
             format: format,
             label: label,
             addedAt: addedAt.flatMap { ISO8601DateFormatter().date(from: $0) }
+        )
+    }
+}
+
+private extension StoredDid {
+    func toKMPStoredDid() -> WalletBridgeStoredDid {
+        WalletBridgeStoredDid(
+            did: did,
+            documentJson: documentJSON
+        )
+    }
+}
+
+private extension WalletBridgeStoredDid {
+    func toSwiftStoredDid() -> StoredDid {
+        StoredDid(
+            did: did,
+            documentJSON: documentJson
+        )
+    }
+}
+
+private extension WalletKeyInfo {
+    func toKMPKeyInfo() -> WalletBridgeKeyInfo {
+        WalletBridgeKeyInfo(
+            keyId: keyID,
+            keyType: keyType.bridgeName,
+            algorithm: algorithm
+        )
+    }
+}
+
+private extension StoredKey {
+    func toKMPStoredKey() -> WalletBridgeStoredKey {
+        WalletBridgeStoredKey(
+            keyId: keyID,
+            keyType: keyType.bridgeName,
+            algorithm: algorithm,
+            serializedKeyJson: serializedKeyJSON
+        )
+    }
+}
+
+private extension WalletBridgeStoredKey {
+    func toSwiftStoredKey() throws -> StoredKey {
+        StoredKey(
+            keyID: keyId,
+            keyType: try WalletKeyType(bridgeName: keyType),
+            algorithm: algorithm,
+            serializedKeyJSON: serializedKeyJson
         )
     }
 }
@@ -282,7 +399,74 @@ private extension WalletAttestationConfiguration {
 }
 
 private extension WalletKeyType {
+    init(bridgeName: String) throws {
+        switch bridgeName {
+        case "Ed25519":
+            self = .ed25519
+        case "secp256k1":
+            self = .secp256k1
+        case "secp256r1":
+            self = .secp256r1
+        case "secp384r1":
+            self = .secp384r1
+        case "secp521r1":
+            self = .secp521r1
+        case "RSA":
+            self = .rsa
+        case "RSA3072":
+            self = .rsa3072
+        case "RSA4096":
+            self = .rsa4096
+        default:
+            throw WalletError.invalidInput("Unsupported wallet key type: \(bridgeName)")
+        }
+    }
+
+    var bridgeName: String {
+        switch self {
+        case .ed25519:
+            return "Ed25519"
+        case .secp256k1:
+            return "secp256k1"
+        case .secp256r1:
+            return "secp256r1"
+        case .secp384r1:
+            return "secp384r1"
+        case .secp521r1:
+            return "secp521r1"
+        case .rsa:
+            return "RSA"
+        case .rsa3072:
+            return "RSA3072"
+        case .rsa4096:
+            return "RSA4096"
+        }
+    }
+
     func toKMPKeyType() -> MobileWalletKeyType {
+        switch self {
+        case .ed25519:
+            return .ed25519
+        case .secp256k1:
+            return .secp256k1
+        case .secp256r1:
+            return .secp256r1
+        case .secp384r1:
+            return .secp384r1
+        case .secp521r1:
+            return .secp521r1
+        case .rsa:
+            return .rsa
+        case .rsa3072:
+            return .rsa3072
+        case .rsa4096:
+            return .rsa4096
+        }
+    }
+}
+
+private extension MobileWalletKeyType {
+    func toSwiftKeyType() -> WalletKeyType {
         switch self {
         case .ed25519:
             return .ed25519

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -152,8 +152,10 @@ public struct StoredCredential: Equatable, Identifiable, Sendable {
     ///
     /// - Parameters:
     ///   - id: Stable local credential identifier.
-    ///   - serializedCredential: Raw serialized credential payload.
-    ///   - format: Credential format, for example `vc+sd-jwt` or `jwt_vc_json`.
+    ///   - serializedCredential: Raw serialized credential, such as a JWT VC,
+    ///     SD-JWT VC, or JSON credential.
+    ///   - format: Credential format, for example `vc+sd-jwt` or
+    ///     `jwt_vc_json`.
     ///   - label: User-facing credential label when available.
     ///   - addedAt: Date the credential was added to the wallet when available.
     public init(
@@ -175,21 +177,24 @@ public struct StoredCredential: Equatable, Identifiable, Sendable {
 public protocol WalletCredentialStore: Sendable {
     /// Returns a credential by wallet-local identifier.
     ///
-    /// - Parameter id: Stable local credential identifier.
+    /// - Parameter id: Stable wallet-local credential identifier.
+    /// - Returns: Stored credential when present, or `nil` when absent.
     func credential(id: String) async throws -> StoredCredential?
 
     /// Lists all credentials in this store.
+    ///
+    /// - Returns: Stored credentials currently owned by this store.
     func credentials() async throws -> [StoredCredential]
 
     /// Adds or replaces a credential entry.
     ///
-    /// - Parameter credential: Credential entry to add or replace.
+    /// - Parameter credential: Credential entry to persist.
     func addCredential(_ credential: StoredCredential) async throws
 
     /// Removes a credential by wallet-local identifier.
     ///
-    /// - Parameter id: Stable local credential identifier.
-    /// - Returns: `true` when a credential existed and was removed.
+    /// - Parameter id: Stable wallet-local credential identifier to remove.
+    /// - Returns: `true` when the store removed an existing credential.
     func removeCredential(id: String) async throws -> Bool
 }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -318,7 +318,7 @@ public struct WalletKeyInfo: Equatable, Identifiable, Sendable {
 ///
 /// The serialized key JSON may contain private signing material. Treat it like a secret and avoid
 /// logging or exporting it outside app-owned secure storage.
-public struct StoredKey: Equatable, Identifiable, Sendable {
+public struct StoredKey: CustomDebugStringConvertible, CustomStringConvertible, Equatable, Identifiable, Sendable {
     /// Stable wallet-local key identifier.
     public let keyID: String
 
@@ -333,6 +333,16 @@ public struct StoredKey: Equatable, Identifiable, Sendable {
 
     /// Stable identifier for SwiftUI and collection APIs.
     public var id: String { keyID }
+
+    /// Text representation that redacts serialized key material.
+    public var description: String {
+        "StoredKey(keyID: \(keyID), keyType: \(keyType), algorithm: \(algorithm ?? "nil"), serializedKeyJSON: <redacted>)"
+    }
+
+    /// Debug representation that redacts serialized key material.
+    public var debugDescription: String {
+        description
+    }
 
     /// Creates a serialized signing-key entry for custom Swift key stores.
     ///

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -73,11 +73,26 @@ public struct WalletStores: Sendable {
     /// Optional credential store override. `nil` uses default encrypted local persistence.
     public var credentials: (any WalletCredentialStore)?
 
+    /// Optional DID document store override. `nil` uses default encrypted local persistence.
+    public var dids: (any WalletDidStore)?
+
+    /// Optional atomic key store and generator override. `nil` uses platform signing-key persistence.
+    public var keys: WalletKeys?
+
     /// Creates wallet store overrides.
     ///
-    /// - Parameter credentials: Optional credential store override.
-    public init(credentials: (any WalletCredentialStore)? = nil) {
+    /// - Parameters:
+    ///   - credentials: Optional credential store override.
+    ///   - dids: Optional DID document store override.
+    ///   - keys: Optional atomic key store and generator override.
+    public init(
+        credentials: (any WalletCredentialStore)? = nil,
+        dids: (any WalletDidStore)? = nil,
+        keys: WalletKeys? = nil
+    ) {
         self.credentials = credentials
+        self.dids = dids
+        self.keys = keys
     }
 }
 
@@ -198,6 +213,53 @@ public protocol WalletCredentialStore: Sendable {
     func removeCredential(id: String) async throws -> Bool
 }
 
+/// DID document entry used by custom Swift DID stores.
+public struct StoredDid: Equatable, Identifiable, Sendable {
+    /// Stable DID string.
+    public let did: String
+
+    /// Serialized DID document JSON object.
+    public let documentJSON: String
+
+    /// Stable identifier for SwiftUI and collection APIs.
+    public var id: String { did }
+
+    /// Creates a DID document entry for custom Swift DID stores.
+    ///
+    /// - Parameters:
+    ///   - did: Stable DID string.
+    ///   - documentJSON: Serialized DID document JSON object.
+    public init(did: String, documentJSON: String) {
+        self.did = did
+        self.documentJSON = documentJSON
+    }
+}
+
+/// App-owned DID document persistence override.
+public protocol WalletDidStore: Sendable {
+    /// Returns a DID document by DID string.
+    ///
+    /// - Parameter id: Stable DID string.
+    /// - Returns: Stored DID document when present, or `nil` when absent.
+    func did(id: String) async throws -> StoredDid?
+
+    /// Lists all DID documents in this store.
+    ///
+    /// - Returns: Stored DID documents currently owned by this store.
+    func dids() async throws -> [StoredDid]
+
+    /// Adds or replaces a DID document entry.
+    ///
+    /// - Parameter did: DID document entry to persist.
+    func addDid(_ did: StoredDid) async throws
+
+    /// Removes a DID document by DID string.
+    ///
+    /// - Parameter id: Stable DID string to remove.
+    /// - Returns: `true` when the store removed an existing DID document.
+    func removeDid(id: String) async throws -> Bool
+}
+
 /// Key algorithms supported by the wallet bridge.
 public enum WalletKeyType: Equatable, Sendable {
     /// Ed25519 elliptic curve key.
@@ -223,6 +285,121 @@ public enum WalletKeyType: Equatable, Sendable {
 
     /// RSA key with a 4096-bit modulus.
     case rsa4096
+}
+
+/// Lightweight metadata about a signing key stored by a custom Swift key store.
+public struct WalletKeyInfo: Equatable, Identifiable, Sendable {
+    /// Stable wallet-local key identifier.
+    public let keyID: String
+
+    /// Signing-key type.
+    public let keyType: WalletKeyType
+
+    /// Optional signing algorithm label, such as `EdDSA` or `ES256`.
+    public let algorithm: String?
+
+    /// Stable identifier for SwiftUI and collection APIs.
+    public var id: String { keyID }
+
+    /// Creates signing-key metadata.
+    ///
+    /// - Parameters:
+    ///   - keyID: Stable wallet-local key identifier.
+    ///   - keyType: Signing-key type.
+    ///   - algorithm: Optional signing algorithm label.
+    public init(keyID: String, keyType: WalletKeyType, algorithm: String? = nil) {
+        self.keyID = keyID
+        self.keyType = keyType
+        self.algorithm = algorithm
+    }
+}
+
+/// Serialized signing key used by custom Swift key stores.
+///
+/// The serialized key JSON may contain private signing material. Treat it like a secret and avoid
+/// logging or exporting it outside app-owned secure storage.
+public struct StoredKey: Equatable, Identifiable, Sendable {
+    /// Stable wallet-local key identifier.
+    public let keyID: String
+
+    /// Signing-key type.
+    public let keyType: WalletKeyType
+
+    /// Optional signing algorithm label, such as `EdDSA` or `ES256`.
+    public let algorithm: String?
+
+    /// walt.id serialized key JSON payload.
+    public let serializedKeyJSON: String
+
+    /// Stable identifier for SwiftUI and collection APIs.
+    public var id: String { keyID }
+
+    /// Creates a serialized signing-key entry for custom Swift key stores.
+    ///
+    /// - Parameters:
+    ///   - keyID: Stable wallet-local key identifier.
+    ///   - keyType: Signing-key type.
+    ///   - algorithm: Optional signing algorithm label.
+    ///   - serializedKeyJSON: walt.id serialized key JSON payload.
+    public init(
+        keyID: String,
+        keyType: WalletKeyType,
+        algorithm: String? = nil,
+        serializedKeyJSON: String
+    ) {
+        self.keyID = keyID
+        self.keyType = keyType
+        self.algorithm = algorithm
+        self.serializedKeyJSON = serializedKeyJSON
+    }
+}
+
+/// App-owned signing-key persistence override.
+public protocol WalletKeyStore: Sendable {
+    /// Returns a serialized signing key by wallet-local identifier.
+    ///
+    /// - Parameter id: Stable wallet-local key identifier.
+    /// - Returns: Stored key when present, or `nil` when absent.
+    func key(id: String) async throws -> StoredKey?
+
+    /// Lists signing-key metadata in this store.
+    ///
+    /// - Returns: Stored signing-key metadata currently owned by this store.
+    func keys() async throws -> [WalletKeyInfo]
+
+    /// Adds or replaces a serialized signing-key entry.
+    ///
+    /// - Parameter key: Serialized signing-key entry to persist.
+    /// - Returns: Stable wallet-local key identifier for the stored key.
+    func addKey(_ key: StoredKey) async throws -> String
+
+    /// Removes a signing key by wallet-local identifier.
+    ///
+    /// - Parameter id: Stable wallet-local key identifier to remove.
+    /// - Returns: `true` when the store removed an existing signing key.
+    func removeKey(id: String) async throws -> Bool
+}
+
+/// Atomic custom signing-key persistence configuration.
+public struct WalletKeys: Sendable {
+    /// App-owned signing-key store.
+    public let store: any WalletKeyStore
+
+    /// App-owned signing-key generator.
+    public let generate: @Sendable (WalletKeyType) async throws -> StoredKey
+
+    /// Creates an atomic signing-key store and generator override.
+    ///
+    /// - Parameters:
+    ///   - store: App-owned signing-key store.
+    ///   - generate: App-owned signing-key generator.
+    public init(
+        store: any WalletKeyStore,
+        generate: @escaping @Sendable (WalletKeyType) async throws -> StoredKey
+    ) {
+        self.store = store
+        self.generate = generate
+    }
 }
 
 /// Wallet attestation settings.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -96,6 +96,23 @@ final class WalletAPITests: XCTestCase {
         XCTAssertFalse(String(describing: key).contains("4 bytes"))
     }
 
+    func testStoredKeyDescriptionRedactsSerializedKeyJSON() {
+        let key = StoredKey(
+            keyID: "key-1",
+            keyType: .secp256r1,
+            algorithm: "ES256",
+            serializedKeyJSON: #"{"type":"jwk","jwk":{"kid":"key-1","d":"secret"}}"#
+        )
+
+        XCTAssertEqual(
+            String(describing: key),
+            "StoredKey(keyID: key-1, keyType: secp256r1, algorithm: ES256, serializedKeyJSON: <redacted>)"
+        )
+        XCTAssertEqual(String(reflecting: key), String(describing: key))
+        XCTAssertFalse(String(describing: key).contains("secret"))
+        XCTAssertFalse(String(reflecting: key).contains("secret"))
+    }
+
     func testPublicModelsAreValueTypesAndEquatable() {
         let credential = Credential(
             id: "credential-1",

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -40,6 +40,29 @@ final class WalletAPITests: XCTestCase {
         XCTAssertNotNil(configuration.persistence.stores.credentials)
     }
 
+    func testPublicPersistenceConfigurationCombinesProvidedDatabaseKeyAndCustomCredentialStore() {
+        let provider = FakeDatabaseKeyProvider()
+        let store = FakeCredentialStore()
+        let configuration = WalletConfiguration(
+            persistence: WalletPersistence(
+                databaseKey: .provided(provider),
+                stores: WalletStores(credentials: store)
+            )
+        )
+
+        acceptsSendable(configuration.persistence)
+        XCTAssertTrue(configuration.persistence.databaseKey.isProvided)
+        XCTAssertNotNil(configuration.persistence.stores.credentials)
+    }
+
+    func testPublicWalletStoresExposeCredentialOverridesOnly() {
+        let store = FakeCredentialStore()
+        let stores = WalletStores(credentials: store)
+
+        acceptsSendable(stores)
+        XCTAssertEqual(Mirror(reflecting: stores).children.compactMap(\.label), ["credentials"])
+    }
+
     func testWalletDatabaseKeyDescriptionRedactsMaterial() {
         let key = WalletDatabaseKey(
             keyID: "consumer-wallet:wallet_consumer-wallet",

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -10,6 +10,8 @@ final class WalletAPITests: XCTestCase {
         XCTAssertEqual(configuration.defaultKeyType, .secp256r1)
         XCTAssertTrue(configuration.persistence.databaseKey.isManaged)
         XCTAssertNil(configuration.persistence.stores.credentials)
+        XCTAssertNil(configuration.persistence.stores.dids)
+        XCTAssertNil(configuration.persistence.stores.keys)
         XCTAssertNil(configuration.attestation)
     }
 
@@ -55,12 +57,28 @@ final class WalletAPITests: XCTestCase {
         XCTAssertNotNil(configuration.persistence.stores.credentials)
     }
 
-    func testPublicWalletStoresExposeCredentialOverridesOnly() {
-        let store = FakeCredentialStore()
-        let stores = WalletStores(credentials: store)
+    func testPublicWalletStoresExposeCredentialDidAndKeyOverrides() {
+        let credentialStore = FakeCredentialStore()
+        let didStore = FakeDidStore()
+        let keyStore = FakeKeyStore()
+        let keys = WalletKeys(store: keyStore) { keyType in
+            StoredKey(
+                keyID: "generated-\(keyType)",
+                keyType: keyType,
+                algorithm: nil,
+                serializedKeyJSON: #"{"type":"jwk","jwk":{"kid":"generated"}}"#
+            )
+        }
+        let stores = WalletStores(
+            credentials: credentialStore,
+            dids: didStore,
+            keys: keys
+        )
 
         acceptsSendable(stores)
-        XCTAssertEqual(Mirror(reflecting: stores).children.compactMap(\.label), ["credentials"])
+        XCTAssertNotNil(stores.credentials)
+        XCTAssertNotNil(stores.dids)
+        XCTAssertNotNil(stores.keys)
     }
 
     func testWalletDatabaseKeyDescriptionRedactsMaterial() {
@@ -101,10 +119,28 @@ final class WalletAPITests: XCTestCase {
         )
         acceptsSendable(storedCredential)
         XCTAssertEqual(storedCredential, storedCredential)
+
+        let storedDid = StoredDid(
+            did: "did:key:wallet",
+            documentJSON: #"{"id":"did:key:wallet"}"#
+        )
+        acceptsSendable(storedDid)
+        XCTAssertEqual(storedDid.id, "did:key:wallet")
+        XCTAssertEqual(storedDid, storedDid)
+
+        let storedKey = StoredKey(
+            keyID: "key-1",
+            keyType: .secp256r1,
+            algorithm: "ES256",
+            serializedKeyJSON: #"{"type":"jwk","jwk":{"kid":"key-1"}}"#
+        )
+        acceptsSendable(storedKey)
+        XCTAssertEqual(storedKey.id, "key-1")
+        XCTAssertEqual(storedKey, storedKey)
     }
 
     func testWalletHasAsyncFacadeShape() async {
-        let wallet = try? await Wallet(configuration: .init())
+        let wallet = Wallet(configuration: .init(), bridge: FakeWalletCoreBridge())
 
         XCTAssertNotNil(wallet)
     }
@@ -293,6 +329,53 @@ private final class FakeCredentialStore: WalletCredentialStore, @unchecked Senda
     }
 
     func removeCredential(id: String) async throws -> Bool {
+        let originalCount = entries.count
+        entries.removeAll { $0.id == id }
+        return entries.count != originalCount
+    }
+}
+
+private final class FakeDidStore: WalletDidStore, @unchecked Sendable {
+    private var entries: [StoredDid] = []
+
+    func did(id: String) async throws -> StoredDid? {
+        entries.first { $0.id == id }
+    }
+
+    func dids() async throws -> [StoredDid] {
+        entries
+    }
+
+    func addDid(_ did: StoredDid) async throws {
+        entries.removeAll { $0.id == did.id }
+        entries.append(did)
+    }
+
+    func removeDid(id: String) async throws -> Bool {
+        let originalCount = entries.count
+        entries.removeAll { $0.id == id }
+        return entries.count != originalCount
+    }
+}
+
+private final class FakeKeyStore: WalletKeyStore, @unchecked Sendable {
+    private var entries: [StoredKey] = []
+
+    func key(id: String) async throws -> StoredKey? {
+        entries.first { $0.id == id }
+    }
+
+    func keys() async throws -> [WalletKeyInfo] {
+        entries.map { WalletKeyInfo(keyID: $0.keyID, keyType: $0.keyType, algorithm: $0.algorithm) }
+    }
+
+    func addKey(_ key: StoredKey) async throws -> String {
+        entries.removeAll { $0.id == key.id }
+        entries.append(key)
+        return key.keyID
+    }
+
+    func removeKey(id: String) async throws -> Bool {
         let originalCount = entries.count
         entries.removeAll { $0.id == id }
         return entries.count != originalCount


### PR DESCRIPTION
## Summary

This follow-up stacks on #1853 and exposes the missing Swift DID and signing-key store override surface instead of leaving those stores as KMP-only configuration. Swift apps can now pass `WalletStores(credentials:dids:keys:)`, where `WalletKeys` supplies the app-owned `WalletKeyStore` and key generator together so generated keys are persisted into the same app-owned key domain.

The branch also keeps the previously added persistence coverage around provided database keys and custom credential stores, then extends it with red/green tests for the new public DID/key models, Swift-to-KMP bridge wiring, and serialized-key redaction behavior.

## What Changed

### Swift public API
- Adds `StoredDid`, `WalletDidStore`, `WalletKeyInfo`, `StoredKey`, `WalletKeyStore`, and `WalletKeys` to the Swift package surface.
- Extends `WalletStores` from credential-only overrides to optional credential, DID, and atomic signing-key overrides.
- Documents that `StoredKey.serializedKeyJSON` may contain private signing material and must be treated like app-owned secret material.
- Redacts `StoredKey` string/debug descriptions so accidental logging matches the existing KMP key-material precedent.

### Swift/KMP bridge
- Adds Swift bridge DTOs and interfaces for DID documents, key metadata, serialized keys, key stores, and key generation.
- Maps Swift DID stores into `MobileWalletStores.dids` and Swift key overrides into `MobileWalletStores.keys`.
- Round-trips DID document JSON objects and serialized walt.id keys through the bridge using existing KMP `WalletDidStore`, `WalletKeyStore`, and `MobileWalletKeys` contracts.
- Redacts `WalletBridgeStoredKey.toString()` so the new bridge DTO does not expose serialized private key payloads in logs.

### Tests
- Adds Swift API coverage for the new public store models, default nil store behavior, combined credential/DID/key `WalletStores` configuration, and `StoredKey` description redaction.
- Adds KMP iOS bridge coverage proving Swift DID/key overrides are mapped into `MobileWalletConfig`, list/get/add/remove/generate paths round-trip through the adapters, and bridge serialized-key DTOs redact string output.
- Keeps coverage for combining provided database keys with Swift credential-store overrides and the iOS app-process database-key integration path from the initial follow-up pass.

### Docs
- Updates README and DocC to show full store override configuration with `WalletStores(credentials:dids:keys:)`.
- Adds the new public DID/key store symbols to DocC topics and removes stale wording that described DID/key overrides as deferred or KMP-only.

## Validation

- `./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:iosSimulatorArm64Test -PenableIosBuild=true`
- `./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:assembleWalletCoreReleaseXCFramework -PenableIosBuild=true`
- `./gradlew :waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:dokkaGeneratePublicationHtml -PenableIosBuild=true`
- `swift test --package-path waltid-libraries/protocols/waltid-wallet-sdk-ios -Xswiftc -strict-concurrency=complete -Xswiftc -warnings-as-errors`
- `xcodebuild test -scheme WalletSDK -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug`
- `waltid-libraries/protocols/waltid-wallet-sdk-ios/scripts/generate-docc.sh`
- `git diff --check`
- stale-doc scan for deferred/KMP-only Swift DID/key wording

## Caveats and Follow-Ups

- `StoredKey.serializedKeyJSON` remains intentionally explicit because app-owned key stores need to persist the serialized key payload. Swift `StoredKey` descriptions and KMP `WalletBridgeStoredKey.toString()` redact that payload, but callers still need to treat the field itself as secret material.
- The iOS simulator package test still emits the existing `WalletCore.framework` deployment-target linker warning (`AESwift.o` built for iOS-simulator 18.5 while linking 15.4); tests pass with that warning.
- GitHub checks were queued/in progress immediately after the latest push.

## Breaking

- None expected for source consumers: existing `WalletStores(credentials:)` call sites keep working because the new `dids` and `keys` parameters default to `nil`.
