### PR TITLE
feat(dcql): Support mdoc namespace/claim_name format in DCQL ClaimsQuery

### DIFF
--- a/waltid-libraries/credentials/waltid-dcql/src/commonMain/kotlin/id/walt/dcql/DcqlMatcher.kt
+++ b/waltid-libraries/credentials/waltid-dcql/src/commonMain/kotlin/id/walt/dcql/DcqlMatcher.kt
@@ -9,6 +9,17 @@ object DcqlMatcher {
 
     private val log = KotlinLogging.logger {}
 
+    /**
+     * Get a string key for a ClaimsQuery to use in selected claims maps.
+     * For JSON path-based queries (SD-JWT), uses the path joined by dots.
+     * For mdoc queries, uses "namespace.claim_name" format.
+     */
+    private fun ClaimsQuery.toKey(): String = when {
+        path != null -> path.joinToString(".")
+        namespace != null && claimName != null -> "$namespace.$claimName"
+        else -> "unknown"
+    }
+
     data class DcqlMatchResult(
         val credential: DcqlCredential,
         /**
@@ -229,7 +240,7 @@ object DcqlMatcher {
                 val matchResult = claimExistsAndMatchesValue(credential, cq, isPotentiallySelectivelyDisclosable)
                 if (matchResult.isSuccess) {
                     matchResult.getOrNull()?.let { // getOrNull because success can be with null value (existence check)
-                        currentSetSelectedClaims[cq.path.joinToString(".")] = it
+                        currentSetSelectedClaims[cq.toKey()] = it
                     }
                 } else {
                     allCurrentSetMatch = false
@@ -286,6 +297,9 @@ object DcqlMatcher {
 
     /**
      * Checks if a single claim exists, matches optional values, and returns the matched value/disclosure.
+     * For SD-JWT credentials, checks disclosures first, then falls back to core JWT.
+     * For mdoc credentials, uses namespace/claim_name.
+     *
      * Returns Result.success(matchedValueOrDisclosure: Any?) or Result.failure.
      * matchedValueOrDisclosure can be SdJwtSelectiveDisclosure or JsonElement.
      * It's null if only existence was checked (claimQuery.values is null/empty) and value was found.
@@ -296,11 +310,40 @@ object DcqlMatcher {
         isCredentialPotentiallySD: Boolean // Pass this info
     ): Result<Any?> {
 
+        // Handle mdoc claims (namespace + claim_name)
+        if (claimQuery.namespace != null && claimQuery.claimName != null) {
+            // For mdoc, we need to look up the claim in the credential's namespaced data
+            // The credential.data should have structure: {"namespace": {"claim_name": value}}
+            val namespaceData = credential.data[claimQuery.namespace]?.jsonObject
+            val claimValue = namespaceData?.get(claimQuery.claimName)
+
+            if (claimValue == null) {
+                log.trace { "mdoc claim ${claimQuery.namespace}.${claimQuery.claimName} not found in ${credential.id}" }
+                return Result.failure(DcqlMatchException("mdoc claim ${claimQuery.namespace}.${claimQuery.claimName} not found in ${credential.id}"))
+            }
+
+            if (!claimQuery.values.isNullOrEmpty()) {
+                val matchesValue = claimQuery.values.any { queryValue -> queryValue == claimValue }
+                if (!matchesValue) {
+                    log.trace { "mdoc claim ${claimQuery.namespace}.${claimQuery.claimName} value '$claimValue' does not match required values ${claimQuery.values} in ${credential.id}" }
+                    return Result.failure(DcqlMatchException("mdoc claim value mismatch for ${claimQuery.namespace}.${claimQuery.claimName}"))
+                }
+            }
+            log.trace { "mdoc claim ${claimQuery.namespace}.${claimQuery.claimName} exists and matches criteria in ${credential.id}" }
+            return Result.success(claimValue)
+        }
+
+        // Handle JSON path-based claims (SD-JWT, JWT VC, etc.)
+        val path = claimQuery.path
+        if (path == null) {
+            return Result.failure(DcqlMatchException("ClaimsQuery has neither path nor namespace/claimName"))
+        }
+
         // If the credential has disclosures and is JWT-based (where SD mechanism applies)
         if (isCredentialPotentiallySD && credential.disclosures != null) {
             // Match on the claim name (path.last()). The disclosure's full Claim Path is available
             // via it.location (SD-JWT VC §4.6.1) for stricter matching if needed in the future.
-            val targetClaimName = claimQuery.path.lastOrNull {
+            val targetClaimName = path.lastOrNull {
                 it is JsonPrimitive && it.isString
             }?.jsonPrimitive?.content
             val matchingDisclosure =
@@ -320,22 +363,22 @@ object DcqlMatcher {
             } else {
                 // If path not found as a disclosure, it might be an always-visible claim in the SD-JWT core.
                 // Fall through to generic path resolution for such cases.
-                log.trace { "Claim path ${claimQuery.path} not found among SD disclosures for ${credential.id}. Checking core JWT." }
+                log.trace { "Claim path $path not found among SD disclosures for ${credential.id}. Checking core JWT." }
             }
         }
 
         // Generic path resolution for non-SD claims or core claims of an SD-JWT
-        val claimJsonElement = resolveClaimPath(credential.data, claimQuery.path)
-            ?: return Result.failure(DcqlMatchException("Claim path ${claimQuery.path} not found in ${credential.id}"))
+        val claimJsonElement = resolveClaimPath(credential.data, path)
+            ?: return Result.failure(DcqlMatchException("Claim path $path not found in ${credential.id}"))
 
         if (!claimQuery.values.isNullOrEmpty()) {
             val matchesValue = claimQuery.values.any { queryValue -> queryValue == claimJsonElement }
             if (!matchesValue) {
-                log.trace { "claimExistsAndMatchesValue: Claim path ${claimQuery.path} value '$claimJsonElement' does not match required values ${claimQuery.values} in ${credential.id} " }
-                return Result.failure(DcqlMatchException("Claim value mismatch for ${claimQuery.path}"))
+                log.trace { "claimExistsAndMatchesValue: Claim path $path value '$claimJsonElement' does not match required values ${claimQuery.values} in ${credential.id} " }
+                return Result.failure(DcqlMatchException("Claim value mismatch for $path"))
             }
         }
-        log.trace { "Claim path ${claimQuery.path} exists and matches criteria in ${credential.id}" }
+        log.trace { "Claim path $path exists and matches criteria in ${credential.id}" }
         // If values were specified and matched, or if no values were specified (existence check), return the element.
         return Result.success(claimJsonElement)
     }
@@ -491,9 +534,35 @@ object DcqlMatcher {
 
     /** Check if a single claim exists at the path and matches optional values. */
     private fun claimExistsAndMatches(credential: DcqlCredential, claimQuery: ClaimsQuery): Boolean {
-        val claimValue = resolveClaimPath(credential.data, claimQuery.path)
+        // Handle mdoc claims (namespace + claim_name)
+        if (claimQuery.namespace != null && claimQuery.claimName != null) {
+            val namespaceData = credential.data[claimQuery.namespace]?.jsonObject
+            val claimValue = namespaceData?.get(claimQuery.claimName)
+            if (claimValue == null) {
+                log.trace { "mdoc claim ${claimQuery.namespace}.${claimQuery.claimName} not found in credential ${credential.id}" }
+                return false
+            }
+            if (!claimQuery.values.isNullOrEmpty()) {
+                val matchesValue = claimQuery.values.any { queryValue -> queryValue == claimValue }
+                if (!matchesValue) {
+                    log.trace { "mdoc claim ${claimQuery.namespace}.${claimQuery.claimName} value '$claimValue' does not match required values ${claimQuery.values} in credential ${credential.id}" }
+                    return false
+                }
+            }
+            log.trace { "mdoc claim ${claimQuery.namespace}.${claimQuery.claimName} exists and matches criteria in credential ${credential.id}" }
+            return true
+        }
+
+        // Handle JSON path-based claims
+        val path = claimQuery.path
+        if (path == null) {
+            log.trace { "ClaimsQuery has neither path nor namespace/claimName for credential ${credential.id}" }
+            return false
+        }
+
+        val claimValue = resolveClaimPath(credential.data, path)
         if (claimValue == null) {
-            log.trace { "Claim path ${claimQuery.path} not found in credential ${credential.id}" }
+            log.trace { "Claim path $path not found in credential ${credential.id}" }
             return false // Claim must exist at the path
         }
 
@@ -505,11 +574,11 @@ object DcqlMatcher {
                 queryValue == claimValue
             }
             if (!matchesValue) {
-                log.trace { "claimExistsAndMatches: Claim path ${claimQuery.path} value '$claimValue' does not match required values ${claimQuery.values} in credential ${credential.id}" }
+                log.trace { "claimExistsAndMatches: Claim path $path value '$claimValue' does not match required values ${claimQuery.values} in credential ${credential.id}" }
                 return false
             }
         }
-        log.trace { "Claim path ${claimQuery.path} exists and matches criteria in credential ${credential.id}" }
+        log.trace { "Claim path $path exists and matches criteria in credential ${credential.id}" }
         return true // Claim exists and matches value constraints (if any)
     }
 

--- a/waltid-libraries/credentials/waltid-dcql/src/commonMain/kotlin/id/walt/dcql/models/ClaimsQuery.kt
+++ b/waltid-libraries/credentials/waltid-dcql/src/commonMain/kotlin/id/walt/dcql/models/ClaimsQuery.kt
@@ -8,14 +8,28 @@ import kotlinx.serialization.json.JsonPrimitive
 /**
  * Represents constraints on specific claims within a credential.
  * See: Section 6.3
+ *
+ * For JSON-based credentials (jwt_vc_json, vc+sd-jwt, dc+sd-jwt):
+ *   - Use `path` to specify the claim location using JSON path syntax
+ *
+ * For ISO mDL/mdoc credentials (mso_mdoc):
+ *   - Use `namespace` and `claim_name` to specify the claim
+ *   - Example: namespace="org.iso.18013.5.1", claim_name="given_name"
  */
 @Serializable
 data class ClaimsQuery(
     /** Required if claim_sets is present in parent CredentialQuery */
     val id: String? = null,
 
-    /** Path to the claim (format-specific interpretation) */
-    val path: List<JsonElement>,
+    /** Path to the claim (format-specific interpretation) - for JSON-based credentials */
+    val path: List<JsonElement>? = null,
+
+    /** Namespace for mdoc claims (e.g., "org.iso.18013.5.1") - for mso_mdoc format */
+    val namespace: String? = null,
+
+    /** Claim name within the namespace - for mso_mdoc format */
+    @SerialName("claim_name")
+    val claimName: String? = null,
 
     /** Optional specific values to match */
     val values: List<JsonPrimitive>? = null,
@@ -32,5 +46,21 @@ data class ClaimsQuery(
         id = id,
         path = pathStrings.map { JsonPrimitive(it) },
         values = values
+    )
+
+    /** Constructor for mdoc claims */
+    constructor(
+        id: String? = null,
+        namespace: String,
+        claimName: String,
+        values: List<JsonPrimitive>? = null,
+        intentToRetain: Boolean? = null
+    ) : this(
+        id = id,
+        path = null,
+        namespace = namespace,
+        claimName = claimName,
+        values = values,
+        intentToRetain = intentToRetain
     )
 }

--- a/waltid-libraries/credentials/waltid-digital-credentials/src/commonMain/kotlin/id/walt/credentials/presentations/formats/DcSdJwtPresentation.kt
+++ b/waltid-libraries/credentials/waltid-digital-credentials/src/commonMain/kotlin/id/walt/credentials/presentations/formats/DcSdJwtPresentation.kt
@@ -218,10 +218,17 @@ data class DcSdJwtPresentation(
             claimsQuery: List<ClaimsQuery>
         ): Result<Unit> {
             for (claimQuery in claimsQuery) {
-                // Use a helper to resolve the path in the credential's data
-                val resolvedValue = resolveClaimPath(credential.credentialData, claimQuery.path)
+                // Handle mdoc claims (namespace + claim_name)
+                val resolvedValue = if (claimQuery.namespace != null && claimQuery.claimName != null) {
+                    val namespaceData = credential.credentialData[claimQuery.namespace]?.jsonObject
+                    namespaceData?.get(claimQuery.claimName)
+                } else {
+                    // Use a helper to resolve the path in the credential's data
+                    claimQuery.path?.let { resolveClaimPath(credential.credentialData, it) }
+                }
 
-                presentationRequireNotNull(resolvedValue, DcqlValidationError.MISSING_CLAIM) { "Claim is: ${claimQuery.path}" }
+                val claimKey = claimQuery.path?.toString() ?: "${claimQuery.namespace}.${claimQuery.claimName}"
+                presentationRequireNotNull(resolvedValue, DcqlValidationError.MISSING_CLAIM) { "Claim is: $claimKey" }
 
                 // Optionally, re-check value constraints if they were present in the query
                 if (!claimQuery.values.isNullOrEmpty()) {

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/presentation/MdocPresenter.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/presentation/MdocPresenter.kt
@@ -12,6 +12,7 @@ import id.walt.credentials.formats.MdocsCredential
 import id.walt.crypto.keys.Key
 import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
 import id.walt.dcql.DcqlMatcher
+import id.walt.dcql.models.ClaimsQuery
 import id.walt.mdoc.crypto.MdocCryptoHelper
 import id.walt.mdoc.encoding.ByteStringWrapper
 import id.walt.mdoc.objects.DeviceSigned
@@ -138,24 +139,36 @@ object MdocPresenter {
         requireNotNull(dcqlQueryClaims) { "Missing claims for DCQL credential query: ${matchResult.originalQuery}" }
 
         //--- SD START
-        val selectedIssuerSignedItems = dcqlQueryClaims
-            // Group by the string content of the first path element (Namespace)
-            .groupBy {
-                (it.path.firstOrNull()
-                    ?: throw IllegalArgumentException("Empty path in ClaimsQuery")
-                        ).jsonPrimitive.content
+        // Helper to extract namespace and element identifier from ClaimsQuery
+        // Supports both: (1) namespace + claimName fields, (2) path-based format [namespace, elementId]
+        data class MdocClaimRef(val namespace: String, val elementIdentifier: String)
+        fun ClaimsQuery.toMdocClaimRef(): MdocClaimRef {
+            // Prefer explicit namespace/claimName if available
+            val ns = namespace
+            val cn = claimName
+            if (ns != null && cn != null) {
+                return MdocClaimRef(ns, cn)
             }
-            .mapValues { (sdNamespace2, claimQueries) ->
+            // Fall back to path-based format
+            val p = this.path
+                ?: throw IllegalArgumentException("ClaimsQuery has neither namespace/claimName nor path")
+            require(p.size >= 2) {
+                "Invalid state: Expected DCQL claim path to have at least two elements (namespace + elementIdentifier), but path was: $p"
+            }
+            return MdocClaimRef(
+                namespace = p[0].jsonPrimitive.content,
+                elementIdentifier = p[1].jsonPrimitive.content
+            )
+        }
+
+        val selectedIssuerSignedItems = dcqlQueryClaims
+            // Group by namespace
+            .groupBy { it.toMdocClaimRef().namespace }
+            .mapValues { (sdNamespace, claimQueries) ->
                 claimQueries.map { claimsQuery ->
-                    val path = claimsQuery.path
-                    // Allow >= 2 because DCQL might query deep inside an mdoc element (e.g., an array index)
-                    require(path.size >= 2) { "Invalid state: Expected DCQL claim path to have at least two elements (namespace + elementIdentifier), but path was: $path" }
+                    val claimRef = claimsQuery.toMdocClaimRef()
 
-                    // Extract the actual Strings from the JsonElements
-                    val sdNamespace: String = path[0].jsonPrimitive.content
-                    val sdElementIdentifier: String = path[1].jsonPrimitive.content
-
-                    check(sdNamespace == sdNamespace2) { "Namespace mismatch: $sdNamespace != $sdNamespace2" }
+                    check(claimRef.namespace == sdNamespace) { "Namespace mismatch: ${claimRef.namespace} != $sdNamespace" }
 
                     val issuerSignedNamespaces: Map<String, IssuerSignedList>? = issuerSigned.namespaces
                     requireNotNull(issuerSignedNamespaces) { "No issuer-signed namespaces to choose from for DCQL query claims!" }
@@ -164,8 +177,8 @@ object MdocPresenter {
                         ?: throw IllegalArgumentException("Namespace does not exist in issuer-signed namespaces for DCQL query claim: $sdNamespace")
 
                     val matchedIssuerSignedItem =
-                        selectedNamespace.entries.find { it.value.elementIdentifier == sdElementIdentifier }?.value
-                            ?: throw IllegalArgumentException("Could not find item for DCQL query: namespace = $sdNamespace, element = $sdElementIdentifier")
+                        selectedNamespace.entries.find { it.value.elementIdentifier == claimRef.elementIdentifier }?.value
+                            ?: throw IllegalArgumentException("Could not find item for DCQL query: namespace = $sdNamespace, element = ${claimRef.elementIdentifier}")
 
                     log.trace { "Mapped sd claim $claimsQuery to ${matchedIssuerSignedItem.elementIdentifier} of namespace $sdNamespace" }
 


### PR DESCRIPTION
Add support for ISO mdoc credential queries in DCQL by extending ClaimsQuery to handle both JSON path-based (SD-JWT) and namespace/claim_name based (mdoc) formats.

Changes:
- ClaimsQuery: Add nullable 'namespace' and 'claimName' fields for mdoc queries, make 'path' nullable to support both formats
- DcqlMatcher: Update claimExistsAndMatchesValue() and claimExistsAndMatches() to handle mdoc namespace lookups alongside path-based resolution
- DcSdJwtPresentation: Update validateClaimsAgainstCredential() for nullable path
- MdocPresenter: Add MdocClaimRef helper and toMdocClaimRef() to extract namespace/elementId from either namespace/claimName or path format

This enables VP Verifier conformance tests to pass for mDL credentials using DCQL queries with namespace-based claim references.

Related: WAL-896

- \-
