### PR TITLE
Re-enable EUDI mobile integration tests

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/EudiPublicBackendE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/EudiPublicBackendE2ETest.kt
@@ -19,14 +19,12 @@ import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForResource
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForStatus
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class EudiPublicBackendE2ETest {
 
-    @Ignore("EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168")
     @Test
     fun receiveAndPresentAgainstEudiPublicBackends() = runBlocking {
         val args = InstrumentationRegistry.getArguments()

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -82,8 +82,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
         XCTAssertTrue(result.message.contains("Received"), "Message should confirm receipt: \(result.message)")
     }
 
-    // EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168
-    func skip_testReceiveAndPresentFullFlow() async throws {
+    func testReceiveAndPresentFullFlow() async throws {
         let controller = makeController()
 
         let bootstrapResult = try await controller.bootstrap()
@@ -114,8 +113,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
         try await TestHelpers.waitForVerifierSuccess(transactionID: transaction.transactionId, timeoutSeconds: verifierPollingTimeout)
     }
 
-    // EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168
-    func skip_testCredentialPersistsAcrossControllerRecreation() async throws {
+    func testCredentialPersistsAcrossControllerRecreation() async throws {
         let controller1 = makeController()
 
         let bootstrapResult = try await controller1.bootstrap()

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -10,7 +10,6 @@ import id.walt.webdatafetching.WebDataFetchingConfiguration
 import id.walt.webdatafetching.config.HttpEngine
 import kotlinx.coroutines.runBlocking
 import org.junit.BeforeClass
-import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -62,7 +61,6 @@ class MobileWalletIntegrationTest {
         assertTrue(credentialIds.isNotEmpty(), "Should receive at least one credential")
     }
 
-    @Ignore("EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168")
     @Test
     fun receiveAndPresentFullFlow() = runBlocking {
         val client = MobileWalletFactory(context).create(
@@ -85,7 +83,6 @@ class MobileWalletIntegrationTest {
         EudiTestBackend.waitForVerifierSuccess(transaction.transactionId)
     }
 
-    @Ignore("EUDI backend certificate expired 2026-07-04 - https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/168")
     @Test
     fun credentialPersistsAcrossWalletRecreation() = runBlocking {
         val walletConfig = MobileWalletConfig(


### PR DESCRIPTION
## Summary

Reverts the mobile EUDI integration test skips from #1856. The default SD-JWT EUDI flows are passing again on Android and iOS.

## Verification

- `:waltid-libraries:protocols:waltid-openid4vc-wallet-mobile:connectedAndroidDeviceTest` with `MobileWalletIntegrationTest` ran 4 tests: 0 skipped, 0 failed.
- `:waltid-applications:waltid-wallet-demo-compose:androidApp:connectedDebugAndroidTest` with `EudiPublicBackendE2ETest` and `eu.europa.ec.eudi.pid_vc_sd_jwt` ran 1 test: 0 skipped, 0 failed.
- `xcodebuildmcp simulator test` for the two restored `MobileWalletIntegrationTests` methods ran 2 tests: 0 skipped, 0 failed.

## Note

mdoc is not enabled as default mobile EUDI coverage in this PR; the manual Android mdoc probe still fails separately during presentation with missing DCQL claims.