### PR TITLE
refactor: use crypto base64 utils in openid4vci

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/attestation/ClientAttestationAssemblerTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/attestation/ClientAttestationAssemblerTest.kt
@@ -3,10 +3,10 @@ package id.waltid.openid4vci.wallet.attestation
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyMeta
 import id.walt.crypto.keys.KeyType
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
-import kotlin.io.encoding.Base64
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -28,8 +28,8 @@ private class AssemblerTestP256Key : Key() {
 
     override suspend fun signJws(plaintext: ByteArray, headers: Map<String, JsonElement>): String {
         val headerJson = JsonObject(headers).toString()
-        val headerB64 = Base64.UrlSafe.encode(headerJson.encodeToByteArray()).trimEnd('=')
-        val payloadB64 = Base64.UrlSafe.encode(plaintext).trimEnd('=')
+        val headerB64 = headerJson.encodeToByteArray().encodeToBase64Url()
+        val payloadB64 = plaintext.encodeToBase64Url()
         return "$headerB64.$payloadB64.mock-sig"
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/attestation/WalletAttestationPopBuilderTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/attestation/WalletAttestationPopBuilderTest.kt
@@ -3,13 +3,14 @@ package id.waltid.openid4vci.wallet.attestation
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyMeta
 import id.walt.crypto.keys.KeyType
+import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlin.io.encoding.Base64
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -34,8 +35,8 @@ private class PopTestP256Key : Key() {
 
     override suspend fun signJws(plaintext: ByteArray, headers: Map<String, JsonElement>): String {
         val headerJson = JsonObject(headers).toString()
-        val headerB64 = Base64.UrlSafe.encode(headerJson.encodeToByteArray()).trimEnd('=')
-        val payloadB64 = Base64.UrlSafe.encode(plaintext).trimEnd('=')
+        val headerB64 = headerJson.encodeToByteArray().encodeToBase64Url()
+        val payloadB64 = plaintext.encodeToBase64Url()
         return "$headerB64.$payloadB64.mock-sig"
     }
 }
@@ -70,16 +71,14 @@ class WalletAttestationPopBuilderTest {
         val parts = jwt.split(".")
         assertEquals(3, parts.size, "JWT should have 3 parts")
 
-        val b64 = Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT_OPTIONAL)
-
         val header = Json.parseToJsonElement(
-            b64.decode(parts[0]).decodeToString()
+            parts[0].decodeFromBase64Url().decodeToString()
         ).jsonObject
         assertEquals("oauth-client-attestation-pop+jwt", header["typ"]?.jsonPrimitive?.content)
         assertEquals("ES256", header["alg"]?.jsonPrimitive?.content)
 
         val payload = Json.parseToJsonElement(
-            b64.decode(parts[1]).decodeToString()
+            parts[1].decodeFromBase64Url().decodeToString()
         ).jsonObject
         assertEquals("wallet-client", payload["iss"]?.jsonPrimitive?.content)
         assertEquals("https://issuer.example.com/token", payload["aud"]?.jsonPrimitive?.content)

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/granttypes/authorizationcode/AuthorizationCodeAuthorizationEndpoint.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/handlers/granttypes/authorizationcode/AuthorizationCodeAuthorizationEndpoint.kt
@@ -1,6 +1,7 @@
 
 package id.walt.openid4vci.handlers.granttypes.authorizationcode
 
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import id.walt.openid4vci.handlers.endpoints.authorization.AuthorizationEndpointHandler
 import id.walt.openid4vci.DEFAULT_AUTHORIZATION_CODE_LIFETIME_SECONDS
 import id.walt.openid4vci.Session
@@ -14,7 +15,6 @@ import id.walt.openid4vci.requests.authorization.AuthorizationRequest
 import id.walt.openid4vci.responses.authorization.AuthorizationResponse
 import id.walt.openid4vci.responses.authorization.AuthorizationResponseResult
 import org.kotlincrypto.random.CryptoRand
-import kotlin.io.encoding.Base64
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -115,7 +115,7 @@ class AuthorizationCodeAuthorizationEndpoint(
     }
 
     private fun generateCode(): String {
-        val bytes = ByteArray(33) //prevent padding
-        return Base64.UrlSafe.encode(CryptoRand.nextBytes(bytes))
+        val bytes = ByteArray(33)
+        return CryptoRand.nextBytes(bytes).encodeToBase64Url()
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/preauthorized/PreAuthorizedCodeIssuer.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/preauthorized/PreAuthorizedCodeIssuer.kt
@@ -1,5 +1,6 @@
 package id.walt.openid4vci.preauthorized
 
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import id.walt.openid4vci.Session
 import id.walt.openid4vci.TokenType
 import id.walt.openid4vci.offers.TxCode
@@ -8,7 +9,6 @@ import id.walt.openid4vci.repository.preauthorized.DefaultPreAuthorizedCodeRecor
 import id.walt.openid4vci.repository.preauthorized.PreAuthorizedCodeRepository
 import org.kotlincrypto.hash.sha2.SHA256
 import org.kotlincrypto.random.CryptoRand
-import kotlin.io.encoding.Base64
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -108,7 +108,7 @@ class DefaultPreAuthorizedCodeIssuer(
         buildRecord: (String) -> DefaultPreAuthorizedCodeRecord,
     ): Pair<String, DefaultPreAuthorizedCodeRecord> {
         repeat(maxGenerateAttempts) { attempt ->
-            val code = Base64.UrlSafe.encode(secureRandomBytes(33))
+            val code = secureRandomBytes(33).encodeToBase64Url()
             try {
                 val record = buildRecord(code)
                 repository.save(record)
@@ -178,7 +178,7 @@ private fun generateRandomString(alphabet: String, length: Int): String =
     }
 
 internal fun hashTxCode(txCode: String): String =
-    Base64.UrlSafe.encode(SHA256().digest(txCode.encodeToByteArray()))
+    SHA256().digest(txCode.encodeToByteArray()).encodeToBase64Url()
 
 internal fun secureRandomBytes(size: Int): ByteArray {
     val bytes = ByteArray(size)

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/requests/RequestIds.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/requests/RequestIds.kt
@@ -1,10 +1,10 @@
 package id.walt.openid4vci.requests
 
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import org.kotlincrypto.random.CryptoRand
-import kotlin.io.encoding.Base64
 
 internal fun generateRequestId(): String {
     val bytes = ByteArray(16)
     CryptoRand.nextBytes(bytes)
-    return Base64.UrlSafe.encode(bytes)
+    return bytes.encodeToBase64Url()
 }

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/tokens/jwt/refresh/JwtRefreshTokenIssuer.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/tokens/jwt/refresh/JwtRefreshTokenIssuer.kt
@@ -1,5 +1,6 @@
 package id.walt.openid4vci.tokens.jwt.refresh
 
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import id.walt.openid4vci.tokens.jwt.JwtPayloadClaims
 import id.walt.openid4vci.tokens.jwt.JwtSigningKeyResolver
 import id.walt.openid4vci.tokens.jwt.JwtTokenSigner
@@ -7,7 +8,6 @@ import id.walt.openid4vci.tokens.jwt.compactJwsSignature
 import id.walt.openid4vci.tokens.refresh.RefreshTokenGenerationRequest
 import id.walt.openid4vci.tokens.refresh.RefreshTokenIssuer
 import org.kotlincrypto.random.CryptoRand
-import kotlin.io.encoding.Base64
 
 const val KEYCLOAK_REFRESH_TOKEN_TYPE = "Refresh"
 
@@ -47,7 +47,7 @@ class JwtRefreshTokenIssuer internal constructor(
         compactJwsSignature(token, "Refresh token")
 
     private fun generateTokenId(): String =
-        Base64.UrlSafe.encode(CryptoRand.nextBytes(ByteArray(TOKEN_ID_BYTES)))
+        CryptoRand.nextBytes(ByteArray(TOKEN_ID_BYTES)).encodeToBase64Url()
 
     private companion object {
         const val TOKEN_ID_BYTES = 32

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/TestConfigFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/TestConfigFactory.kt
@@ -1,5 +1,7 @@
 package id.walt.openid4vci
 
+import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import id.walt.openid4vci.core.OAuth2ProviderConfig
 import id.walt.openid4vci.preauthorized.DefaultPreAuthorizedCodeIssuer
 import id.walt.openid4vci.repository.authorization.InMemoryAuthorizationCodeRepository
@@ -23,7 +25,6 @@ import id.walt.openid4vci.validation.DefaultAuthorizationRequestValidator
 import id.walt.openid4vci.validation.CredentialRequestValidator
 import id.walt.openid4vci.validation.DefaultCredentialRequestValidator
 import id.walt.openid4vci.validation.IssuerStateValidator
-import kotlin.io.encoding.Base64
 import kotlin.random.Random
 import kotlin.time.Clock
 
@@ -79,8 +80,8 @@ internal class TestRefreshTokenIssuer : RefreshTokenIssuer, RefreshTokenVerifier
             request.sessionId.orEmpty(),
             request.scopes.joinToString(" "),
         ).joinToString("|")
-        val encodedPayload = Base64.UrlSafe.encode(payload.encodeToByteArray())
-        val signature = Base64.UrlSafe.encode(Random.nextBytes(32))
+        val encodedPayload = payload.encodeToByteArray().encodeToBase64Url()
+        val signature = Random.nextBytes(32).encodeToBase64Url()
         return "test-refresh.$encodedPayload.$signature"
     }
 
@@ -113,7 +114,7 @@ internal class TestRefreshTokenIssuer : RefreshTokenIssuer, RefreshTokenVerifier
     private fun decodeClaims(token: String): RefreshTokenClaims {
         val parts = token.split('.')
         require(parts.size == 3) { "Invalid refresh token" }
-        val values = Base64.UrlSafe.decode(parts[1]).decodeToString().split('|')
+        val values = parts[1].decodeFromBase64Url().decodeToString().split('|')
         require(values.size == 7) { "Invalid refresh token payload" }
         val scopes = values[6].splitToSequence(' ')
             .filter { it.isNotBlank() }


### PR DESCRIPTION
## Description

[WAL-1091](https://linear.app/walt-new/issue/WAL-1091/use-waltidcrypto-for-base64-in-lib)

## Type of Change

- [x] bug fix - change which fixes an issue
- [ ] new feature - change which adds functionality

## Checklist

- [ ] code cleanup and self-review
- [ ] unit + e2e test coverage
- [ ] documentation updated accordingly

## Breaking

- \-
