### PR TITLE
Fix Swift parity gate empty changes

### DIFF
--- a/.github/workflows/macos-eligibility.yml
+++ b/.github/workflows/macos-eligibility.yml
@@ -81,6 +81,7 @@ jobs:
               ".github/actions/gradle-setup-action/*"
               ".github/actions/ios-build-setup/*"
               ".github/actions/set-properties/*"
+              "scripts/check-mobile-swift-parity-decision.sh"
               "build-logic/*"
               "build.gradle.kts"
               "gradle/*"

--- a/scripts/check-mobile-swift-parity-decision.sh
+++ b/scripts/check-mobile-swift-parity-decision.sh
@@ -130,6 +130,11 @@ fi
 mobile_abi_changed=false
 swift_parity_evidence=false
 
+if (( ${#changed_files[@]} == 0 )); then
+  echo "No changed files detected; Swift parity gate skipped."
+  exit 0
+fi
+
 for changed_file in "${changed_files[@]}"; do
   case "$changed_file" in
     waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/*|\

--- a/scripts/test-mobile-swift-parity-gate.sh
+++ b/scripts/test-mobile-swift-parity-gate.sh
@@ -64,6 +64,9 @@ expect_git_fail() {
 
 changes="$TMP_DIR/changes.txt"
 
+: > "$changes"
+expect_pass "empty change list" "$changes"
+
 write_changes "$changes" \
   "waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt"
 expect_pass "private/source-only mobile change" "$changes"


### PR DESCRIPTION
## Summary
- skip the Swift parity gate cleanly when the changed-file list is empty
- add a regression case for empty changed-file input
- include the parity gate script in macOS eligibility so this docs check runs when the gate changes

## Observed failure
This fixes the `Mobile SDK API docs` failure on `main` from https://github.com/walt-id/waltid-identity/actions/runs/29078696286, where `Check mobile SDK API contract` passed the Gradle ABI checks and then failed in `scripts/check-mobile-swift-parity-decision.sh` with `changed_files[@]: unbound variable`.

## Root cause
On macOS bash 3.2, expanding an empty array under `set -u` can fail with `changed_files[@]: unbound variable`. The Mobile SDK API docs workflow hit that path after the ABI checks passed and the parity gate saw no changed files.

## Validation
- `scripts/test-mobile-swift-parity-gate.sh`
- `/bin/bash scripts/check-mobile-swift-parity-decision.sh --changed-files-file <empty file>`
