### PR TITLE
[WAL-751] follow-up: add claim-level selective disclosure

### DIFF
--- a/.github/workflows/gradle-macos.yml
+++ b/.github/workflows/gradle-macos.yml
@@ -105,7 +105,7 @@ jobs:
         uses: walt-id/waltid-identity/.github/actions/gradle-setup-action@c95b601fc5095d5668eb8c906af992d8e00ed513
 
       - name: Run Compose iOS demo tests
-        timeout-minutes: 25
+        timeout-minutes: 45
         uses: walt-id/waltid-identity/.github/actions/gradle-ios@c95b601fc5095d5668eb8c906af992d8e00ed513
         with:
           waltid-directory: 'waltid-identity'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,10 @@ gradle-shadow = "9.4.2"
 buildconfig = "6.0.10"
 compose-multiplatform = "1.11.1"
 compose-material3 = "1.11.0-alpha07"
+compose-material-icons = "1.7.3"
+compose-navigation3 = "1.1.1"
 dokka = "2.2.0"
+coil = "3.5.0"
 
 # Plugins / Dependencies
 ktor = "3.5.0"
@@ -261,6 +264,9 @@ compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "
 compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-multiplatform" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-multiplatform" }
 compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose-material3" }
+compose-material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "compose-material-icons" }
+compose-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "compose-navigation3" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-rules" }

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PublicDemoBackendE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PublicDemoBackendE2ETest.kt
@@ -6,15 +6,13 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import id.walt.mobile.test.backend.DemoTestBackend
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.CREDENTIAL_OPERATION_TIMEOUT
-import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.POST_PRESENT_DELAY
-import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.QUICK_STATUS_CHECK_TIMEOUT
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.UI_ELEMENT_TIMEOUT
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.VERIFIER_POLLING_TIMEOUT
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.assertResourceTextEquals
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.clickByTag
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.launchAndUnlock
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.latestStatus
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.sendDeepLink
-import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForResource
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForStatus
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
@@ -36,9 +34,12 @@ class PublicDemoBackendE2ETest {
         launchAndUnlock(context, device)
 
         sendDeepLink(context, offer.offerUrl)
-        assertTrue(
-            "Offer URL did not appear in UI after deep link",
-            waitForResource(device, "wallet.offerInput", UI_ELEMENT_TIMEOUT)?.text == offer.offerUrl
+        assertResourceTextEquals(
+            device = device,
+            tag = "wallet.offerInput",
+            expected = offer.offerUrl,
+            timeoutMs = UI_ELEMENT_TIMEOUT,
+            message = "Offer URL did not appear in UI after deep link",
         )
 
         clickByTag(device, "wallet.receiveButton")
@@ -53,22 +54,32 @@ class PublicDemoBackendE2ETest {
 
         val session = DemoTestBackend.createVerifierSession(scenario)
         sendDeepLink(context, session.authorizationRequestUri)
-
-        val startedWithoutTap = waitForStatus(
+        assertResourceTextEquals(
             device = device,
-            timeoutMs = QUICK_STATUS_CHECK_TIMEOUT,
-            matcher = {
-                it.startsWith("Presenting credential") ||
-                    it.startsWith("Presentation sent") ||
-                    it.startsWith("Presentation finished")
-            },
+            tag = "wallet.presentationInput",
+            expected = session.authorizationRequestUri,
+            timeoutMs = UI_ELEMENT_TIMEOUT,
+            message = "Presentation request URL did not appear in UI after deep link",
+        )
+
+        clickByTag(device, "wallet.presentButton")
+        val previewReady = waitForStatus(
+            device = device,
+            timeoutMs = CREDENTIAL_OPERATION_TIMEOUT,
+            matcher = { it == "Review presentation request" },
+            failurePrefixes = listOf("Preview failed", "Present failed", "Receive failed", "Bootstrap failed")
+        )
+        assertTrue("Presentation preview did not load. Latest status: ${latestStatus(device)}", previewReady)
+
+        clickByTag(device, "wallet.presentationSubmitButton")
+        val presentSuccess = waitForStatus(
+            device = device,
+            timeoutMs = CREDENTIAL_OPERATION_TIMEOUT,
+            matcher = { it.startsWith("Presentation sent") || it.startsWith("Presentation finished") },
             failurePrefixes = listOf("Present failed", "Receive failed", "Bootstrap failed")
         )
-        if (!startedWithoutTap) {
-            clickByTag(device, "wallet.presentButton")
-        }
+        assertTrue("Presentation did not complete in app. Latest status: ${latestStatus(device)}", presentSuccess)
 
-        Thread.sleep(POST_PRESENT_DELAY)
         val statusAfterPresent = latestStatus(device)
         assertTrue(
             "Presentation failed in app. Latest status: $statusAfterPresent",

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
+import org.junit.Assert.fail
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 
@@ -13,6 +14,7 @@ internal object WalletComposeE2EHelper {
     const val PIN = "1234"
     const val WALLET_READY_TIMEOUT = 60_000L
     const val UI_ELEMENT_TIMEOUT = 30_000L
+    private const val CLICK_VISIBLE_TIMEOUT = 3_000L
     const val CREDENTIAL_OPERATION_TIMEOUT = 90_000L
     const val VERIFIER_POLLING_TIMEOUT = 30_000L
     const val QUICK_STATUS_CHECK_TIMEOUT = 5_000L
@@ -26,6 +28,8 @@ internal object WalletComposeE2EHelper {
         "Received",
         "Receive failed",
         "Bootstrap failed",
+        "Resolving presentation",
+        "Review presentation request",
         "Presenting credential",
         "Presentation sent",
         "Presentation finished",
@@ -63,17 +67,52 @@ internal object WalletComposeE2EHelper {
     }
 
     fun sendDeepLink(context: Context, url: String) {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-            `package` = context.packageName
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val intent = Intent(
+            Intent.ACTION_VIEW,
+            Uri.parse(url),
+            context,
+            MainActivity::class.java,
+        ).apply {
+            addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP
+            )
         }
         context.startActivity(intent)
     }
 
+    fun assertResourceTextEquals(
+        device: UiDevice,
+        tag: String,
+        expected: String,
+        timeoutMs: Long,
+        message: String,
+    ) {
+        val node = waitForResource(device, tag, timeoutMs)
+        if (node?.text != expected) {
+            fail(
+                """
+                    $message
+                    expected=$expected
+                    actual=${node?.text ?: "<missing>"}
+                    ${visibleUiSnapshot(device)}
+                """.trimIndent()
+            )
+        }
+    }
+
     fun clickByTag(device: UiDevice, tag: String) {
-        val node = waitForResource(device, tag, UI_ELEMENT_TIMEOUT)
-        assertNotNull("$tag not found", node)
-        node!!.clickableAncestorOrSelf()?.click() ?: node.click()
+        val node = waitForResource(device, tag, CLICK_VISIBLE_TIMEOUT)
+            ?: findVisibleResource(device, tag)
+            ?: findResourceAfterScrolling(device, tag)
+        if (node == null) {
+            fail("$tag not found.\n${visibleUiSnapshot(device)}")
+        }
+        assertTrue("$tag is disabled", node!!.isEnabled)
+        device.waitForIdle()
+        node.clickableAncestorOrSelf()?.click() ?: node.click()
+        device.waitForIdle()
     }
 
     fun waitForResource(device: UiDevice, tag: String, timeoutMs: Long): UiObject2? {
@@ -81,7 +120,31 @@ internal object WalletComposeE2EHelper {
         while (System.currentTimeMillis() < deadline) {
             val node = device.findObject(By.res(tag))
             if (node != null) return node
+            findVisibleResource(device, tag)?.let { return it }
             Thread.sleep(500)
+        }
+        return null
+    }
+
+    private fun findVisibleResource(device: UiDevice, tag: String): UiObject2? =
+        device.findObjects(By.pkg("id.walt.walletdemo.compose"))
+            .flatMap { it.flatten() }
+            .firstOrNull { node ->
+                runCatching { node.resourceName == tag }.getOrDefault(false)
+            }
+
+    private fun findResourceAfterScrolling(device: UiDevice, tag: String): UiObject2? {
+        repeat(6) {
+            device.swipe(
+                device.displayWidth / 2,
+                (device.displayHeight * 0.72).toInt(),
+                device.displayWidth / 2,
+                (device.displayHeight * 0.36).toInt(),
+                24,
+            )
+            device.waitForIdle()
+            waitForResource(device, tag, 1_000L)?.let { return it }
+            findVisibleResource(device, tag)?.let { return it }
         }
         return null
     }
@@ -121,4 +184,44 @@ internal object WalletComposeE2EHelper {
         }
         return null
     }
+
+    private fun visibleUiSnapshot(device: UiDevice): String {
+        val roots = device.findObjects(By.pkg("id.walt.walletdemo.compose"))
+        val nodes = roots
+            .flatMap { it.flatten() }
+            .distinctBy { node ->
+                node.snapshotIdentity()
+            }
+            .take(80)
+            .mapNotNull { it.describeForSnapshot() }
+            .joinToString("\n")
+
+        return """
+            package=${device.currentPackageName}
+            latestStatus=${latestStatus(device)}
+            visibleWalletNodes:
+            ${nodes.ifBlank { "<none>" }}
+        """.trimIndent()
+    }
+
+    private fun UiObject2.flatten(): List<UiObject2> =
+        listOf(this) + runCatching { children.flatMap { it.flatten() } }.getOrDefault(emptyList())
+
+    private fun UiObject2.snapshotIdentity(): String =
+        runCatching {
+            listOf(
+                resourceName.orEmpty(),
+                text.orEmpty(),
+                contentDescription.orEmpty(),
+                visibleBounds.toShortString(),
+            ).joinToString("|")
+        }.getOrDefault("stale")
+
+    private fun UiObject2.describeForSnapshot(): String? =
+        runCatching {
+            val text = text?.takeIf { it.isNotBlank() }?.let { " text='$it'" }.orEmpty()
+            val res = resourceName?.takeIf { it.isNotBlank() }?.let { " res='$it'" }.orEmpty()
+            val desc = contentDescription?.takeIf { it.isNotBlank() }?.let { " desc='$it'" }.orEmpty()
+            "$className$res$text$desc bounds=${visibleBounds.toShortString()}"
+        }.getOrNull()
 }

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
@@ -12,6 +12,7 @@ final class PublicDemoBackendE2ETests: XCTestCase {
     // Timeouts (aligned with Android for cross-platform consistency)
     private let walletReadyTimeout: TimeInterval = 60
     private let credentialOperationTimeout: TimeInterval = 90
+    private let presentationOperationTimeout: TimeInterval = 180
     private let verifierPollingTimeout: TimeInterval = 30
 
     func testBootstrapCreatesDid() async throws {
@@ -71,16 +72,55 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         XCTAssertTrue(presentationURLApplied, "Presentation request URL did not appear in UI after deep link")
         ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Present")
 
-        let presentStatus = ui.waitForStatus(
-            prefixes: ["Presentation sent", "Presentation finished", "Present failed", "Receive failed", "Bootstrap failed"],
+        let previewStatus = ui.waitForStatus(
+            prefixes: ["Review presentation request", "Preview failed", "Present failed", "Receive failed", "Bootstrap failed"],
             timeout: credentialOperationTimeout
         )
-        XCTAssertNotNil(presentStatus)
-        XCTAssertFalse(presentStatus!.starts(with: "Present failed"), "Present failed: \(presentStatus!)")
-        XCTAssertFalse(presentStatus!.starts(with: "Receive failed"), "Receive failed during presentation: \(presentStatus!)")
-        XCTAssertFalse(presentStatus!.starts(with: "Bootstrap failed"), "Bootstrap failed during presentation: \(presentStatus!)")
+        XCTAssertEqual(previewStatus, "Review presentation request", "Presentation preview did not load, status: \(previewStatus ?? "nil")")
 
-        try await backend.waitForVerifierSuccess(sessionID: session.sessionID, timeoutSeconds: verifierPollingTimeout)
+        ui.tapButton(identifier: "wallet.presentationSubmitButton", fallbackLabel: "Share", useCoordinateTap: true)
+        var submitStatus = ui.waitForStatus(
+            prefixes: ["Presenting credential", "Presentation sent", "Present failed", "Receive failed", "Bootstrap failed"],
+            timeout: 10
+        )
+        if submitStatus == nil {
+            ui.tapButton(identifier: "wallet.presentationSubmitButton", fallbackLabel: "Share", useCoordinateTap: true)
+            submitStatus = ui.waitForStatus(
+                prefixes: ["Presenting credential", "Presentation sent", "Present failed", "Receive failed", "Bootstrap failed"],
+                timeout: 10
+            )
+        }
+        guard let submitStatus else {
+            let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+            screenshot.name = "Presentation submit did not change status"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+
+            let hierarchy = XCTAttachment(string: app.debugDescription)
+            hierarchy.name = "Presentation submit UI hierarchy"
+            hierarchy.lifetime = .keepAlways
+            add(hierarchy)
+
+            XCTFail("Presentation submit did not update app status after tapping Share")
+            return
+        }
+        XCTAssertFalse(submitStatus.starts(with: "Present failed"), "Present failed: \(submitStatus)")
+        XCTAssertFalse(submitStatus.starts(with: "Receive failed"), "Receive failed during presentation: \(submitStatus)")
+        XCTAssertFalse(submitStatus.starts(with: "Bootstrap failed"), "Bootstrap failed during presentation: \(submitStatus)")
+
+        try await backend.waitForVerifierSuccess(
+            sessionID: session.sessionID,
+            timeoutSeconds: presentationOperationTimeout
+        )
+
+        if let presentStatus = ui.waitForStatus(
+            prefixes: ["Presentation sent", "Presentation finished", "Present failed", "Receive failed", "Bootstrap failed"],
+            timeout: verifierPollingTimeout
+        ) {
+            XCTAssertFalse(presentStatus.starts(with: "Present failed"), "Present failed: \(presentStatus)")
+            XCTAssertFalse(presentStatus.starts(with: "Receive failed"), "Receive failed during presentation: \(presentStatus)")
+            XCTAssertFalse(presentStatus.starts(with: "Bootstrap failed"), "Bootstrap failed during presentation: \(presentStatus)")
+        }
     }
 
     func testDemoCredentialPersistsAcrossAppRestart() async throws {

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/WalletE2EHelpers.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/WalletE2EHelpers.swift
@@ -90,12 +90,17 @@ final class WalletE2EUI {
         return false
     }
 
-    func tapButton(identifier: String, fallbackLabel: String) {
+    func tapButton(identifier: String, fallbackLabel: String, useCoordinateTap: Bool = false) {
         let targetButton = button(identifier: identifier, fallbackLabel: fallbackLabel)
         XCTAssertTrue(targetButton.waitForExistence(timeout: 20), "Button not found: \(identifier)")
         makeHittable(targetButton)
         XCTAssertTrue(targetButton.isHittable, "Button is not hittable: \(identifier)")
-        targetButton.tap()
+        XCTAssertTrue(targetButton.isEnabled, "Button is not enabled: \(identifier)")
+        if useCoordinateTap {
+            targetButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        } else {
+            targetButton.tap()
+        }
     }
 
     private func replaceText(in element: XCUIElement, value: String) {

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/build.gradle.kts
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/build.gradle.kts
@@ -25,6 +25,9 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(identityLibs.kotlinx.coroutines.core)
+            implementation(identityLibs.kotlinx.datetime)
+            implementation(identityLibs.kotlinx.serialization.json)
+            implementation(identityLibs.ktor.http)
         }
 
         if (enableMobileWallet) {

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/ClaimPath.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/ClaimPath.kt
@@ -1,0 +1,84 @@
+package id.walt.walletdemo.compose.logic
+
+internal data class ClaimPath(
+    val itemPath: ClaimItemPath,
+    val components: List<String>,
+) {
+    val leaf: String = components.lastOrNull().orEmpty()
+    val topLevel: String = components.firstOrNull().orEmpty()
+    val isTopLevel: Boolean = components.size <= 1
+
+    companion object {
+        fun topLevel(name: String): ClaimPath =
+            ClaimPath(itemPath = ClaimItemPath.topLevel(name), components = listOf(name))
+
+        fun child(parent: ClaimPath, child: String): ClaimPath =
+            ClaimPath(
+                itemPath = parent.itemPath.child(child),
+                components = parent.components + child,
+            )
+
+        fun indexed(parent: ClaimPath, index: Int): ClaimPath =
+            ClaimPath(itemPath = parent.itemPath.indexedChild(index), components = parent.components)
+
+        fun disclosure(index: Int, rawPath: String, label: String): ClaimPath {
+            val sourcePath = ClaimSourcePath.parse(rawPath)
+            val semanticLeaf = sourcePath?.semanticLeaf
+                ?: label.takeIf { it.isNotBlank() }
+                ?: ClaimPathRoot.Disclosures.singularId
+            return ClaimPath(
+                itemPath = ClaimItemPath.disclosure(index = index, semanticLeaf = semanticLeaf, sourcePath = sourcePath),
+                components = ClaimPathRoot.Disclosures.componentsWith(semanticLeaf),
+            )
+        }
+
+        fun semanticLeaf(rawPath: String): String? = semanticClaimName(rawPath)
+    }
+}
+
+internal class ClaimSourcePath private constructor(
+    val value: String,
+    val semanticLeaf: String?,
+) {
+    companion object {
+        fun parse(rawPath: String): ClaimSourcePath? {
+            val value = rawPath.trim().takeIf { it.isNotBlank() } ?: return null
+            return ClaimSourcePath(
+                value = value,
+                semanticLeaf = ClaimPathExpression.parse(value).leafKey,
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ClaimSourcePath) return false
+        return value == other.value && semanticLeaf == other.semanticLeaf
+    }
+
+    override fun hashCode(): Int {
+        var result = value.hashCode()
+        result = 31 * result + (semanticLeaf?.hashCode() ?: 0)
+        return result
+    }
+}
+
+private fun semanticClaimName(rawPath: String): String? =
+    ClaimSourcePath.parse(rawPath)?.semanticLeaf
+
+internal enum class ClaimPathRoot(val id: String) {
+    Root("$"),
+    Disclosures("disclosures"),
+    ;
+
+    val singularId: String
+        get() = when (this) {
+            Disclosures -> "disclosure"
+            else -> id
+        }
+
+    fun componentsWith(child: String): List<String> =
+        listOf(id, child)
+            .filter { it.isNotBlank() }
+            .distinct()
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/ClaimPathExpression.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/ClaimPathExpression.kt
@@ -1,0 +1,112 @@
+package id.walt.walletdemo.compose.logic
+
+internal data class ClaimPathExpression(
+    val segments: List<Segment>,
+) {
+    val leafKey: String? = segments.asReversed()
+        .firstNotNullOfOrNull { segment -> (segment as? Segment.Key)?.value }
+
+    sealed interface Segment {
+        data class Key(val value: String) : Segment
+        data class Index(val value: Int) : Segment
+        data object Wildcard : Segment
+    }
+
+    companion object {
+        fun parse(rawValue: String): ClaimPathExpression =
+            ClaimPathExpressionParser(rawValue).parse()
+    }
+}
+
+private class ClaimPathExpressionParser(rawValue: String) {
+    private val path = rawValue.trim()
+    private var index = 0
+    private val segments = mutableListOf<ClaimPathExpression.Segment>()
+
+    fun parse(): ClaimPathExpression {
+        while (index < path.length) {
+            when (path[index]) {
+                '$', '.', ' ', '\n', '\r', '\t' -> index += 1
+                '[' -> addBracketSegment()
+                else -> addKey(readDotSegment())
+            }
+        }
+        return ClaimPathExpression(segments)
+    }
+
+    private fun addBracketSegment() {
+        index += 1
+        skipWhitespace()
+        val segment = if (index < path.length && path[index].isQuote()) {
+            readQuotedSegment(path[index])
+        } else {
+            readUnquotedBracketSegment()
+        }
+        skipUntilBracketEnd()
+        addToken(segment)
+    }
+
+    private fun addToken(rawSegment: String) {
+        val segment = rawSegment.trim()
+        when {
+            segment.isBlank() -> Unit
+            segment == "*" -> segments += ClaimPathExpression.Segment.Wildcard
+            segment.toIntOrNull() != null -> segments += ClaimPathExpression.Segment.Index(segment.toInt())
+            else -> addKey(segment)
+        }
+    }
+
+    private fun addKey(rawSegment: String) {
+        val segment = rawSegment.trim()
+        if (segment.isNotBlank()) {
+            segments += ClaimPathExpression.Segment.Key(segment)
+        }
+    }
+
+    private fun skipWhitespace() {
+        while (index < path.length && path[index].isWhitespace()) index += 1
+    }
+
+    private fun skipUntilBracketEnd() {
+        while (index < path.length && path[index] != ']') index += 1
+        if (index < path.length) index += 1
+    }
+
+    private fun readDotSegment(): String {
+        val start = index
+        while (index < path.length && path[index] != '.' && path[index] != '[') index += 1
+        return path.substring(start, index)
+    }
+
+    private fun readUnquotedBracketSegment(): String {
+        val start = index
+        while (index < path.length && path[index] != ']') index += 1
+        return path.substring(start, index)
+    }
+
+    private fun readQuotedSegment(quote: Char): String {
+        index += 1
+        val segment = StringBuilder()
+        while (index < path.length) {
+            val char = path[index]
+            when {
+                char == '\\' && index + 1 < path.length -> {
+                    index += 1
+                    segment.append(path[index])
+                    index += 1
+                }
+                char == quote -> {
+                    index += 1
+                    return segment.toString()
+                }
+                else -> {
+                    segment.append(char)
+                    index += 1
+                }
+            }
+        }
+        return segment.toString()
+    }
+}
+
+private fun Char.isQuote(): Boolean = this == '\'' || this == '"'

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialCardDisplayData.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialCardDisplayData.kt
@@ -1,0 +1,93 @@
+package id.walt.walletdemo.compose.logic
+
+data class CredentialCardDisplayData(
+    val id: String,
+    val title: String,
+    val credentialType: String?,
+    val format: String,
+    val issuer: String?,
+    val holderName: String?,
+    val date: String?,
+    val validity: String?,
+    val portrait: DisplayValue.Image?,
+)
+
+fun CredentialDetails.toCardDisplayData(): CredentialCardDisplayData {
+    val allItems = groups.flatMap { it.items }.flatMap { it.flatten() }
+    val givenName = allItems.firstTextForRole(ClaimRole.GivenName)
+    val familyName = allItems.firstTextForRole(ClaimRole.FamilyName)
+    val holderName = listOfNotNull(givenName, familyName)
+        .joinToString(" ")
+        .ifBlank { summary.subject.orEmpty() }
+        .ifBlank { null }
+    val expiryDate = allItems.firstExpiryDateText()
+    val fallbackAddedDate = summary.addedAt
+
+    return CredentialCardDisplayData(
+        id = summary.id,
+        title = summary.label,
+        credentialType = allItems.firstCredentialTypeText(),
+        format = summary.format,
+        issuer = summary.issuer,
+        holderName = holderName,
+        date = expiryDate ?: fallbackAddedDate,
+        validity = expiryDate?.let { CredentialDisplayText.expires(it) }
+            ?: fallbackAddedDate?.let { CredentialDisplayText.added(it) },
+        portrait = allItems.firstImageForRole(ClaimRole.Image),
+    )
+}
+
+private fun ClaimItem.flatten(): List<ClaimItem> =
+    when (val displayValue = value) {
+        is DisplayValue.ObjectValue -> listOf(this) + displayValue.entries.flatMap { it.flatten() }
+        else -> listOf(this)
+    }
+
+private fun List<ClaimItem>.firstTextForRole(role: ClaimRole): String? =
+    firstNotNullOfOrNull { item ->
+        if (item.hasRole(role)) item.value.asPlainText() else null
+    }
+
+private fun List<ClaimItem>.firstExpiryDateText(): String? =
+    firstNotNullOfOrNull { item ->
+        if (item.hasRole(ClaimRole.ExpiryDate)) item.value.asPlainText() else null
+    }
+
+private fun List<ClaimItem>.firstCredentialTypeText(): String? =
+    firstNotNullOfOrNull { item ->
+        if (item.hasRole(ClaimRole.CredentialType)) {
+            item.value.asCredentialTypeText()?.let(CredentialDisplayVocabulary::readableCredentialType)
+        } else {
+            null
+        }
+    }
+
+private fun List<ClaimItem>.firstImageForRole(role: ClaimRole): DisplayValue.Image? =
+    firstNotNullOfOrNull { item ->
+        if (item.hasRole(role)) item.value as? DisplayValue.Image else null
+    }
+
+private fun ClaimItem.hasRole(role: ClaimRole): Boolean =
+    role in roles
+
+private fun DisplayValue.asCredentialTypeText(): String? =
+    when (this) {
+        is DisplayValue.ListValue -> values
+            .mapNotNull { it.asPlainText() }
+            .firstOrNull { !it.isGenericVcType() }
+            ?: values.firstNotNullOfOrNull { it.asPlainText() }
+        else -> asPlainText()
+    }
+
+private fun DisplayValue.asPlainText(): String? =
+    when (this) {
+        is DisplayValue.BooleanValue -> value.toString()
+        is DisplayValue.DecodedText -> value
+        is DisplayValue.NumberValue -> value
+        is DisplayValue.Raw -> value
+        is DisplayValue.Text -> value
+        else -> null
+    }
+
+private fun String.isGenericVcType(): Boolean =
+    CredentialDisplayVocabulary.isGenericCredentialType(this)

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayMapping.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayMapping.kt
@@ -1,0 +1,47 @@
+package id.walt.walletdemo.compose.logic
+
+fun CredentialSummary.toCredentialDetails(): CredentialDetails =
+    CredentialDisplayNormalizer.toDetails(this)
+
+fun WalletDemoPresentationPreview.toVerifierDetails(): VerifierDetails =
+    VerifierDetails(
+        name = verifierName,
+        clientId = clientId,
+        responseUri = responseUri,
+        state = state,
+        nonce = nonce,
+    )
+
+fun WalletDemoPresentationCredentialOption.toCredentialDetails(): CredentialDetails {
+    val summary = CredentialSummary(
+        id = credentialId,
+        format = format,
+        issuer = issuer,
+        subject = subject,
+        label = label,
+        addedAt = null,
+        credentialDataJson = credentialDataJson,
+    )
+    val parsed = summary.toCredentialDetails()
+    val requestedGroup = ClaimGroup(
+        title = CredentialDisplayVocabulary.RequestedDisclosuresTitle,
+        items = disclosures.mapIndexed { index, disclosure ->
+            val path = ClaimPath.disclosure(index = index, rawPath = disclosure.path, label = disclosure.label)
+            ClaimItem(
+                path = path.itemPath,
+                label = disclosure.label,
+                value = CredentialDisplayNormalizer.toDisclosureValue(
+                    valueJson = disclosure.valueJson,
+                    displayValue = disclosure.displayValue,
+                    path = path,
+                ),
+                rawValue = disclosure.valueJson,
+                requested = true,
+                shareable = disclosure.selectivelyDisclosable,
+                roles = CredentialDisplayVocabulary.roles(path),
+            )
+        },
+    )
+
+    return parsed.copy(groups = listOf(requestedGroup) + parsed.groups)
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayModels.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayModels.kt
@@ -1,0 +1,154 @@
+package id.walt.walletdemo.compose.logic
+
+data class CredentialDetails(
+    val summary: CredentialSummary,
+    val groups: List<ClaimGroup>,
+    val technicalGroups: List<ClaimGroup> = emptyList(),
+)
+
+data class ClaimGroup(
+    val title: String,
+    val items: List<ClaimItem>,
+)
+
+class ClaimItemPath private constructor(
+    private val renderedId: RenderedClaimPath,
+    private val renderedSourcePath: RenderedClaimPath? = null,
+) {
+    val id: String = renderedId.value
+    val sourcePath: String? = renderedSourcePath?.value
+
+    fun indexedChild(index: Int): ClaimItemPath =
+        ClaimItemPath(
+            renderedId = renderedId.indexed(index),
+            renderedSourcePath = renderedSourcePath?.indexed(index),
+        )
+
+    fun child(name: String): ClaimItemPath =
+        ClaimItemPath(
+            renderedId = renderedId.child(name),
+            renderedSourcePath = renderedSourcePath?.child(name),
+        )
+
+    companion object {
+        fun root(): ClaimItemPath = ClaimItemPath(renderedId = RenderedClaimPath.raw(ClaimPathRoot.Root.id))
+
+        fun topLevel(name: String): ClaimItemPath = ClaimItemPath(renderedId = RenderedClaimPath.raw(name))
+
+        internal fun disclosure(index: Int, semanticLeaf: String, sourcePath: ClaimSourcePath?): ClaimItemPath =
+            ClaimItemPath(
+                renderedId = RenderedClaimPath.raw(ClaimPathRoot.Disclosures.id)
+                    .indexed(index)
+                    .child(semanticLeaf),
+                renderedSourcePath = sourcePath?.value?.let(RenderedClaimPath::raw),
+            )
+
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ClaimItemPath) return false
+
+        return id == other.id && sourcePath == other.sourcePath
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + (sourcePath?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "ClaimItemPath(id=$id, sourcePath=$sourcePath)"
+}
+
+private data class RenderedClaimPath(
+    private val root: String,
+    private val operations: List<PathOperation> = emptyList(),
+) {
+    val value: String
+        get() = buildString {
+            append(root)
+            operations.forEach { operation ->
+                when (operation) {
+                    is PathOperation.Child -> append('.').append(operation.name)
+                    is PathOperation.Index -> append('[').append(operation.value).append(']')
+                }
+            }
+        }
+
+    fun child(name: String): RenderedClaimPath =
+        copy(operations = operations + PathOperation.Child(name))
+
+    fun indexed(index: Int): RenderedClaimPath =
+        copy(operations = operations + PathOperation.Index(index))
+
+    companion object {
+        fun raw(value: String): RenderedClaimPath = RenderedClaimPath(root = value)
+    }
+}
+
+private sealed interface PathOperation {
+    data class Child(val name: String) : PathOperation
+    data class Index(val value: Int) : PathOperation
+}
+
+data class ClaimItem(
+    val path: ClaimItemPath,
+    val label: String,
+    val value: DisplayValue,
+    val rawValue: String? = null,
+    val requested: Boolean = false,
+    val shareable: Boolean = true,
+    val roles: Set<ClaimRole> = emptySet(),
+)
+
+sealed interface DisplayValue {
+    data class Text(val value: String) : DisplayValue
+    data class NumberValue(val value: String) : DisplayValue
+    data class BooleanValue(val value: Boolean) : DisplayValue
+    data class ObjectValue(val entries: List<ClaimItem>) : DisplayValue
+    data class ListValue(val values: List<DisplayValue>) : DisplayValue
+    data class Image(
+        val encoded: String,
+        val bytes: ByteArray,
+        val mimeType: String?,
+        val byteCount: Int,
+    ) : DisplayValue {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Image) return false
+
+            return encoded == other.encoded &&
+                    bytes.contentEquals(other.bytes) &&
+                    mimeType == other.mimeType &&
+                    byteCount == other.byteCount
+        }
+
+        override fun hashCode(): Int {
+            var result = encoded.hashCode()
+            result = 31 * result + bytes.contentHashCode()
+            result = 31 * result + (mimeType?.hashCode() ?: 0)
+            result = 31 * result + byteCount
+            return result
+        }
+    }
+    data class DecodedText(val value: String) : DisplayValue
+    data class Raw(val value: String) : DisplayValue
+    data object NullValue : DisplayValue
+}
+
+data class VerifierDetails(
+    val name: String?,
+    val clientId: String?,
+    val responseUri: String? = null,
+    val state: String? = null,
+    val nonce: String? = null,
+    val trustStatus: String = CredentialDisplayText.Unknown,
+)
+
+data class PresentationReview(
+    val verifier: VerifierDetails,
+    val credentialOptions: List<CredentialDetails>,
+    val selectedCredentialIds: Set<String> = emptySet(),
+)

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayNormalizer.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayNormalizer.kt
@@ -1,0 +1,188 @@
+package id.walt.walletdemo.compose.logic
+
+import kotlin.time.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonObject
+
+object CredentialDisplayNormalizer {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+    private val valueDecoder = CredentialDisplayValueDecoder(json) { element, path -> element.toDisplayValue(path) }
+
+    fun toDetails(summary: CredentialSummary): CredentialDetails {
+        val rawJson = summary.credentialDataJson?.trim().orEmpty()
+        if (rawJson.isBlank()) {
+            return CredentialDetails(summary = summary, groups = emptyList())
+        }
+
+        val parsed = runCatching { json.parseToJsonElement(rawJson).jsonObject }.getOrNull()
+            ?: return CredentialDetails(
+                summary = summary,
+                groups = emptyList(),
+                technicalGroups = listOf(
+                    ClaimGroup(
+                        title = CredentialDisplayVocabulary.RawCredentialDataTitle,
+                        items = listOf(
+                            ClaimItem(
+                                path = ClaimItemPath.root(),
+                                label = CredentialDisplayVocabulary.RawCredentialDataLabel,
+                                value = DisplayValue.Raw(rawJson),
+                                rawValue = rawJson,
+                                shareable = false,
+                            )
+                        ),
+                    )
+                ),
+            )
+
+        val groupedItems = parsed.entries
+            .map { (key, value) ->
+                val path = ClaimPath.topLevel(key)
+                CredentialDisplayVocabulary.groupKind(path) to
+                        value.toClaimItem(path = path, label = CredentialDisplayVocabulary.humanizedClaimLabel(key))
+            }
+            .groupBy(keySelector = { it.first }, valueTransform = { it.second })
+            .entries
+            .sortedBy { it.key.order }
+            .map { (group, items) -> ClaimGroup(title = group.title, items = items) }
+
+        return CredentialDetails(
+            summary = summary,
+            groups = groupedItems,
+            technicalGroups = listOf(
+                ClaimGroup(
+                    title = CredentialDisplayVocabulary.RawCredentialDataTitle,
+                    items = listOf(
+                        ClaimItem(
+                            path = ClaimItemPath.root(),
+                            label = CredentialDisplayVocabulary.CredentialDataJsonLabel,
+                            value = DisplayValue.Raw(rawJson),
+                            rawValue = rawJson,
+                            shareable = false,
+                        )
+                    ),
+                )
+            ),
+        )
+    }
+
+    internal fun toDisclosureValue(valueJson: String, displayValue: String?, path: ClaimPath): DisplayValue {
+        val parsed = runCatching { json.parseToJsonElement(valueJson) }.getOrNull()
+        if (parsed != null) {
+            val parsedValue = parsed.toDisplayValue(path)
+            if (parsedValue is DisplayValue.Text && !displayValue.isNullOrBlank()) {
+                return DisplayValue.Text(displayValue)
+            }
+            return parsedValue
+        }
+
+        return displayValue
+            ?.takeIf { it.isNotBlank() }
+            ?.let(DisplayValue::Text)
+            ?: DisplayValue.Raw(valueJson)
+    }
+
+    private fun JsonElement.toClaimItem(path: ClaimPath, label: String): ClaimItem =
+        ClaimItem(
+            path = path.itemPath,
+            label = label,
+            value = toDisplayValue(path),
+            rawValue = toString(),
+            roles = CredentialDisplayVocabulary.roles(path),
+        )
+
+    private fun claimItemsFromJson(rawJson: String, path: ClaimPath, fallbackLabel: String): List<ClaimItem> {
+        val trimmed = rawJson.trim()
+        if (trimmed.isBlank()) return emptyList()
+
+        val parsed = runCatching { json.parseToJsonElement(trimmed) }.getOrNull()
+            ?: return listOf(
+                ClaimItem(
+                    path = path.itemPath,
+                    label = fallbackLabel,
+                    value = DisplayValue.Raw(trimmed),
+                    rawValue = trimmed,
+                    shareable = false,
+                    roles = CredentialDisplayVocabulary.roles(path),
+                )
+            )
+
+        return when (parsed) {
+            is JsonObject -> parsed.entries.map { (key, value) ->
+                value.toClaimItem(
+                    path = ClaimPath.child(path, key),
+                    label = CredentialDisplayVocabulary.humanizedClaimLabel(key),
+                ).copy(shareable = false)
+            }
+            else -> listOf(
+                ClaimItem(
+                    path = path.itemPath,
+                    label = fallbackLabel,
+                    value = parsed.toDisplayValue(path),
+                    rawValue = parsed.toString(),
+                    shareable = false,
+                    roles = CredentialDisplayVocabulary.roles(path),
+                )
+            )
+        }
+    }
+
+    private fun JsonElement.toDisplayValue(path: ClaimPath): DisplayValue =
+        when (this) {
+            JsonNull -> DisplayValue.NullValue
+            is JsonObject -> DisplayValue.ObjectValue(
+                entries = entries.map { (key, value) ->
+                    value.toClaimItem(path = ClaimPath.child(path, key), label = CredentialDisplayVocabulary.humanizedClaimLabel(key))
+                }
+            )
+            is JsonArray -> valueDecoder.imageFromByteArray(this, CredentialDisplayVocabulary.roles(path))
+                ?: DisplayValue.ListValue(mapIndexed { index, value -> value.toDisplayValue(ClaimPath.indexed(path, index)) })
+            is JsonPrimitive -> toPrimitiveDisplayValue(path)
+        }
+
+    private fun JsonPrimitive.toPrimitiveDisplayValue(path: ClaimPath): DisplayValue {
+        booleanOrNull?.let { return DisplayValue.BooleanValue(it) }
+        if (!isString) {
+            content.formatEpochDateIfTemporal(path)?.let { return DisplayValue.Text(it) }
+            doubleOrNull?.let { return DisplayValue.NumberValue(content) }
+        }
+
+        val text = contentOrNull.orEmpty()
+        text.formatEpochDateIfTemporal(path)?.let { return DisplayValue.Text(it) }
+
+        val decoded = valueDecoder.decodedString(text, path)
+        if (decoded != null) {
+            return decoded
+        }
+
+        return DisplayValue.Text(text)
+    }
+
+    private fun String.formatEpochDateIfTemporal(path: ClaimPath): String? {
+        if (!CredentialDisplayVocabulary.hasRole(path = path, role = ClaimRole.Temporal)) return null
+        val rawEpoch = trim().toLongOrNull() ?: return null
+        val epochSeconds = when {
+            rawEpoch < minimumCredibleEpochSeconds -> return null
+            rawEpoch >= epochMillisecondsThreshold -> rawEpoch / 1_000
+            else -> rawEpoch
+        }
+
+        return runCatching {
+            Instant.fromEpochSeconds(epochSeconds).toLocalDateTime(TimeZone.UTC).date.toString()
+        }.getOrNull()
+    }
+    private const val minimumCredibleEpochSeconds = 100_000_000L
+    private const val epochMillisecondsThreshold = 10_000_000_000L
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayValueDecoder.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayValueDecoder.kt
@@ -1,0 +1,169 @@
+@file:OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
+
+package id.walt.walletdemo.compose.logic
+
+import kotlin.io.encoding.Base64
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+internal class CredentialDisplayValueDecoder(
+    private val json: Json,
+    private val renderJson: (JsonElement, ClaimPath) -> DisplayValue,
+) {
+    fun decodedString(value: String, path: ClaimPath): DisplayValue? {
+        val payload = EncodedPayload.parse(value) ?: return null
+        val bytes = payload.base64.decode() ?: return null
+        ImageBytes.detectMime(bytes, payload.imageMimeTypeHint)?.let { mime ->
+            return bytes.toImageValue(mime, encoded = payload.base64.value)
+        }
+
+        val decodedText = runCatching { bytes.decodeToString() }.getOrNull()
+            ?.takeIf { it.isMostlyReadable() }
+            ?: return null
+
+        val decodedJson = runCatching { json.parseToJsonElement(decodedText) }.getOrNull()
+        if (decodedJson != null) {
+            return renderJson(decodedJson, path)
+        }
+
+        return DisplayValue.DecodedText(decodedText)
+    }
+
+    fun imageFromByteArray(value: JsonArray, roles: Set<ClaimRole>): DisplayValue.Image? {
+        if (ClaimRole.Image !in roles) return null
+        val bytes = value.toByteArrayOrNull() ?: return null
+        val mime = ImageBytes.detectMime(bytes, mimeHint = null) ?: return null
+        return bytes.toImageValue(mime)
+    }
+
+    private fun JsonArray.toByteArrayOrNull(): ByteArray? {
+        if (isEmpty()) return null
+        return map { element ->
+            val number = (element as? JsonPrimitive)?.contentOrNull?.toIntOrNull() ?: return null
+            if (number !in -128..255) return null
+            number.toByte()
+        }.toByteArray()
+    }
+
+    private fun ByteArray.toImageValue(mime: String, encoded: String = Base64.Default.encode(this)): DisplayValue.Image {
+        return DisplayValue.Image(
+            encoded = encoded,
+            bytes = this,
+            mimeType = mime,
+            byteCount = size,
+        )
+    }
+}
+
+private data class EncodedPayload(
+    val imageMimeTypeHint: String?,
+    val base64: Base64Payload,
+) {
+    companion object {
+        private const val schemePrefix = "data:"
+        private const val base64Marker = ";base64,"
+
+        fun parse(rawValue: String): EncodedPayload? {
+            val value = rawValue.trim()
+            val plainPayload = { payload: String ->
+                Base64Payload.parse(payload)?.let { base64 ->
+                    EncodedPayload(imageMimeTypeHint = null, base64 = base64)
+                }
+            }
+
+            if (!value.startsWith(schemePrefix, ignoreCase = true)) {
+                return plainPayload(value)
+            }
+
+            val markerIndex = value.indexOf(base64Marker, ignoreCase = true)
+            if (markerIndex < 0) {
+                return plainPayload(value)
+            }
+
+            val metadata = value.substring(schemePrefix.length, markerIndex)
+            val base64 = Base64Payload.parse(value.substring(markerIndex + base64Marker.length))
+                ?: return null
+            return EncodedPayload(
+                imageMimeTypeHint = MediaTypeHint.imageType(metadata),
+                base64 = base64,
+            )
+        }
+    }
+}
+
+private object MediaTypeHint {
+    fun imageType(metadata: String): String? {
+        val mediaType = metadata.substringBefore(';').trim().lowercase()
+        return mediaType.takeIf { it.startsWith(ImageMime.Prefix) }
+    }
+}
+
+private class Base64Payload private constructor(val value: String) {
+    fun decode(): ByteArray? {
+        val padded = value.padEnd(value.length + ((base64BlockSize - value.length % base64BlockSize) % base64BlockSize), '=')
+        return runCatching { Base64.Default.decode(padded) }.getOrNull()
+            ?: runCatching { Base64.UrlSafe.decode(padded) }.getOrNull()
+    }
+
+    companion object {
+        fun parse(rawValue: String): Base64Payload? {
+            val value = rawValue.trim()
+            return Base64Payload(value).takeIf { looksValid(value) }
+        }
+
+        private fun looksValid(value: String): Boolean {
+            if (value.length < minimumPayloadLength || value.any { it.isWhitespace() }) return false
+            val allowed = value.all { it.isLetterOrDigit() || it == '+' || it == '/' || it == '-' || it == '_' || it == '=' }
+            return allowed && value.length % base64BlockSize != invalidBase64Remainder
+        }
+
+        private const val minimumPayloadLength = 12
+        private const val base64BlockSize = 4
+        private const val invalidBase64Remainder = 1
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Base64Payload) return false
+        return value == other.value
+    }
+
+    override fun hashCode(): Int =
+        value.hashCode()
+}
+
+private object ImageMime {
+    const val Prefix = "image/"
+    const val Png = "image/png"
+    const val Jpeg = "image/jpeg"
+    const val Gif = "image/gif"
+    const val Webp = "image/webp"
+}
+
+private object ImageBytes {
+    fun detectMime(bytes: ByteArray, mimeHint: String?): String? =
+        when {
+            mimeHint?.startsWith(ImageMime.Prefix) == true -> mimeHint
+            bytes.startsWith(0x89, 0x50, 0x4E, 0x47) -> ImageMime.Png
+            bytes.startsWith(0xFF, 0xD8, 0xFF) -> ImageMime.Jpeg
+            bytes.startsWithAscii("GIF87a") || bytes.startsWithAscii("GIF89a") -> ImageMime.Gif
+            bytes.size >= 12 && bytes.startsWithAscii("RIFF") && bytes.copyOfRange(8, 12).decodeToString() == "WEBP" -> ImageMime.Webp
+            else -> null
+        }
+
+    private fun ByteArray.startsWith(vararg prefix: Int): Boolean =
+        size >= prefix.size && prefix.indices.all { this[it].toInt() and 0xFF == prefix[it] }
+
+    private fun ByteArray.startsWithAscii(prefix: String): Boolean =
+        size >= prefix.length && prefix.indices.all { this[it].toInt().toChar() == prefix[it] }
+}
+
+private fun String.isMostlyReadable(): Boolean =
+    isNotBlank() &&
+            '\uFFFD' !in this &&
+            count { it == '\n' || it == '\r' || it == '\t' || !it.isISOControl() } >= length * readableCharacterRatio
+
+private const val readableCharacterRatio = 0.9

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayVocabulary.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayVocabulary.kt
@@ -1,0 +1,151 @@
+package id.walt.walletdemo.compose.logic
+
+internal enum class ClaimGroupKind(
+    val title: String,
+    val order: Int,
+) {
+    Personal(title = "Personal details", order = 0),
+    Address(title = "Address", order = 1),
+    Other(title = "Other claims", order = 2),
+    Technical(title = "Technical claims", order = 3),
+}
+
+enum class ClaimRole {
+    GivenName,
+    FamilyName,
+    Temporal,
+    ExpiryDate,
+    Image,
+    CredentialType,
+}
+
+private data class ClaimDescriptor(
+    val name: String,
+    val aliases: Set<String> = emptySet(),
+    val label: String? = null,
+    val group: ClaimGroupKind = ClaimGroupKind.Other,
+    val roles: Set<ClaimRole> = emptySet(),
+) {
+    val recognizedNames: Set<String> = aliases + name
+}
+
+private data class NormalizedClaimKey(val value: String) {
+    companion object {
+        fun from(name: String): NormalizedClaimKey =
+            NormalizedClaimKey(
+                buildString {
+                    for (char in name) {
+                        if (char.isLetterOrDigit()) append(char.lowercaseChar())
+                    }
+                }
+            )
+    }
+}
+
+internal object CredentialDisplayVocabulary {
+    const val RawCredentialDataTitle = "Raw credential data"
+    const val RawCredentialDataLabel = "Raw credential data"
+    const val CredentialDataJsonLabel = "Credential data JSON"
+    const val GenericVerifiableCredentialType = "VerifiableCredential"
+    const val RequestedDisclosuresTitle = "Requested disclosures"
+
+    private const val GivenNameClaim = "given_name"
+    private const val FamilyNameClaim = "family_name"
+
+    private val descriptors = listOf(
+        ClaimDescriptor(GivenNameClaim, aliases = setOf("Given name"), label = "Given name", group = ClaimGroupKind.Personal, roles = setOf(ClaimRole.GivenName)),
+        ClaimDescriptor(FamilyNameClaim, aliases = setOf("Family name"), label = "Family name", group = ClaimGroupKind.Personal, roles = setOf(ClaimRole.FamilyName)),
+        ClaimDescriptor("birth_date", aliases = setOf("Date of birth"), label = "Date of birth", group = ClaimGroupKind.Personal),
+        ClaimDescriptor("birth_place", aliases = setOf("Place of birth"), label = "Place of birth", group = ClaimGroupKind.Personal),
+        ClaimDescriptor("age", group = ClaimGroupKind.Personal),
+        ClaimDescriptor("age_over_18", label = "Age over 18", group = ClaimGroupKind.Personal),
+        ClaimDescriptor("portrait", aliases = setOf("Portrait"), label = "Portrait", group = ClaimGroupKind.Personal, roles = setOf(ClaimRole.Image)),
+        ClaimDescriptor("photo", roles = setOf(ClaimRole.Image)),
+        ClaimDescriptor("picture", roles = setOf(ClaimRole.Image)),
+        ClaimDescriptor("image", roles = setOf(ClaimRole.Image)),
+        ClaimDescriptor("logo", roles = setOf(ClaimRole.Image)),
+        ClaimDescriptor("nationalities", label = "Nationalities", group = ClaimGroupKind.Personal),
+        ClaimDescriptor("resident_address", label = "Resident address", group = ClaimGroupKind.Address),
+        ClaimDescriptor("street_address", label = "Street address", group = ClaimGroupKind.Address),
+        ClaimDescriptor("locality", group = ClaimGroupKind.Address),
+        ClaimDescriptor("postal_code", label = "Postal code", group = ClaimGroupKind.Address),
+        ClaimDescriptor("country", group = ClaimGroupKind.Address),
+        ClaimDescriptor("iss", label = "Issuer", group = ClaimGroupKind.Technical),
+        ClaimDescriptor("vct", label = "Credential type", group = ClaimGroupKind.Technical, roles = setOf(ClaimRole.CredentialType)),
+        ClaimDescriptor("credential_type", aliases = setOf("Credential type", "credentialType"), roles = setOf(ClaimRole.CredentialType)),
+        ClaimDescriptor("exp", label = "Expires", group = ClaimGroupKind.Technical, roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("expires", aliases = setOf("Expires"), roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("expiry", aliases = setOf("Expiry"), roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("expiry_date", aliases = setOf("Expiry date"), roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("expiration", aliases = setOf("Expiration"), roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("expiration_date", aliases = setOf("Expiration date"), roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("valid_until", aliases = setOf("Valid until"), roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("valid_to", aliases = setOf("Valid to"), roles = setOf(ClaimRole.Temporal, ClaimRole.ExpiryDate)),
+        ClaimDescriptor("valid_from", aliases = setOf("Valid from"), roles = setOf(ClaimRole.Temporal)),
+        ClaimDescriptor("nbf", label = "Valid from", group = ClaimGroupKind.Technical, roles = setOf(ClaimRole.Temporal)),
+        ClaimDescriptor("not_before", roles = setOf(ClaimRole.Temporal)),
+        ClaimDescriptor("iat", label = "Issued at", group = ClaimGroupKind.Technical, roles = setOf(ClaimRole.Temporal)),
+        ClaimDescriptor("issued_at", roles = setOf(ClaimRole.Temporal)),
+        ClaimDescriptor("issuance_date", roles = setOf(ClaimRole.Temporal)),
+        ClaimDescriptor("cnf", label = "Confirmation key", group = ClaimGroupKind.Technical),
+    )
+        .flatMap { descriptor -> descriptor.recognizedNames.map { name -> NormalizedClaimKey.from(name) to descriptor } }
+        .toMap()
+
+    private val topLevelCredentialTypeClaimNames = setOf("type").map(NormalizedClaimKey::from).toSet()
+
+    fun groupKind(path: ClaimPath): ClaimGroupKind =
+        descriptorFor(path.topLevel)?.group ?: ClaimGroupKind.Other
+
+    fun humanizedClaimLabel(key: String): String =
+        descriptorFor(key)?.label ?: ClaimLabelFormatter.humanize(key)
+
+    fun disclosureLabel(name: String?, path: String): String =
+        name
+            ?.takeIf { it.isNotBlank() }
+            ?: ClaimPath.semanticLeaf(path)?.let(::humanizedClaimLabel)
+            ?: path
+
+    fun roles(path: ClaimPath): Set<ClaimRole> {
+        val leaf = path.leaf
+        val roles = descriptorFor(leaf)?.roles.orEmpty().toMutableSet()
+        if (path.isTopLevel && NormalizedClaimKey.from(leaf) in topLevelCredentialTypeClaimNames) roles += ClaimRole.CredentialType
+        if (pathHasRole(path, ClaimRole.Image)) roles += ClaimRole.Image
+        return roles
+    }
+
+    fun hasRole(path: ClaimPath, role: ClaimRole): Boolean =
+        role in roles(path = path)
+
+    fun isGenericCredentialType(value: String): Boolean =
+        CredentialTypeIdentifier.token(value)?.equals(GenericVerifiableCredentialType, ignoreCase = true) == true
+
+    fun readableCredentialType(value: String): String? {
+        val token = CredentialTypeIdentifier.token(value)
+            ?: return null
+
+        if (isGenericCredentialType(token)) return null
+
+        return ClaimLabelFormatter.humanize(token).takeIf { it.isNotBlank() }
+    }
+
+    private fun pathHasRole(path: ClaimPath, role: ClaimRole): Boolean =
+        path.components.any { pathComponent ->
+            role in descriptorFor(pathComponent)?.roles.orEmpty()
+        }
+
+    private fun descriptorFor(name: String): ClaimDescriptor? =
+        descriptors[NormalizedClaimKey.from(name)]
+}
+
+private object ClaimLabelFormatter {
+    private val wordSeparators = Regex("[_\\-. ]+")
+    private val camelCaseBoundary = Regex("([a-z])([A-Z])")
+
+    fun humanize(key: String): String =
+        key.replace(camelCaseBoundary, "$1 $2")
+            .split(wordSeparators)
+            .filter { it.isNotBlank() }
+            .joinToString(" ") { word -> word.lowercase() }
+            .replaceFirstChar { it.titlecase() }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialTypeIdentifier.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/CredentialTypeIdentifier.kt
@@ -1,0 +1,29 @@
+package id.walt.walletdemo.compose.logic
+
+import io.ktor.http.Url
+
+internal object CredentialTypeIdentifier {
+    fun token(rawValue: String): String? {
+        val value = rawValue.trim().takeIf { it.isNotBlank() } ?: return null
+        return (value.httpUrlToken() ?: value.trailingIdentifierToken())
+            .takeIf { it.isNotBlank() }
+    }
+
+    private fun String.httpUrlToken(): String? {
+        val parsed = runCatching { Url(this) }.getOrNull()
+            ?: return null
+        if (parsed.protocol.name !in httpProtocols) return null
+
+        return parsed.encodedPath
+            .split('/')
+            .lastOrNull { it.isNotBlank() }
+    }
+
+    private fun String.trailingIdentifierToken(): String {
+        val index = lastIndexOfAny(identifierDelimiters)
+        return if (index >= 0) substring(index + 1) else this
+    }
+
+    private val httpProtocols = setOf("http", "https")
+    private val identifierDelimiters = charArrayOf('/', '#', ':')
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/DemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/DemoWallet.kt
@@ -5,4 +5,10 @@ interface DemoWallet {
     suspend fun listCredentials(): List<WalletDemoCredential>
     suspend fun receive(offerUrl: String): List<String>
     suspend fun present(requestUrl: String, did: String? = null): WalletDemoOperationResult
+    suspend fun previewPresentation(requestUrl: String): WalletDemoPresentationPreview
+    suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String? = null,
+    ): WalletDemoOperationResult
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/LazyDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/LazyDemoWallet.kt
@@ -25,4 +25,14 @@ internal class LazyDemoWallet(
 
     override suspend fun present(requestUrl: String, did: String?): WalletDemoOperationResult =
         wallet().present(requestUrl, did)
+
+    override suspend fun previewPresentation(requestUrl: String): WalletDemoPresentationPreview =
+        wallet().previewPresentation(requestUrl)
+
+    override suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String?,
+    ): WalletDemoOperationResult =
+        wallet().submitPresentation(requestUrl, selectedCredentialIds, did)
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/NetworkOrigin.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/NetworkOrigin.kt
@@ -1,0 +1,21 @@
+package id.walt.walletdemo.compose.logic
+
+import io.ktor.http.Url
+
+internal data class NetworkOrigin(
+    val host: String,
+) {
+    companion object {
+        fun parse(rawValue: String): NetworkOrigin? {
+            val parsed = runCatching { Url(rawValue.trim()) }.getOrNull()
+                ?: return null
+            if (parsed.protocol.name !in httpProtocols) return null
+
+            return parsed.host
+                .takeIf { it.isNotBlank() }
+                ?.let(::NetworkOrigin)
+        }
+
+        private val httpProtocols = setOf("http", "https")
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/VerifierClientIdentifier.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/VerifierClientIdentifier.kt
@@ -1,0 +1,58 @@
+package id.walt.walletdemo.compose.logic
+
+internal data class VerifierClientIdentifier(
+    val scheme: Scheme,
+    val value: String,
+    val rawValue: String,
+) {
+    enum class Scheme(
+        val prefix: String?,
+        val genericLabel: String?,
+    ) {
+        RedirectUri(prefix = "redirect_uri", genericLabel = null),
+        X509SanDns(prefix = "x509_san_dns", genericLabel = null),
+        X509Hash(prefix = "x509_hash", genericLabel = "X.509 verifier"),
+        DecentralizedIdentifier(prefix = "decentralized_identifier", genericLabel = "DID verifier"),
+        LegacyDid(prefix = "did", genericLabel = "DID verifier"),
+        VerifierAttestation(prefix = "verifier_attestation", genericLabel = "Verifier attestation"),
+        OpenIdFederation(prefix = "openid_federation", genericLabel = "OpenID Federation verifier"),
+        PreRegistered(prefix = null, genericLabel = null),
+        Unsupported(prefix = null, genericLabel = null),
+    }
+
+    companion object {
+        fun parse(rawClientId: String): VerifierClientIdentifier? {
+            val rawValue = rawClientId.trim().takeIf { it.isNotBlank() } ?: return null
+            if (NetworkOrigin.parse(rawValue) != null) {
+                return VerifierClientIdentifier(scheme = Scheme.PreRegistered, value = rawValue, rawValue = rawValue)
+            }
+
+            val prefixedValue = ClientIdentifierPrefix.split(rawValue)
+            if (prefixedValue == null) {
+                return VerifierClientIdentifier(scheme = Scheme.PreRegistered, value = rawValue, rawValue = rawValue)
+            }
+
+            val scheme = Scheme.entries.firstOrNull { it.prefix == prefixedValue.prefix }
+                ?: Scheme.Unsupported
+
+            return VerifierClientIdentifier(scheme = scheme, value = prefixedValue.value, rawValue = rawValue)
+        }
+    }
+}
+
+private data class ClientIdentifierPrefix(
+    val prefix: String,
+    val value: String,
+) {
+    companion object {
+        fun split(rawValue: String): ClientIdentifierPrefix? {
+            val separatorIndex = rawValue.indexOf(':')
+            if (separatorIndex <= 0) return null
+
+            return ClientIdentifierPrefix(
+                prefix = rawValue.take(separatorIndex),
+                value = rawValue.drop(separatorIndex + 1),
+            )
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/VerifierDisplayName.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/VerifierDisplayName.kt
@@ -1,0 +1,32 @@
+package id.walt.walletdemo.compose.logic
+
+val VerifierDetails.displayName: String
+    get() = humanReadableVerifierName(name = name, clientId = clientId, responseUri = responseUri)
+
+fun humanReadableVerifierName(name: String?, clientId: String?, responseUri: String? = null): String {
+    name?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+
+    val response = responseUri?.trim().orEmpty()
+    val parsedClientId = clientId?.let(VerifierClientIdentifier::parse)
+
+    return parsedClientId?.host()
+        ?: parsedClientId?.displayName()
+        ?: NetworkOrigin.parse(response)?.host
+        ?: "Unknown verifier"
+}
+
+private fun VerifierClientIdentifier.host(): String? =
+    when (scheme) {
+        VerifierClientIdentifier.Scheme.RedirectUri,
+        VerifierClientIdentifier.Scheme.PreRegistered,
+        VerifierClientIdentifier.Scheme.OpenIdFederation -> NetworkOrigin.parse(value)?.host
+        else -> null
+    }
+
+private fun VerifierClientIdentifier.displayName(): String? {
+    scheme.genericLabel?.let { return it }
+    if (scheme == VerifierClientIdentifier.Scheme.X509SanDns) {
+        return value.takeIf { it.isNotBlank() }
+    }
+    return rawValue.takeIf { scheme == VerifierClientIdentifier.Scheme.PreRegistered && it.length <= 48 }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
@@ -57,22 +57,87 @@ class WalletDemoController(
         }
     }
 
+    fun selectTab(tab: WalletDemoTab) {
+        _state.update { it.copy(selectedTab = tab) }
+    }
+
     fun updateOfferUrl(value: String) {
         _state.update {
-            it.copy(requestDrafts = it.requestDrafts.copy(offerUrl = value))
+            it.copy(
+                requestDrafts = it.requestDrafts.copy(offerUrl = value),
+                lastReceivedCredentialIds = emptyList(),
+                receiveCompleted = false,
+            )
         }
     }
 
     fun updatePresentationRequestUrl(value: String) {
         _state.update {
-            it.copy(requestDrafts = it.requestDrafts.copy(presentationRequestUrl = value))
+            it.copy(
+                requestDrafts = it.requestDrafts.copy(presentationRequestUrl = value),
+                presentationPreview = null,
+                selectedPresentationCredentialIds = emptySet(),
+                presentationCompleted = false,
+            )
         }
     }
 
     fun handleDeepLink(url: String) {
-        when {
-            url.startsWith("openid-credential-offer:") -> updateOfferUrl(url)
-            url.startsWith("openid4vp:") -> updatePresentationRequestUrl(url)
+        when (WalletDeepLinkScheme.parse(url)) {
+            WalletDeepLinkScheme.CredentialOffer -> {
+                _state.update {
+                    it.copy(
+                        selectedTab = WalletDemoTab.Receive,
+                        requestDrafts = it.requestDrafts.copy(offerUrl = url),
+                        lastReceivedCredentialIds = emptyList(),
+                        receiveCompleted = false,
+                        receiveNavigationResetKey = it.receiveNavigationResetKey + 1,
+                        presentationPreview = null,
+                        selectedPresentationCredentialIds = emptySet(),
+                        presentationCompleted = false,
+                        operation = WalletOperationState.Idle,
+                    )
+                }
+            }
+            WalletDeepLinkScheme.PresentationRequest -> {
+                _state.update {
+                    it.copy(
+                        selectedTab = WalletDemoTab.Present,
+                        requestDrafts = it.requestDrafts.copy(presentationRequestUrl = url),
+                        presentationPreview = null,
+                        selectedPresentationCredentialIds = emptySet(),
+                        presentationCompleted = false,
+                        presentationNavigationResetKey = it.presentationNavigationResetKey + 1,
+                        operation = WalletOperationState.Idle,
+                    )
+                }
+            }
+            null -> Unit
+        }
+    }
+
+    fun startNewReceiveFlow() {
+        _state.update {
+            it.copy(
+                requestDrafts = it.requestDrafts.copy(offerUrl = ""),
+                lastReceivedCredentialIds = emptyList(),
+                receiveCompleted = false,
+                receiveNavigationResetKey = it.receiveNavigationResetKey + 1,
+                operation = WalletOperationState.Idle,
+            )
+        }
+    }
+
+    fun startNewPresentationFlow() {
+        _state.update {
+            it.copy(
+                requestDrafts = it.requestDrafts.copy(presentationRequestUrl = ""),
+                presentationPreview = null,
+                selectedPresentationCredentialIds = emptySet(),
+                presentationCompleted = false,
+                presentationNavigationResetKey = it.presentationNavigationResetKey + 1,
+                operation = WalletOperationState.Idle,
+            )
         }
     }
 
@@ -89,14 +154,44 @@ class WalletDemoController(
                 val credentials = wallet.listCredentials()
                 ids to credentials
             }.onSuccess { (ids, credentials) ->
+                val receivedCredentialIds = resolvedReceivedCredentialIds(
+                    returnedCredentialIds = ids,
+                    previousCredentials = ready.credentials,
+                    refreshedCredentials = credentials,
+                )
+                val displayableReceivedCredentialIds = receivedCredentialIds
+                    .filter { receivedCredentialId -> credentials.any { it.id == receivedCredentialId } }
+                if (displayableReceivedCredentialIds.isEmpty()) {
+                    _state.update {
+                        it.copy(
+                            session = ready.copy(credentials = credentials),
+                            operation = WalletOperationState.Failed(
+                                message = WalletDisplayText.failure(
+                                    WalletDisplayText.ReceiveFailed,
+                                    WalletDisplayText.ReceivedCredentialsUnavailable,
+                                ),
+                                tab = WalletDemoTab.Receive,
+                            ),
+                            lastReceivedCredentialIds = emptyList(),
+                            receiveCompleted = false,
+                        )
+                    }
+                    return@onSuccess
+                }
+
                 _state.update {
                     it.copy(
                         session = ready.copy(credentials = credentials),
-                        operation = WalletOperationState.Succeeded("Received ${ids.size} credential(s)"),
+                        operation = WalletOperationState.Succeeded(
+                            message = WalletDisplayText.receivedCredentials(displayableReceivedCredentialIds.size),
+                            tab = WalletDemoTab.Receive,
+                        ),
+                        lastReceivedCredentialIds = displayableReceivedCredentialIds,
+                        receiveCompleted = true,
                     )
                 }
             }.onFailure { error ->
-                setOperationError("Receive failed", error)
+                setOperationError(WalletDisplayText.ReceiveFailed, error, WalletDemoTab.Receive)
             }
         }
     }
@@ -115,26 +210,127 @@ class WalletDemoController(
                 _state.update {
                     it.copy(
                         operation = when (result) {
-                            is WalletDemoOperationResult.Success -> WalletOperationState.Succeeded(result.message)
-                            is WalletDemoOperationResult.Failure -> WalletOperationState.Failed(result.message)
+                            is WalletDemoOperationResult.Success -> WalletOperationState.Succeeded(
+                                message = result.message,
+                                tab = WalletDemoTab.Present,
+                            )
+                            is WalletDemoOperationResult.Failure -> WalletOperationState.Failed(
+                                message = result.message,
+                                tab = WalletDemoTab.Present,
+                            )
                         },
                     )
                 }
             }.onFailure { error ->
-                setOperationError("Present failed", error)
+                setOperationError(WalletDisplayText.PresentFailed, error, WalletDemoTab.Present)
             }
+        }
+    }
+
+    fun previewPresentation() {
+        val current = _state.value
+        current.session as? WalletSessionState.Ready ?: return
+        val requestUrl = current.requestDrafts.presentationRequestUrl.trim()
+        if (requestUrl.isBlank()) return
+
+        scope.launch(dispatcher) {
+            _state.update {
+                it.copy(
+                    operation = WalletOperationState.ResolvingPresentation,
+                    presentationPreview = null,
+                    selectedPresentationCredentialIds = emptySet(),
+                    presentationCompleted = false,
+                )
+            }
+            runCatching {
+                wallet.previewPresentation(requestUrl)
+            }.onSuccess { preview ->
+                _state.update {
+                    it.copy(
+                        operation = WalletOperationState.Idle,
+                        presentationPreview = preview,
+                        selectedPresentationCredentialIds = preview.credentialOptions
+                            .map { option -> option.credentialId }
+                            .toSet(),
+                    )
+                }
+            }.onFailure { error ->
+                setOperationError(WalletDisplayText.PreviewFailed, error, WalletDemoTab.Present)
+            }
+        }
+    }
+
+    fun togglePresentationCredential(credentialId: String) {
+        _state.update { state ->
+            val selected = state.selectedPresentationCredentialIds
+            state.copy(
+                selectedPresentationCredentialIds = if (credentialId in selected) {
+                    selected - credentialId
+                } else {
+                    selected + credentialId
+                }
+            )
+        }
+    }
+
+    fun submitPresentation() {
+        val current = _state.value
+        val ready = current.session as? WalletSessionState.Ready ?: return
+        val requestUrl = current.requestDrafts.presentationRequestUrl.trim()
+        val selectedCredentialIds = current.selectedPresentationCredentialIds.toList()
+        if (requestUrl.isBlank() || selectedCredentialIds.isEmpty()) return
+
+        scope.launch(dispatcher) {
+            _state.update { it.copy(operation = WalletOperationState.Presenting) }
+            runCatching {
+                wallet.submitPresentation(requestUrl, selectedCredentialIds, ready.did)
+            }.onSuccess { result ->
+                _state.update {
+                    it.copy(
+                        operation = when (result) {
+                            is WalletDemoOperationResult.Success -> WalletOperationState.Succeeded(
+                                message = result.message,
+                                tab = WalletDemoTab.Present,
+                            )
+                            is WalletDemoOperationResult.Failure -> WalletOperationState.Failed(
+                                message = result.message,
+                                tab = WalletDemoTab.Present,
+                            )
+                        },
+                        selectedPresentationCredentialIds = emptySet(),
+                        presentationCompleted = result is WalletDemoOperationResult.Success,
+                    )
+                }
+            }.onFailure { error ->
+                setOperationError(WalletDisplayText.PresentFailed, error, WalletDemoTab.Present)
+            }
+        }
+    }
+
+    fun cancelPresentationReview() {
+        _state.update {
+            it.copy(
+                operation = WalletOperationState.Succeeded(
+                    message = WalletDisplayText.PresentationReviewCancelled,
+                    tab = WalletDemoTab.Present,
+                ),
+                presentationPreview = null,
+                selectedPresentationCredentialIds = emptySet(),
+                presentationCompleted = false,
+                presentationNavigationResetKey = it.presentationNavigationResetKey + 1,
+            )
         }
     }
 
     private fun submitSetupPin(auth: WalletAuthState.Setup) {
         val pin = auth.pin
         if (!isValidPin(pin)) {
-            setSetupPinError("PIN must contain 4 to 8 digits")
+            setSetupPinError(WalletDisplayText.PinMustContain4To8Digits)
             return
         }
 
         if (pin != auth.confirmation) {
-            setSetupPinError("PIN confirmation does not match")
+            setSetupPinError(WalletDisplayText.PinConfirmationDoesNotMatch)
             return
         }
 
@@ -146,12 +342,12 @@ class WalletDemoController(
     private fun submitLoginPin(auth: WalletAuthState.Login) {
         val pin = auth.pin
         if (!isValidPin(pin)) {
-            setLoginPinError("PIN must contain 4 to 8 digits")
+            setLoginPinError(WalletDisplayText.PinMustContain4To8Digits)
             return
         }
 
         if (configuredPin != pin) {
-            setLoginPinError("Wrong PIN")
+            setLoginPinError(WalletDisplayText.WrongPin)
             return
         }
 
@@ -190,7 +386,7 @@ class WalletDemoController(
             }.onFailure { error ->
                 _state.update {
                     it.copy(
-                        session = WalletSessionState.Failed(errorMessage("Bootstrap failed", error)),
+                        session = WalletSessionState.Failed(WalletDisplayText.failure(WalletDisplayText.BootstrapFailed, error)),
                         operation = WalletOperationState.Idle,
                     )
                 }
@@ -212,14 +408,16 @@ class WalletDemoController(
         }
     }
 
-    private fun setOperationError(prefix: String, error: Throwable) {
+    private fun setOperationError(prefix: String, error: Throwable, tab: WalletDemoTab) {
         _state.update {
-            it.copy(operation = WalletOperationState.Failed(errorMessage(prefix, error)))
+            it.copy(
+                operation = WalletOperationState.Failed(
+                    message = WalletDisplayText.failure(prefix, error),
+                    tab = tab,
+                )
+            )
         }
     }
-
-    private fun errorMessage(prefix: String, error: Throwable): String =
-        "$prefix: ${error.message ?: error::class.simpleName ?: "Unexpected error"}"
 
     private companion object {
         val pinPattern = Regex("\\d{4,8}")

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoCredential.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoCredential.kt
@@ -1,9 +1,13 @@
 package id.walt.walletdemo.compose.logic
 
-data class WalletDemoCredential(
+data class CredentialSummary(
     val id: String,
     val format: String,
-    val issuer: String,
+    val issuer: String?,
+    val subject: String? = null,
     val label: String,
-    val addedAt: String,
+    val addedAt: String?,
+    val credentialDataJson: String? = null,
 )
+
+typealias WalletDemoCredential = CredentialSummary

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoPresentationModels.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoPresentationModels.kt
@@ -1,0 +1,29 @@
+package id.walt.walletdemo.compose.logic
+
+data class WalletDemoPresentationPreview(
+    val verifierName: String?,
+    val clientId: String?,
+    val responseUri: String? = null,
+    val state: String? = null,
+    val nonce: String? = null,
+    val credentialOptions: List<WalletDemoPresentationCredentialOption>,
+)
+
+data class WalletDemoPresentationCredentialOption(
+    val queryId: String,
+    val credentialId: String,
+    val label: String,
+    val issuer: String,
+    val subject: String? = null,
+    val format: String,
+    val credentialDataJson: String? = null,
+    val disclosures: List<WalletDemoPresentationDisclosure>,
+)
+
+data class WalletDemoPresentationDisclosure(
+    val label: String,
+    val path: String = "",
+    val valueJson: String,
+    val displayValue: String? = null,
+    val selectivelyDisclosable: Boolean,
+)

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoTab.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoTab.kt
@@ -1,0 +1,7 @@
+package id.walt.walletdemo.compose.logic
+
+enum class WalletDemoTab {
+    Credentials,
+    Receive,
+    Present,
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiState.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiState.kt
@@ -4,5 +4,37 @@ data class WalletDemoUiState(
     val auth: WalletAuthState = WalletAuthState.Setup(),
     val session: WalletSessionState = WalletSessionState.NotBootstrapped,
     val operation: WalletOperationState = WalletOperationState.Idle,
+    val selectedTab: WalletDemoTab = WalletDemoTab.Credentials,
     val requestDrafts: WalletRequestDrafts = WalletRequestDrafts(),
+    val lastReceivedCredentialIds: List<String> = emptyList(),
+    val receiveCompleted: Boolean = false,
+    val receiveNavigationResetKey: Int = 0,
+    val presentationPreview: WalletDemoPresentationPreview? = null,
+    val selectedPresentationCredentialIds: Set<String> = emptySet(),
+    val presentationCompleted: Boolean = false,
+    val presentationNavigationResetKey: Int = 0,
 )
+
+fun WalletDemoUiState.receivedCredentials(): List<WalletDemoCredential> {
+    val ready = session as? WalletSessionState.Ready ?: return emptyList()
+    val credentialsById = ready.credentials.associateBy { it.id }
+    return lastReceivedCredentialIds.mapNotNull { id -> credentialsById[id] }
+}
+
+internal fun resolvedReceivedCredentialIds(
+    returnedCredentialIds: List<String>,
+    previousCredentials: List<WalletDemoCredential>,
+    refreshedCredentials: List<WalletDemoCredential>,
+): List<String> {
+    val refreshedIds = refreshedCredentials.map { it.id }.toSet()
+    val returnedResolvedIds = returnedCredentialIds.filter { id -> id in refreshedIds }
+    if (returnedResolvedIds.isNotEmpty()) {
+        return returnedResolvedIds
+    }
+
+    val previousIds = previousCredentials.map { it.id }.toSet()
+    val newCredentialIds = refreshedCredentials
+        .map { it.id }
+        .filterNot { id -> id in previousIds }
+    return newCredentialIds.ifEmpty { returnedCredentialIds }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiStateDerivedProperties.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiStateDerivedProperties.kt
@@ -3,29 +3,107 @@ package id.walt.walletdemo.compose.logic
 val WalletDemoUiState.isBusy: Boolean
     get() = session is WalletSessionState.Bootstrapping ||
         operation is WalletOperationState.Receiving ||
+        operation is WalletOperationState.ResolvingPresentation ||
         operation is WalletOperationState.Presenting
 
 val WalletDemoUiState.isError: Boolean
-    get() = session is WalletSessionState.Failed ||
-        operation is WalletOperationState.Failed
+    get() = isErrorFor(selectedTab)
+
+val WalletDemoUiState.isStatusBusy: Boolean
+    get() = session is WalletSessionState.Bootstrapping ||
+        (operation.belongsTo(selectedTab) && operation.isBusyOperation)
+
+val WalletDemoUiState.receiveUrlEntryEnabled: Boolean
+    get() = !isBusy && !receiveCompleted
+
+val WalletDemoUiState.receiveActionEnabled: Boolean
+    get() = session is WalletSessionState.Ready &&
+        requestDrafts.offerUrl.isNotBlank() &&
+        receiveUrlEntryEnabled
+
+val WalletDemoUiState.presentationUrlEntryEnabled: Boolean
+    get() = !isBusy && presentationPreview == null && !presentationCompleted
+
+val WalletDemoUiState.presentationPreviewActionEnabled: Boolean
+    get() = (session as? WalletSessionState.Ready)?.credentials?.isNotEmpty() == true &&
+        requestDrafts.presentationRequestUrl.isNotBlank() &&
+        presentationUrlEntryEnabled
+
+val WalletDemoUiState.presentationReviewEnabled: Boolean
+    get() = !isBusy && presentationPreview != null && !presentationCompleted
 
 val WalletDemoUiState.statusText: String
-    get() = when (operation) {
-        WalletOperationState.Idle -> session.statusText(auth)
-        WalletOperationState.Receiving -> "Receiving credential..."
-        WalletOperationState.Presenting -> "Presenting credential..."
-        is WalletOperationState.Succeeded -> operation.message
-        is WalletOperationState.Failed -> operation.message
+    get() = statusText(selectedTab)
+
+fun WalletDemoUiState.statusText(tab: WalletDemoTab): String =
+    operation.statusTextFor(tab)
+        ?: tabStatusText(tab)
+        ?: session.statusText(auth)
+
+private fun WalletDemoUiState.isErrorFor(tab: WalletDemoTab): Boolean =
+    session is WalletSessionState.Failed ||
+        (operation is WalletOperationState.Failed && operation.belongsTo(tab))
+
+private fun WalletDemoUiState.tabStatusText(tab: WalletDemoTab): String? =
+    when (tab) {
+        WalletDemoTab.Credentials -> null
+        WalletDemoTab.Receive -> if (receiveCompleted && lastReceivedCredentialIds.isNotEmpty()) {
+            WalletDisplayText.receivedCredentials(lastReceivedCredentialIds.size)
+        } else {
+            null
+        }
+        WalletDemoTab.Present -> when {
+            presentationCompleted -> WalletDisplayText.PresentationSent
+            presentationPreview != null -> WalletDisplayText.ReviewPresentationRequest
+            else -> null
+        }
     }
 
 private fun WalletSessionState.statusText(auth: WalletAuthState): String =
     when (this) {
         WalletSessionState.NotBootstrapped -> when (auth) {
-            is WalletAuthState.Setup -> "Set up a PIN to unlock the wallet"
-            is WalletAuthState.Login -> "Enter PIN to unlock the wallet"
-            WalletAuthState.Unlocked -> "Wallet not ready"
+            is WalletAuthState.Setup -> WalletDisplayText.SetupPin
+            is WalletAuthState.Login -> WalletDisplayText.UnlockPin
+            WalletAuthState.Unlocked -> WalletDisplayText.WalletNotReady
         }
-        WalletSessionState.Bootstrapping -> "Bootstrapping wallet..."
-        is WalletSessionState.Ready -> "Wallet ready"
+        WalletSessionState.Bootstrapping -> WalletDisplayText.BootstrappingWallet
+        is WalletSessionState.Ready -> WalletDisplayText.WalletReady
         is WalletSessionState.Failed -> message
+    }
+
+private fun WalletOperationState.statusTextFor(tab: WalletDemoTab): String? =
+    if (!belongsTo(tab)) {
+        null
+    } else {
+        when (this) {
+            WalletOperationState.Idle -> null
+            WalletOperationState.Receiving -> WalletDisplayText.ReceivingCredential
+            WalletOperationState.ResolvingPresentation -> WalletDisplayText.ResolvingPresentation
+            WalletOperationState.Presenting -> WalletDisplayText.PresentingCredential
+            is WalletOperationState.Succeeded -> message
+            is WalletOperationState.Failed -> message
+        }
+    }
+
+private fun WalletOperationState.belongsTo(tab: WalletDemoTab): Boolean =
+    when (this) {
+        WalletOperationState.Idle -> false
+        WalletOperationState.Receiving -> tab == WalletDemoTab.Receive
+        WalletOperationState.ResolvingPresentation,
+        WalletOperationState.Presenting,
+        -> tab == WalletDemoTab.Present
+        is WalletOperationState.Succeeded -> this.tab == null || this.tab == tab
+        is WalletOperationState.Failed -> this.tab == null || this.tab == tab
+    }
+
+private val WalletOperationState.isBusyOperation: Boolean
+    get() = when (this) {
+        WalletOperationState.Receiving,
+        WalletOperationState.ResolvingPresentation,
+        WalletOperationState.Presenting,
+        -> true
+        WalletOperationState.Idle,
+        is WalletOperationState.Succeeded,
+        is WalletOperationState.Failed,
+        -> false
     }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDisplayText.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDisplayText.kt
@@ -1,0 +1,57 @@
+package id.walt.walletdemo.compose.logic
+
+internal enum class WalletDeepLinkScheme(val scheme: String) {
+    CredentialOffer("openid-credential-offer"),
+    PresentationRequest("openid4vp"),
+    ;
+
+    companion object {
+        fun parse(rawUrl: String): WalletDeepLinkScheme? {
+            val scheme = rawUrl.substringBefore(':', missingDelimiterValue = "").takeIf { it.isNotBlank() }
+                ?: return null
+            return entries.firstOrNull { it.scheme == scheme }
+        }
+    }
+}
+
+internal object CredentialDisplayText {
+    const val Unknown = "Unknown"
+
+    fun expires(date: String): String = "Expires $date"
+    fun added(date: String): String = "Added $date"
+}
+
+internal object WalletDisplayText {
+    const val ReviewPresentationRequest = "Review presentation request"
+    const val StartingWallet = "Starting wallet..."
+    const val ReceivingCredential = "Receiving credential..."
+    const val ResolvingPresentation = "Resolving presentation..."
+    const val PresentingCredential = "Presenting credential..."
+    const val SetupPin = "Set up a PIN to unlock the wallet"
+    const val UnlockPin = "Enter PIN to unlock the wallet"
+    const val WalletNotReady = "Wallet not ready"
+    const val BootstrappingWallet = "Bootstrapping wallet..."
+    const val WalletReady = "Wallet ready"
+    const val PresentationSent = "Presentation sent"
+    const val PresentationReviewCancelled = "Presentation review cancelled"
+    const val PresentationFinishedWithoutVerifierConfirmation = "Presentation finished without verifier confirmation"
+    const val ReceiveFailed = "Receive failed"
+    const val PreviewFailed = "Preview failed"
+    const val PresentFailed = "Present failed"
+    const val BootstrapFailed = "Bootstrap failed"
+    const val InvalidOfferUrl = "invalid offer URL"
+    const val InvalidRequestUrl = "invalid request URL"
+    const val SelectAtLeastOneCredential = "select at least one credential"
+    const val PinMustContain4To8Digits = "PIN must contain 4 to 8 digits"
+    const val PinConfirmationDoesNotMatch = "PIN confirmation does not match"
+    const val WrongPin = "Wrong PIN"
+    const val ReceivedCredentialsUnavailable = "received credentials are not available locally"
+    const val UnexpectedError = "Unexpected error"
+
+    fun receivedCredentials(count: Int): String = "Received $count credential(s)"
+
+    fun failure(prefix: String, reason: String): String = "$prefix: $reason"
+
+    fun failure(prefix: String, error: Throwable): String =
+        failure(prefix, error.message ?: error::class.simpleName ?: UnexpectedError)
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletOperationState.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletOperationState.kt
@@ -3,13 +3,16 @@ package id.walt.walletdemo.compose.logic
 sealed interface WalletOperationState {
     data object Idle : WalletOperationState
     data object Receiving : WalletOperationState
+    data object ResolvingPresentation : WalletOperationState
     data object Presenting : WalletOperationState
 
     data class Succeeded(
         val message: String,
+        val tab: WalletDemoTab? = null,
     ) : WalletOperationState
 
     data class Failed(
         val message: String,
+        val tab: WalletDemoTab? = null,
     ) : WalletOperationState
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayNormalizerTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayNormalizerTest.kt
@@ -1,0 +1,565 @@
+package id.walt.walletdemo.compose.logic
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalEncodingApi::class)
+class CredentialDisplayNormalizerTest {
+
+    @Test
+    fun parsesCredentialJsonIntoReadableClaimGroups() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = "did:web:issuer.example",
+                subject = "did:key:holder",
+                label = "PID",
+                addedAt = "2026-07-09T12:00:00Z",
+                credentialDataJson = """
+                    {
+                      "given_name": "Ada",
+                      "family_name": "Lovelace",
+                      "age_over_18": true,
+                      "age": 28,
+                      "resident_address": {
+                        "street_address": "1 Infinite Loop",
+                        "locality": "Cupertino"
+                      },
+                      "nationalities": ["AT", "HU"]
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        assertEquals("PID", details.summary.label)
+        val personal = assertNotNull(details.groups.firstOrNull { it.title == "Personal details" })
+        assertEquals("Given name", personal.items.first { it.path.id == "given_name" }.label)
+        assertEquals(DisplayValue.Text("Ada"), personal.items.first { it.path.id == "given_name" }.value)
+        assertEquals(DisplayValue.BooleanValue(true), personal.items.first { it.path.id == "age_over_18" }.value)
+        assertEquals(DisplayValue.NumberValue("28"), personal.items.first { it.path.id == "age" }.value)
+
+        val address = assertNotNull(details.groups.firstOrNull { it.title == "Address" })
+        val residentAddress = address.items.first { it.path.id == "resident_address" }
+        assertEquals("Resident address", residentAddress.label)
+        assertIs<DisplayValue.ObjectValue>(residentAddress.value)
+
+        val technical = assertNotNull(details.technicalGroups.firstOrNull { it.title == "Raw credential data" })
+        assertTrue(technical.items.any { it.path.id == "$" })
+    }
+
+    @Test
+    fun decodesBase64TextAndJsonValues() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "vc+sd-jwt",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "plain_note": "SGVsbG8sIHdhbGxldA==",
+                      "json_note": "eyJwdXJwb3NlIjoiYWdlIHByb29mIn0"
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        val claims = details.groups.flatMap { it.items }
+        assertEquals(DisplayValue.DecodedText("Hello, wallet"), claims.first { it.path.id == "plain_note" }.value)
+        val decodedJson = assertIs<DisplayValue.ObjectValue>(claims.first { it.path.id == "json_note" }.value)
+        assertEquals(DisplayValue.Text("age proof"), decodedJson.entries.first { it.label == "Purpose" }.value)
+    }
+
+    @Test
+    fun classifiesBase64ImageDataWithoutDumpingBinary() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "vc+sd-jwt",
+                addedAt = null,
+                credentialDataJson = """{"portrait":"$onePixelPngBase64"}""",
+            )
+        )
+
+        val portrait = details.groups.flatMap { it.items }.first { it.path.id == "portrait" }
+        val image = assertIs<DisplayValue.Image>(portrait.value)
+        assertEquals("image/png", image.mimeType)
+        assertTrue(image.byteCount > 0)
+        assertTrue(image.encoded.length < onePixelPngBase64.length + 10)
+        assertTrue(image.bytes.contentEquals(Base64.Default.decode(onePixelPngBase64)))
+    }
+
+    @Test
+    fun normalizesParameterizedDataUriImageMimeType() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "vc+sd-jwt",
+                addedAt = null,
+                credentialDataJson = """{"portrait":"DATA:image/PNG;charset=utf-8;base64,  $onePixelPngBase64  "}""",
+            )
+        )
+
+        val portrait = details.groups.flatMap { it.items }.first { it.path.id == "portrait" }
+        val image = assertIs<DisplayValue.Image>(portrait.value)
+
+        assertEquals("image/png", image.mimeType)
+        assertTrue(image.bytes.contentEquals(Base64.Default.decode(onePixelPngBase64)))
+    }
+
+    @Test
+    fun classifiesPortraitByteArrayDataAsImage() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "mso_mdoc",
+                issuer = null,
+                subject = null,
+                label = "mso_mdoc",
+                addedAt = null,
+                credentialDataJson = """{"portrait":${onePixelPngByteArrayJson()}}""",
+            )
+        )
+
+        val portrait = details.groups.flatMap { it.items }.first { it.path.id == "portrait" }
+        val image = assertIs<DisplayValue.Image>(portrait.value)
+        assertEquals("image/png", image.mimeType)
+        assertTrue(image.bytes.contentEquals(Base64.Default.decode(onePixelPngBase64)))
+    }
+
+    @Test
+    fun classifiesNestedPortraitByteArrayDataAsImage() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "mso_mdoc",
+                issuer = null,
+                subject = null,
+                label = "mso_mdoc",
+                addedAt = null,
+                credentialDataJson = """{"portrait":{"elementValue":${onePixelPngByteArrayJson()}}}""",
+            )
+        )
+
+        val portrait = details.groups
+            .flatMap { it.items }
+            .first { it.path.id == "portrait" }
+        val portraitObject = assertIs<DisplayValue.ObjectValue>(portrait.value)
+        val image = assertIs<DisplayValue.Image>(portraitObject.entries.first { it.path.id == "portrait.elementValue" }.value)
+
+        assertEquals("image/png", image.mimeType)
+        assertTrue(image.bytes.contentEquals(Base64.Default.decode(onePixelPngBase64)))
+        assertEquals(image, details.toCardDisplayData().portrait)
+    }
+
+    @Test
+    fun classifiesPresentationDisclosureByteArrayDataAsImage() {
+        val details = WalletDemoPresentationCredentialOption(
+            queryId = "pid",
+            credentialId = "cred-1",
+            label = "PID",
+            issuer = "Example Issuer",
+            format = "mso_mdoc",
+            credentialDataJson = null,
+            disclosures = listOf(
+                WalletDemoPresentationDisclosure(
+                    label = "Portrait",
+                    path = "$.portrait",
+                    valueJson = onePixelPngByteArrayJson(),
+                    displayValue = null,
+                    selectivelyDisclosable = true,
+                )
+            ),
+        ).toCredentialDetails()
+
+        val disclosure = details.groups
+            .first { it.title == CredentialDisplayVocabulary.RequestedDisclosuresTitle }
+            .items
+            .single()
+        val image = assertIs<DisplayValue.Image>(disclosure.value)
+
+        assertEquals("disclosures[0].portrait", disclosure.path.id)
+        assertEquals("$.portrait", disclosure.path.sourcePath)
+        assertEquals("image/png", image.mimeType)
+        assertTrue(image.bytes.contentEquals(Base64.Default.decode(onePixelPngBase64)))
+        assertEquals(onePixelPngByteArrayJson(), disclosure.rawValue)
+    }
+
+    @Test
+    fun classifiesDisclosureSemanticsFromSdkPathWhenNameIsMissing() {
+        val disclosurePath = "$.portrait"
+        val details = WalletDemoPresentationCredentialOption(
+            queryId = "pid",
+            credentialId = "cred-1",
+            label = "PID",
+            issuer = "Example Issuer",
+            format = "mso_mdoc",
+            credentialDataJson = null,
+            disclosures = listOf(
+                WalletDemoPresentationDisclosure(
+                    label = CredentialDisplayVocabulary.disclosureLabel(name = null, path = disclosurePath),
+                    path = disclosurePath,
+                    valueJson = onePixelPngByteArrayJson(),
+                    displayValue = null,
+                    selectivelyDisclosable = true,
+                )
+            ),
+        ).toCredentialDetails()
+
+        val disclosure = details.groups
+            .first { it.title == CredentialDisplayVocabulary.RequestedDisclosuresTitle }
+            .items
+            .single()
+
+        assertEquals("Portrait", disclosure.label)
+        assertIs<DisplayValue.Image>(disclosure.value)
+    }
+
+    @Test
+    fun buildsReadableDisclosureLabelsFromSdkPath() {
+        assertEquals("Portrait", CredentialDisplayVocabulary.disclosureLabel(name = null, path = "$.portrait"))
+        assertEquals("Given name", CredentialDisplayVocabulary.disclosureLabel(name = null, path = "$.given_name"))
+        assertEquals("Family name", CredentialDisplayVocabulary.disclosureLabel(name = null, path = "$.credentialSubject['family.name']"))
+        assertEquals("Resident address", CredentialDisplayVocabulary.disclosureLabel(name = null, path = "$['credentialSubject']['resident.address']"))
+        assertEquals("Visible name", CredentialDisplayVocabulary.disclosureLabel(name = "Visible name", path = "$.given_name"))
+        assertEquals("Given name", CredentialDisplayVocabulary.disclosureLabel(name = "   ", path = "$.given_name"))
+    }
+
+    @Test
+    fun classifiesHumanLabelledMdocClaimsForDetailsAndCards() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "mso_mdoc",
+                issuer = null,
+                subject = null,
+                label = "mso_mdoc",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "Given name": "Ada",
+                      "Family name": "Lovelace",
+                      "Date of birth": "1815-12-10",
+                      "Place of birth": "London",
+                      "Valid to": 1781654400,
+                      "Portrait": {
+                        "elementValue": ${onePixelPngByteArrayJson()}
+                      }
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        val personal = assertNotNull(details.groups.firstOrNull { it.title == "Personal details" })
+        assertEquals(DisplayValue.Text("1815-12-10"), personal.items.first { it.path.id == "Date of birth" }.value)
+        assertEquals(DisplayValue.Text("London"), personal.items.first { it.path.id == "Place of birth" }.value)
+        val portrait = personal.items.first { it.path.id == "Portrait" }
+        val portraitObject = assertIs<DisplayValue.ObjectValue>(portrait.value)
+        val image = assertIs<DisplayValue.Image>(portraitObject.entries.first { it.path.id == "Portrait.elementValue" }.value)
+        val card = details.toCardDisplayData()
+
+        assertEquals("Ada Lovelace", card.holderName)
+        assertEquals("2026-06-17", card.date)
+        assertEquals("Expires 2026-06-17", card.validity)
+        assertEquals(image, card.portrait)
+    }
+
+    @Test
+    fun formatsNumericTemporalClaimsAsReadableDatesForDetailsAndCards() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "PID",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "given_name": "Ada",
+                      "family_name": "Lovelace",
+                      "exp": 1781654400,
+                      "nbf": 1781568000000
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        val claims = details.groups.flatMap { it.items }
+
+        assertEquals(DisplayValue.Text("2026-06-17"), claims.first { it.path.id == "exp" }.value)
+        assertEquals(DisplayValue.Text("2026-06-16"), claims.first { it.path.id == "nbf" }.value)
+        assertEquals("2026-06-17", details.toCardDisplayData().date)
+        assertEquals("Expires 2026-06-17", details.toCardDisplayData().validity)
+    }
+
+    @Test
+    fun ignoresNonTemporalClaimsThatContainExpWhenBuildingCardDate() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "PID",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "expected_value": "not an expiry date",
+                      "exp": 1781654400
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        assertEquals("2026-06-17", details.toCardDisplayData().date)
+    }
+
+    @Test
+    fun doesNotInferClaimRolesFromPunctuationInsideClaimNames() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "PID",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "metadata.exp": 1781654400
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        val metadataExpiry = details.groups.flatMap { it.items }.first { it.path.id == "metadata.exp" }
+
+        assertEquals(DisplayValue.NumberValue("1781654400"), metadataExpiry.value)
+        assertEquals(null, details.toCardDisplayData().date)
+    }
+
+    @Test
+    fun labelsAddedAtFallbackWhenCardHasNoExpiryClaim() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "PID",
+                addedAt = "2026-07-09",
+                credentialDataJson = """{"given_name":"Ada"}""",
+            )
+        )
+
+        assertEquals("2026-07-09", details.toCardDisplayData().date)
+        assertEquals("Added 2026-07-09", details.toCardDisplayData().validity)
+    }
+
+    @Test
+    fun buildsCardCredentialTypeFromReadableCredentialTypeClaim() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "PID",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "vct": "https://issuer.example/credential-types/mobile-driving-licence",
+                      "given_name": "Ada"
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        assertEquals("Mobile driving licence", details.toCardDisplayData().credentialType)
+    }
+
+    @Test
+    fun buildsCardCredentialTypeFromUrlClaimWithoutQueryOrFragmentNoise() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "PID",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "vct": "https://issuer.example/credential-types/mobile-driving-licence?version=1#current",
+                      "given_name": "Ada"
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        assertEquals("Mobile driving licence", details.toCardDisplayData().credentialType)
+    }
+
+    @Test
+    fun buildsCardCredentialTypeFromVcTypeArray() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "jwt_vc_json",
+                issuer = null,
+                subject = null,
+                label = "Example Credential",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+                      "given_name": "Ada"
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        assertEquals("University degree credential", details.toCardDisplayData().credentialType)
+    }
+
+    @Test
+    fun buildsCardCredentialTypeFromUrnTypeArray() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "jwt_vc_json",
+                issuer = null,
+                subject = null,
+                label = "Example Credential",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "type": ["VerifiableCredential", "urn:example:ExampleCredential"],
+                      "given_name": "Ada"
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        assertEquals("Example credential", details.toCardDisplayData().credentialType)
+    }
+
+    @Test
+    fun ignoresNestedTypeClaimsWhenBuildingCardCredentialType() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "jwt_vc_json",
+                issuer = null,
+                subject = null,
+                label = "Example Credential",
+                addedAt = null,
+                credentialDataJson = """
+                    {
+                      "document": {
+                        "type": "metadata"
+                      },
+                      "given_name": "Ada"
+                    }
+                """.trimIndent(),
+            )
+        )
+
+        assertEquals(null, details.toCardDisplayData().credentialType)
+    }
+
+    @Test
+    fun keepsMalformedJsonAsReadableRawFallback() {
+        val details = CredentialDisplayNormalizer.toDetails(
+            CredentialSummary(
+                id = "cred-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = "vc+sd-jwt",
+                addedAt = null,
+                credentialDataJson = "{not-json",
+            )
+        )
+
+        assertTrue(details.groups.isEmpty())
+        val technical = assertNotNull(details.technicalGroups.firstOrNull { it.title == "Raw credential data" })
+        assertEquals(DisplayValue.Raw("{not-json"), technical.items.single().value)
+    }
+
+    @Test
+    fun buildsHumanReadableVerifierNamesWithoutDumpingRawIdentifiers() {
+        assertEquals(
+            "Example Verifier",
+            VerifierDetails(
+                name = "Example Verifier",
+                clientId = "decentralized_identifier:did:jwk:abc",
+            ).displayName,
+        )
+        assertEquals(
+            "DID verifier",
+            VerifierDetails(
+                name = null,
+                clientId = "decentralized_identifier:did:jwk:abc",
+            ).displayName,
+        )
+        assertEquals(
+            "DID verifier",
+            VerifierDetails(
+                name = null,
+                clientId = "did:jwk:legacy-abc",
+            ).displayName,
+        )
+        assertEquals(
+            "verifier.example",
+            VerifierDetails(
+                name = null,
+                clientId = "https://verifier.example:8443/client?x=1#fragment",
+            ).displayName,
+        )
+        assertEquals(
+            "verifier.example",
+            VerifierDetails(
+                name = null,
+                clientId = "HTTPS://verifier.example/client",
+            ).displayName,
+        )
+        assertEquals(
+            "verifier.example",
+            VerifierDetails(
+                name = null,
+                clientId = "redirect_uri:https://verifier.example/callback",
+            ).displayName,
+        )
+        assertEquals(
+            "verifier.example",
+            VerifierDetails(
+                name = null,
+                clientId = "x509_san_dns:verifier.example",
+            ).displayName,
+        )
+    }
+
+    private companion object {
+        const val onePixelPngBase64 =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+
+        fun onePixelPngByteArrayJson(): String =
+            Base64.Default.decode(onePixelPngBase64).joinToString(prefix = "[", postfix = "]") { it.toString() }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/WalletDemoControllerTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/WalletDemoControllerTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -92,13 +93,18 @@ class WalletDemoControllerTest {
         val controller = unlockedControllerWith(wallet, this)
 
         wallet.credentials = listOf(sampleCredential)
+        controller.selectTab(WalletDemoTab.Receive)
         controller.updateOfferUrl("openid-credential-offer://example")
         controller.receive()
         runCurrent()
 
         assertEquals("openid-credential-offer://example", wallet.receivedOfferUrl)
-        assertEquals(WalletOperationState.Succeeded("Received 2 credential(s)"), controller.state.value.operation)
-        assertEquals("Received 2 credential(s)", controller.state.value.statusText)
+        assertEquals(
+            WalletOperationState.Succeeded("Received 1 credential(s)", WalletDemoTab.Receive),
+            controller.state.value.operation,
+        )
+        assertEquals("Received 1 credential(s)", controller.state.value.statusText)
+        assertEquals(listOf("cred-1"), controller.state.value.lastReceivedCredentialIds)
         val session = controller.state.value.session as WalletSessionState.Ready
         assertEquals(listOf(sampleCredential), session.credentials)
     }
@@ -121,13 +127,74 @@ class WalletDemoControllerTest {
         val wallet = FakeDemoWallet(presentationResult = WalletDemoOperationResult.Success("Presentation sent"))
         val controller = unlockedControllerWith(wallet, this)
 
+        controller.selectTab(WalletDemoTab.Present)
         controller.updatePresentationRequestUrl("openid4vp://example")
         controller.present()
         runCurrent()
 
         assertEquals("openid4vp://example", wallet.presentedRequestUrl)
-        assertEquals(WalletOperationState.Succeeded("Presentation sent"), controller.state.value.operation)
+        assertEquals(
+            WalletOperationState.Succeeded("Presentation sent", WalletDemoTab.Present),
+            controller.state.value.operation,
+        )
         assertEquals("Presentation sent", controller.state.value.statusText)
+    }
+
+    @Test
+    fun presentationPreviewApproveAndRejectUseStepwiseWalletApi() = runTest {
+        val preview = WalletDemoPresentationPreview(
+            verifierName = "Example Verifier",
+            clientId = "https://verifier.example",
+            credentialOptions = listOf(
+                WalletDemoPresentationCredentialOption(
+                    queryId = "pid",
+                    credentialId = "cred-1",
+                    label = "Example Credential",
+                    issuer = "Example Issuer",
+                    format = "jwt_vc_json",
+                    disclosures = listOf(
+                        WalletDemoPresentationDisclosure(
+                            label = "given_name",
+                            valueJson = "\"Ada\"",
+                            displayValue = "Ada",
+                            selectivelyDisclosable = true,
+                        )
+                    ),
+                )
+            ),
+        )
+        val wallet = FakeDemoWallet(presentationPreview = preview)
+        val controller = unlockedControllerWith(wallet, this)
+
+        controller.selectTab(WalletDemoTab.Present)
+        controller.updatePresentationRequestUrl("openid4vp://example")
+        controller.previewPresentation()
+        runCurrent()
+
+        assertEquals(preview, controller.state.value.presentationPreview)
+        assertEquals(WalletOperationState.Idle, controller.state.value.operation)
+        assertEquals("Review presentation request", controller.state.value.statusText)
+        assertEquals(setOf("cred-1"), controller.state.value.selectedPresentationCredentialIds)
+
+        controller.submitPresentation()
+        runCurrent()
+
+        assertEquals(listOf("cred-1"), wallet.submittedCredentialIds)
+        assertEquals(
+            WalletOperationState.Succeeded("Presentation sent", WalletDemoTab.Present),
+            controller.state.value.operation,
+        )
+
+        controller.previewPresentation()
+        runCurrent()
+        controller.cancelPresentationReview()
+
+        assertEquals(
+            WalletOperationState.Succeeded("Presentation review cancelled", WalletDemoTab.Present),
+            controller.state.value.operation,
+        )
+        assertEquals(null, controller.state.value.presentationPreview)
+        assertEquals(emptySet(), controller.state.value.selectedPresentationCredentialIds)
     }
 
     @Test
@@ -150,11 +217,213 @@ class WalletDemoControllerTest {
         val presentationUrl = "openid4vp://example"
 
         controller.handleDeepLink(offerUrl)
+        assertEquals(WalletDemoTab.Receive, controller.state.value.selectedTab)
         controller.handleDeepLink(presentationUrl)
+        assertEquals(WalletDemoTab.Present, controller.state.value.selectedTab)
         controller.handleDeepLink("https://example.com/ignored")
 
         assertEquals(offerUrl, controller.state.value.requestDrafts.offerUrl)
         assertEquals(presentationUrl, controller.state.value.requestDrafts.presentationRequestUrl)
+    }
+
+    @Test
+    fun handleDeepLinkResetsCompletedReceiveAndPresentationState() = runTest {
+        val offerUrl = "openid-credential-offer://example"
+        val presentationUrl = "openid4vp://example"
+        val wallet = FakeDemoWallet(
+            credentials = listOf(sampleCredential),
+            presentationPreview = WalletDemoPresentationPreview(
+                verifierName = "Example Verifier",
+                clientId = "https://verifier.example",
+                credentialOptions = listOf(
+                    WalletDemoPresentationCredentialOption(
+                        queryId = "pid",
+                        credentialId = "cred-1",
+                        label = "Example Credential",
+                        issuer = "Example Issuer",
+                        format = "jwt_vc_json",
+                        disclosures = emptyList(),
+                    )
+                ),
+            )
+        )
+        val controller = unlockedControllerWith(wallet, this)
+
+        controller.updateOfferUrl(offerUrl)
+        controller.receive()
+        runCurrent()
+        assertTrue(controller.state.value.receiveCompleted)
+
+        controller.updatePresentationRequestUrl(presentationUrl)
+        controller.previewPresentation()
+        runCurrent()
+        controller.submitPresentation()
+        runCurrent()
+        assertTrue(controller.state.value.presentationCompleted)
+
+        controller.handleDeepLink(offerUrl)
+
+        assertEquals(WalletDemoTab.Receive, controller.state.value.selectedTab)
+        assertEquals(offerUrl, controller.state.value.requestDrafts.offerUrl)
+        assertEquals(1, controller.state.value.receiveNavigationResetKey)
+        assertEquals(0, controller.state.value.presentationNavigationResetKey)
+        assertEquals(emptyList(), controller.state.value.lastReceivedCredentialIds)
+        assertFalse(controller.state.value.receiveCompleted)
+        assertEquals(WalletOperationState.Idle, controller.state.value.operation)
+        assertTrue(controller.state.value.receiveUrlEntryEnabled)
+        assertTrue(controller.state.value.receiveActionEnabled)
+        assertEquals("Wallet ready", controller.state.value.statusText)
+
+        controller.handleDeepLink(presentationUrl)
+
+        assertEquals(WalletDemoTab.Present, controller.state.value.selectedTab)
+        assertEquals(presentationUrl, controller.state.value.requestDrafts.presentationRequestUrl)
+        assertEquals(1, controller.state.value.receiveNavigationResetKey)
+        assertEquals(1, controller.state.value.presentationNavigationResetKey)
+        assertEquals(null, controller.state.value.presentationPreview)
+        assertEquals(emptySet(), controller.state.value.selectedPresentationCredentialIds)
+        assertFalse(controller.state.value.presentationCompleted)
+        assertEquals(WalletOperationState.Idle, controller.state.value.operation)
+        assertTrue(controller.state.value.presentationUrlEntryEnabled)
+        assertTrue(controller.state.value.presentationPreviewActionEnabled)
+        assertEquals("Wallet ready", controller.state.value.statusText)
+
+        controller.handleDeepLink(presentationUrl)
+
+        assertEquals(2, controller.state.value.presentationNavigationResetKey)
+    }
+
+    @Test
+    fun receiveCompletionTracksReceivedCredentialsAndCanStartNewFlow() = runTest {
+        val wallet = FakeDemoWallet(receivedCredentialIds = listOf("cred-1"))
+        val controller = unlockedControllerWith(wallet, this)
+
+        assertTrue(controller.state.value.receiveUrlEntryEnabled)
+        assertFalse(controller.state.value.receiveActionEnabled)
+
+        controller.selectTab(WalletDemoTab.Receive)
+        controller.updateOfferUrl("openid-credential-offer://example")
+        assertTrue(controller.state.value.receiveActionEnabled)
+
+        wallet.credentials = listOf(sampleCredential)
+        controller.receive()
+        runCurrent()
+
+        assertTrue(controller.state.value.receiveCompleted)
+        assertFalse(controller.state.value.receiveUrlEntryEnabled)
+        assertFalse(controller.state.value.receiveActionEnabled)
+        assertEquals(listOf("cred-1"), controller.state.value.lastReceivedCredentialIds)
+        assertEquals(WalletDemoTab.Receive, controller.state.value.selectedTab)
+
+        val resetKeyBeforeNewFlow = controller.state.value.receiveNavigationResetKey
+        controller.startNewReceiveFlow()
+
+        assertEquals("", controller.state.value.requestDrafts.offerUrl)
+        assertEquals(emptyList(), controller.state.value.lastReceivedCredentialIds)
+        assertTrue(!controller.state.value.receiveCompleted)
+        assertTrue(controller.state.value.receiveUrlEntryEnabled)
+        assertFalse(controller.state.value.receiveActionEnabled)
+        assertEquals(resetKeyBeforeNewFlow + 1, controller.state.value.receiveNavigationResetKey)
+        assertEquals(WalletOperationState.Idle, controller.state.value.operation)
+        assertEquals("Wallet ready", controller.state.value.statusText)
+    }
+
+    @Test
+    fun receiveCompletionDerivesNewCredentialsWhenWalletReturnsNoIds() = runTest {
+        val existingCredential = sampleCredential.copy(id = "old-cred", label = "Existing Credential")
+        val newCredential = sampleCredential.copy(id = "new-cred", label = "New Credential")
+        val wallet = FakeDemoWallet(credentials = listOf(existingCredential), receivedCredentialIds = emptyList())
+        val controller = unlockedControllerWith(wallet, this)
+
+        wallet.credentials = listOf(existingCredential, newCredential)
+        controller.selectTab(WalletDemoTab.Receive)
+        controller.updateOfferUrl("openid-credential-offer://example")
+        controller.receive()
+        runCurrent()
+
+        assertTrue(controller.state.value.receiveCompleted)
+        assertEquals(listOf("new-cred"), controller.state.value.lastReceivedCredentialIds)
+        assertEquals("Received 1 credential(s)", controller.state.value.statusText)
+        assertEquals(listOf(newCredential), controller.state.value.receivedCredentials())
+    }
+
+    @Test
+    fun receiveDoesNotCompleteWhenNoDisplayableCredentialIsAvailable() = runTest {
+        val wallet = FakeDemoWallet(credentials = emptyList(), receivedCredentialIds = listOf("missing-cred"))
+        val controller = unlockedControllerWith(wallet, this)
+
+        controller.selectTab(WalletDemoTab.Receive)
+        controller.updateOfferUrl("openid-credential-offer://example")
+        controller.receive()
+        runCurrent()
+
+        assertFalse(controller.state.value.receiveCompleted)
+        assertEquals(emptyList(), controller.state.value.lastReceivedCredentialIds)
+        assertTrue(controller.state.value.receiveUrlEntryEnabled)
+        assertEquals(
+            WalletOperationState.Failed(
+                "Receive failed: received credentials are not available locally",
+                WalletDemoTab.Receive,
+            ),
+            controller.state.value.operation,
+        )
+        assertEquals(
+            "Receive failed: received credentials are not available locally",
+            controller.state.value.statusText,
+        )
+    }
+
+    @Test
+    fun presentationCompletionCanStartNewFlow() = runTest {
+        val preview = WalletDemoPresentationPreview(
+            verifierName = "Example Verifier",
+            clientId = "https://verifier.example",
+            credentialOptions = listOf(
+                WalletDemoPresentationCredentialOption(
+                    queryId = "pid",
+                    credentialId = "cred-1",
+                    label = "Example Credential",
+                    issuer = "Example Issuer",
+                    format = "jwt_vc_json",
+                    disclosures = emptyList(),
+                )
+            ),
+        )
+        val wallet = FakeDemoWallet(presentationPreview = preview)
+        val controller = unlockedControllerWith(wallet, this)
+
+        controller.selectTab(WalletDemoTab.Present)
+        controller.updatePresentationRequestUrl("openid4vp://example")
+        assertTrue(controller.state.value.presentationUrlEntryEnabled)
+        assertFalse(controller.state.value.presentationPreviewActionEnabled)
+
+        controller.previewPresentation()
+        runCurrent()
+        assertFalse(controller.state.value.presentationUrlEntryEnabled)
+        assertFalse(controller.state.value.presentationPreviewActionEnabled)
+
+        controller.submitPresentation()
+        runCurrent()
+
+        assertTrue(controller.state.value.presentationCompleted)
+        assertEquals(preview, controller.state.value.presentationPreview)
+        assertEquals(emptySet(), controller.state.value.selectedPresentationCredentialIds)
+        assertFalse(controller.state.value.presentationUrlEntryEnabled)
+        assertFalse(controller.state.value.presentationPreviewActionEnabled)
+        assertEquals(WalletDemoTab.Present, controller.state.value.selectedTab)
+
+        val resetKeyBeforeNewFlow = controller.state.value.presentationNavigationResetKey
+        controller.startNewPresentationFlow()
+
+        assertEquals("", controller.state.value.requestDrafts.presentationRequestUrl)
+        assertEquals(null, controller.state.value.presentationPreview)
+        assertEquals(emptySet(), controller.state.value.selectedPresentationCredentialIds)
+        assertTrue(!controller.state.value.presentationCompleted)
+        assertTrue(controller.state.value.presentationUrlEntryEnabled)
+        assertFalse(controller.state.value.presentationPreviewActionEnabled)
+        assertEquals(resetKeyBeforeNewFlow + 1, controller.state.value.presentationNavigationResetKey)
+        assertEquals(WalletOperationState.Idle, controller.state.value.operation)
+        assertEquals("Wallet ready", controller.state.value.statusText)
     }
 
     private fun controllerWith(wallet: DemoWallet, scope: TestScope): WalletDemoController =
@@ -187,11 +456,19 @@ class WalletDemoControllerTest {
 private class FakeDemoWallet(
     var credentials: List<WalletDemoCredential> = emptyList(),
     private val receivedCredentialIds: List<String> = listOf("cred-1"),
-    private val presentationResult: WalletDemoOperationResult = WalletDemoOperationResult.Success("Presentation sent"),
+    private val presentationResult: WalletDemoOperationResult = WalletDemoOperationResult.Success(WalletDisplayText.PresentationSent),
+    private val presentationPreview: WalletDemoPresentationPreview = WalletDemoPresentationPreview(
+        verifierName = null,
+        clientId = null,
+        credentialOptions = emptyList(),
+    ),
 ) : DemoWallet {
     var bootstrapCalls = 0
     var receivedOfferUrl: String? = null
     var presentedRequestUrl: String? = null
+    var previewedRequestUrl: String? = null
+    var submittedRequestUrl: String? = null
+    var submittedCredentialIds: List<String>? = null
 
     override suspend fun bootstrap(): WalletDemoBootstrapResult {
         bootstrapCalls += 1
@@ -208,5 +485,20 @@ private class FakeDemoWallet(
     override suspend fun present(requestUrl: String, did: String?): WalletDemoOperationResult {
         presentedRequestUrl = requestUrl
         return presentationResult
+    }
+
+    override suspend fun previewPresentation(requestUrl: String): WalletDemoPresentationPreview {
+        previewedRequestUrl = requestUrl
+        return presentationPreview
+    }
+
+    override suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String?,
+    ): WalletDemoOperationResult {
+        submittedRequestUrl = requestUrl
+        submittedCredentialIds = selectedCredentialIds
+        return WalletDemoOperationResult.Success(WalletDisplayText.PresentationSent)
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileDemoWallet.kt
@@ -1,6 +1,7 @@
 package id.walt.walletdemo.compose.logic
 
 import id.walt.wallet2.mobile.MobileWallet
+import id.walt.wallet2.mobile.MobileWalletPresentationPreview
 import id.walt.wallet2.mobile.WalletAttestationConfig
 
 internal class MobileDemoWallet(
@@ -19,9 +20,11 @@ internal class MobileDemoWallet(
             WalletDemoCredential(
                 id = credential.id,
                 format = credential.format,
-                issuer = credential.issuer ?: "Unknown",
+                issuer = credential.issuer ?: CredentialDisplayText.Unknown,
+                subject = credential.subject,
                 label = credential.label ?: credential.format,
                 addedAt = credential.addedAt ?: "",
+                credentialDataJson = credential.credentialDataJson,
             )
         }
 
@@ -30,11 +33,32 @@ internal class MobileDemoWallet(
     override suspend fun present(requestUrl: String, did: String?): WalletDemoOperationResult =
         mobileWallet.present(requestUrl = requestUrl, did = did).let { result ->
             if (result.success) {
-                WalletDemoOperationResult.Success("Presentation sent")
+                WalletDemoOperationResult.Success(WalletDisplayText.PresentationSent)
             } else {
-                WalletDemoOperationResult.Failure("Presentation finished without verifier confirmation")
+                WalletDemoOperationResult.Failure(WalletDisplayText.PresentationFinishedWithoutVerifierConfirmation)
             }
         }
+
+    override suspend fun previewPresentation(requestUrl: String): WalletDemoPresentationPreview =
+        mobileWallet.previewPresentation(requestUrl).toDemoPreview()
+
+    override suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String?,
+    ): WalletDemoOperationResult =
+        mobileWallet.submitPresentation(
+            requestUrl = requestUrl,
+            selectedCredentialIds = selectedCredentialIds,
+            did = did,
+        ).let { result ->
+            if (result.success) {
+                WalletDemoOperationResult.Success(WalletDisplayText.PresentationSent)
+            } else {
+                WalletDemoOperationResult.Failure(WalletDisplayText.PresentationFinishedWithoutVerifierConfirmation)
+            }
+        }
+
 }
 
 internal fun DemoWalletConfig.toWalletAttestationConfig(): WalletAttestationConfig? =
@@ -46,3 +70,32 @@ internal fun DemoWalletConfig.toWalletAttestationConfig(): WalletAttestationConf
             hostHeader = attestationHostHeader,
         )
     }
+
+private fun MobileWalletPresentationPreview.toDemoPreview(): WalletDemoPresentationPreview =
+    WalletDemoPresentationPreview(
+        verifierName = request.verifierName,
+        clientId = request.clientId,
+        responseUri = request.responseUri,
+        state = request.state,
+        nonce = request.nonce,
+        credentialOptions = credentialOptions.map { option ->
+            WalletDemoPresentationCredentialOption(
+                queryId = option.queryId,
+                credentialId = option.credentialId,
+                label = option.label ?: option.format,
+                issuer = option.issuer ?: CredentialDisplayText.Unknown,
+                subject = option.subject,
+                format = option.format,
+                credentialDataJson = option.credentialDataJson,
+                disclosures = option.disclosures.map { disclosure ->
+                    WalletDemoPresentationDisclosure(
+                        label = CredentialDisplayVocabulary.disclosureLabel(disclosure.name, disclosure.path),
+                        path = disclosure.path,
+                        valueJson = disclosure.valueJson,
+                        displayValue = disclosure.displayValue,
+                        selectivelyDisclosable = disclosure.selectivelyDisclosable,
+                    )
+                },
+            )
+        },
+    )

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/build.gradle.kts
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/build.gradle.kts
@@ -40,6 +40,9 @@ kotlin {
             implementation(identityLibs.compose.foundation)
             implementation(identityLibs.compose.ui)
             implementation(identityLibs.compose.material3)
+            implementation(identityLibs.compose.material.icons.core)
+            implementation(identityLibs.compose.navigation3.ui)
+            implementation(identityLibs.coil.compose)
         }
 
         commonTest.dependencies {

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/androidHostTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppAndroidTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/androidHostTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppAndroidTest.kt
@@ -11,20 +11,60 @@ class WalletDemoAppAndroidTest {
     private val scenarios = WalletDemoAppTestScenarios()
 
     @Test
-    fun pinSetupBootstrapsWalletAndShowsCredentials() =
-        scenarios.pinSetupBootstrapsWalletAndShowsCredentials()
+    fun credentialsTabShowsCompactCardsAndNavigatesToDetails() =
+        scenarios.credentialsTabShowsCompactCardsAndNavigatesToDetails()
 
     @Test
-    fun receiveFlowUpdatesStatusAndCredentialList() =
-        scenarios.receiveFlowUpdatesStatusAndCredentialList()
+    fun credentialsTabShowsEmptyStateAndUpdatesAfterReceive() =
+        scenarios.credentialsTabShowsEmptyStateAndUpdatesAfterReceive()
 
     @Test
-    fun presentFlowUpdatesStatus() =
-        scenarios.presentFlowUpdatesStatus()
+    fun receiveTabCanStartNewFlowAfterSuccess() =
+        scenarios.receiveTabCanStartNewFlowAfterSuccess()
 
     @Test
-    fun deepLinkReceiveAndPresentFlowUpdatesStatus() =
-        scenarios.deepLinkReceiveAndPresentFlowUpdatesStatus()
+    fun receiveDetailsStayScopedToReceiveTabNavigationStack() =
+        scenarios.receiveDetailsStayScopedToReceiveTabNavigationStack()
+
+    @Test
+    fun receiveTabDisablesUrlControlsWhileReceiving() =
+        scenarios.receiveTabDisablesUrlControlsWhileReceiving()
+
+    @Test
+    fun presentTabExplainsWhyPreviewIsUnavailableWithoutCredentials() =
+        scenarios.presentTabExplainsWhyPreviewIsUnavailableWithoutCredentials()
+
+    @Test
+    fun presentTabPreviewsCredentialsAndCanStartNewFlowAfterSuccess() =
+        scenarios.presentTabPreviewsCredentialsAndCanStartNewFlowAfterSuccess()
+
+    @Test
+    fun presentationDisclosureImagesRenderAsImages() =
+        scenarios.presentationDisclosureImagesRenderAsImages()
+
+    @Test
+    fun presentTabShowsReadableVerifierFallbackForDidClientIds() =
+        scenarios.presentTabShowsReadableVerifierFallbackForDidClientIds()
+
+    @Test
+    fun presentTabShowsReadableVerifierFallbackForX509SanDnsClientIds() =
+        scenarios.presentTabShowsReadableVerifierFallbackForX509SanDnsClientIds()
+
+    @Test
+    fun presentDetailsStayScopedToPresentTabNavigationStack() =
+        scenarios.presentDetailsStayScopedToPresentTabNavigationStack()
+
+    @Test
+    fun presentTabDisablesUrlControlsWhilePreviewing() =
+        scenarios.presentTabDisablesUrlControlsWhilePreviewing()
+
+    @Test
+    fun deepLinksRouteToReceiveAndPresentTabs() =
+        scenarios.deepLinksRouteToReceiveAndPresentTabs()
+
+    @Test
+    fun deepLinksResetReceiveAndPresentDetailStacksEvenWhenUrlIsUnchanged() =
+        scenarios.deepLinksResetReceiveAndPresentDetailStacksEvenWhenUrlIsUnchanged()
 
     @Test
     fun credentialsPersistAcrossControllerRecreation() =

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletRoute.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletRoute.kt
@@ -1,0 +1,8 @@
+package id.walt.walletdemo.compose.ui
+
+import androidx.navigation3.runtime.NavKey
+
+internal sealed interface WalletRoute : NavKey {
+    data object Root : WalletRoute
+    data class CredentialDetails(val credentialId: String) : WalletRoute
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletUiTestTags.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletUiTestTags.kt
@@ -1,0 +1,49 @@
+package id.walt.walletdemo.compose.ui
+
+internal object WalletUiTestTags {
+    val Status = tag("status")
+    val CredentialsEmpty = tag("credentials", "empty")
+    val CredentialDetailsScreen = tag("credentialDetailsScreen")
+    val DetailsBack = tag("detailsBack")
+    val Did = tag("did")
+    val OfferInput = tag("offerInput")
+    val ReceiveButton = tag("receiveButton")
+    val ReceiveNewButton = tag("receiveNewButton")
+    val ReceiveTabContent = tag("receiveTabContent")
+    val PresentationInput = tag("presentationInput")
+    val PresentButton = tag("presentButton")
+    val PresentationNewButton = tag("presentationNewButton")
+    val PresentTabContent = tag("presentTabContent")
+    val PresentationReview = tag("presentationReview")
+    val PresentationActions = tag("presentationActions")
+    val PresentationSubmitButton = tag("presentationSubmitButton")
+    val PresentationCancelButton = tag("presentationCancelButton")
+    val PresentationVerifier = tag("presentationVerifier")
+    val VerifierTechnicalDetailsToggle = tag("verifierTechnicalDetailsToggle")
+    val VerifierTechnicalDetails = tag("verifierTechnicalDetails")
+    val PinInput = tag("pinInput")
+    val PinConfirmationInput = tag("pinConfirmationInput")
+    val PinSubmitButton = tag("pinSubmitButton")
+    val CredentialsTab = tag("tab", "credentials")
+    val ReceiveTab = tag("tab", "receive")
+    val PresentTab = tag("tab", "present")
+
+    fun claim(path: String): String = dynamicTag("claim", path)
+    fun claimImage(path: String): String = dynamicTag("claimImage", path)
+    fun claimGroup(title: String): String = dynamicTag("claimGroup", title)
+    fun credentialCard(id: String): String = tag("credentialCard", id)
+    fun credentialDetails(id: String): String = tag("credentialDetails", id)
+    fun credentialOverview(id: String): String = tag("credentialOverview", id)
+    fun presentationCredential(id: String): String = tag("presentationCredential", id)
+
+    private fun tag(vararg segments: String): String =
+        (listOf(Namespace) + segments).joinToString(separator = ".")
+
+    private fun dynamicTag(kind: String, rawValue: String): String =
+        tag(kind, rawValue.toTestTagSegment())
+
+    private const val Namespace = "wallet"
+}
+
+private fun String.toTestTagSegment(): String =
+    map { if (it.isLetterOrDigit()) it else '_' }.joinToString("")

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/ClaimGroupSection.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/ClaimGroupSection.kt
@@ -1,0 +1,41 @@
+package id.walt.walletdemo.compose.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.ClaimGroup
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+
+@Composable
+internal fun ClaimGroupSection(group: ClaimGroup, modifier: Modifier = Modifier) {
+    if (group.items.isEmpty()) return
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(WalletUiTestTags.claimGroup(group.title)),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            group.title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+        group.items.forEach { item ->
+            ClaimValueRow(
+                item = item,
+                modifier = Modifier.padding(start = if (item.requested) 0.dp else 4.dp),
+            )
+        }
+        HorizontalDivider()
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/ClaimValueRow.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/ClaimValueRow.kt
@@ -1,0 +1,133 @@
+package id.walt.walletdemo.compose.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import id.walt.walletdemo.compose.logic.ClaimItem
+import id.walt.walletdemo.compose.logic.ClaimItemPath
+import id.walt.walletdemo.compose.logic.DisplayValue
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+
+@Composable
+internal fun ClaimValueRow(item: ClaimItem, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(WalletUiTestTags.claim(item.path.id)),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            item.label,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = if (item.requested) FontWeight.SemiBold else FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        ClaimValue(value = item.value, path = item.path, modifier = Modifier.fillMaxWidth())
+    }
+}
+
+@Composable
+private fun ClaimValue(value: DisplayValue, path: ClaimItemPath, modifier: Modifier = Modifier) {
+    when (value) {
+        is DisplayValue.BooleanValue -> Text(
+            value.value.toString(),
+            modifier = modifier,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        is DisplayValue.DecodedText -> Text(
+            value.value,
+            modifier = modifier,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        is DisplayValue.Image -> ImageValue(value, path, modifier)
+        is DisplayValue.ListValue -> Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            value.values.forEachIndexed { index, child ->
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text("${index + 1}.", style = MaterialTheme.typography.bodySmall)
+                    ClaimValue(child, path.indexedChild(index), Modifier.weight(1f))
+                }
+            }
+        }
+        DisplayValue.NullValue -> Text(
+            "Not provided",
+            modifier = modifier,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        is DisplayValue.NumberValue -> Text(
+            value.value,
+            modifier = modifier,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        is DisplayValue.ObjectValue -> Column(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            value.entries.forEach { entry ->
+                ClaimValueRow(entry)
+            }
+        }
+        is DisplayValue.Raw -> Text(
+            value.value,
+            modifier = modifier,
+            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        is DisplayValue.Text -> Text(
+            value.value,
+            modifier = modifier,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun ImageValue(value: DisplayValue.Image, path: ClaimItemPath, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .testTag(WalletUiTestTags.claimImage(path.id))
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(10.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            AsyncImage(
+                model = value.bytes,
+                contentDescription = "Credential image",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 96.dp, max = 180.dp),
+                contentScale = ContentScale.Fit,
+            )
+            Text(
+                value.mimeType ?: "Image",
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                listOfNotNull(
+                    "${value.byteCount} bytes",
+                ).joinToString(" • "),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCard.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCard.kt
@@ -1,7 +1,9 @@
 package id.walt.walletdemo.compose.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
@@ -9,26 +11,65 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import id.walt.walletdemo.compose.logic.WalletDemoCredential
+import id.walt.walletdemo.compose.logic.CredentialDetails
+import id.walt.walletdemo.compose.logic.toCardDisplayData
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
 
 @Composable
-internal fun CredentialCard(credential: WalletDemoCredential) {
+internal fun CredentialCard(
+    details: CredentialDetails,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val display = details.toCardDisplayData()
     Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(WalletUiTestTags.credentialCard(display.id))
+            .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {
-        Column(
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(credential.label, style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Medium)
-            Text("Issuer: ${credential.issuer}", style = MaterialTheme.typography.bodySmall)
-            Text("Format: ${credential.format}", style = MaterialTheme.typography.bodySmall)
-            Text("ID: ${credential.id}", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            CredentialPortrait(portrait = display.portrait, size = 64.dp)
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                Text(
+                    display.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                display.credentialType?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+                }
+                display.holderName?.let {
+                    Text(it, style = MaterialTheme.typography.bodyMedium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                }
+                display.issuer?.let {
+                    Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(display.format, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    display.validity?.let {
+                        Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
         }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialDetailsContent.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialDetailsContent.kt
@@ -1,0 +1,54 @@
+package id.walt.walletdemo.compose.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.CredentialDetails
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+
+@Composable
+internal fun CredentialDetailsContent(
+    details: CredentialDetails,
+    modifier: Modifier = Modifier,
+    includeTechnicalDetails: Boolean = false,
+) {
+    var showTechnicalDetails by rememberSaveable(details.summary.id) { mutableStateOf(false) }
+    val hasTechnicalDetails = includeTechnicalDetails && details.technicalGroups.any { it.items.isNotEmpty() }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(WalletUiTestTags.credentialDetails(details.summary.id)),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CredentialOverviewSection(details)
+        if (details.groups.isEmpty() && details.technicalGroups.isEmpty()) {
+            Text(
+                "No credential details available",
+            )
+        }
+        details.groups.forEach { group ->
+            ClaimGroupSection(group)
+        }
+        if (hasTechnicalDetails) {
+            TextButton(onClick = { showTechnicalDetails = !showTechnicalDetails }) {
+                Text(if (showTechnicalDetails) "Hide raw credential data" else "Show raw credential data")
+            }
+        }
+        if (showTechnicalDetails) {
+            details.technicalGroups.forEach { group ->
+                ClaimGroupSection(group)
+            }
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialOverviewSection.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialOverviewSection.kt
@@ -1,0 +1,67 @@
+package id.walt.walletdemo.compose.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.CredentialDetails
+import id.walt.walletdemo.compose.logic.toCardDisplayData
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+
+@Composable
+internal fun CredentialOverviewSection(details: CredentialDetails, modifier: Modifier = Modifier) {
+    val display = details.toCardDisplayData()
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .testTag(WalletUiTestTags.credentialOverview(display.id))
+            .padding(14.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        CredentialPortrait(portrait = display.portrait, size = 72.dp)
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                display.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            display.credentialType?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.primary)
+            }
+            display.holderName?.let {
+                Text(it, style = MaterialTheme.typography.bodyMedium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
+            display.issuer?.let {
+                Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(display.format, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                display.validity?.let {
+                    Text(it, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialPortrait.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialPortrait.kt
@@ -1,0 +1,43 @@
+package id.walt.walletdemo.compose.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import id.walt.walletdemo.compose.logic.DisplayValue
+
+@Composable
+internal fun CredentialPortrait(
+    portrait: DisplayValue.Image?,
+    size: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier
+            .size(size)
+            .clip(RoundedCornerShape(8.dp)),
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        if (portrait == null) {
+            Box(contentAlignment = Alignment.Center) {
+                Text("ID", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        } else {
+            AsyncImage(
+                model = portrait.bytes,
+                contentDescription = "Credential portrait",
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/PresentationReviewSection.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/PresentationReviewSection.kt
@@ -1,0 +1,124 @@
+package id.walt.walletdemo.compose.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.WalletDemoPresentationPreview
+import id.walt.walletdemo.compose.logic.toCredentialDetails
+import id.walt.walletdemo.compose.logic.toVerifierDetails
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+
+@Composable
+internal fun PresentationReviewSection(
+    preview: WalletDemoPresentationPreview,
+    selectedCredentialIds: Set<String>,
+    enabled: Boolean,
+    readOnly: Boolean = false,
+    onToggleCredential: (String) -> Unit,
+    onCredentialClick: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(WalletUiTestTags.PresentationReview),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        VerifierDetailsCard(preview.toVerifierDetails())
+
+        Text(
+            "Shared credentials",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+
+        preview.credentialOptions.forEach { option ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(WalletUiTestTags.presentationCredential(option.credentialId)),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                if (!readOnly) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Checkbox(
+                            checked = option.credentialId in selectedCredentialIds,
+                            onCheckedChange = { onToggleCredential(option.credentialId) },
+                            enabled = enabled,
+                        )
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(option.label, style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
+                            Text(option.issuer, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            option.subject?.let {
+                                Text("Subject: $it", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            }
+                            Text(option.format, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                    }
+                }
+
+                CredentialCard(
+                    details = option.toCredentialDetails(),
+                    modifier = Modifier.padding(start = if (readOnly) 0.dp else 48.dp),
+                    onClick = { onCredentialClick(option.credentialId) },
+                )
+                HorizontalDivider()
+            }
+        }
+
+        if (!readOnly) {
+            ReviewActionsRow(
+                enabled = enabled,
+                hasSelection = selectedCredentialIds.isNotEmpty(),
+                onSubmit = onSubmit,
+                onCancel = onCancel,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReviewActionsRow(
+    enabled: Boolean,
+    hasSelection: Boolean,
+    onSubmit: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.testTag(WalletUiTestTags.PresentationActions),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Button(
+            onClick = onSubmit,
+            enabled = enabled && hasSelection,
+            modifier = Modifier.testTag(WalletUiTestTags.PresentationSubmitButton),
+        ) {
+            Text("Share")
+        }
+        TextButton(
+            onClick = onCancel,
+            enabled = enabled,
+            modifier = Modifier.testTag(WalletUiTestTags.PresentationCancelButton),
+        ) {
+            Text("Cancel review")
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/StatusCard.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/StatusCard.kt
@@ -12,20 +12,21 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import id.walt.walletdemo.compose.logic.WalletDemoUiState
-import id.walt.walletdemo.compose.logic.isBusy
 import id.walt.walletdemo.compose.logic.isError
+import id.walt.walletdemo.compose.logic.isStatusBusy
 import id.walt.walletdemo.compose.logic.statusText
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
 
 @Composable
 internal fun StatusCard(state: WalletDemoUiState) {
     val containerColor = when {
         state.isError -> MaterialTheme.colorScheme.errorContainer
-        state.isBusy -> MaterialTheme.colorScheme.secondaryContainer
+        state.isStatusBusy -> MaterialTheme.colorScheme.secondaryContainer
         else -> Color(0xFFD8E2FF)
     }
     val contentColor = when {
         state.isError -> MaterialTheme.colorScheme.onErrorContainer
-        state.isBusy -> MaterialTheme.colorScheme.onSecondaryContainer
+        state.isStatusBusy -> MaterialTheme.colorScheme.onSecondaryContainer
         else -> Color(0xFF002E69)
     }
 
@@ -37,7 +38,7 @@ internal fun StatusCard(state: WalletDemoUiState) {
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 12.dp)
-                .testTag("wallet.status"),
+                .testTag(WalletUiTestTags.Status),
             style = MaterialTheme.typography.bodyMedium,
         )
     }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/UrlActionSection.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/UrlActionSection.kt
@@ -21,6 +21,7 @@ internal fun UrlActionSection(
     label: String,
     buttonText: String,
     enabled: Boolean,
+    inputEnabled: Boolean = true,
     inputTestTag: String,
     buttonTestTag: String,
     onClick: () -> Unit,
@@ -34,8 +35,9 @@ internal fun UrlActionSection(
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag(inputTestTag),
-            minLines = 3,
-            maxLines = 3,
+            enabled = inputEnabled,
+            minLines = 1,
+            maxLines = 2,
         )
         Button(
             enabled = enabled,

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/VerifierDetailsCard.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/VerifierDetailsCard.kt
@@ -1,0 +1,73 @@
+package id.walt.walletdemo.compose.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.VerifierDetails
+import id.walt.walletdemo.compose.logic.displayName
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+
+@Composable
+internal fun VerifierDetailsCard(verifier: VerifierDetails, modifier: Modifier = Modifier) {
+    var technicalDetailsExpanded by rememberSaveable { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(WalletUiTestTags.PresentationVerifier),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text("Verifier", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Text(
+            verifier.displayName,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Medium,
+        )
+        DetailLine("Trust", verifier.trustStatus)
+
+        TextButton(
+            onClick = { technicalDetailsExpanded = !technicalDetailsExpanded },
+            modifier = Modifier.testTag(WalletUiTestTags.VerifierTechnicalDetailsToggle),
+        ) {
+            Text(if (technicalDetailsExpanded) "Hide technical details" else "Show technical details")
+        }
+
+        if (technicalDetailsExpanded) {
+            Column(
+                modifier = Modifier.testTag(WalletUiTestTags.VerifierTechnicalDetails),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                DetailLine("Client ID", verifier.clientId)
+                DetailLine("Response URI", verifier.responseUri)
+                DetailLine("State", verifier.state)
+                DetailLine("Nonce", verifier.nonce)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailLine(label: String, value: String?) {
+    if (value.isNullOrBlank()) return
+
+    Column(verticalArrangement = Arrangement.spacedBy(1.dp)) {
+        Text(
+            label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(value, style = MaterialTheme.typography.bodySmall)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/CredentialDetailsScreen.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/CredentialDetailsScreen.kt
@@ -1,0 +1,67 @@
+package id.walt.walletdemo.compose.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.CredentialDetails
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+import id.walt.walletdemo.compose.ui.components.CredentialDetailsContent
+
+@Composable
+internal fun CredentialDetailsScreen(details: CredentialDetails, onBack: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(WalletUiTestTags.CredentialDetailsScreen),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 4.dp, end = 20.dp, top = 8.dp, bottom = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            IconButton(
+                onClick = onBack,
+                modifier = Modifier.testTag(WalletUiTestTags.DetailsBack),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                )
+            }
+            Text(
+                "Credential details",
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        CredentialDetailsContent(
+            details = details,
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 8.dp),
+            includeTechnicalDetails = true,
+        )
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/CredentialsTab.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/CredentialsTab.kt
@@ -1,0 +1,63 @@
+package id.walt.walletdemo.compose.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.WalletDemoCredential
+import id.walt.walletdemo.compose.logic.toCredentialDetails
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+import id.walt.walletdemo.compose.ui.components.CredentialCard
+
+@Composable
+internal fun CredentialsTab(credentials: List<WalletDemoCredential>, onCredentialClick: (String) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text("Credentials", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        if (credentials.isEmpty()) {
+            EmptyCredentialsState()
+        } else {
+            credentials.forEach { credential ->
+                CredentialCard(
+                    details = credential.toCredentialDetails(),
+                    onClick = { onCredentialClick(credential.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyCredentialsState() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(WalletUiTestTags.CredentialsEmpty)
+            .padding(vertical = 56.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text("No credentials yet", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Medium)
+        Text(
+            "Receive a credential to see it here.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/PinScreen.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/PinScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import id.walt.walletdemo.compose.logic.WalletAuthState
 import id.walt.walletdemo.compose.logic.WalletDemoController
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
 
 @Composable
 internal fun PinScreen(
@@ -71,7 +72,7 @@ internal fun PinScreen(
             isError = error != null,
             modifier = Modifier
                 .fillMaxWidth()
-                .testTag("wallet.pinInput"),
+                .testTag(WalletUiTestTags.PinInput),
             singleLine = true,
         )
 
@@ -85,7 +86,7 @@ internal fun PinScreen(
                 isError = error != null,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .testTag("wallet.pinConfirmationInput"),
+                    .testTag(WalletUiTestTags.PinConfirmationInput),
                 singleLine = true,
             )
         }
@@ -99,7 +100,7 @@ internal fun PinScreen(
             enabled = !isBusy,
             modifier = Modifier
                 .fillMaxWidth()
-                .testTag("wallet.pinSubmitButton"),
+                .testTag(WalletUiTestTags.PinSubmitButton),
         ) {
             Text(if (setup != null) "Set PIN" else "Unlock")
         }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/PresentTab.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/PresentTab.kt
@@ -1,0 +1,92 @@
+package id.walt.walletdemo.compose.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.WalletDemoUiState
+import id.walt.walletdemo.compose.logic.WalletRequestDrafts
+import id.walt.walletdemo.compose.logic.WalletSessionState
+import id.walt.walletdemo.compose.logic.presentationPreviewActionEnabled
+import id.walt.walletdemo.compose.logic.presentationReviewEnabled
+import id.walt.walletdemo.compose.logic.presentationUrlEntryEnabled
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+import id.walt.walletdemo.compose.ui.components.PresentationReviewSection
+import id.walt.walletdemo.compose.ui.components.UrlActionSection
+
+@Composable
+internal fun PresentTab(
+    state: WalletDemoUiState,
+    requestDrafts: WalletRequestDrafts,
+    onPresentationRequestUrlChange: (String) -> Unit,
+    onPreview: () -> Unit,
+    onStartNew: () -> Unit,
+    onToggleCredential: (String) -> Unit,
+    onCredentialClick: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val credentials = (state.session as? WalletSessionState.Ready)?.credentials.orEmpty()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(WalletUiTestTags.PresentTabContent)
+            .verticalScroll(scrollState)
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        UrlActionSection(
+            title = "Present",
+            value = requestDrafts.presentationRequestUrl,
+            onValueChange = onPresentationRequestUrlChange,
+            label = "OpenID4VP request URL",
+            buttonText = "Preview",
+            enabled = state.presentationPreviewActionEnabled,
+            inputEnabled = state.presentationUrlEntryEnabled,
+            inputTestTag = WalletUiTestTags.PresentationInput,
+            buttonTestTag = WalletUiTestTags.PresentButton,
+            onClick = onPreview,
+        )
+
+        if (credentials.isEmpty()) {
+            Text(
+                "No credentials available",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+
+        if (state.presentationCompleted) {
+            OutlinedButton(
+                onClick = onStartNew,
+                modifier = Modifier.testTag(WalletUiTestTags.PresentationNewButton),
+            ) {
+                Text("New presentation")
+            }
+        }
+
+        state.presentationPreview?.let { preview ->
+            PresentationReviewSection(
+                preview = preview,
+                selectedCredentialIds = state.selectedPresentationCredentialIds,
+                enabled = state.presentationReviewEnabled,
+                readOnly = state.presentationCompleted,
+                onToggleCredential = onToggleCredential,
+                onCredentialClick = onCredentialClick,
+                onSubmit = onSubmit,
+                onCancel = onCancel,
+            )
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/ReceiveTab.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/ReceiveTab.kt
@@ -1,0 +1,75 @@
+package id.walt.walletdemo.compose.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.WalletDemoUiState
+import id.walt.walletdemo.compose.logic.WalletRequestDrafts
+import id.walt.walletdemo.compose.logic.receivedCredentials
+import id.walt.walletdemo.compose.logic.receiveActionEnabled
+import id.walt.walletdemo.compose.logic.receiveUrlEntryEnabled
+import id.walt.walletdemo.compose.logic.toCredentialDetails
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+import id.walt.walletdemo.compose.ui.components.CredentialCard
+import id.walt.walletdemo.compose.ui.components.UrlActionSection
+
+@Composable
+internal fun ReceiveTab(
+    state: WalletDemoUiState,
+    requestDrafts: WalletRequestDrafts,
+    onOfferUrlChange: (String) -> Unit,
+    onReceive: () -> Unit,
+    onStartNew: () -> Unit,
+    onCredentialClick: (String) -> Unit,
+) {
+    val receivedCredentials = state.receivedCredentials()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag(WalletUiTestTags.ReceiveTabContent)
+            .verticalScroll(rememberScrollState())
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        UrlActionSection(
+            title = "Receive",
+            value = requestDrafts.offerUrl,
+            onValueChange = onOfferUrlChange,
+            label = "Credential offer URL",
+            buttonText = "Receive",
+            enabled = state.receiveActionEnabled,
+            inputEnabled = state.receiveUrlEntryEnabled,
+            inputTestTag = WalletUiTestTags.OfferInput,
+            buttonTestTag = WalletUiTestTags.ReceiveButton,
+            onClick = onReceive,
+        )
+
+        if (state.receiveCompleted) {
+            OutlinedButton(
+                onClick = onStartNew,
+                modifier = Modifier.testTag(WalletUiTestTags.ReceiveNewButton),
+            ) {
+                Text("New receive")
+            }
+            Text("Received credentials", style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+            receivedCredentials.forEach { credential ->
+                CredentialCard(
+                    details = credential.toCredentialDetails(),
+                    onClick = { onCredentialClick(credential.id) },
+                )
+            }
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletBottomBar.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletBottomBar.kt
@@ -1,0 +1,63 @@
+package id.walt.walletdemo.compose.ui.screens
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import id.walt.walletdemo.compose.logic.WalletDemoTab
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+
+@Composable
+internal fun WalletBottomBar(selectedTab: WalletDemoTab, onSelectedTab: (WalletDemoTab) -> Unit) {
+    NavigationBar {
+        WalletDemoTab.entries.forEach { tab ->
+            NavigationBarItem(
+                selected = selectedTab == tab,
+                onClick = { onSelectedTab(tab) },
+                icon = {
+                    Icon(
+                        imageVector = tab.icon,
+                        contentDescription = null,
+                    )
+                },
+                label = { Text(tab.title) },
+                modifier = Modifier
+                    .testTag(tab.testTag)
+                    .semantics {
+                        contentDescription = "${tab.title} tab"
+                    },
+            )
+        }
+    }
+}
+
+private val WalletDemoTab.title: String
+    get() = when (this) {
+        WalletDemoTab.Credentials -> "Credentials"
+        WalletDemoTab.Receive -> "Receive"
+        WalletDemoTab.Present -> "Present"
+    }
+
+private val WalletDemoTab.icon: ImageVector
+    get() = when (this) {
+        WalletDemoTab.Credentials -> Icons.Filled.AccountBox
+        WalletDemoTab.Receive -> Icons.Filled.AddCircle
+        WalletDemoTab.Present -> Icons.AutoMirrored.Filled.Send
+    }
+
+private val WalletDemoTab.testTag: String
+    get() = when (this) {
+        WalletDemoTab.Credentials -> WalletUiTestTags.CredentialsTab
+        WalletDemoTab.Receive -> WalletUiTestTags.ReceiveTab
+        WalletDemoTab.Present -> WalletUiTestTags.PresentTab
+    }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletHeader.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletHeader.kt
@@ -1,0 +1,52 @@
+package id.walt.walletdemo.compose.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import id.walt.walletdemo.compose.logic.WalletDemoUiState
+import id.walt.walletdemo.compose.ui.WalletUiTestTags
+import id.walt.walletdemo.compose.ui.components.StatusCard
+
+@Composable
+internal fun WalletHeader(did: String?, state: WalletDemoUiState, onLock: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("walt.id Wallet", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+                if (!did.isNullOrBlank()) {
+                    Text(
+                        did,
+                        modifier = Modifier.testTag(WalletUiTestTags.Did),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            OutlinedButton(onClick = onLock) {
+                Text("Lock")
+            }
+        }
+        StatusCard(state)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletScreen.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletScreen.kt
@@ -1,103 +1,111 @@
 package id.walt.walletdemo.compose.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import id.walt.walletdemo.compose.logic.WalletDemoController
+import id.walt.walletdemo.compose.logic.WalletDemoTab
 import id.walt.walletdemo.compose.logic.WalletDemoUiState
 import id.walt.walletdemo.compose.logic.WalletSessionState
-import id.walt.walletdemo.compose.logic.isBusy
-import id.walt.walletdemo.compose.ui.components.CredentialCard
-import id.walt.walletdemo.compose.ui.components.StatusCard
-import id.walt.walletdemo.compose.ui.components.UrlActionSection
+import id.walt.walletdemo.compose.logic.receivedCredentials
+import id.walt.walletdemo.compose.logic.toCredentialDetails
+import id.walt.walletdemo.compose.ui.WalletRoute
 
 @Composable
 internal fun WalletScreen(controller: WalletDemoController, state: WalletDemoUiState) {
     val ready = state.session as? WalletSessionState.Ready
-    val requestDrafts = state.requestDrafts
+    val credentials = ready?.credentials.orEmpty()
+    val credentialsBackStack = remember { mutableStateListOf<WalletRoute>(WalletRoute.Root) }
+    val receiveBackStack = remember { mutableStateListOf<WalletRoute>(WalletRoute.Root) }
+    val presentBackStack = remember { mutableStateListOf<WalletRoute>(WalletRoute.Root) }
 
-    Column(
-        modifier = Modifier
+    LaunchedEffect(state.receiveNavigationResetKey) {
+        receiveBackStack.resetToRoot()
+    }
+    LaunchedEffect(state.presentationNavigationResetKey) {
+        presentBackStack.resetToRoot()
+    }
+
+    Scaffold(
+        topBar = {
+            WalletHeader(
+                did = ready?.did,
+                state = state,
+                onLock = controller::lock,
+            )
+        },
+        bottomBar = {
+            WalletBottomBar(
+                selectedTab = state.selectedTab,
+                onSelectedTab = controller::selectTab,
+            )
+        },
+    ) { contentPadding ->
+        val modifier = Modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(20.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Column {
-                Text("walt.id Wallet", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
-                if (ready != null && ready.did.isNotBlank()) {
-                    Text(
-                        ready.did,
-                        modifier = Modifier.testTag("wallet.did"),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+            .padding(contentPadding)
+
+        when (state.selectedTab) {
+            WalletDemoTab.Credentials -> WalletTabNavDisplay(
+                backStack = credentialsBackStack,
+                details = credentials.map { it.toCredentialDetails() },
+                modifier = modifier,
+                root = {
+                    CredentialsTab(
+                        credentials = credentials,
+                        onCredentialClick = { credentialId -> credentialsBackStack.pushDetails(credentialId) },
                     )
-                }
+                },
+            )
+            WalletDemoTab.Receive -> {
+                val receivedDetails = state.receivedCredentials()
+                    .map { it.toCredentialDetails() }
+
+                WalletTabNavDisplay(
+                    backStack = receiveBackStack,
+                    details = receivedDetails,
+                    modifier = modifier,
+                    root = {
+                        ReceiveTab(
+                            state = state,
+                            requestDrafts = state.requestDrafts,
+                            onOfferUrlChange = controller::updateOfferUrl,
+                            onReceive = controller::receive,
+                            onStartNew = controller::startNewReceiveFlow,
+                            onCredentialClick = { credentialId -> receiveBackStack.pushDetails(credentialId) },
+                        )
+                    },
+                )
             }
-            OutlinedButton(onClick = controller::lock) {
-                Text("Lock")
-            }
-        }
+            WalletDemoTab.Present -> {
+                val presentationDetails = state.presentationPreview
+                    ?.credentialOptions
+                    .orEmpty()
+                    .map { it.toCredentialDetails() }
 
-        StatusCard(state)
-
-        HorizontalDivider()
-        UrlActionSection(
-            title = "Receive",
-            value = requestDrafts.offerUrl,
-            onValueChange = controller::updateOfferUrl,
-            label = "Credential offer URL",
-            buttonText = "Receive",
-            enabled = ready != null &&
-                requestDrafts.offerUrl.isNotBlank() &&
-                !state.isBusy,
-            inputTestTag = "wallet.offerInput",
-            buttonTestTag = "wallet.receiveButton",
-            onClick = controller::receive,
-        )
-
-        HorizontalDivider()
-        UrlActionSection(
-            title = "Present",
-            value = requestDrafts.presentationRequestUrl,
-            onValueChange = controller::updatePresentationRequestUrl,
-            label = "OpenID4VP request URL",
-            buttonText = "Present",
-            enabled = ready != null &&
-                requestDrafts.presentationRequestUrl.isNotBlank() &&
-                ready.credentials.isNotEmpty() &&
-                !state.isBusy,
-            inputTestTag = "wallet.presentationInput",
-            buttonTestTag = "wallet.presentButton",
-            onClick = controller::present,
-        )
-
-        HorizontalDivider()
-        Text("Credentials", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-        val credentials = ready?.credentials.orEmpty()
-        if (credentials.isEmpty()) {
-            Text("No credentials", color = MaterialTheme.colorScheme.onSurfaceVariant)
-        } else {
-            credentials.forEach { credential ->
-                CredentialCard(credential)
+                WalletTabNavDisplay(
+                    backStack = presentBackStack,
+                    details = presentationDetails.ifEmpty { credentials.map { it.toCredentialDetails() } },
+                    modifier = modifier,
+                    root = {
+                        PresentTab(
+                            state = state,
+                            requestDrafts = state.requestDrafts,
+                            onPresentationRequestUrlChange = controller::updatePresentationRequestUrl,
+                            onPreview = controller::previewPresentation,
+                            onStartNew = controller::startNewPresentationFlow,
+                            onToggleCredential = controller::togglePresentationCredential,
+                            onCredentialClick = { credentialId -> presentBackStack.pushDetails(credentialId) },
+                            onSubmit = controller::submitPresentation,
+                            onCancel = controller::cancelPresentationReview,
+                        )
+                    },
+                )
             }
         }
     }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletTabNavDisplay.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletTabNavDisplay.kt
@@ -1,0 +1,48 @@
+package id.walt.walletdemo.compose.ui.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.ui.NavDisplay
+import id.walt.walletdemo.compose.logic.CredentialDetails
+import id.walt.walletdemo.compose.ui.WalletRoute
+
+@Composable
+internal fun WalletTabNavDisplay(
+    backStack: SnapshotStateList<WalletRoute>,
+    details: List<CredentialDetails>,
+    modifier: Modifier,
+    root: @Composable () -> Unit,
+) {
+    NavDisplay(
+        backStack = backStack,
+        modifier = modifier,
+        entryProvider = entryProvider {
+            entry<WalletRoute.Root> {
+                root()
+            }
+            entry<WalletRoute.CredentialDetails> { route ->
+                val selectedDetails = details.firstOrNull { it.summary.id == route.credentialId }
+                if (selectedDetails == null) {
+                    root()
+                } else {
+                    CredentialDetailsScreen(
+                        details = selectedDetails,
+                        onBack = { backStack.removeLastOrNull() },
+                    )
+                }
+            }
+        },
+    )
+}
+
+internal fun SnapshotStateList<WalletRoute>.pushDetails(credentialId: String) {
+    removeAll { it is WalletRoute.CredentialDetails }
+    add(WalletRoute.CredentialDetails(credentialId))
+}
+
+internal fun SnapshotStateList<WalletRoute>.resetToRoot() {
+    clear()
+    add(WalletRoute.Root)
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppIosTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppIosTest.kt
@@ -6,20 +6,60 @@ class WalletDemoAppIosTest {
     private val scenarios = WalletDemoAppTestScenarios()
 
     @Test
-    fun pinSetupBootstrapsWalletAndShowsCredentials() =
-        scenarios.pinSetupBootstrapsWalletAndShowsCredentials()
+    fun credentialsTabShowsCompactCardsAndNavigatesToDetails() =
+        scenarios.credentialsTabShowsCompactCardsAndNavigatesToDetails()
 
     @Test
-    fun receiveFlowUpdatesStatusAndCredentialList() =
-        scenarios.receiveFlowUpdatesStatusAndCredentialList()
+    fun credentialsTabShowsEmptyStateAndUpdatesAfterReceive() =
+        scenarios.credentialsTabShowsEmptyStateAndUpdatesAfterReceive()
 
     @Test
-    fun presentFlowUpdatesStatus() =
-        scenarios.presentFlowUpdatesStatus()
+    fun receiveTabCanStartNewFlowAfterSuccess() =
+        scenarios.receiveTabCanStartNewFlowAfterSuccess()
 
     @Test
-    fun deepLinkReceiveAndPresentFlowUpdatesStatus() =
-        scenarios.deepLinkReceiveAndPresentFlowUpdatesStatus()
+    fun receiveDetailsStayScopedToReceiveTabNavigationStack() =
+        scenarios.receiveDetailsStayScopedToReceiveTabNavigationStack()
+
+    @Test
+    fun receiveTabDisablesUrlControlsWhileReceiving() =
+        scenarios.receiveTabDisablesUrlControlsWhileReceiving()
+
+    @Test
+    fun presentTabExplainsWhyPreviewIsUnavailableWithoutCredentials() =
+        scenarios.presentTabExplainsWhyPreviewIsUnavailableWithoutCredentials()
+
+    @Test
+    fun presentTabPreviewsCredentialsAndCanStartNewFlowAfterSuccess() =
+        scenarios.presentTabPreviewsCredentialsAndCanStartNewFlowAfterSuccess()
+
+    @Test
+    fun presentationDisclosureImagesRenderAsImages() =
+        scenarios.presentationDisclosureImagesRenderAsImages()
+
+    @Test
+    fun presentTabShowsReadableVerifierFallbackForDidClientIds() =
+        scenarios.presentTabShowsReadableVerifierFallbackForDidClientIds()
+
+    @Test
+    fun presentTabShowsReadableVerifierFallbackForX509SanDnsClientIds() =
+        scenarios.presentTabShowsReadableVerifierFallbackForX509SanDnsClientIds()
+
+    @Test
+    fun presentDetailsStayScopedToPresentTabNavigationStack() =
+        scenarios.presentDetailsStayScopedToPresentTabNavigationStack()
+
+    @Test
+    fun presentTabDisablesUrlControlsWhilePreviewing() =
+        scenarios.presentTabDisablesUrlControlsWhilePreviewing()
+
+    @Test
+    fun deepLinksRouteToReceiveAndPresentTabs() =
+        scenarios.deepLinksRouteToReceiveAndPresentTabs()
+
+    @Test
+    fun deepLinksResetReceiveAndPresentDetailStacksEvenWhenUrlIsUnchanged() =
+        scenarios.deepLinksResetReceiveAndPresentDetailStacksEvenWhenUrlIsUnchanged()
 
     @Test
     fun credentialsPersistAcrossControllerRecreation() =

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
@@ -4,10 +4,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -20,14 +29,20 @@ import id.walt.walletdemo.compose.logic.DemoWallet
 import id.walt.walletdemo.compose.logic.WalletDemoController
 import id.walt.walletdemo.compose.logic.WalletDemoCredential
 import id.walt.walletdemo.compose.logic.WalletDemoOperationResult
+import id.walt.walletdemo.compose.logic.WalletDemoPresentationCredentialOption
+import id.walt.walletdemo.compose.logic.WalletDemoPresentationDisclosure
+import id.walt.walletdemo.compose.logic.WalletDemoPresentationPreview
+import id.walt.walletdemo.compose.logic.WalletOperationState
 import id.walt.walletdemo.compose.logic.WalletSessionState
 import id.walt.walletdemo.compose.logic.statusText
+import kotlinx.coroutines.CompletableDeferred
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class WalletDemoAppTestScenarios {
 
-    fun pinSetupBootstrapsWalletAndShowsCredentials() = runComposeUiTest {
+    fun credentialsTabShowsCompactCardsAndNavigatesToDetails() = runComposeUiTest {
         val wallet = FakeDemoWallet(credentials = listOf(sampleCredential))
         val controller = WalletDemoController(wallet)
 
@@ -37,11 +52,44 @@ class WalletDemoAppTestScenarios {
 
         waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
         onNodeWithTag("wallet.status").assertTextContains("Wallet ready")
-        onNodeWithText("Example Credential").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.tab.credentials").assertIsDisplayed()
+        onNodeWithTag("wallet.tab.receive").assertIsDisplayed()
+        onNodeWithTag("wallet.tab.present").assertIsDisplayed()
+        onNodeWithContentDescription("Credentials tab").assertIsDisplayed()
+        onNodeWithContentDescription("Receive tab").assertIsDisplayed()
+        onNodeWithContentDescription("Present tab").assertIsDisplayed()
+        onNodeWithTag("wallet.credentialCard.cred-1").assertIsDisplayed()
+        onNodeWithContentDescription("Credential portrait").assertIsDisplayed()
+        onNodeWithText("Example Credential").assertIsDisplayed()
+        onNodeWithText("Mobile driving licence").assertIsDisplayed()
+        onNodeWithText("Ada Lovelace").assertIsDisplayed()
+        onNodeWithText("Expires 2026-06-17").assertIsDisplayed()
+
+        onNodeWithTag("wallet.credentialCard.cred-1").performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+        onNodeWithContentDescription("Back").assertIsDisplayed()
+        onNodeWithText("Credential details").assertIsDisplayed()
+        onAllNodesWithText("Example Credential").assertCountEquals(1)
+        onNodeWithText("Example Issuer").performScrollTo().assertIsDisplayed()
+        onNodeWithText("jwt_vc_json").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Given name").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Ada").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Resident address").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Main Street 1").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Portrait").performScrollTo().assertIsDisplayed()
+        onNodeWithContentDescription("Credential image").performScrollTo().assertIsDisplayed()
+        onNodeWithText("image/png").performScrollTo().assertIsDisplayed()
+        onAllNodesWithText("Raw credential data").assertCountEquals(0)
+        onNodeWithText("Show raw credential data").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Show raw credential data").performClick()
+        onNodeWithText("Raw credential data").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Credential data JSON").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.detailsBack").performClick()
+        onNodeWithTag("wallet.credentialCard.cred-1").assertIsDisplayed()
         assertEquals(1, wallet.bootstrapCalls)
     }
 
-    fun receiveFlowUpdatesStatusAndCredentialList() = runComposeUiTest {
+    fun credentialsTabShowsEmptyStateAndUpdatesAfterReceive() = runComposeUiTest {
         val wallet = FakeDemoWallet(receivedCredentialIds = listOf("cred-1", "cred-2"))
         val controller = WalletDemoController(wallet)
 
@@ -49,20 +97,80 @@ class WalletDemoAppTestScenarios {
         unlockWithPin()
         waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
 
+        onNodeWithTag("wallet.credentials.empty").assertIsDisplayed()
+        onNodeWithTag("wallet.tab.receive").performClick()
         wallet.credentials = listOf(sampleCredential)
-        onNodeWithTag("wallet.offerInput").performScrollTo().performTextInput("openid-credential-offer://example")
-        onNodeWithTag("wallet.receiveButton").performScrollTo().performSemanticsAction(SemanticsActions.OnClick)
+        onNodeWithTag("wallet.offerInput").performTextInput("openid-credential-offer://example")
+        onNodeWithTag("wallet.receiveButton").performSemanticsAction(SemanticsActions.OnClick)
 
         waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText.startsWith("Received") }
-        onNodeWithTag("wallet.status").assertTextContains("Received 2 credential(s)")
-        onNodeWithText("Example Credential").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.status").assertTextContains("Received 1 credential(s)")
+        onNodeWithTag("wallet.offerInput").assertIsNotEnabled()
+        onNodeWithTag("wallet.receiveNewButton").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.credentialCard.cred-1").performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+        onNodeWithText("Given name").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Ada").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.detailsBack").performClick()
+        onNodeWithTag("wallet.receiveTabContent").assertIsDisplayed()
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
+
+        onNodeWithTag("wallet.tab.credentials").performClick()
+        onNodeWithTag("wallet.credentialCard.cred-1").assertIsDisplayed()
         assertEquals("openid-credential-offer://example", wallet.receivedOfferUrl)
     }
 
-    fun presentFlowUpdatesStatus() = runComposeUiTest {
+    fun receiveTabCanStartNewFlowAfterSuccess() = runComposeUiTest {
+        val wallet = FakeDemoWallet(credentialsAfterReceive = listOf(sampleCredential))
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag("wallet.tab.receive").performClick()
+        onNodeWithTag("wallet.offerInput").performTextInput("openid-credential-offer://example")
+        onNodeWithTag("wallet.receiveButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText.startsWith("Received") }
+
+        onNodeWithTag("wallet.offerInput").assertIsNotEnabled()
+        onNodeWithTag("wallet.receiveNewButton").performScrollTo().performClick()
+        onNodeWithTag("wallet.offerInput").assertIsEnabled()
+        onNodeWithTag("wallet.offerInput").assertTextContains("")
+        onNodeWithTag("wallet.receiveButton").assertIsNotEnabled()
+    }
+
+    fun receiveDetailsStayScopedToReceiveTabNavigationStack() = runComposeUiTest {
+        val wallet = FakeDemoWallet(credentialsAfterReceive = listOf(sampleCredential))
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag("wallet.tab.receive").performClick()
+        onNodeWithTag("wallet.offerInput").performTextInput("openid-credential-offer://example")
+        onNodeWithTag("wallet.receiveButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText.startsWith("Received") }
+
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+
+        onNodeWithTag("wallet.tab.credentials").performClick()
+        onNodeWithTag("wallet.credentialCard.cred-1").assertIsDisplayed()
+        onAllNodesWithTag("wallet.credentialDetailsScreen").assertCountEquals(0)
+
+        onNodeWithTag("wallet.tab.receive").performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+        onNodeWithText("Given name").performScrollTo().assertIsDisplayed()
+    }
+
+    fun receiveTabDisablesUrlControlsWhileReceiving() = runComposeUiTest {
+        val receiveGate = CompletableDeferred<Unit>()
         val wallet = FakeDemoWallet(
-            credentials = listOf(sampleCredential),
-            presentationResult = WalletDemoOperationResult.Success("Presentation sent"),
+            credentialsAfterReceive = listOf(sampleCredential),
+            receiveGate = receiveGate,
         )
         val controller = WalletDemoController(wallet)
 
@@ -70,20 +178,224 @@ class WalletDemoAppTestScenarios {
         unlockWithPin()
         waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
 
-        onNodeWithTag("wallet.presentationInput").performScrollTo().performTextInput("openid4vp://example")
-        onNodeWithTag("wallet.presentButton").performScrollTo().performSemanticsAction(SemanticsActions.OnClick)
+        onNodeWithTag("wallet.tab.receive").performClick()
+        onNodeWithTag("wallet.offerInput").performTextInput("openid-credential-offer://example")
+        onNodeWithTag("wallet.receiveButton").performSemanticsAction(SemanticsActions.OnClick)
+
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.operation is WalletOperationState.Receiving }
+        onNodeWithTag("wallet.offerInput").assertIsNotEnabled()
+        onNodeWithTag("wallet.receiveButton").assertIsNotEnabled()
+
+        receiveGate.complete(Unit)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText.startsWith("Received") }
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
+    }
+
+    fun presentTabExplainsWhyPreviewIsUnavailableWithoutCredentials() = runComposeUiTest {
+        val wallet = FakeDemoWallet(credentials = emptyList())
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag(WalletUiTestTags.PresentTab).performClick()
+        onNodeWithTag(WalletUiTestTags.PresentationInput).performTextInput("openid4vp://example")
+
+        onNodeWithTag(WalletUiTestTags.PresentButton).assertIsNotEnabled()
+        onNodeWithText("No credentials available").performScrollTo().assertIsDisplayed()
+    }
+
+    fun presentTabPreviewsCredentialsAndCanStartNewFlowAfterSuccess() = runComposeUiTest {
+        val wallet = FakeDemoWallet(
+            credentials = listOf(sampleCredential),
+            presentationResult = WalletDemoOperationResult.Success("Presentation sent"),
+            presentationPreview = samplePresentationPreview,
+        )
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag("wallet.tab.present").performClick()
+        onNodeWithTag("wallet.presentationInput").performTextInput("openid4vp://example")
+        onNodeWithTag("wallet.presentButton").performSemanticsAction(SemanticsActions.OnClick)
+
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+        assertPresentationActionsFollowReviewContent()
+        onNodeWithTag("wallet.presentationInput").assertIsDisplayed()
+        onNodeWithTag("wallet.presentationInput").assertIsNotEnabled()
+        onNodeWithTag("wallet.presentationSubmitButton").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.presentationVerifier").performScrollTo().assertIsDisplayed()
+        onNodeWithText("Example Verifier").performScrollTo().assertIsDisplayed()
+        assertVerifierTechnicalDetailsCollapsedUntilRequested()
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
+
+        onNodeWithTag("wallet.credentialCard.cred-1").performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+        onNodeWithText("Disclosure 7").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.detailsBack").performClick()
+
+        onNodeWithTag("wallet.presentationSubmitButton").performScrollTo().performSemanticsAction(SemanticsActions.OnClick)
 
         waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText == "Presentation sent" }
         onNodeWithTag("wallet.status").assertTextContains("Presentation sent")
-        assertEquals("openid4vp://example", wallet.presentedRequestUrl)
+        onNodeWithTag("wallet.tab.credentials").performClick()
+        onNodeWithTag("wallet.status").assertTextContains("Wallet ready")
+        onNodeWithTag("wallet.tab.present").performClick()
+        onNodeWithTag("wallet.status").assertTextContains("Presentation sent")
+        onNodeWithTag("wallet.presentationInput").assertIsNotEnabled()
+        assertPresentationNewActionPrecedesReadOnlyReview()
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
+        onAllNodesWithTag("wallet.presentationSubmitButton").assertCountEquals(0)
+        onAllNodesWithTag("wallet.presentationCancelButton").assertCountEquals(0)
+        onNodeWithTag("wallet.presentationNewButton").performScrollTo().performClick()
+        onNodeWithTag("wallet.presentationInput").assertIsEnabled()
+        onNodeWithTag("wallet.presentButton").assertIsNotEnabled()
+        assertEquals("openid4vp://example", wallet.previewedRequestUrl)
+        assertEquals("openid4vp://example", wallet.submittedRequestUrl)
     }
 
-    fun deepLinkReceiveAndPresentFlowUpdatesStatus() = runComposeUiTest {
+    fun presentationDisclosureImagesRenderAsImages() = runComposeUiTest {
+        val wallet = FakeDemoWallet(
+            credentials = listOf(sampleCredential),
+            presentationPreview = samplePresentationPreview.copy(
+                credentialOptions = listOf(pathOnlyPortraitDisclosureCredentialOption),
+            ),
+        )
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag(WalletUiTestTags.PresentTab).performClick()
+        onNodeWithTag(WalletUiTestTags.PresentationInput).performTextInput("openid4vp://example")
+        onNodeWithTag(WalletUiTestTags.PresentButton).performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+
+        onNodeWithTag(WalletUiTestTags.credentialCard("cred-1")).performScrollTo().performClick()
+        onNodeWithTag(WalletUiTestTags.CredentialDetailsScreen).assertIsDisplayed()
+        onAllNodesWithText("$.portrait").assertCountEquals(0)
+        val portraitDisclosurePath = "disclosures[0].portrait"
+        onNodeWithTag(WalletUiTestTags.claim(portraitDisclosurePath)).performScrollTo().assertIsDisplayed()
+        onAllNodesWithText("Portrait").assertCountEquals(2)
+        onNodeWithTag(WalletUiTestTags.claimImage(portraitDisclosurePath)).assertIsDisplayed()
+    }
+
+    fun presentTabShowsReadableVerifierFallbackForDidClientIds() = runComposeUiTest {
+        val wallet = FakeDemoWallet(
+            credentials = listOf(sampleCredential),
+            presentationPreview = samplePresentationPreview.copy(
+                verifierName = null,
+                clientId = sampleDidClientId,
+            ),
+        )
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag("wallet.tab.present").performClick()
+        onNodeWithTag("wallet.presentationInput").performTextInput("openid4vp://example")
+        onNodeWithTag("wallet.presentButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+
+        onNodeWithText("DID verifier").performScrollTo().assertIsDisplayed()
+        onAllNodesWithText(sampleDidClientId).assertCountEquals(0)
+        onNodeWithTag("wallet.verifierTechnicalDetailsToggle").performScrollTo().performClick()
+        onNodeWithText(sampleDidClientId).performScrollTo().assertIsDisplayed()
+    }
+
+    fun presentTabShowsReadableVerifierFallbackForX509SanDnsClientIds() = runComposeUiTest {
+        val wallet = FakeDemoWallet(
+            credentials = listOf(sampleCredential),
+            presentationPreview = samplePresentationPreview.copy(
+                verifierName = null,
+                clientId = sampleX509SanDnsClientId,
+            ),
+        )
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag("wallet.tab.present").performClick()
+        onNodeWithTag("wallet.presentationInput").performTextInput("openid4vp://example")
+        onNodeWithTag("wallet.presentButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+
+        onNodeWithText("verifier.example").performScrollTo().assertIsDisplayed()
+        onAllNodesWithText(sampleX509SanDnsClientId).assertCountEquals(0)
+        onNodeWithTag("wallet.verifierTechnicalDetailsToggle").performScrollTo().performClick()
+        onNodeWithText(sampleX509SanDnsClientId).performScrollTo().assertIsDisplayed()
+    }
+
+    fun presentDetailsStayScopedToPresentTabNavigationStack() = runComposeUiTest {
+        val wallet = FakeDemoWallet(
+            credentials = listOf(sampleCredential),
+            presentationPreview = samplePresentationPreview,
+        )
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag("wallet.tab.present").performClick()
+        onNodeWithTag("wallet.presentationInput").performTextInput("openid4vp://example")
+        onNodeWithTag("wallet.presentButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+
+        onNodeWithTag("wallet.tab.credentials").performClick()
+        onNodeWithTag("wallet.credentialCard.cred-1").assertIsDisplayed()
+        onAllNodesWithTag("wallet.credentialDetailsScreen").assertCountEquals(0)
+
+        onNodeWithTag("wallet.tab.present").performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+        onNodeWithText("Requested disclosures").performScrollTo().assertIsDisplayed()
+    }
+
+    fun presentTabDisablesUrlControlsWhilePreviewing() = runComposeUiTest {
+        val previewGate = CompletableDeferred<Unit>()
+        val wallet = FakeDemoWallet(
+            credentials = listOf(sampleCredential),
+            presentationPreview = samplePresentationPreview,
+            previewGate = previewGate,
+        )
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        onNodeWithTag("wallet.tab.present").performClick()
+        onNodeWithTag("wallet.presentationInput").performTextInput("openid4vp://example")
+        onNodeWithTag("wallet.presentButton").performSemanticsAction(SemanticsActions.OnClick)
+
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText == "Resolving presentation..." }
+        onNodeWithTag("wallet.status").assertTextContains("Resolving presentation...")
+        onNodeWithTag("wallet.presentationInput").assertIsNotEnabled()
+        onNodeWithTag("wallet.presentButton").assertIsNotEnabled()
+
+        previewGate.complete(Unit)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+        onNodeWithTag("wallet.presentationSubmitButton").performScrollTo().assertIsDisplayed()
+    }
+
+    fun deepLinksRouteToReceiveAndPresentTabs() = runComposeUiTest {
         val offerUrl = "openid-credential-offer://example"
         val requestUrl = "openid4vp://example"
         val wallet = FakeDemoWallet(
             credentialsAfterReceive = listOf(sampleCredential),
             presentationResult = WalletDemoOperationResult.Success("Presentation sent"),
+            presentationPreview = samplePresentationPreview,
         )
         val controller = WalletDemoController(wallet)
 
@@ -93,22 +405,67 @@ class WalletDemoAppTestScenarios {
 
         controller.handleDeepLink(offerUrl)
         waitForIdle()
-        onNodeWithTag("wallet.offerInput").performScrollTo().assertTextContains(offerUrl)
+        onNodeWithTag("wallet.receiveTabContent").assertIsDisplayed()
+        onNodeWithTag("wallet.offerInput").assertTextContains(offerUrl)
 
-        onNodeWithTag("wallet.receiveButton").performScrollTo().performSemanticsAction(SemanticsActions.OnClick)
+        onNodeWithTag("wallet.receiveButton").performSemanticsAction(SemanticsActions.OnClick)
         waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText.startsWith("Received") }
         onNodeWithTag("wallet.status").assertTextContains("Received 1 credential(s)")
-        onNodeWithText("Example Credential").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
 
         controller.handleDeepLink(requestUrl)
         waitForIdle()
-        onNodeWithTag("wallet.presentationInput").performScrollTo().assertTextContains(requestUrl)
+        onNodeWithTag("wallet.presentTabContent").assertIsDisplayed()
+        onNodeWithTag("wallet.presentationInput").assertTextContains(requestUrl)
 
-        onNodeWithTag("wallet.presentButton").performScrollTo().performSemanticsAction(SemanticsActions.OnClick)
+        onNodeWithTag("wallet.presentButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+        onNodeWithTag("wallet.presentationSubmitButton").performSemanticsAction(SemanticsActions.OnClick)
         waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText == "Presentation sent" }
         onNodeWithTag("wallet.status").assertTextContains("Presentation sent")
         assertEquals(offerUrl, wallet.receivedOfferUrl)
-        assertEquals(requestUrl, wallet.presentedRequestUrl)
+        assertEquals(requestUrl, wallet.previewedRequestUrl)
+        assertEquals(requestUrl, wallet.submittedRequestUrl)
+    }
+
+    fun deepLinksResetReceiveAndPresentDetailStacksEvenWhenUrlIsUnchanged() = runComposeUiTest {
+        val offerUrl = "openid-credential-offer://example"
+        val requestUrl = "openid4vp://example"
+        val wallet = FakeDemoWallet(
+            credentialsAfterReceive = listOf(sampleCredential),
+            presentationPreview = samplePresentationPreview,
+        )
+        val controller = WalletDemoController(wallet)
+
+        setContent { WalletDemoApp(controller) }
+        unlockWithPin()
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.session is WalletSessionState.Ready }
+
+        controller.handleDeepLink(offerUrl)
+        onNodeWithTag("wallet.receiveButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.statusText.startsWith("Received") }
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+
+        controller.handleDeepLink(offerUrl)
+        waitForIdle()
+        onNodeWithTag("wallet.receiveTabContent").assertIsDisplayed()
+        onAllNodesWithTag("wallet.credentialDetailsScreen").assertCountEquals(0)
+        onNodeWithTag("wallet.offerInput").assertTextContains(offerUrl)
+        onNodeWithTag("wallet.receiveButton").assertIsEnabled()
+
+        controller.handleDeepLink(requestUrl)
+        onNodeWithTag("wallet.presentButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitUntil(timeoutMillis = 5_000) { controller.state.value.presentationPreview != null }
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().performClick()
+        onNodeWithTag("wallet.credentialDetailsScreen").assertIsDisplayed()
+
+        controller.handleDeepLink(requestUrl)
+        waitForIdle()
+        onNodeWithTag("wallet.presentTabContent").assertIsDisplayed()
+        onAllNodesWithTag("wallet.credentialDetailsScreen").assertCountEquals(0)
+        onNodeWithTag("wallet.presentationInput").assertTextContains(requestUrl)
+        onNodeWithTag("wallet.presentButton").assertIsEnabled()
     }
 
     fun credentialsPersistAcrossControllerRecreation() = runComposeUiTest {
@@ -121,9 +478,9 @@ class WalletDemoAppTestScenarios {
         waitUntil(timeoutMillis = 5_000) { firstController.state.value.session is WalletSessionState.Ready }
 
         firstController.handleDeepLink("openid-credential-offer://example")
-        onNodeWithTag("wallet.receiveButton").performScrollTo().performSemanticsAction(SemanticsActions.OnClick)
+        onNodeWithTag("wallet.receiveButton").performSemanticsAction(SemanticsActions.OnClick)
         waitUntil(timeoutMillis = 5_000) { firstController.state.value.statusText.startsWith("Received") }
-        onNodeWithText("Example Credential").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
 
         val recreatedController = WalletDemoController(wallet)
         activeController = recreatedController
@@ -131,7 +488,7 @@ class WalletDemoAppTestScenarios {
         unlockWithPin()
         waitUntil(timeoutMillis = 5_000) { recreatedController.state.value.session is WalletSessionState.Ready }
 
-        onNodeWithText("Example Credential").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.credentialCard.cred-1").assertIsDisplayed()
         assertEquals(2, wallet.bootstrapCalls)
     }
 
@@ -143,14 +500,145 @@ class WalletDemoAppTestScenarios {
         waitForIdle()
     }
 
-    private companion object {
+    private fun ComposeUiTest.assertPresentationActionsFollowReviewContent() {
+        val reviewLandmarkTags = onAllNodes(
+            matcher = hasAnyAncestor(hasTestTag("wallet.presentationReview")) and (
+                hasTestTag("wallet.presentationVerifier") or
+                    hasTestTag("wallet.presentationCredential.cred-1") or
+                    hasTestTag("wallet.presentationActions")
+                ),
+            useUnmergedTree = true,
+        )
+            .fetchSemanticsNodes()
+            .mapNotNull { it.config.getOrElseNullable(SemanticsProperties.TestTag) { null } }
+
+        val verifierIndex = reviewLandmarkTags.indexOf("wallet.presentationVerifier")
+        val credentialIndex = reviewLandmarkTags.indexOf("wallet.presentationCredential.cred-1")
+        val actionsIndex = reviewLandmarkTags.indexOf("wallet.presentationActions")
+
+        assertTrue(verifierIndex >= 0, "Verifier details are missing from presentation review: $reviewLandmarkTags")
+        assertTrue(credentialIndex >= 0, "Shared credential is missing from presentation review: $reviewLandmarkTags")
+        assertTrue(actionsIndex >= 0, "Share actions are missing from presentation review: $reviewLandmarkTags")
+        assertTrue(
+            verifierIndex < actionsIndex,
+            "Share action should follow verifier details so the verifier is reviewed before consent: $reviewLandmarkTags",
+        )
+        assertTrue(
+            credentialIndex < actionsIndex,
+            "Share action should follow shared credential details so the credential is reviewed before consent: $reviewLandmarkTags",
+        )
+    }
+
+    private fun ComposeUiTest.assertVerifierTechnicalDetailsCollapsedUntilRequested() {
+        onAllNodesWithText("Client ID").assertCountEquals(0)
+        onNodeWithTag("wallet.verifierTechnicalDetailsToggle").performScrollTo().assertIsDisplayed()
+        onNodeWithTag("wallet.verifierTechnicalDetailsToggle").performClick()
+        onNodeWithText("Client ID").performScrollTo().assertIsDisplayed()
+        onNodeWithText("https://verifier.example/response").performScrollTo().assertIsDisplayed()
+        onNodeWithText("state-123").performScrollTo().assertIsDisplayed()
+        onNodeWithText("nonce-456").performScrollTo().assertIsDisplayed()
+    }
+
+    private fun ComposeUiTest.assertPresentationNewActionPrecedesReadOnlyReview() {
+        val presentTabLandmarkTags = onAllNodes(
+            matcher = hasAnyAncestor(hasTestTag("wallet.presentTabContent")) and (
+                hasTestTag("wallet.presentationNewButton") or
+                    hasTestTag("wallet.presentationReview")
+                ),
+            useUnmergedTree = true,
+        )
+            .fetchSemanticsNodes()
+            .mapNotNull { it.config.getOrElseNullable(SemanticsProperties.TestTag) { null } }
+
+        val newActionIndex = presentTabLandmarkTags.indexOf("wallet.presentationNewButton")
+        val reviewIndex = presentTabLandmarkTags.indexOf("wallet.presentationReview")
+
+        assertTrue(newActionIndex >= 0, "New presentation action is missing: $presentTabLandmarkTags")
+        assertTrue(reviewIndex >= 0, "Read-only presentation review is missing: $presentTabLandmarkTags")
+        assertTrue(
+            newActionIndex < reviewIndex,
+            "New presentation action should precede the read-only review so starting over stays easy: $presentTabLandmarkTags",
+        )
+    }
+
+    companion object {
         val sampleCredential = WalletDemoCredential(
             id = "cred-1",
             format = "jwt_vc_json",
             issuer = "Example Issuer",
             label = "Example Credential",
-            addedAt = "2026-06-17",
+            addedAt = "2026-07-09",
+            credentialDataJson = """
+                {
+                  "vct": "https://issuer.example/credential-types/mobile-driving-licence",
+                  "given_name": "Ada",
+                  "family_name": "Lovelace",
+                  "valid_to": 1781654400,
+                  "resident_address": {
+                    "street_address": "Main Street 1",
+                    "locality": "Vienna"
+                  },
+                  "portrait": {
+                    "elementValue": [-119, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4, 0, 0, 0, -75, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, -38, 99, -4, -1, 31, 0, 3, 3, 2, 0, -17, -65, -89, -34, 0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126]
+                  }
+                }
+            """.trimIndent(),
         )
+
+        val samplePresentationPreview = WalletDemoPresentationPreview(
+            verifierName = "Example Verifier",
+            clientId = "https://verifier.example/client",
+            responseUri = "https://verifier.example/response",
+            state = "state-123",
+            nonce = "nonce-456",
+            credentialOptions = listOf(
+                WalletDemoPresentationCredentialOption(
+                    queryId = "pid",
+                    credentialId = "cred-1",
+                    label = "Example Credential",
+                    issuer = "Example Issuer",
+                    format = "jwt_vc_json",
+                    credentialDataJson = sampleCredential.credentialDataJson,
+                    disclosures = (1..7).map { index ->
+                        WalletDemoPresentationDisclosure(
+                            label = "Disclosure $index",
+                            valueJson = "\"Value $index\"",
+                            displayValue = "Value $index",
+                            selectivelyDisclosable = true,
+                        )
+                    } + WalletDemoPresentationDisclosure(
+                        label = "Portrait",
+                        path = "$.portrait",
+                        valueJson = samplePortraitDisclosureValueJson,
+                        displayValue = null,
+                        selectivelyDisclosable = true,
+                    ),
+                )
+            ),
+        )
+
+        val pathOnlyPortraitDisclosureCredentialOption = WalletDemoPresentationCredentialOption(
+            queryId = "pid",
+            credentialId = "cred-1",
+            label = "Example Credential",
+            issuer = "Example Issuer",
+            format = "jwt_vc_json",
+            credentialDataJson = sampleCredential.credentialDataJson,
+            disclosures = listOf(
+                WalletDemoPresentationDisclosure(
+                    label = "Portrait",
+                    path = "$.portrait",
+                    valueJson = samplePortraitDisclosureValueJson,
+                    displayValue = null,
+                    selectivelyDisclosable = true,
+                )
+            ),
+        )
+
+        const val sampleDidClientId = "decentralized_identifier:did:jwk:abc"
+        const val sampleX509SanDnsClientId = "x509_san_dns:verifier.example"
+        private const val samplePortraitDisclosureValueJson =
+            "[-119, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4, 0, 0, 0, -75, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, -38, 99, -4, -1, 31, 0, 3, 3, 2, 0, -17, -65, -89, -34, 0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126]"
     }
 }
 
@@ -159,10 +647,15 @@ private class FakeDemoWallet(
     private val receivedCredentialIds: List<String> = listOf("cred-1"),
     private val credentialsAfterReceive: List<WalletDemoCredential>? = null,
     private val presentationResult: WalletDemoOperationResult = WalletDemoOperationResult.Success("Presentation sent"),
+    private val presentationPreview: WalletDemoPresentationPreview = WalletDemoAppTestScenarios.samplePresentationPreview,
+    private val receiveGate: CompletableDeferred<Unit>? = null,
+    private val previewGate: CompletableDeferred<Unit>? = null,
 ) : DemoWallet {
     var bootstrapCalls = 0
     var receivedOfferUrl: String? = null
     var presentedRequestUrl: String? = null
+    var previewedRequestUrl: String? = null
+    var submittedRequestUrl: String? = null
 
     override suspend fun bootstrap(): WalletDemoBootstrapResult {
         bootstrapCalls += 1
@@ -173,12 +666,28 @@ private class FakeDemoWallet(
 
     override suspend fun receive(offerUrl: String): List<String> {
         receivedOfferUrl = offerUrl
+        receiveGate?.await()
         credentialsAfterReceive?.let { credentials = it }
         return receivedCredentialIds
     }
 
     override suspend fun present(requestUrl: String, did: String?): WalletDemoOperationResult {
         presentedRequestUrl = requestUrl
+        return presentationResult
+    }
+
+    override suspend fun previewPresentation(requestUrl: String): WalletDemoPresentationPreview {
+        previewedRequestUrl = requestUrl
+        previewGate?.await()
+        return presentationPreview
+    }
+
+    override suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String?,
+    ): WalletDemoOperationResult {
+        submittedRequestUrl = requestUrl
         return presentationResult
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -12,12 +12,34 @@
 		71E100012FDAE00000000001 /* WalletSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 519D794773D1421EEC9493DE /* WalletSDK */; };
 		71E100022FDAE00000000002 /* TestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D690444A2FDAA5D2009AB1FB /* TestHelpers.framework */; };
 		A1000001AAAA000100000001 /* WalletViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000001AAAA000000000001 /* WalletViewModel.swift */; };
+		A1000020AAAA000100000020 /* WalletClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000020AAAA000000000020 /* WalletClient.swift */; };
+		A1000021AAAA000100000021 /* MockWalletClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000021AAAA000000000021 /* MockWalletClient.swift */; };
 		A1000002AAAA000100000002 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000002AAAA000000000002 /* HomeView.swift */; };
 		A1000003AAAA000100000003 /* ReceiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000003AAAA000000000003 /* ReceiveView.swift */; };
 		A1000004AAAA000100000004 /* PresentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000004AAAA000000000004 /* PresentView.swift */; };
+		A1000015AAAA000100000015 /* CredentialDetailsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000015AAAA000000000015 /* CredentialDetailsScreen.swift */; };
+		A1000016AAAA000100000016 /* CredentialCardSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000016AAAA000000000016 /* CredentialCardSummary.swift */; };
+		A1000017AAAA000100000017 /* CredentialsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000017AAAA000000000017 /* CredentialsTabView.swift */; };
+		A1000018AAAA000100000018 /* CredentialDetailsDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000018AAAA000000000018 /* CredentialDetailsDestination.swift */; };
+		A1000019AAAA000100000019 /* EmptyCredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000019AAAA000000000019 /* EmptyCredentialsView.swift */; };
+		A100001AAAAA00010000001A /* UrlEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001AAAAA00000000001A /* UrlEditor.swift */; };
 		A1000006AAAA000100000006 /* StatusBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000006AAAA000000000006 /* StatusBannerView.swift */; };
 		A1000007AAAA000100000007 /* CredentialCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000007AAAA000000000007 /* CredentialCardView.swift */; };
 		A1000008AAAA000100000008 /* WalletColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000008AAAA000000000008 /* WalletColors.swift */; };
+		A1000009AAAA000100000009 /* CredentialDisplayModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000009AAAA000000000009 /* CredentialDisplayModels.swift */; };
+		A100000AAAAA00010000000A /* CredentialDisplayNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000AAAAA00000000000A /* CredentialDisplayNormalizer.swift */; };
+		A1000022AAAA000100000022 /* CredentialDisplayVocabulary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000022AAAA000000000022 /* CredentialDisplayVocabulary.swift */; };
+		A1000023AAAA000100000023 /* CredentialDisplayValueDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000023AAAA000000000023 /* CredentialDisplayValueDecoder.swift */; };
+		A1000029AAAA000100000029 /* ClaimPathExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000029AAAA000000000029 /* ClaimPathExpression.swift */; };
+		A1000028AAAA000100000028 /* CredentialTypeIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000028AAAA000000000028 /* CredentialTypeIdentifier.swift */; };
+		A1000024AAAA000100000024 /* VerifierDisplayName.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000024AAAA000000000024 /* VerifierDisplayName.swift */; };
+		A1000027AAAA000100000027 /* VerifierClientIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000027AAAA000000000027 /* VerifierClientIdentifier.swift */; };
+		A1000025AAAA000100000025 /* WalletAccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000025AAAA000000000025 /* WalletAccessibilityID.swift */; };
+		A100000BAAAA00010000000B /* ClaimValueRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000BAAAA00000000000B /* ClaimValueRow.swift */; };
+		A100000CAAAA00010000000C /* ClaimGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000CAAAA00000000000C /* ClaimGroupView.swift */; };
+		A100000DAAAA00010000000D /* CredentialDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000DAAAA00000000000D /* CredentialDetailsView.swift */; };
+		A100000EAAAA00010000000E /* VerifierDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000EAAAA00000000000E /* VerifierDetailsView.swift */; };
+		A100000FAAAA00010000000F /* PresentationReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100000FAAAA00000000000F /* PresentationReviewView.swift */; };
 		B33B17EA2C2C394F001A32F7 /* WalletDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33B17E92C2C394F001A32F7 /* WalletDemoApp.swift */; };
 		B33B17EC2C2C394F001A32F7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B33B17EB2C2C394F001A32F7 /* ContentView.swift */; };
 		B33B17EE2C2C3957001A32F7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B33B17ED2C2C3957001A32F7 /* Assets.xcassets */; };
@@ -25,6 +47,7 @@
 		D69044582FDAA6DB009AB1FB /* TestHelpers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D690444A2FDAA5D2009AB1FB /* TestHelpers.framework */; };
 		E2E00002AAAA000100000002 /* PublicDemoBackendE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E00002AAAA000000000002 /* PublicDemoBackendE2ETests.swift */; };
 		E2E00003AAAA000100000003 /* WalletE2EHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E00003AAAA000000000003 /* WalletE2EHelpers.swift */; };
+		E2E00004AAAA000100000004 /* MockWalletUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E00004AAAA000000000014 /* MockWalletUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,12 +76,34 @@
 
 /* Begin PBXFileReference section */
 		A1000001AAAA000000000001 /* WalletViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletViewModel.swift; sourceTree = "<group>"; };
+		A1000020AAAA000000000020 /* WalletClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletClient.swift; sourceTree = "<group>"; };
+		A1000021AAAA000000000021 /* MockWalletClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWalletClient.swift; sourceTree = "<group>"; };
 		A1000002AAAA000000000002 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		A1000003AAAA000000000003 /* ReceiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveView.swift; sourceTree = "<group>"; };
 		A1000004AAAA000000000004 /* PresentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentView.swift; sourceTree = "<group>"; };
+		A1000015AAAA000000000015 /* CredentialDetailsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDetailsScreen.swift; sourceTree = "<group>"; };
+		A1000016AAAA000000000016 /* CredentialCardSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialCardSummary.swift; sourceTree = "<group>"; };
+		A1000017AAAA000000000017 /* CredentialsTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsTabView.swift; sourceTree = "<group>"; };
+		A1000018AAAA000000000018 /* CredentialDetailsDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDetailsDestination.swift; sourceTree = "<group>"; };
+		A1000019AAAA000000000019 /* EmptyCredentialsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCredentialsView.swift; sourceTree = "<group>"; };
+		A100001AAAAA00000000001A /* UrlEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlEditor.swift; sourceTree = "<group>"; };
 		A1000006AAAA000000000006 /* StatusBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBannerView.swift; sourceTree = "<group>"; };
 		A1000007AAAA000000000007 /* CredentialCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialCardView.swift; sourceTree = "<group>"; };
 		A1000008AAAA000000000008 /* WalletColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletColors.swift; sourceTree = "<group>"; };
+		A1000009AAAA000000000009 /* CredentialDisplayModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDisplayModels.swift; sourceTree = "<group>"; };
+		A100000AAAAA00000000000A /* CredentialDisplayNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDisplayNormalizer.swift; sourceTree = "<group>"; };
+		A1000022AAAA000000000022 /* CredentialDisplayVocabulary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDisplayVocabulary.swift; sourceTree = "<group>"; };
+		A1000023AAAA000000000023 /* CredentialDisplayValueDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDisplayValueDecoder.swift; sourceTree = "<group>"; };
+		A1000029AAAA000000000029 /* ClaimPathExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimPathExpression.swift; sourceTree = "<group>"; };
+		A1000028AAAA000000000028 /* CredentialTypeIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialTypeIdentifier.swift; sourceTree = "<group>"; };
+		A1000024AAAA000000000024 /* VerifierDisplayName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifierDisplayName.swift; sourceTree = "<group>"; };
+		A1000027AAAA000000000027 /* VerifierClientIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifierClientIdentifier.swift; sourceTree = "<group>"; };
+		A1000025AAAA000000000025 /* WalletAccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAccessibilityID.swift; sourceTree = "<group>"; };
+		A100000BAAAA00000000000B /* ClaimValueRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimValueRow.swift; sourceTree = "<group>"; };
+		A100000CAAAA00000000000C /* ClaimGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimGroupView.swift; sourceTree = "<group>"; };
+		A100000DAAAA00000000000D /* CredentialDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialDetailsView.swift; sourceTree = "<group>"; };
+		A100000EAAAA00000000000E /* VerifierDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifierDetailsView.swift; sourceTree = "<group>"; };
+		A100000FAAAA00000000000F /* PresentationReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationReviewView.swift; sourceTree = "<group>"; };
 		B30E22802C2D8AD700D4781C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B33B17E62C2C394F001A32F7 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B33B17E92C2C394F001A32F7 /* WalletDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletDemoApp.swift; sourceTree = "<group>"; };
@@ -69,6 +114,7 @@
 		D6B7A34A2FD94CC3009C69E7 /* iosAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2E00002AAAA000000000002 /* PublicDemoBackendE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicDemoBackendE2ETests.swift; sourceTree = "<group>"; };
 		E2E00003AAAA000000000003 /* WalletE2EHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletE2EHelpers.swift; sourceTree = "<group>"; };
+		E2E00004AAAA000000000014 /* MockWalletUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWalletUITests.swift; sourceTree = "<group>"; };
 		E2E00004AAAA000000000004 /* iosAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -164,6 +210,8 @@
 			isa = PBXGroup;
 			children = (
 				A1000001AAAA000000000001 /* WalletViewModel.swift */,
+				A1000020AAAA000000000020 /* WalletClient.swift */,
+				A1000021AAAA000000000021 /* MockWalletClient.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -172,8 +220,11 @@
 			isa = PBXGroup;
 			children = (
 				A1000002AAAA000000000002 /* HomeView.swift */,
+				A1000017AAAA000000000017 /* CredentialsTabView.swift */,
 				A1000003AAAA000000000003 /* ReceiveView.swift */,
 				A1000004AAAA000000000004 /* PresentView.swift */,
+				A1000015AAAA000000000015 /* CredentialDetailsScreen.swift */,
+				A1000018AAAA000000000018 /* CredentialDetailsDestination.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -182,9 +233,32 @@
 			isa = PBXGroup;
 			children = (
 				A1000006AAAA000000000006 /* StatusBannerView.swift */,
+				A100001AAAAA00000000001A /* UrlEditor.swift */,
 				A1000007AAAA000000000007 /* CredentialCardView.swift */,
+				A1000019AAAA000000000019 /* EmptyCredentialsView.swift */,
+				A100000BAAAA00000000000B /* ClaimValueRow.swift */,
+				A100000CAAAA00000000000C /* ClaimGroupView.swift */,
+				A100000DAAAA00000000000D /* CredentialDetailsView.swift */,
+				A100000EAAAA00000000000E /* VerifierDetailsView.swift */,
+				A100000FAAAA00000000000F /* PresentationReviewView.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		A1000014AAAA000000000014 /* Display */ = {
+			isa = PBXGroup;
+			children = (
+				A1000009AAAA000000000009 /* CredentialDisplayModels.swift */,
+				A1000029AAAA000000000029 /* ClaimPathExpression.swift */,
+				A1000022AAAA000000000022 /* CredentialDisplayVocabulary.swift */,
+				A100000AAAAA00000000000A /* CredentialDisplayNormalizer.swift */,
+				A1000023AAAA000000000023 /* CredentialDisplayValueDecoder.swift */,
+				A1000028AAAA000000000028 /* CredentialTypeIdentifier.swift */,
+				A1000016AAAA000000000016 /* CredentialCardSummary.swift */,
+				A1000027AAAA000000000027 /* VerifierClientIdentifier.swift */,
+				A1000024AAAA000000000024 /* VerifierDisplayName.swift */,
+			);
+			path = Display;
 			sourceTree = "<group>";
 		};
 		A1000013AAAA000000000013 /* Theme */ = {
@@ -226,8 +300,10 @@
 				B30E22802C2D8AD700D4781C /* Info.plist */,
 				B33B17E92C2C394F001A32F7 /* WalletDemoApp.swift */,
 				B33B17EB2C2C394F001A32F7 /* ContentView.swift */,
+				A1000025AAAA000000000025 /* WalletAccessibilityID.swift */,
 				A1000010AAAA000000000010 /* ViewModels */,
 				A1000011AAAA000000000011 /* Views */,
+				A1000014AAAA000000000014 /* Display */,
 				A1000012AAAA000000000012 /* Components */,
 				A1000013AAAA000000000013 /* Theme */,
 				B33B17ED2C2C3957001A32F7 /* Assets.xcassets */,
@@ -239,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				E2E00002AAAA000000000002 /* PublicDemoBackendE2ETests.swift */,
+				E2E00004AAAA000000000014 /* MockWalletUITests.swift */,
 				E2E00003AAAA000000000003 /* WalletE2EHelpers.swift */,
 			);
 			path = iosAppUITests;
@@ -458,12 +535,34 @@
 				B33B17EC2C2C394F001A32F7 /* ContentView.swift in Sources */,
 				B33B17EA2C2C394F001A32F7 /* WalletDemoApp.swift in Sources */,
 				A1000001AAAA000100000001 /* WalletViewModel.swift in Sources */,
+				A1000020AAAA000100000020 /* WalletClient.swift in Sources */,
+				A1000021AAAA000100000021 /* MockWalletClient.swift in Sources */,
 				A1000002AAAA000100000002 /* HomeView.swift in Sources */,
+				A1000017AAAA000100000017 /* CredentialsTabView.swift in Sources */,
 				A1000003AAAA000100000003 /* ReceiveView.swift in Sources */,
 				A1000004AAAA000100000004 /* PresentView.swift in Sources */,
+				A1000015AAAA000100000015 /* CredentialDetailsScreen.swift in Sources */,
+				A1000018AAAA000100000018 /* CredentialDetailsDestination.swift in Sources */,
 				A1000006AAAA000100000006 /* StatusBannerView.swift in Sources */,
+				A100001AAAAA00010000001A /* UrlEditor.swift in Sources */,
 				A1000007AAAA000100000007 /* CredentialCardView.swift in Sources */,
+				A1000019AAAA000100000019 /* EmptyCredentialsView.swift in Sources */,
 				A1000008AAAA000100000008 /* WalletColors.swift in Sources */,
+				A1000009AAAA000100000009 /* CredentialDisplayModels.swift in Sources */,
+				A1000029AAAA000100000029 /* ClaimPathExpression.swift in Sources */,
+				A1000022AAAA000100000022 /* CredentialDisplayVocabulary.swift in Sources */,
+				A100000AAAAA00010000000A /* CredentialDisplayNormalizer.swift in Sources */,
+				A1000023AAAA000100000023 /* CredentialDisplayValueDecoder.swift in Sources */,
+				A1000028AAAA000100000028 /* CredentialTypeIdentifier.swift in Sources */,
+				A1000016AAAA000100000016 /* CredentialCardSummary.swift in Sources */,
+				A1000027AAAA000100000027 /* VerifierClientIdentifier.swift in Sources */,
+				A1000024AAAA000100000024 /* VerifierDisplayName.swift in Sources */,
+				A1000025AAAA000100000025 /* WalletAccessibilityID.swift in Sources */,
+				A100000BAAAA00010000000B /* ClaimValueRow.swift in Sources */,
+				A100000CAAAA00010000000C /* ClaimGroupView.swift in Sources */,
+				A100000DAAAA00010000000D /* CredentialDetailsView.swift in Sources */,
+				A100000EAAAA00010000000E /* VerifierDetailsView.swift in Sources */,
+				A100000FAAAA00010000000F /* PresentationReviewView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -493,6 +592,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E2E00002AAAA000100000002 /* PublicDemoBackendE2ETests.swift in Sources */,
+				E2E00004AAAA000100000004 /* MockWalletUITests.swift in Sources */,
 				E2E00003AAAA000100000003 /* WalletE2EHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -570,7 +670,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -627,7 +727,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -708,7 +808,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -746,7 +846,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -783,7 +883,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = id.walt.iosAppEnterpriseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -809,7 +909,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = id.walt.iosAppEnterpriseTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -835,7 +935,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = id.walt.iosAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -861,7 +961,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = id.walt.iosAppTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -881,7 +981,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -902,7 +1002,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/ClaimGroupView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/ClaimGroupView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ClaimGroupView: View {
+    let group: ClaimGroup
+
+    var body: some View {
+        if !group.items.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(group.title)
+                    .font(.subheadline.weight(.semibold))
+                    .accessibilityIdentifier(WalletAccessibilityID.claimGroup(group.title))
+                ForEach(group.items) { item in
+                    ClaimValueRow(item: item)
+                }
+            }
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/ClaimValueRow.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/ClaimValueRow.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import UIKit
+
+struct ClaimValueRow: View {
+    let item: ClaimItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(item.label)
+                .font(.caption.weight(item.requested ? .semibold : .medium))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityIdentifier(WalletAccessibilityID.claim(item.path.id))
+            ClaimValueView(value: item.value, path: item.path)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+private struct ClaimValueView: View {
+    let value: DisplayValue
+    let path: ClaimItemPath
+
+    var body: some View {
+        switch value {
+        case .bool(let value):
+            Text(value ? "true" : "false")
+                .font(.caption)
+        case .decodedText(let value), .text(let value), .number(let value):
+            Text(value)
+                .font(.caption)
+        case .image(_, let data, let mimeType, let byteCount):
+            ImageValue(data: data, mimeType: mimeType, byteCount: byteCount, path: path)
+        case .list(let values):
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(values.enumerated()), id: \.offset) { index, value in
+                    HStack(alignment: .top, spacing: 4) {
+                        Text("\(index + 1).")
+                            .font(.caption)
+                        ClaimValueView(value: value, path: path.indexedChild(index))
+                    }
+                }
+            }
+        case .null:
+            Text("Not provided")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        case .object(let entries):
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(entries) { entry in
+                    ClaimValueRow(item: entry)
+                }
+            }
+        case .raw(let value):
+            Text(value)
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+private struct ImageValue: View {
+    let data: Data
+    let mimeType: String?
+    let byteCount: Int
+    let path: ClaimItemPath
+
+    var body: some View {
+        if let image {
+            content(image: image)
+                .accessibilityIdentifier(WalletAccessibilityID.claimImage(path.id))
+        } else {
+            content(image: nil)
+        }
+    }
+
+    private func content(image: UIImage?) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 160)
+                    .accessibilityLabel("Credential image")
+            }
+            Text(mimeType ?? "Image")
+                .font(.caption.weight(.medium))
+            Text(metadata)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(8)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var image: UIImage? {
+        return UIImage(data: data)
+    }
+
+    private var metadata: String {
+        "\(byteCount) bytes"
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/CredentialCardView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/CredentialCardView.swift
@@ -1,32 +1,91 @@
 import SwiftUI
+import UIKit
 import WalletSDK
 
 struct CredentialCardView: View {
-    let credential: Credential
+    let details: CredentialDetails
+
+    init(details: CredentialDetails) {
+        self.details = details
+    }
+
+    init(credential: Credential) {
+        self.details = CredentialDisplayNormalizer.details(for: credential)
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(credential.label ?? credential.format)
-                .font(.headline)
-                .lineLimit(1)
-            HStack {
-                Text(credential.issuer ?? "Unknown")
+        HStack(alignment: .top, spacing: 12) {
+            CredentialPortraitView(summary: details.cardSummary, size: 56)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(details.cardSummary.title)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+                if let credentialType = details.cardSummary.credentialType {
+                    Text(credentialType)
+                        .font(.caption)
+                        .foregroundColor(.accentColor)
+                }
+                if let holderName = details.cardSummary.holderName {
+                    Text(holderName)
+                        .font(.caption)
+                        .foregroundColor(.primary)
+                }
+                Text(details.issuer ?? "Unknown issuer")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .lineLimit(1)
-                Spacer()
-                if let addedAt = credential.addedAt {
-                    Text(addedAt.formatted(date: .abbreviated, time: .omitted))
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
+                HStack(spacing: 8) {
+                    Text(details.format)
+                    if let validityText = details.cardSummary.validityText {
+                        Text(validityText)
+                    }
                 }
-            }
-            Text("Format: \(credential.format)")
                 .font(.caption2)
-                .foregroundColor(.gray)
+                .foregroundColor(.secondary)
+            }
+
+            Spacer(minLength: 0)
         }
         .padding()
         .background(Color(.systemGray6))
-        .cornerRadius(12)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct CredentialCardButton: View {
+    let details: CredentialDetails
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            CredentialCardView(details: details)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(WalletAccessibilityID.credentialCard(details.id))
+    }
+}
+
+struct CredentialPortraitView: View {
+    let summary: CredentialCardSummary
+    let size: CGFloat
+
+    var body: some View {
+        Group {
+            if let data = summary.portraitData, let image = UIImage(data: data) {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Image(systemName: "person.text.rectangle")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(width: size, height: size)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityLabel("Credential portrait")
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/CredentialDetailsView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/CredentialDetailsView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct CredentialDetailsView: View {
+    let details: CredentialDetails
+    var includeTechnicalDetails = false
+    @State private var showTechnicalDetails = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Credential details")
+                .font(.subheadline.weight(.semibold))
+                .accessibilityIdentifier(WalletAccessibilityID.credentialDetails(details.id))
+
+            CredentialOverviewView(details: details)
+
+            if details.groups.isEmpty && details.technicalGroups.isEmpty {
+                Text("No credential details available")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            ForEach(details.groups) { group in
+                ClaimGroupView(group: group)
+            }
+
+            if includeTechnicalDetails && !details.technicalGroups.isEmpty {
+                Button(showTechnicalDetails ? "Hide raw credential data" : "Show raw credential data") {
+                    showTechnicalDetails.toggle()
+                }
+                .buttonStyle(.borderless)
+            }
+
+            if showTechnicalDetails {
+                ForEach(details.technicalGroups) { group in
+                    ClaimGroupView(group: group)
+                }
+            }
+        }
+    }
+}
+
+private struct CredentialOverviewView: View {
+    let details: CredentialDetails
+
+    private var summary: CredentialCardSummary {
+        details.cardSummary
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            CredentialPortraitView(summary: summary, size: 64)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(summary.title)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+
+                if let credentialType = summary.credentialType {
+                    Text(credentialType)
+                        .font(.caption)
+                        .foregroundStyle(.tint)
+                }
+
+                if let holderName = summary.holderName {
+                    Text(holderName)
+                        .font(.caption)
+                }
+
+                Text(details.issuer ?? "Unknown issuer")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                HStack(spacing: 8) {
+                    Text(details.format)
+                    if let validityText = summary.validityText {
+                        Text(validityText)
+                    }
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityIdentifier(WalletAccessibilityID.credentialOverview(details.id))
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/EmptyCredentialsView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/EmptyCredentialsView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct EmptyCredentialsView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: "wallet.pass")
+                .font(.title)
+                .foregroundStyle(.secondary)
+            Text("No credentials yet")
+                .font(.headline)
+            Text("Received credentials will appear here automatically.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityIdentifier(WalletAccessibilityID.credentialsEmpty)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/PresentationReviewView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/PresentationReviewView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import WalletSDK
+
+struct PresentationReviewView: View {
+    let preview: PresentationPreview
+    let selectedCredentialIDs: Set<String>
+    let isLoading: Bool
+    let isReadOnly: Bool
+    let onToggleCredential: (String) -> Void
+    let onCredentialSelected: (String) -> Void
+    let onSubmit: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VerifierDetailsView(request: preview.request)
+
+            Text("Shared credentials")
+                .font(.subheadline.weight(.semibold))
+
+            ForEach(preview.credentialOptions) { option in
+                VStack(alignment: .leading, spacing: 10) {
+                    let details = CredentialDisplayNormalizer.details(for: option)
+                    if !isReadOnly {
+                        Toggle(isOn: Binding(get: {
+                            selectedCredentialIDs.contains(option.credentialID)
+                        }, set: { _ in
+                            onToggleCredential(option.credentialID)
+                        })) {
+                            Text(option.label ?? option.format)
+                                .font(.subheadline.weight(.medium))
+                        }
+                        .disabled(isLoading)
+                        .accessibilityIdentifier(WalletAccessibilityID.presentationCredential(option.credentialID))
+                    }
+
+                    CredentialCardButton(details: details) {
+                        onCredentialSelected(option.credentialID)
+                    }
+                    .padding(.leading, isReadOnly ? 0 : 28)
+
+                    Divider()
+                }
+            }
+
+            if !isReadOnly {
+                PresentationReviewActionsView(
+                    selectedCredentialIDs: selectedCredentialIDs,
+                    isLoading: isLoading,
+                    onSubmit: onSubmit,
+                    onCancel: onCancel
+                )
+            }
+        }
+    }
+}
+
+private struct PresentationReviewActionsView: View {
+    let selectedCredentialIDs: Set<String>
+    let isLoading: Bool
+    let onSubmit: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button("Share", action: onSubmit)
+                .buttonStyle(.borderedProminent)
+                .tint(.waltBlue)
+                .disabled(isLoading || selectedCredentialIDs.isEmpty)
+                .accessibilityIdentifier(WalletAccessibilityID.presentationSubmitButton)
+
+            Button("Cancel review", action: onCancel)
+                .buttonStyle(.bordered)
+                .disabled(isLoading)
+                .accessibilityIdentifier(WalletAccessibilityID.presentationCancelButton)
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/StatusBannerView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/StatusBannerView.swift
@@ -14,7 +14,7 @@ struct StatusBannerView: View {
             Text(message)
                 .font(.subheadline)
                 .lineLimit(2)
-                .accessibilityIdentifier("wallet.status")
+                .accessibilityIdentifier(WalletAccessibilityID.status)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/UrlEditor.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/UrlEditor.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct UrlEditor: View {
+    let title: String
+    let label: String
+    @Binding var text: String
+    let inputIdentifier: String
+    let isEnabled: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.headline)
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            TextEditor(text: $text)
+                .font(.footnote.monospaced())
+                .frame(minHeight: 52, maxHeight: 76)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(.separator), lineWidth: 1)
+                )
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .disabled(!isEnabled)
+                .accessibilityIdentifier(inputIdentifier)
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/VerifierDetailsView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/VerifierDetailsView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import WalletSDK
+
+struct VerifierDetailsView: View {
+    let request: PresentationRequestInfo
+    @State private var technicalDetailsExpanded = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Verifier")
+                .font(.subheadline.weight(.semibold))
+            Text(VerifierDisplayName.value(
+                verifierName: request.verifierName,
+                clientID: request.clientID,
+                responseURI: request.responseURI
+            ))
+                .font(.subheadline.weight(.medium))
+            DetailLine(label: "Trust", value: CredentialDisplayText.unknown)
+
+            Button(technicalDetailsExpanded ? "Hide technical details" : "Show technical details") {
+                technicalDetailsExpanded.toggle()
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier(WalletAccessibilityID.verifierTechnicalDetailsToggle)
+
+            if technicalDetailsExpanded {
+                VStack(alignment: .leading, spacing: 6) {
+                    DetailLine(label: "Client ID", value: request.clientID)
+                    DetailLine(label: "Response URI", value: request.responseURI?.absoluteString)
+                    DetailLine(label: "State", value: request.state)
+                    DetailLine(label: "Nonce", value: request.nonce)
+                }
+                .accessibilityIdentifier(WalletAccessibilityID.verifierTechnicalDetails)
+            }
+        }
+        .accessibilityIdentifier(WalletAccessibilityID.presentationVerifier)
+    }
+}
+
+private struct DetailLine: View {
+    let label: String
+    let value: String?
+
+    var body: some View {
+        if let value, !value.isEmpty {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(value)
+                    .font(.caption)
+            }
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/ClaimPathExpression.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/ClaimPathExpression.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+struct ClaimPathExpression {
+    enum Segment: Equatable {
+        case key(String)
+        case index(Int)
+        case wildcard
+    }
+
+    let segments: [Segment]
+
+    var leafKey: String? {
+        segments.reversed().compactMap { segment in
+            if case .key(let value) = segment { return value }
+            return nil
+        }.first
+    }
+
+    static func parse(_ rawValue: String) -> ClaimPathExpression {
+        var parser = ClaimPathExpressionParser(rawValue: rawValue)
+        return parser.parse()
+    }
+}
+
+private struct ClaimPathExpressionParser {
+    private let characters: [Character]
+    private var index = 0
+    private var segments: [ClaimPathExpression.Segment] = []
+
+    init(rawValue: String) {
+        self.characters = Array(rawValue.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    mutating func parse() -> ClaimPathExpression {
+        while index < characters.count {
+            switch characters[index] {
+            case "$", ".", " ", "\n", "\r", "\t":
+                index += 1
+            case "[":
+                addBracketSegment()
+            default:
+                addKey(readDotSegment())
+            }
+        }
+        return ClaimPathExpression(segments: segments)
+    }
+
+    private mutating func addBracketSegment() {
+        index += 1
+        skipWhitespace()
+        let segment: String
+        if index < characters.count, characters[index].isQuote {
+            segment = readQuotedSegment(quote: characters[index])
+        } else {
+            segment = readUnquotedBracketSegment()
+        }
+        skipUntilBracketEnd()
+        addToken(segment)
+    }
+
+    private mutating func addToken(_ rawSegment: String) {
+        let segment = rawSegment.trimmingCharacters(in: .whitespacesAndNewlines)
+        if segment.isEmpty {
+            return
+        }
+        if segment == "*" {
+            segments.append(.wildcard)
+        } else if let intValue = Int(segment) {
+            segments.append(.index(intValue))
+        } else {
+            addKey(segment)
+        }
+    }
+
+    private mutating func addKey(_ rawSegment: String) {
+        let segment = rawSegment.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !segment.isEmpty {
+            segments.append(.key(segment))
+        }
+    }
+
+    private mutating func skipWhitespace() {
+        while index < characters.count, characters[index].isWhitespace {
+            index += 1
+        }
+    }
+
+    private mutating func skipUntilBracketEnd() {
+        while index < characters.count, characters[index] != "]" {
+            index += 1
+        }
+        if index < characters.count {
+            index += 1
+        }
+    }
+
+    private mutating func readDotSegment() -> String {
+        let start = index
+        while index < characters.count, characters[index] != ".", characters[index] != "[" {
+            index += 1
+        }
+        return String(characters[start..<index])
+    }
+
+    private mutating func readUnquotedBracketSegment() -> String {
+        let start = index
+        while index < characters.count, characters[index] != "]" {
+            index += 1
+        }
+        return String(characters[start..<index])
+    }
+
+    private mutating func readQuotedSegment(quote: Character) -> String {
+        index += 1
+        var segment = ""
+        while index < characters.count {
+            let character = characters[index]
+            if character == "\\", index + 1 < characters.count {
+                index += 1
+                segment.append(characters[index])
+                index += 1
+            } else if character == quote {
+                index += 1
+                return segment
+            } else {
+                segment.append(character)
+                index += 1
+            }
+        }
+        return segment
+    }
+}
+
+private extension Character {
+    var isQuote: Bool {
+        self == "'" || self == "\""
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialCardSummary.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialCardSummary.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+struct CredentialCardSummary {
+    let title: String
+    let credentialType: String?
+    let holderName: String?
+    let dateText: String?
+    let validityText: String?
+    let portraitData: Data?
+    let portraitMimeType: String?
+}
+
+extension CredentialDetails {
+    var cardSummary: CredentialCardSummary {
+        let items = groups.flatMap(\.items)
+        let holderName = [
+            firstText(in: items, role: .givenName),
+            firstText(in: items, role: .familyName)
+        ]
+            .compactMap { $0 }
+            .joined(separator: " ")
+        let portrait = firstImage(in: items)
+        let expiryDate = firstExpiryDate(in: items)
+        let addedDate = addedAt.map(Self.cardDateFormatter.string(from:))
+
+        return CredentialCardSummary(
+            title: title,
+            credentialType: firstCredentialType(in: items),
+            holderName: holderName.isEmpty ? subject : holderName,
+            dateText: expiryDate ?? addedDate,
+            validityText: expiryDate.map(CredentialDisplayText.expires) ?? addedDate.map(CredentialDisplayText.added),
+            portraitData: portrait?.data,
+            portraitMimeType: portrait?.mimeType
+        )
+    }
+
+    private static let cardDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}
+
+private func firstText(in items: [ClaimItem], role: ClaimRole) -> String? {
+    for item in items {
+        if item.hasRole(role), let text = textValue(item.value) {
+            return text
+        }
+        if case .object(let children) = item.value, let nested = firstText(in: children, role: role) {
+            return nested
+        }
+    }
+    return nil
+}
+
+private func firstExpiryDate(in items: [ClaimItem]) -> String? {
+    for item in items {
+        if item.hasRole(.expiryDate), let text = textValue(item.value) {
+            return text
+        }
+        if case .object(let children) = item.value, let nested = firstExpiryDate(in: children) {
+            return nested
+        }
+    }
+    return nil
+}
+
+private func firstCredentialType(in items: [ClaimItem]) -> String? {
+    for item in items {
+        if item.hasRole(.credentialType) {
+            if let type = credentialTypeValue(item.value).flatMap(CredentialDisplayVocabulary.readableCredentialType) {
+                return type
+            }
+        }
+        if case .object(let children) = item.value, let nested = firstCredentialType(in: children) {
+            return nested
+        }
+    }
+    return nil
+}
+
+private func firstImage(in items: [ClaimItem]) -> (data: Data, mimeType: String?)? {
+    for item in items {
+        if item.hasRole(.image), case .image(_, let data, let mimeType, _) = item.value {
+            return (data, mimeType)
+        }
+        if case .object(let children) = item.value, let nested = firstImage(in: children) {
+            return nested
+        }
+    }
+    return nil
+}
+
+private func credentialTypeValue(_ value: DisplayValue) -> String? {
+    switch value {
+    case .list(let values):
+        return values.compactMap(textValue).first { !CredentialDisplayVocabulary.isGenericCredentialType($0) } ??
+            values.compactMap(textValue).first
+    default:
+        return textValue(value)
+    }
+}
+
+private extension ClaimItem {
+    func hasRole(_ role: ClaimRole) -> Bool {
+        roles.contains(role)
+    }
+}
+
+private func textValue(_ value: DisplayValue) -> String? {
+    switch value {
+    case .decodedText(let value), .text(let value), .number(let value), .raw(let value):
+        return value
+    case .bool(let value):
+        return value ? "true" : "false"
+    case .null, .object, .list, .image:
+        return nil
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayModels.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayModels.swift
@@ -1,0 +1,260 @@
+import Foundation
+
+struct CredentialDetails: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let issuer: String?
+    let subject: String?
+    let format: String
+    let addedAt: Date?
+    let groups: [ClaimGroup]
+    let technicalGroups: [ClaimGroup]
+}
+
+struct ClaimGroup: Equatable, Identifiable {
+    let title: String
+    let items: [ClaimItem]
+
+    var id: String { title }
+}
+
+struct ClaimItem: Equatable, Identifiable {
+    let path: ClaimItemPath
+    let label: String
+    let value: DisplayValue
+    let rawValue: String?
+    let requested: Bool
+    let shareable: Bool
+    let roles: Set<ClaimRole>
+
+    var id: String { path.id }
+
+    init(
+        path: ClaimItemPath,
+        label: String,
+        value: DisplayValue,
+        rawValue: String?,
+        requested: Bool,
+        shareable: Bool,
+        roles: Set<ClaimRole> = []
+    ) {
+        self.path = path
+        self.label = label
+        self.value = value
+        self.rawValue = rawValue
+        self.requested = requested
+        self.shareable = shareable
+        self.roles = roles
+    }
+}
+
+enum DisplayValue: Equatable {
+    case text(String)
+    case number(String)
+    case bool(Bool)
+    case object([ClaimItem])
+    case list([DisplayValue])
+    case image(encoded: String, data: Data, mimeType: String?, byteCount: Int)
+    case decodedText(String)
+    case raw(String)
+    case null
+}
+
+struct ClaimItemPath: Hashable {
+    private let renderedID: RenderedClaimPath
+    private let renderedSourcePath: RenderedClaimPath?
+
+    var id: String {
+        renderedID.value
+    }
+
+    var sourcePath: String? {
+        renderedSourcePath?.value
+    }
+
+    init(id: String, sourcePath: String? = nil) {
+        self.renderedID = .raw(id)
+        self.renderedSourcePath = sourcePath.map(RenderedClaimPath.raw)
+    }
+
+    private init(renderedID: RenderedClaimPath, renderedSourcePath: RenderedClaimPath? = nil) {
+        self.renderedID = renderedID
+        self.renderedSourcePath = renderedSourcePath
+    }
+
+    func indexedChild(_ index: Int) -> ClaimItemPath {
+        ClaimItemPath(
+            renderedID: renderedID.indexed(index),
+            renderedSourcePath: renderedSourcePath?.indexed(index)
+        )
+    }
+
+    func child(_ name: String) -> ClaimItemPath {
+        ClaimItemPath(
+            renderedID: renderedID.child(name),
+            renderedSourcePath: renderedSourcePath?.child(name)
+        )
+    }
+
+    static func root() -> ClaimItemPath {
+        ClaimItemPath(renderedID: .raw(DisplayClaimPathRoot.root.id))
+    }
+
+    static func topLevel(_ name: String) -> ClaimItemPath {
+        ClaimItemPath(renderedID: .raw(name))
+    }
+
+    static func disclosure(index: Int, semanticLeaf: String, sourcePath: DisplayClaimSourcePath?) -> ClaimItemPath {
+        ClaimItemPath(
+            renderedID: RenderedClaimPath
+                .raw(DisplayClaimPathRoot.disclosures.id)
+                .indexed(index)
+                .child(semanticLeaf),
+            renderedSourcePath: sourcePath.map { .raw($0.value) }
+        )
+    }
+
+}
+
+private struct RenderedClaimPath: Hashable {
+    private enum Operation: Hashable {
+        case child(String)
+        case index(Int)
+    }
+
+    private let root: String
+    private let operations: [Operation]
+
+    var value: String {
+        operations.reduce(root) { partial, operation in
+            switch operation {
+            case .child(let name): return "\(partial).\(name)"
+            case .index(let index): return "\(partial)[\(index)]"
+            }
+        }
+    }
+
+    func child(_ name: String) -> RenderedClaimPath {
+        RenderedClaimPath(root: root, operations: operations + [.child(name)])
+    }
+
+    func indexed(_ index: Int) -> RenderedClaimPath {
+        RenderedClaimPath(root: root, operations: operations + [.index(index)])
+    }
+
+    static func raw(_ value: String) -> RenderedClaimPath {
+        RenderedClaimPath(root: value, operations: [])
+    }
+}
+
+enum ClaimGroupKind: CaseIterable {
+    case personal
+    case address
+    case other
+    case technical
+
+    var title: String {
+        switch self {
+        case .personal: return "Personal details"
+        case .address: return "Address"
+        case .other: return "Other claims"
+        case .technical: return "Technical claims"
+        }
+    }
+
+    var order: Int {
+        switch self {
+        case .personal: return 0
+        case .address: return 1
+        case .other: return 2
+        case .technical: return 3
+        }
+    }
+}
+
+enum ClaimRole: Hashable {
+    case givenName
+    case familyName
+    case temporal
+    case expiryDate
+    case image
+    case credentialType
+}
+
+enum CredentialDisplayText {
+    static let unknown = "Unknown"
+
+    static func expires(_ date: String) -> String { "Expires \(date)" }
+    static func added(_ date: String) -> String { "Added \(date)" }
+}
+
+struct DisplayClaimPath {
+    let itemPath: ClaimItemPath
+    let components: [String]
+
+    static func topLevel(_ name: String) -> DisplayClaimPath {
+        DisplayClaimPath(itemPath: ClaimItemPath.topLevel(name), components: [name])
+    }
+
+    func child(_ child: String) -> DisplayClaimPath {
+        DisplayClaimPath(
+            itemPath: itemPath.child(child),
+            components: components + [child]
+        )
+    }
+
+    func indexed(_ index: Int) -> DisplayClaimPath {
+        DisplayClaimPath(itemPath: itemPath.indexedChild(index), components: components)
+    }
+
+    static func disclosure(index: Int, rawPath: String, label: String) -> DisplayClaimPath {
+        let sourcePath = DisplayClaimSourcePath.parse(rawPath)
+        let semanticLeaf = sourcePath?.semanticLeaf ?? (label.isEmpty ? DisplayClaimPathRoot.disclosures.singularID : label)
+        return DisplayClaimPath(
+            itemPath: ClaimItemPath.disclosure(index: index, semanticLeaf: semanticLeaf, sourcePath: sourcePath),
+            components: DisplayClaimPathRoot.disclosures.components(with: semanticLeaf)
+        )
+    }
+
+}
+
+struct DisplayClaimSourcePath {
+    let value: String
+    let semanticLeaf: String?
+
+    static func parse(_ rawPath: String) -> DisplayClaimSourcePath? {
+        let value = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+        return DisplayClaimSourcePath(
+            value: value,
+            semanticLeaf: ClaimPathExpression.parse(value).leafKey
+        )
+    }
+}
+
+enum DisplayClaimPathRoot {
+    case root
+    case disclosures
+
+    var id: String {
+        switch self {
+        case .root: return "$"
+        case .disclosures: return "disclosures"
+        }
+    }
+
+    var singularID: String {
+        switch self {
+        case .disclosures: return "disclosure"
+        case .root: return id
+        }
+    }
+
+    func components(with child: String) -> [String] {
+        [id, child].reduce(into: [String]()) { result, component in
+            if !component.isEmpty, !result.contains(component) {
+                result.append(component)
+            }
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayNormalizer.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayNormalizer.swift
@@ -1,0 +1,269 @@
+import Foundation
+import WalletSDK
+
+enum CredentialDisplayNormalizer {
+
+    static func details(for credential: Credential) -> CredentialDetails {
+        details(
+            id: credential.id,
+            title: credential.label ?? credential.format,
+            issuer: credential.issuer,
+            subject: credential.subject,
+            format: credential.format,
+            addedAt: credential.addedAt,
+            credentialDataJSON: credential.credentialDataJSON
+        )
+    }
+
+    static func details(for option: PresentationCredentialOption) -> CredentialDetails {
+        let parsed = details(
+            id: option.credentialID,
+            title: option.label ?? option.format,
+            issuer: option.issuer,
+            subject: option.subject,
+            format: option.format,
+            addedAt: nil,
+            credentialDataJSON: option.credentialDataJSON
+        )
+        let disclosures = ClaimGroup(
+            title: CredentialDisplayVocabulary.requestedDisclosuresTitle,
+            items: option.disclosures.enumerated().map { index, disclosure in
+                let label = CredentialDisplayVocabulary.disclosureLabel(name: disclosure.name, path: disclosure.path)
+                let path = DisplayClaimPath.disclosure(index: index, rawPath: disclosure.path, label: label)
+                return ClaimItem(
+                    path: path.itemPath,
+                    label: label,
+                    value: displayValue(fromJSON: disclosure.valueJSON, displayValue: disclosure.displayValue, path: path),
+                    rawValue: disclosure.valueJSON,
+                    requested: true,
+                    shareable: disclosure.selectivelyDisclosable,
+                    roles: CredentialDisplayVocabulary.roles(for: path.components)
+                )
+            }
+        )
+        return CredentialDetails(
+            id: parsed.id,
+            title: parsed.title,
+            issuer: parsed.issuer,
+            subject: parsed.subject,
+            format: parsed.format,
+            addedAt: parsed.addedAt,
+            groups: [disclosures] + parsed.groups,
+            technicalGroups: parsed.technicalGroups
+        )
+    }
+
+    private static func displayValue(fromJSON rawJSON: String, displayValue: String?, path: DisplayClaimPath) -> DisplayValue {
+        let trimmed = rawJSON.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let data = trimmed.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) {
+            let parsed = self.displayValue(for: json, path: path)
+            if case .text = parsed, let displayValue, !displayValue.isEmpty {
+                return .text(displayValue)
+            }
+            return parsed
+        }
+
+        if let displayValue, !displayValue.isEmpty {
+            return .text(displayValue)
+        }
+        return .raw(rawJSON)
+    }
+
+    private static func details(
+        id: String,
+        title: String,
+        issuer: String?,
+        subject: String?,
+        format: String,
+        addedAt: Date?,
+        credentialDataJSON: String?
+    ) -> CredentialDetails {
+        let rawJSON = credentialDataJSON?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !rawJSON.isEmpty, let data = rawJSON.data(using: .utf8) else {
+            return CredentialDetails(
+                id: id,
+                title: title,
+                issuer: issuer,
+                subject: subject,
+                format: format,
+                addedAt: addedAt,
+                groups: [],
+                technicalGroups: []
+            )
+        }
+
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return CredentialDetails(
+                id: id,
+                title: title,
+                issuer: issuer,
+                subject: subject,
+                format: format,
+                addedAt: addedAt,
+                groups: [],
+                technicalGroups: [
+                    ClaimGroup(
+                        title: CredentialDisplayVocabulary.rawCredentialDataTitle,
+                        items: [ClaimItem(path: ClaimItemPath.root(), label: CredentialDisplayVocabulary.rawCredentialDataLabel, value: .raw(rawJSON), rawValue: rawJSON, requested: false, shareable: false)]
+                    )
+                ]
+            )
+        }
+
+        let groupedItems = object.keys.sorted().map { key in
+            let path = DisplayClaimPath.topLevel(key)
+            return (
+                CredentialDisplayVocabulary.groupKind(for: path.components),
+                claimItem(path: path, label: CredentialDisplayVocabulary.humanizedLabel(key), value: object[key] as Any)
+            )
+        }
+        let groups = Dictionary(grouping: groupedItems, by: { $0.0 })
+            .sorted { $0.key.order < $1.key.order }
+            .map { ClaimGroup(title: $0.key.title, items: $0.value.map(\.1)) }
+
+        return CredentialDetails(
+            id: id,
+            title: title,
+            issuer: issuer,
+            subject: subject,
+            format: format,
+            addedAt: addedAt,
+            groups: groups,
+            technicalGroups: [
+                ClaimGroup(
+                    title: CredentialDisplayVocabulary.rawCredentialDataTitle,
+                    items: [ClaimItem(path: ClaimItemPath.root(), label: CredentialDisplayVocabulary.credentialDataJSONLabel, value: .raw(rawJSON), rawValue: rawJSON, requested: false, shareable: false)]
+                )
+            ]
+        )
+    }
+
+    private static func claimItems(fromJSON rawJSON: String, pathPrefix: DisplayClaimPath, fallbackLabel: String) -> [ClaimItem] {
+        let trimmed = rawJSON.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else {
+            return []
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else {
+            return [
+                ClaimItem(
+                    path: pathPrefix.itemPath,
+                    label: fallbackLabel,
+                    value: .raw(trimmed),
+                    rawValue: trimmed,
+                    requested: false,
+                    shareable: false,
+                    roles: CredentialDisplayVocabulary.roles(for: pathPrefix.components)
+                )
+            ]
+        }
+
+        if let object = json as? [String: Any] {
+            return object.keys.sorted().map { key in
+                claimItem(path: pathPrefix.child(key), label: CredentialDisplayVocabulary.humanizedLabel(key), value: object[key] as Any)
+            }
+        }
+
+        return [
+            ClaimItem(
+                path: pathPrefix.itemPath,
+                label: fallbackLabel,
+                value: displayValue(for: json, path: pathPrefix),
+                rawValue: rawString(json),
+                requested: false,
+                shareable: false,
+                roles: CredentialDisplayVocabulary.roles(for: pathPrefix.components)
+            )
+        ]
+    }
+
+    private static func claimItem(path: DisplayClaimPath, label: String, value: Any) -> ClaimItem {
+        ClaimItem(
+            path: path.itemPath,
+            label: label,
+            value: displayValue(for: value, path: path),
+            rawValue: rawString(value),
+            requested: false,
+            shareable: true,
+            roles: CredentialDisplayVocabulary.roles(for: path.components)
+        )
+    }
+
+    private static func displayValue(for value: Any, path: DisplayClaimPath) -> DisplayValue {
+        if value is NSNull {
+            return .null
+        }
+        if let string = value as? String {
+            if let dateText = epochDateStringIfTemporal(value: string, path: path) {
+                return .text(dateText)
+            }
+            return CredentialDisplayValueDecoder.decodedValue(
+                for: string,
+                path: path,
+                renderJSON: { json, jsonPath in displayValue(for: json, path: jsonPath) }
+            ) ?? .text(string)
+        }
+        if let number = value as? NSNumber {
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool(number.boolValue)
+            }
+            if let dateText = epochDateStringIfTemporal(value: number.stringValue, path: path) {
+                return .text(dateText)
+            }
+            return .number(number.stringValue)
+        }
+        if let object = value as? [String: Any] {
+            let items = object.keys.sorted().map { key in
+                claimItem(path: path.child(key), label: CredentialDisplayVocabulary.humanizedLabel(key), value: object[key] as Any)
+            }
+            return .object(items)
+        }
+        if let list = value as? [Any] {
+            if let image = CredentialDisplayValueDecoder.imageDisplayValue(
+                for: list,
+                roles: CredentialDisplayVocabulary.roles(for: path.components)
+            ) {
+                return image
+            }
+            return .list(list.enumerated().map { index, element in
+                displayValue(for: element, path: path.indexed(index))
+            })
+        }
+        return .raw(String(describing: value))
+    }
+
+    private static func rawString(_ value: Any) -> String? {
+        if JSONSerialization.isValidJSONObject(value),
+           let data = try? JSONSerialization.data(withJSONObject: value),
+           let string = String(data: data, encoding: .utf8) {
+            return string
+        }
+        if value is NSNull {
+            return "null"
+        }
+        return String(describing: value)
+    }
+
+    private static func epochDateStringIfTemporal(value: String, path: DisplayClaimPath) -> String? {
+        guard CredentialDisplayVocabulary.roles(for: path.components).contains(.temporal),
+              let rawEpoch = Int64(value.trimmingCharacters(in: .whitespacesAndNewlines)),
+              rawEpoch >= minimumCredibleEpochSeconds else {
+            return nil
+        }
+        let epochSeconds = rawEpoch >= epochMillisecondsThreshold ? rawEpoch / 1_000 : rawEpoch
+        return utcDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(epochSeconds)))
+    }
+
+    private static let utcDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let minimumCredibleEpochSeconds: Int64 = 100_000_000
+    private static let epochMillisecondsThreshold: Int64 = 10_000_000_000
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayValueDecoder.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayValueDecoder.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+enum CredentialDisplayValueDecoder {
+    static func decodedValue(
+        for value: String,
+        path: DisplayClaimPath,
+        renderJSON: (Any, DisplayClaimPath) -> DisplayValue
+    ) -> DisplayValue? {
+        guard let payload = EncodedPayload.parse(value),
+              let bytes = payload.base64.decode() else {
+            return nil
+        }
+        if let mimeType = ImageBytes.mimeType(for: bytes, hint: payload.imageMimeTypeHint) {
+            return imageValue(for: bytes, mimeType: mimeType, encoded: payload.base64.value)
+        }
+        guard let decoded = String(data: bytes, encoding: .utf8), decoded.isMostlyReadable else {
+            return nil
+        }
+        if let data = decoded.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) {
+            return renderJSON(json, path)
+        }
+        return .decodedText(decoded)
+    }
+
+    static func imageDisplayValue(for list: [Any], roles: Set<ClaimRole>) -> DisplayValue? {
+        guard roles.contains(.image),
+              let data = byteArrayData(from: list),
+              let mimeType = ImageBytes.mimeType(for: data, hint: nil) else {
+            return nil
+        }
+        return imageValue(for: data, mimeType: mimeType)
+    }
+
+    private static func byteArrayData(from list: [Any]) -> Data? {
+        guard !list.isEmpty else { return nil }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(list.count)
+        for element in list {
+            guard let number = element as? NSNumber,
+                  CFGetTypeID(number) != CFBooleanGetTypeID() else {
+                return nil
+            }
+            let value = number.intValue
+            guard (-128...255).contains(value) else {
+                return nil
+            }
+            bytes.append(UInt8(truncatingIfNeeded: value))
+        }
+        return Data(bytes)
+    }
+
+    private static func imageValue(for data: Data, mimeType: String, encoded: String? = nil) -> DisplayValue {
+        return .image(
+            encoded: encoded ?? data.base64EncodedString(),
+            data: data,
+            mimeType: mimeType,
+            byteCount: data.count
+        )
+    }
+}
+
+private struct EncodedPayload {
+    let imageMimeTypeHint: String?
+    let base64: Base64Payload
+
+    static func parse(_ rawValue: String) -> EncodedPayload? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let prefixRange = value.range(of: schemePrefix, options: [.anchored, .caseInsensitive]),
+              let markerRange = value.range(of: base64Marker, options: .caseInsensitive) else {
+            return Base64Payload(value).map {
+                EncodedPayload(imageMimeTypeHint: nil, base64: $0)
+            }
+        }
+
+        let metadata = String(value[prefixRange.upperBound..<markerRange.lowerBound])
+        guard let base64 = Base64Payload(String(value[markerRange.upperBound...])) else {
+            return nil
+        }
+        return EncodedPayload(
+            imageMimeTypeHint: MediaTypeHint.imageType(from: metadata),
+            base64: base64
+        )
+    }
+
+    private static let schemePrefix = "data:"
+    private static let base64Marker = ";base64,"
+}
+
+private enum MediaTypeHint {
+    static func imageType(from metadata: String) -> String? {
+        guard let rawMediaType = metadata
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: false)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            rawMediaType.hasPrefix(ImageMime.prefix) else {
+            return nil
+        }
+        return rawMediaType
+    }
+}
+
+private struct Base64Payload {
+    let value: String
+
+    init?(_ rawValue: String) {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard Self.looksValid(value) else {
+            return nil
+        }
+        self.value = value
+    }
+
+    func decode() -> Data? {
+        let normalized = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padded = normalized.padding(
+            toLength: normalized.count + ((Self.base64BlockSize - normalized.count % Self.base64BlockSize) % Self.base64BlockSize),
+            withPad: "=",
+            startingAt: 0
+        )
+        return Data(base64Encoded: padded)
+    }
+
+    private static func looksValid(_ value: String) -> Bool {
+        guard value.count >= minimumPayloadLength, value.count % base64BlockSize != invalidBase64Remainder else { return false }
+        return value.allSatisfy { character in
+            character.isLetter || character.isNumber || ["+", "/", "-", "_", "="].contains(character)
+        }
+    }
+
+    private static let minimumPayloadLength = 12
+    private static let base64BlockSize = 4
+    private static let invalidBase64Remainder = 1
+}
+
+private enum ImageMime {
+    static let prefix = "image/"
+    static let png = "image/png"
+    static let jpeg = "image/jpeg"
+    static let gif = "image/gif"
+    static let webp = "image/webp"
+}
+
+private enum ImageBytes {
+    static func mimeType(for data: Data, hint: String?) -> String? {
+        if let hint, hint.hasPrefix(ImageMime.prefix) {
+            return hint
+        }
+        let bytes = [UInt8](data.prefix(12))
+        if bytes.starts(with: [0x89, 0x50, 0x4E, 0x47]) { return ImageMime.png }
+        if bytes.starts(with: [0xFF, 0xD8, 0xFF]) { return ImageMime.jpeg }
+        if data.count >= 6, let prefix = String(data: data.prefix(6), encoding: .ascii), ["GIF87a", "GIF89a"].contains(prefix) { return ImageMime.gif }
+        if data.count >= 12,
+           let riff = String(data: data.prefix(4), encoding: .ascii),
+           let webp = String(data: data.dropFirst(8).prefix(4), encoding: .ascii),
+           riff == "RIFF",
+           webp == "WEBP" {
+            return ImageMime.webp
+        }
+        return nil
+    }
+}
+
+private extension String {
+    var isMostlyReadable: Bool {
+        let allowedControls = Set(["\n", "\r", "\t"].compactMap { $0.unicodeScalars.first })
+        return !isEmpty &&
+            unicodeScalars.filter {
+                !CharacterSet.controlCharacters.contains($0) || allowedControls.contains($0)
+            }.count >= Int(Double(unicodeScalars.count) * Self.readableCharacterRatio)
+    }
+
+    private static let readableCharacterRatio = 0.9
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayVocabulary.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayVocabulary.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+private struct ClaimDescriptor {
+    let name: String
+    let aliases: [String]
+    let label: String?
+    let group: ClaimGroupKind
+    let roles: Set<ClaimRole>
+
+    init(
+        _ name: String,
+        aliases: [String] = [],
+        label: String? = nil,
+        group: ClaimGroupKind = .other,
+        roles: Set<ClaimRole> = []
+    ) {
+        self.name = name
+        self.aliases = aliases
+        self.label = label
+        self.group = group
+        self.roles = roles
+    }
+
+    var recognizedNames: [String] {
+        [name] + aliases
+    }
+}
+
+private struct ClaimPath {
+    let components: [String]
+
+    var leaf: String {
+        components.last ?? ""
+    }
+
+    var topLevel: String {
+        components.first ?? ""
+    }
+
+    var isTopLevel: Bool {
+        components.count <= 1
+    }
+
+    init(components: [String]) {
+        self.components = components
+    }
+}
+
+private struct NormalizedClaimKey: Hashable {
+    let value: String
+
+    init(_ rawValue: String) {
+        self.value = rawValue
+            .filter { $0.isLetter || $0.isNumber }
+            .lowercased()
+    }
+}
+
+enum CredentialDisplayVocabulary {
+    static let rawCredentialDataTitle = "Raw credential data"
+    static let rawCredentialDataLabel = "Raw credential data"
+    static let credentialDataJSONLabel = "Credential data JSON"
+    static let genericVerifiableCredentialType = "VerifiableCredential"
+    static let requestedDisclosuresTitle = "Requested disclosures"
+
+    private static let givenNameClaim = "given_name"
+    private static let familyNameClaim = "family_name"
+
+    private static let descriptorsByName: [NormalizedClaimKey: ClaimDescriptor] = {
+        let descriptors = [
+            ClaimDescriptor(givenNameClaim, aliases: ["Given name"], label: "Given name", group: .personal, roles: [.givenName]),
+            ClaimDescriptor(familyNameClaim, aliases: ["Family name"], label: "Family name", group: .personal, roles: [.familyName]),
+            ClaimDescriptor("birth_date", aliases: ["Date of birth"], label: "Date of birth", group: .personal),
+            ClaimDescriptor("birth_place", aliases: ["Place of birth"], label: "Place of birth", group: .personal),
+            ClaimDescriptor("age", group: .personal),
+            ClaimDescriptor("age_over_18", label: "Age over 18", group: .personal),
+            ClaimDescriptor("portrait", aliases: ["Portrait"], label: "Portrait", group: .personal, roles: [.image]),
+            ClaimDescriptor("photo", roles: [.image]),
+            ClaimDescriptor("picture", roles: [.image]),
+            ClaimDescriptor("image", roles: [.image]),
+            ClaimDescriptor("logo", roles: [.image]),
+            ClaimDescriptor("nationalities", label: "Nationalities", group: .personal),
+            ClaimDescriptor("resident_address", label: "Resident address", group: .address),
+            ClaimDescriptor("street_address", label: "Street address", group: .address),
+            ClaimDescriptor("locality", group: .address),
+            ClaimDescriptor("postal_code", label: "Postal code", group: .address),
+            ClaimDescriptor("country", group: .address),
+            ClaimDescriptor("iss", label: "Issuer", group: .technical),
+            ClaimDescriptor("vct", label: "Credential type", group: .technical, roles: [.credentialType]),
+            ClaimDescriptor("credential_type", aliases: ["Credential type", "credentialType"], roles: [.credentialType]),
+            ClaimDescriptor("exp", label: "Expires", group: .technical, roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("expires", aliases: ["Expires"], roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("expiry", aliases: ["Expiry"], roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("expiry_date", aliases: ["Expiry date"], roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("expiration", aliases: ["Expiration"], roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("expiration_date", aliases: ["Expiration date"], roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("valid_until", aliases: ["Valid until"], roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("valid_to", aliases: ["Valid to"], roles: [.temporal, .expiryDate]),
+            ClaimDescriptor("valid_from", aliases: ["Valid from"], roles: [.temporal]),
+            ClaimDescriptor("nbf", label: "Valid from", group: .technical, roles: [.temporal]),
+            ClaimDescriptor("not_before", roles: [.temporal]),
+            ClaimDescriptor("iat", label: "Issued at", group: .technical, roles: [.temporal]),
+            ClaimDescriptor("issued_at", roles: [.temporal]),
+            ClaimDescriptor("issuance_date", roles: [.temporal]),
+            ClaimDescriptor("cnf", label: "Confirmation key", group: .technical)
+        ]
+        return descriptors.reduce(into: [:]) { result, descriptor in
+            for name in descriptor.recognizedNames {
+                result[NormalizedClaimKey(name)] = descriptor
+            }
+        }
+    }()
+
+    private static let topLevelCredentialTypeClaimNames = Set(["type"].map(NormalizedClaimKey.init))
+
+    static func groupKind(for components: [String]) -> ClaimGroupKind {
+        descriptor(for: ClaimPath(components: components).topLevel)?.group ?? .other
+    }
+
+    static func humanizedLabel(_ key: String) -> String {
+        descriptor(for: key)?.label ?? ClaimLabelFormatter.humanize(key)
+    }
+
+    static func disclosureLabel(name: String?, path: String) -> String {
+        if let name = name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            return name
+        }
+        if let leaf = ClaimPathExpression.parse(path).leafKey {
+            return humanizedLabel(leaf)
+        }
+        return path
+    }
+
+    static func roles(for components: [String]) -> Set<ClaimRole> {
+        roles(for: ClaimPath(components: components))
+    }
+
+    private static func roles(for claimPath: ClaimPath) -> Set<ClaimRole> {
+        let leaf = claimPath.leaf
+        var roles = descriptor(for: leaf)?.roles ?? []
+        if claimPath.isTopLevel && topLevelCredentialTypeClaimNames.contains(NormalizedClaimKey(leaf)) {
+            roles.insert(.credentialType)
+        }
+        if pathHasRole(claimPath, role: .image) {
+            roles.insert(.image)
+        }
+        return roles
+    }
+
+    static func isGenericCredentialType(_ value: String) -> Bool {
+        CredentialTypeIdentifier.token(value)?.compare(genericVerifiableCredentialType, options: .caseInsensitive) == .orderedSame
+    }
+
+    static func readableCredentialType(_ value: String) -> String? {
+        guard let token = CredentialTypeIdentifier.token(value),
+            !isGenericCredentialType(token) else {
+            return nil
+        }
+
+        let label = ClaimLabelFormatter.humanize(String(token))
+        return label.isEmpty ? nil : label
+    }
+
+    private static func pathHasRole(_ path: ClaimPath, role: ClaimRole) -> Bool {
+        path.components.contains { component in
+            descriptor(for: component)?.roles.contains(role) == true
+        }
+    }
+
+    private static func descriptor(for name: String) -> ClaimDescriptor? {
+        descriptorsByName[NormalizedClaimKey(name)]
+    }
+}
+
+private enum ClaimLabelFormatter {
+    private static let camelCaseBoundaryPattern = #"([a-z])([A-Z])"#
+    private static let wordSeparators = CharacterSet(charactersIn: "_-. ")
+
+    static func humanize(_ key: String) -> String {
+        let words = key
+            .replacingOccurrences(of: camelCaseBoundaryPattern, with: "$1 $2", options: .regularExpression)
+            .components(separatedBy: wordSeparators)
+            .filter { !$0.isEmpty }
+            .map { $0.lowercased() }
+            .joined(separator: " ")
+        return words.prefix(1).uppercased() + words.dropFirst()
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialTypeIdentifier.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialTypeIdentifier.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum CredentialTypeIdentifier {
+    static func token(_ rawValue: String) -> String? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        let token = httpURLToken(value) ?? trailingIdentifierToken(value)
+        return token.isEmpty ? nil : token
+    }
+
+    private static func httpURLToken(_ value: String) -> String? {
+        guard let components = URLComponents(string: value),
+              let scheme = components.scheme?.lowercased(),
+              httpSchemes.contains(scheme) else {
+            return nil
+        }
+
+        return components.path
+            .split(separator: "/")
+            .last
+            .map(String.init)
+    }
+
+    private static func trailingIdentifierToken(_ value: String) -> String {
+        guard let delimiterIndex = value.lastIndex(where: identifierDelimiters.contains) else {
+            return value
+        }
+        return String(value[value.index(after: delimiterIndex)...])
+    }
+
+    private static let httpSchemes: Set<String> = ["http", "https"]
+    private static let identifierDelimiters: Set<Character> = ["/", "#", ":"]
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/VerifierClientIdentifier.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/VerifierClientIdentifier.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct VerifierClientIdentifier {
+    let scheme: Scheme
+    let value: String
+    let rawValue: String
+
+    enum Scheme: CaseIterable {
+        case redirectURI
+        case x509SanDNS
+        case x509Hash
+        case decentralizedIdentifier
+        case legacyDID
+        case verifierAttestation
+        case openIDFederation
+        case preRegistered
+        case unsupported
+
+        var prefix: String? {
+            switch self {
+            case .redirectURI: return "redirect_uri"
+            case .x509SanDNS: return "x509_san_dns"
+            case .x509Hash: return "x509_hash"
+            case .decentralizedIdentifier: return "decentralized_identifier"
+            case .legacyDID: return "did"
+            case .verifierAttestation: return "verifier_attestation"
+            case .openIDFederation: return "openid_federation"
+            case .preRegistered, .unsupported: return nil
+            }
+        }
+
+        var genericLabel: String? {
+            switch self {
+            case .x509Hash: return "X.509 verifier"
+            case .decentralizedIdentifier, .legacyDID: return "DID verifier"
+            case .verifierAttestation: return "Verifier attestation"
+            case .openIDFederation: return "OpenID Federation verifier"
+            case .redirectURI, .x509SanDNS, .preRegistered, .unsupported: return nil
+            }
+        }
+    }
+
+    static func parse(_ rawClientID: String) -> VerifierClientIdentifier? {
+        let rawValue = rawClientID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawValue.isEmpty else { return nil }
+
+        if NetworkOrigin.parse(rawValue) != nil {
+            return VerifierClientIdentifier(scheme: .preRegistered, value: rawValue, rawValue: rawValue)
+        }
+
+        guard let prefixedValue = ClientIdentifierPrefix.split(rawValue) else {
+            return VerifierClientIdentifier(scheme: .preRegistered, value: rawValue, rawValue: rawValue)
+        }
+
+        let scheme = Scheme.allCases.first { $0.prefix == prefixedValue.prefix } ?? .unsupported
+
+        return VerifierClientIdentifier(scheme: scheme, value: prefixedValue.value, rawValue: rawValue)
+    }
+}
+
+private struct ClientIdentifierPrefix {
+    let prefix: String
+    let value: String
+
+    static func split(_ rawValue: String) -> ClientIdentifierPrefix? {
+        guard let separator = rawValue.firstIndex(of: ":"),
+              separator != rawValue.startIndex else {
+            return nil
+        }
+
+        return ClientIdentifierPrefix(
+            prefix: String(rawValue[..<separator]),
+            value: String(rawValue[rawValue.index(after: separator)...])
+        )
+    }
+}
+
+struct NetworkOrigin {
+    let host: String
+
+    static func parse(_ rawValue: String) -> NetworkOrigin? {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty,
+              let url = URL(string: value),
+              let scheme = url.scheme?.lowercased(),
+              httpSchemes.contains(scheme),
+              let host = url.host,
+              !host.isEmpty else {
+            return nil
+        }
+
+        return NetworkOrigin(host: host)
+    }
+
+    private static let httpSchemes: Set<String> = ["http", "https"]
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/VerifierDisplayName.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/VerifierDisplayName.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum VerifierDisplayName {
+    static func value(verifierName: String?, clientID: String?, responseURI: URL?) -> String {
+        if let verifierName = verifierName?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !verifierName.isEmpty {
+            return verifierName
+        }
+
+        if let clientIdentifier = clientID.flatMap(VerifierClientIdentifier.parse) {
+            if let host = clientIdentifier.host {
+                return host
+            }
+            if let displayName = clientIdentifier.displayName {
+                return displayName
+            }
+        }
+
+        if let host = responseURI?.host, !host.isEmpty {
+            return host
+        }
+
+        return "Unknown verifier"
+    }
+
+}
+
+private extension VerifierClientIdentifier {
+    var host: String? {
+        switch scheme {
+        case .redirectURI, .preRegistered, .openIDFederation:
+            return NetworkOrigin.parse(value)?.host
+        case .x509SanDNS, .x509Hash, .decentralizedIdentifier, .legacyDID, .verifierAttestation, .unsupported:
+            return nil
+        }
+    }
+
+    var displayName: String? {
+        if let genericLabel = scheme.genericLabel {
+            return genericLabel
+        }
+        if scheme == .x509SanDNS {
+            return value.isEmpty ? nil : value
+        }
+        if scheme == .preRegistered, rawValue.count <= 48 {
+            return rawValue
+        }
+        return nil
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/MockWalletClient.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/MockWalletClient.swift
@@ -1,0 +1,140 @@
+import Foundation
+import WalletSDK
+
+actor MockWalletClient: WalletClient {
+    enum VerifierStyle {
+        case named
+        case did
+        case x509SanDns
+    }
+
+    private var storedCredentials: [Credential]
+    private let operationDelayNanoseconds: UInt64
+    private let verifierStyle: VerifierStyle
+
+    init(
+        storedCredentials: [Credential] = [],
+        operationDelayMilliseconds: UInt64 = 0,
+        verifierStyle: VerifierStyle = .named
+    ) {
+        self.storedCredentials = storedCredentials
+        self.operationDelayNanoseconds = operationDelayMilliseconds * 1_000_000
+        self.verifierStyle = verifierStyle
+    }
+
+    func bootstrap() async throws -> WalletBootstrapResult {
+        WalletBootstrapResult(keyID: "mock-key-1", did: "did:key:mock")
+    }
+
+    func credentials() async throws -> [Credential] {
+        storedCredentials
+    }
+
+    func receive(offer: URL) async throws -> [String] {
+        try await delayOperation()
+        storedCredentials = [Self.sampleCredential]
+        return storedCredentials.map(\.id)
+    }
+
+    func present(request: URL, did: String?) async throws -> PresentationResult {
+        try await delayOperation()
+        return PresentationResult(success: true, redirectTo: nil, verifierResponseJSON: nil)
+    }
+
+    func previewPresentation(request: URL) async throws -> PresentationPreview {
+        try await delayOperation()
+        return PresentationPreview(
+            request: previewRequestInfo,
+            credentialOptions: [
+                PresentationCredentialOption(
+                    queryID: "pid",
+                    credentialID: Self.sampleCredential.id,
+                    format: Self.sampleCredential.format,
+                    issuer: Self.sampleCredential.issuer,
+                    subject: Self.sampleCredential.subject,
+                    label: Self.sampleCredential.label,
+                    credentialDataJSON: Self.sampleCredential.credentialDataJSON,
+                    disclosures: [
+                        PresentationDisclosure(
+                            path: "$.given_name",
+                            name: "given_name",
+                            valueJSON: "\"Ada\"",
+                            displayValue: "Ada",
+                            selectivelyDisclosable: true
+                        ),
+                        PresentationDisclosure(
+                            path: "$.portrait",
+                            name: nil,
+                            valueJSON: Self.samplePortraitDisclosureValueJSON,
+                            displayValue: nil,
+                            selectivelyDisclosable: true
+                        )
+                    ]
+                )
+            ]
+        )
+    }
+
+    func submitPresentation(request: URL, selectedCredentialIDs: [String], did: String?) async throws -> PresentationResult {
+        try await delayOperation()
+        return PresentationResult(success: true, redirectTo: nil, verifierResponseJSON: nil)
+    }
+
+    private func delayOperation() async throws {
+        guard operationDelayNanoseconds > 0 else { return }
+        try await Task.sleep(nanoseconds: operationDelayNanoseconds)
+    }
+
+    private var previewRequestInfo: PresentationRequestInfo {
+        PresentationRequestInfo(
+            clientID: verifierClientID,
+            verifierName: verifierName,
+            responseURI: URL(string: "https://verifier.example/response"),
+            state: "state-123",
+            nonce: "nonce-456"
+        )
+    }
+
+    private var verifierClientID: String {
+        switch verifierStyle {
+        case .named: return "https://verifier.example/client"
+        case .did: return Self.didClientID
+        case .x509SanDns: return Self.x509SanDnsClientID
+        }
+    }
+
+    private var verifierName: String? {
+        switch verifierStyle {
+        case .named: return "Example Verifier"
+        case .did, .x509SanDns: return nil
+        }
+    }
+
+    private static let didClientID = "decentralized_identifier:did:jwk:abc"
+    private static let x509SanDnsClientID = "x509_san_dns:verifier.example"
+    private static let samplePortraitDisclosureValueJSON = "[-119, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4, 0, 0, 0, -75, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, -38, 99, -4, -1, 31, 0, 3, 3, 2, 0, -17, -65, -89, -34, 0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126]"
+
+    private static let sampleCredential = Credential(
+        id: "cred-1",
+        format: "jwt_vc_json",
+        issuer: "Example Issuer",
+        subject: nil,
+        label: "Example Credential",
+        addedAt: ISO8601DateFormatter().date(from: "2026-07-09T12:00:00Z"),
+        credentialDataJSON: """
+        {
+          "vct": "https://issuer.example/credential-types/mobile-driving-licence",
+          "given_name": "Ada",
+          "family_name": "Lovelace",
+          "valid_to": 1781654400,
+          "resident_address": {
+            "street_address": "Main Street 1",
+            "locality": "Vienna"
+          },
+          "portrait": {
+            "elementValue": [-119, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4, 0, 0, 0, -75, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, -38, 99, -4, -1, 31, 0, 3, 3, 2, 0, -17, -65, -89, -34, 0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126]
+          }
+        }
+        """
+    )
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletClient.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletClient.swift
@@ -1,0 +1,58 @@
+import Foundation
+import WalletSDK
+
+protocol WalletClient {
+    func bootstrap() async throws -> WalletBootstrapResult
+    func credentials() async throws -> [Credential]
+    func receive(offer: URL) async throws -> [String]
+    func present(request: URL, did: String?) async throws -> PresentationResult
+    func previewPresentation(request: URL) async throws -> PresentationPreview
+    func submitPresentation(request: URL, selectedCredentialIDs: [String], did: String?) async throws -> PresentationResult
+}
+
+final class SDKWalletClient: WalletClient {
+    private let configuration: WalletConfiguration
+    private var cachedWallet: Wallet?
+
+    init(configuration: WalletConfiguration) {
+        self.configuration = configuration
+    }
+
+    func bootstrap() async throws -> WalletBootstrapResult {
+        try await wallet().bootstrap()
+    }
+
+    func credentials() async throws -> [Credential] {
+        try await wallet().credentials()
+    }
+
+    func receive(offer: URL) async throws -> [String] {
+        try await wallet().receive(offer: offer)
+    }
+
+    func present(request: URL, did: String?) async throws -> PresentationResult {
+        try await wallet().present(request: request, did: did)
+    }
+
+    func previewPresentation(request: URL) async throws -> PresentationPreview {
+        try await wallet().previewPresentation(request: request)
+    }
+
+    func submitPresentation(request: URL, selectedCredentialIDs: [String], did: String?) async throws -> PresentationResult {
+        try await wallet().submitPresentation(
+            request: request,
+            selectedCredentialIDs: selectedCredentialIDs,
+            did: did
+        )
+    }
+
+    private func wallet() async throws -> Wallet {
+        if let cachedWallet {
+            return cachedWallet
+        }
+
+        let wallet = try await Wallet(configuration: configuration)
+        cachedWallet = wallet
+        return wallet
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletViewModel.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletViewModel.swift
@@ -1,28 +1,126 @@
 import Foundation
 import WalletSDK
 
+enum WalletTab: Hashable {
+    case credentials
+    case receive
+    case present
+}
+
+private enum WalletDeepLinkScheme: String {
+    case credentialOffer = "openid-credential-offer"
+    case presentationRequest = "openid4vp"
+}
+
+private enum WalletStatusText {
+    static let startingWallet = "Starting wallet..."
+    static let walletReady = "Wallet ready"
+    static let receivingCredential = "Receiving credential..."
+    static let resolvingPresentation = "Resolving presentation..."
+    static let presentingCredential = "Presenting credential..."
+    static let bootstrappingWallet = "Bootstrapping wallet..."
+    static let reviewPresentationRequest = "Review presentation request"
+    static let presentationSent = "Presentation sent"
+    static let presentationReviewCancelled = "Presentation review cancelled"
+    static let presentationFinishedWithoutVerifierConfirmation = "Presentation finished without verifier confirmation"
+    static let receiveFailed = "Receive failed"
+    static let previewFailed = "Preview failed"
+    static let presentFailed = "Present failed"
+    static let bootstrapFailed = "Bootstrap failed"
+    static let invalidOfferURL = "invalid offer URL"
+    static let invalidRequestURL = "invalid request URL"
+    static let selectAtLeastOneCredential = "select at least one credential"
+    static let receivedCredentialsUnavailable = "received credentials are not available locally"
+
+    static func receivedCredentials(_ count: Int) -> String {
+        "Received \(count) credential(s)"
+    }
+
+    static func failure(_ prefix: String, _ reason: String) -> String {
+        "\(prefix): \(reason)"
+    }
+
+    static func failure(_ prefix: String, _ error: Error) -> String {
+        failure(prefix, error.localizedDescription)
+    }
+}
+
 @MainActor
 class WalletViewModel: ObservableObject {
     @Published var isReady = false
     @Published var did = ""
     @Published var credentials: [Credential] = []
-    @Published var statusMessage = "Starting wallet..."
+    @Published var statusMessage = WalletStatusText.startingWallet
     @Published var isLoading = false
     @Published var isError = false
     @Published var offerUrl = ""
     @Published var presentationRequestUrl = ""
+    @Published var presentationPreview: PresentationPreview?
+    @Published var selectedPresentationCredentialIDs: Set<String> = []
+    @Published var selectedTab: WalletTab = .credentials
+    @Published var lastReceivedCredentialIDs: [String] = []
+    @Published var receiveCompleted = false
+    @Published var presentationCompleted = false
+    @Published var receiveNavigationResetKey = 0
+    @Published var presentationNavigationResetKey = 0
+    private var statusTab: WalletTab?
 
-    private let configuration: WalletConfiguration
-    private var cachedWallet: Wallet?
+    var receiveUrlEntryEnabled: Bool {
+        !isLoading && !receiveCompleted
+    }
+
+    var receiveActionEnabled: Bool {
+        isReady &&
+            !offerUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            receiveUrlEntryEnabled
+    }
+
+    var receivedCredentials: [Credential] {
+        var credentialsByID: [String: Credential] = [:]
+        credentials.forEach { credential in
+            credentialsByID[credential.id] = credential
+        }
+        return lastReceivedCredentialIDs.compactMap { credentialsByID[$0] }
+    }
+
+    var presentationUrlEntryEnabled: Bool {
+        !isLoading && presentationPreview == nil && !presentationCompleted
+    }
+
+    var presentationPreviewActionEnabled: Bool {
+        isReady &&
+            !presentationRequestUrl.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !credentials.isEmpty &&
+            presentationUrlEntryEnabled
+    }
+
+    var presentationReviewEnabled: Bool {
+        !isLoading && presentationPreview != nil && !presentationCompleted
+    }
+
+    func statusMessage(for tab: WalletTab) -> String {
+        statusApplies(to: tab) ? statusMessage : fallbackStatusMessage(for: tab)
+    }
+
+    func statusIsLoading(for tab: WalletTab) -> Bool {
+        isLoading && statusApplies(to: tab)
+    }
+
+    func statusIsError(for tab: WalletTab) -> Bool {
+        isError && statusApplies(to: tab)
+    }
+
+    private let walletClient: any WalletClient
 
     init(
         walletID: String = "default",
         attestationBaseUrl: String? = nil,
         attestationAttesterPath: String? = nil,
         attestationBearerToken: String? = nil,
-        attestationHostHeader: String? = nil
+        attestationHostHeader: String? = nil,
+        walletClient: (any WalletClient)? = nil
     ) {
-        configuration = WalletConfiguration(
+        let configuration = WalletConfiguration(
             walletID: walletID,
             attestation: Self.attestationConfiguration(
                 baseUrl: attestationBaseUrl,
@@ -31,37 +129,93 @@ class WalletViewModel: ObservableObject {
                 hostHeader: attestationHostHeader
             )
         )
+        self.walletClient = walletClient ?? SDKWalletClient(configuration: configuration)
         bootstrap()
     }
 
     func handleDeepLink(_ url: URL) {
         logE2E("Deep link received: \(url.scheme ?? "unknown")")
-        switch url.scheme {
-        case "openid-credential-offer":
+        switch url.scheme.flatMap(WalletDeepLinkScheme.init(rawValue:)) {
+        case .credentialOffer:
+            selectedTab = .receive
             offerUrl = url.absoluteString
-        case "openid4vp":
+            lastReceivedCredentialIDs = []
+            receiveCompleted = false
+            receiveNavigationResetKey += 1
+            presentationPreview = nil
+            selectedPresentationCredentialIDs = []
+            presentationCompleted = false
+            resetFlowStatusForIncomingURL()
+        case .presentationRequest:
+            selectedTab = .present
             presentationRequestUrl = url.absoluteString
-        default:
+            presentationPreview = nil
+            selectedPresentationCredentialIDs = []
+            presentationCompleted = false
+            presentationNavigationResetKey += 1
+            resetFlowStatusForIncomingURL()
+        case nil:
             break
         }
+    }
+
+    func startNewReceiveFlow() {
+        offerUrl = ""
+        lastReceivedCredentialIDs = []
+        receiveCompleted = false
+        receiveNavigationResetKey += 1
+        isLoading = false
+        isError = false
+        statusTab = nil
+        statusMessage = WalletStatusText.walletReady
+    }
+
+    func startNewPresentationFlow() {
+        presentationRequestUrl = ""
+        presentationPreview = nil
+        selectedPresentationCredentialIDs = []
+        presentationCompleted = false
+        presentationNavigationResetKey += 1
+        isLoading = false
+        isError = false
+        statusTab = nil
+        statusMessage = WalletStatusText.walletReady
     }
 
     func receiveCredential() {
         let trimmedOfferUrl = offerUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let offer = URL(string: trimmedOfferUrl) else {
-            setError("Receive failed: invalid offer URL")
+            setError(WalletStatusText.failure(WalletStatusText.receiveFailed, WalletStatusText.invalidOfferURL), tab: .receive)
             return
         }
+        let previousCredentials = credentials
 
-        setLoading("Receiving credential...")
+        setLoading(WalletStatusText.receivingCredential, tab: .receive)
         Task {
             do {
-                let wallet = try await wallet()
-                let credentialIDs = try await wallet.receive(offer: offer)
-                credentials = try await wallet.credentials()
-                setSuccess("Received \(credentialIDs.count) credential(s)")
+                let credentialIDs = try await walletClient.receive(offer: offer)
+                let refreshedCredentials = try await walletClient.credentials()
+                let receivedCredentialIDs = Self.resolvedReceivedCredentialIDs(
+                    returnedCredentialIDs: credentialIDs,
+                    previousCredentials: previousCredentials,
+                    refreshedCredentials: refreshedCredentials
+                )
+                let refreshedCredentialIDs = Set(refreshedCredentials.map(\.id))
+                let displayableReceivedCredentialIDs = receivedCredentialIDs.filter { refreshedCredentialIDs.contains($0) }
+                guard !displayableReceivedCredentialIDs.isEmpty else {
+                    credentials = refreshedCredentials
+                    lastReceivedCredentialIDs = []
+                    receiveCompleted = false
+                    setError(WalletStatusText.failure(WalletStatusText.receiveFailed, WalletStatusText.receivedCredentialsUnavailable), tab: .receive)
+                    return
+                }
+
+                credentials = refreshedCredentials
+                lastReceivedCredentialIDs = displayableReceivedCredentialIDs
+                receiveCompleted = true
+                setSuccess(WalletStatusText.receivedCredentials(displayableReceivedCredentialIDs.count), tab: .receive)
             } catch {
-                setError("Receive failed: \(error.localizedDescription)")
+                setError(WalletStatusText.failure(WalletStatusText.receiveFailed, error), tab: .receive)
             }
         }
     }
@@ -69,59 +223,125 @@ class WalletViewModel: ObservableObject {
     func presentCredential() {
         let trimmedRequestUrl = presentationRequestUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let request = URL(string: trimmedRequestUrl) else {
-            setError("Present failed: invalid request URL")
+            setError(WalletStatusText.failure(WalletStatusText.presentFailed, WalletStatusText.invalidRequestURL), tab: .present)
             return
         }
 
-        setLoading("Presenting credential...")
+        setLoading(WalletStatusText.presentingCredential, tab: .present)
         Task {
             do {
-                let wallet = try await wallet()
-                let result = try await wallet.present(
+                let result = try await walletClient.present(
                     request: request,
                     did: did.isEmpty ? nil : did
                 )
-                setSuccess(result.success ? "Presentation sent" : "Presentation finished without verifier confirmation")
+                presentationCompleted = result.success
+                setSuccess(
+                    result.success
+                        ? WalletStatusText.presentationSent
+                        : WalletStatusText.presentationFinishedWithoutVerifierConfirmation,
+                    tab: .present
+                )
             } catch {
-                setError("Present failed: \(error.localizedDescription)")
+                setError(WalletStatusText.failure(WalletStatusText.presentFailed, error), tab: .present)
             }
         }
     }
 
+    func previewPresentation() {
+        let trimmedRequestUrl = presentationRequestUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let request = URL(string: trimmedRequestUrl) else {
+            setError(WalletStatusText.failure(WalletStatusText.previewFailed, WalletStatusText.invalidRequestURL), tab: .present)
+            return
+        }
+
+        setLoading(WalletStatusText.resolvingPresentation, tab: .present)
+        presentationPreview = nil
+        selectedPresentationCredentialIDs = []
+        presentationCompleted = false
+        Task {
+            do {
+                let preview = try await walletClient.previewPresentation(request: request)
+                presentationPreview = preview
+                selectedPresentationCredentialIDs = Set(preview.credentialOptions.map(\.credentialID))
+                setSuccess(WalletStatusText.reviewPresentationRequest, tab: .present)
+            } catch {
+                setError(WalletStatusText.failure(WalletStatusText.previewFailed, error), tab: .present)
+            }
+        }
+    }
+
+    func togglePresentationCredential(_ credentialID: String) {
+        if selectedPresentationCredentialIDs.contains(credentialID) {
+            selectedPresentationCredentialIDs.remove(credentialID)
+        } else {
+            selectedPresentationCredentialIDs.insert(credentialID)
+        }
+    }
+
+    func submitPresentation() {
+        let trimmedRequestUrl = presentationRequestUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let request = URL(string: trimmedRequestUrl) else {
+            setError(WalletStatusText.failure(WalletStatusText.presentFailed, WalletStatusText.invalidRequestURL), tab: .present)
+            return
+        }
+        guard !selectedPresentationCredentialIDs.isEmpty else {
+            setError(WalletStatusText.failure(WalletStatusText.presentFailed, WalletStatusText.selectAtLeastOneCredential), tab: .present)
+            return
+        }
+
+        setLoading(WalletStatusText.presentingCredential, tab: .present)
+        Task {
+            do {
+                let result = try await walletClient.submitPresentation(
+                    request: request,
+                    selectedCredentialIDs: Array(selectedPresentationCredentialIDs),
+                    did: did.isEmpty ? nil : did
+                )
+                selectedPresentationCredentialIDs = []
+                presentationCompleted = result.success
+                setSuccess(
+                    result.success
+                        ? WalletStatusText.presentationSent
+                        : WalletStatusText.presentationFinishedWithoutVerifierConfirmation,
+                    tab: .present
+                )
+            } catch {
+                setError(WalletStatusText.failure(WalletStatusText.presentFailed, error), tab: .present)
+            }
+        }
+    }
+
+    func cancelPresentationReview() {
+        presentationPreview = nil
+        selectedPresentationCredentialIDs = []
+        presentationCompleted = false
+        presentationNavigationResetKey += 1
+        setSuccess(WalletStatusText.presentationReviewCancelled, tab: .present)
+    }
+
     private func bootstrap() {
-        setLoading("Bootstrapping wallet...")
+        setLoading(WalletStatusText.bootstrappingWallet)
         logE2E("Bootstrap started")
         Task {
             do {
-                let wallet = try await wallet()
                 logE2E("Bootstrap: calling wallet.bootstrap()")
-                let result = try await wallet.bootstrap()
+                let result = try await walletClient.bootstrap()
                 logE2E("Bootstrap: success, DID: \(result.did)")
 
                 logE2E("Bootstrap: calling wallet.credentials()")
-                let list = try await wallet.credentials()
+                let list = try await walletClient.credentials()
                 logE2E("Bootstrap: listCredentials returned \(list.count) credentials")
 
                 did = result.did
                 credentials = list
                 isReady = true
-                setSuccess("Wallet ready")
+                setSuccess(WalletStatusText.walletReady)
                 logE2E("Bootstrap: completed successfully, wallet is ready")
             } catch {
                 logE2E("Bootstrap: FAILED with error: \(error.localizedDescription)")
-                setError("Bootstrap failed: \(error.localizedDescription)")
+                setError(WalletStatusText.failure(WalletStatusText.bootstrapFailed, error))
             }
         }
-    }
-
-    private func wallet() async throws -> Wallet {
-        if let cachedWallet {
-            return cachedWallet
-        }
-
-        let wallet = try await Wallet(configuration: configuration)
-        cachedWallet = wallet
-        return wallet
     }
 
     private static func attestationConfiguration(
@@ -143,25 +363,82 @@ class WalletViewModel: ObservableObject {
         )
     }
 
-    private func setLoading(_ message: String) {
+    private func setLoading(_ message: String, tab: WalletTab? = nil) {
         isLoading = true
         isError = false
+        statusTab = tab
         statusMessage = message
         logE2E("STATUS \(message)")
     }
 
-    private func setSuccess(_ message: String) {
+    private func setSuccess(_ message: String, tab: WalletTab? = nil) {
         isLoading = false
         isError = false
+        statusTab = tab
         statusMessage = message
         logE2E("STATUS \(message)")
     }
 
-    private func setError(_ message: String) {
+    private static func resolvedReceivedCredentialIDs(
+        returnedCredentialIDs: [String],
+        previousCredentials: [Credential],
+        refreshedCredentials: [Credential]
+    ) -> [String] {
+        let refreshedIDs = Set(refreshedCredentials.map(\.id))
+        let returnedResolvedIDs = returnedCredentialIDs.filter { refreshedIDs.contains($0) }
+        if !returnedResolvedIDs.isEmpty {
+            return returnedResolvedIDs
+        }
+
+        let previousIDs = Set(previousCredentials.map(\.id))
+        let newCredentialIDs = refreshedCredentials
+            .map(\.id)
+            .filter { !previousIDs.contains($0) }
+        return newCredentialIDs.isEmpty ? returnedCredentialIDs : newCredentialIDs
+    }
+
+    private func setError(_ message: String, tab: WalletTab? = nil) {
         isLoading = false
         isError = true
+        statusTab = tab
         statusMessage = message
         logE2E("STATUS \(message)")
+    }
+
+    private func resetFlowStatusForIncomingURL() {
+        isLoading = !isReady
+        isError = false
+        statusTab = nil
+        statusMessage = isReady ? WalletStatusText.walletReady : WalletStatusText.startingWallet
+        logE2E("STATUS \(statusMessage)")
+    }
+
+    private func statusApplies(to tab: WalletTab) -> Bool {
+        statusTab == nil || statusTab == tab
+    }
+
+    private func fallbackStatusMessage(for tab: WalletTab) -> String {
+        switch tab {
+        case .credentials:
+            return baseStatusMessage
+        case .receive:
+            if receiveCompleted && !lastReceivedCredentialIDs.isEmpty {
+                return WalletStatusText.receivedCredentials(lastReceivedCredentialIDs.count)
+            }
+            return baseStatusMessage
+        case .present:
+            if presentationCompleted {
+                return WalletStatusText.presentationSent
+            }
+            if presentationPreview != nil {
+                return WalletStatusText.reviewPresentationRequest
+            }
+            return baseStatusMessage
+        }
+    }
+
+    private var baseStatusMessage: String {
+        isReady ? WalletStatusText.walletReady : WalletStatusText.startingWallet
     }
 
     private func logE2E(_ message: String) {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialDetailsDestination.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialDetailsDestination.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct CredentialDetailsDestination: View {
+    let credentialID: String
+    let details: [CredentialDetails]
+
+    var body: some View {
+        if let item = details.first(where: { $0.id == credentialID }) {
+            CredentialDetailsScreen(details: item)
+        } else {
+            Text("Credential details unavailable")
+                .foregroundStyle(.secondary)
+                .navigationTitle("Credential")
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialDetailsScreen.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialDetailsScreen.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct CredentialDetailsScreen: View {
+    let details: CredentialDetails
+
+    var body: some View {
+        ScrollView {
+            CredentialDetailsView(details: details, includeTechnicalDetails: true)
+                .padding()
+        }
+        .navigationTitle("Credential details")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialsTabView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialsTabView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import WalletSDK
+
+struct CredentialsTabView: View {
+    @ObservedObject var viewModel: WalletViewModel
+    @Binding var path: [String]
+
+    private var details: [CredentialDetails] {
+        viewModel.credentials.map(CredentialDisplayNormalizer.details(for:))
+    }
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    StatusBannerView(
+                        message: viewModel.statusMessage(for: .credentials),
+                        isLoading: viewModel.statusIsLoading(for: .credentials),
+                        isError: viewModel.statusIsError(for: .credentials)
+                    )
+
+                    if details.isEmpty {
+                        EmptyCredentialsView()
+                    } else {
+                        ForEach(details) { item in
+                            CredentialCardButton(details: item) {
+                                path.append(item.id)
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Credentials")
+            .navigationDestination(for: String.self) { credentialID in
+                CredentialDetailsDestination(
+                    credentialID: credentialID,
+                    details: details
+                )
+            }
+        }
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/HomeView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/HomeView.swift
@@ -2,34 +2,44 @@ import SwiftUI
 
 struct HomeView: View {
     @ObservedObject var viewModel: WalletViewModel
+    @State private var credentialsPath: [String] = []
+    @State private var receivePath: [String] = []
+    @State private var presentPath: [String] = []
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                StatusBannerView(
-                    message: viewModel.statusMessage,
-                    isLoading: viewModel.isLoading,
-                    isError: viewModel.isError
-                )
-
-                ReceiveView(viewModel: viewModel)
-                Divider()
-                PresentView(viewModel: viewModel)
-                Divider()
-
-                Text("Credentials")
-                    .font(.headline)
-
-                if viewModel.credentials.isEmpty {
-                    Text("No credentials")
-                        .foregroundColor(.secondary)
-                } else {
-                    ForEach(viewModel.credentials, id: \.id) { credential in
-                        CredentialCardView(credential: credential)
-                    }
-                }
+        TabView(selection: $viewModel.selectedTab) {
+            CredentialsTabView(
+                viewModel: viewModel,
+                path: $credentialsPath
+            )
+            .tabItem {
+                Label("Credentials", systemImage: "wallet.pass")
             }
-            .padding()
+            .tag(WalletTab.credentials)
+
+            ReceiveView(
+                viewModel: viewModel,
+                path: $receivePath
+            )
+            .tabItem {
+                Label("Receive", systemImage: "tray.and.arrow.down")
+            }
+            .tag(WalletTab.receive)
+
+            PresentView(
+                viewModel: viewModel,
+                path: $presentPath
+            )
+            .tabItem {
+                Label("Present", systemImage: "person.badge.key")
+            }
+            .tag(WalletTab.present)
+        }
+        .onChange(of: viewModel.receiveNavigationResetKey) { _ in
+            receivePath = []
+        }
+        .onChange(of: viewModel.presentationNavigationResetKey) { _ in
+            presentPath = []
         }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/PresentView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/PresentView.swift
@@ -2,30 +2,73 @@ import SwiftUI
 
 struct PresentView: View {
     @ObservedObject var viewModel: WalletViewModel
+    @Binding var path: [String]
+
+    private var presentationDetails: [CredentialDetails] {
+        viewModel.presentationPreview?.credentialOptions.map(CredentialDisplayNormalizer.details(for:)) ?? []
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Present")
-                .font(.headline)
+        NavigationStack(path: $path) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    UrlEditor(
+                        title: "Present",
+                        label: "OpenID4VP request URL",
+                        text: $viewModel.presentationRequestUrl,
+                        inputIdentifier: WalletAccessibilityID.presentationInput,
+                        isEnabled: viewModel.presentationUrlEntryEnabled
+                    )
 
-            TextEditor(text: $viewModel.presentationRequestUrl)
-                .font(.footnote.monospaced())
-                .frame(minHeight: 72, maxHeight: 96)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color(.separator), lineWidth: 1)
-                )
-                .textInputAutocapitalization(.never)
-                .disableAutocorrection(true)
-                .accessibilityIdentifier("wallet.presentationInput")
+                    Button("Preview") {
+                        viewModel.previewPresentation()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.waltBlue)
+                    .disabled(!viewModel.presentationPreviewActionEnabled)
+                    .accessibilityIdentifier(WalletAccessibilityID.presentButton)
 
-            Button("Present") {
-                viewModel.presentCredential()
+                    if viewModel.credentials.isEmpty {
+                        Text("No credentials available")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    StatusBannerView(
+                        message: viewModel.statusMessage(for: .present),
+                        isLoading: viewModel.statusIsLoading(for: .present),
+                        isError: viewModel.statusIsError(for: .present)
+                    )
+
+                    if viewModel.presentationCompleted {
+                        Button("New presentation", action: viewModel.startNewPresentationFlow)
+                            .buttonStyle(.bordered)
+                            .accessibilityIdentifier(WalletAccessibilityID.presentationNewButton)
+                    }
+
+                    if let preview = viewModel.presentationPreview {
+                        PresentationReviewView(
+                            preview: preview,
+                            selectedCredentialIDs: viewModel.selectedPresentationCredentialIDs,
+                            isLoading: !viewModel.presentationReviewEnabled,
+                            isReadOnly: viewModel.presentationCompleted,
+                            onToggleCredential: viewModel.togglePresentationCredential,
+                            onCredentialSelected: { credentialID in path.append(credentialID) },
+                            onSubmit: viewModel.submitPresentation,
+                            onCancel: viewModel.cancelPresentationReview
+                        )
+                    }
+                }
+                .padding()
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.waltBlue)
-            .disabled(!viewModel.isReady || viewModel.presentationRequestUrl.isEmpty || viewModel.credentials.isEmpty || viewModel.isLoading)
-            .accessibilityIdentifier("wallet.presentButton")
+            .navigationTitle("Present")
+            .navigationDestination(for: String.self) { credentialID in
+                CredentialDetailsDestination(
+                    credentialID: credentialID,
+                    details: presentationDetails
+                )
+            }
+            .accessibilityIdentifier(WalletAccessibilityID.presentTabContent)
         }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/ReceiveView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/ReceiveView.swift
@@ -2,30 +2,63 @@ import SwiftUI
 
 struct ReceiveView: View {
     @ObservedObject var viewModel: WalletViewModel
+    @Binding var path: [String]
+
+    private var receivedDetails: [CredentialDetails] {
+        viewModel.receivedCredentials.map(CredentialDisplayNormalizer.details(for:))
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Receive")
-                .font(.headline)
+        NavigationStack(path: $path) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    UrlEditor(
+                        title: "Receive",
+                        label: "Credential offer URL",
+                        text: $viewModel.offerUrl,
+                        inputIdentifier: WalletAccessibilityID.offerInput,
+                        isEnabled: viewModel.receiveUrlEntryEnabled
+                    )
 
-            TextEditor(text: $viewModel.offerUrl)
-                .font(.footnote.monospaced())
-                .frame(minHeight: 72, maxHeight: 96)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(Color(.separator), lineWidth: 1)
-                )
-                .textInputAutocapitalization(.never)
-                .disableAutocorrection(true)
-                .accessibilityIdentifier("wallet.offerInput")
+                    Button("Receive") {
+                        viewModel.receiveCredential()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.waltBlue)
+                    .disabled(!viewModel.receiveActionEnabled)
+                    .accessibilityIdentifier(WalletAccessibilityID.receiveButton)
 
-            Button("Receive") {
-                viewModel.receiveCredential()
+                    StatusBannerView(
+                        message: viewModel.statusMessage(for: .receive),
+                        isLoading: viewModel.statusIsLoading(for: .receive),
+                        isError: viewModel.statusIsError(for: .receive)
+                    )
+
+                    if viewModel.receiveCompleted {
+                        Button("New receive", action: viewModel.startNewReceiveFlow)
+                            .buttonStyle(.bordered)
+                            .accessibilityIdentifier(WalletAccessibilityID.receiveNewButton)
+
+                        Text("Received credentials")
+                            .font(.subheadline.weight(.semibold))
+
+                        ForEach(receivedDetails) { item in
+                            CredentialCardButton(details: item) {
+                                path.append(item.id)
+                            }
+                        }
+                    }
+                }
+                .padding()
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.waltBlue)
-            .disabled(!viewModel.isReady || viewModel.offerUrl.isEmpty || viewModel.isLoading)
-            .accessibilityIdentifier("wallet.receiveButton")
+            .navigationTitle("Receive")
+            .navigationDestination(for: String.self) { credentialID in
+                CredentialDetailsDestination(
+                    credentialID: credentialID,
+                    details: receivedDetails
+                )
+            }
+            .accessibilityIdentifier(WalletAccessibilityID.receiveTabContent)
         }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletAccessibilityID.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletAccessibilityID.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+enum WalletAccessibilityID {
+    static let status = identifier("status")
+    static let credentialsEmpty = identifier("credentials", "empty")
+    static let offerInput = identifier("offerInput")
+    static let receiveButton = identifier("receiveButton")
+    static let receiveNewButton = identifier("receiveNewButton")
+    static let receiveTabContent = identifier("receiveTabContent")
+    static let presentationInput = identifier("presentationInput")
+    static let presentButton = identifier("presentButton")
+    static let presentationNewButton = identifier("presentationNewButton")
+    static let presentTabContent = identifier("presentTabContent")
+    static let presentationSubmitButton = identifier("presentationSubmitButton")
+    static let presentationCancelButton = identifier("presentationCancelButton")
+    static let presentationVerifier = identifier("presentationVerifier")
+    static let verifierTechnicalDetailsToggle = identifier("verifierTechnicalDetailsToggle")
+    static let verifierTechnicalDetails = identifier("verifierTechnicalDetails")
+
+    static func claim(_ path: String) -> String {
+        dynamicIdentifier("claim", path)
+    }
+
+    static func claimImage(_ path: String) -> String {
+        dynamicIdentifier("claimImage", path)
+    }
+
+    static func claimGroup(_ title: String) -> String {
+        dynamicIdentifier("claimGroup", title)
+    }
+
+    static func credentialCard(_ id: String) -> String {
+        identifier("credentialCard", id)
+    }
+
+    static func credentialDetails(_ id: String) -> String {
+        identifier("credentialDetails", id)
+    }
+
+    static func credentialOverview(_ id: String) -> String {
+        identifier("credentialOverview", id)
+    }
+
+    static func presentationCredential(_ id: String) -> String {
+        identifier("presentationCredential", id)
+    }
+
+    private static func identifier(_ segments: String...) -> String {
+        ([namespace] + segments).joined(separator: ".")
+    }
+
+    private static func dynamicIdentifier(_ kind: String, _ rawValue: String) -> String {
+        identifier(kind, rawValue.identifierSegment)
+    }
+
+    private static let namespace = "wallet"
+}
+
+private extension String {
+    var identifierSegment: String {
+        map { $0.isLetter || $0.isNumber ? String($0) : "_" }.joined()
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletDemoApp.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletDemoApp.swift
@@ -6,6 +6,16 @@ struct WalletDemoApp: App {
         let env = ProcessInfo.processInfo.environment
         let defaults = UserDefaults.standard
         let walletID = env["E2E_WALLET_ID"] ?? defaults.string(forKey: "E2E_WALLET_ID") ?? "default"
+        if env["E2E_MOCK_WALLET"] == "1" {
+            let delayMilliseconds = UInt64(env["E2E_MOCK_WALLET_DELAY_MS"] ?? "") ?? 0
+            return WalletViewModel(
+                walletID: walletID,
+                walletClient: MockWalletClient(
+                    operationDelayMilliseconds: delayMilliseconds,
+                    verifierStyle: Self.mockVerifierStyle(environment: env)
+                )
+            )
+        }
         let baseUrl = env["ATTESTATION_BASE_URL"] ?? defaults.string(forKey: "ATTESTATION_BASE_URL")
         if let baseUrl, !baseUrl.isEmpty {
             return WalletViewModel(
@@ -21,15 +31,21 @@ struct WalletDemoApp: App {
 
     var body: some Scene {
         WindowGroup {
-            NavigationView {
-                ContentView(viewModel: viewModel)
-                    .navigationTitle("walt.id Wallet")
-            }
-            .navigationViewStyle(.stack)
+            ContentView(viewModel: viewModel)
             .tint(.waltBlue)
             .onOpenURL { url in
                 viewModel.handleDeepLink(url)
             }
         }
+    }
+
+    private static func mockVerifierStyle(environment: [String: String]) -> MockWalletClient.VerifierStyle {
+        if environment["E2E_MOCK_DNS_VERIFIER"] == "1" {
+            return .x509SanDns
+        }
+        if environment["E2E_MOCK_DID_VERIFIER"] == "1" {
+            return .did
+        }
+        return .named
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
@@ -1,0 +1,1002 @@
+import XCTest
+@testable import iosApp
+import WalletSDK
+
+final class CredentialDisplayNormalizerTests: XCTestCase {
+
+    func testParsesCredentialJsonIntoReadableGroups() {
+        let imageBytes = Self.tinyPngBytes
+        let credential = Credential(
+            id: "cred-1",
+            format: "vc+sd-jwt",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "given_name": "Ada",
+              "resident_address": {
+                "street_address": "Main Street 1"
+              },
+              "portrait": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII="
+            }
+            """
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+
+        XCTAssertTrue(details.groups.contains { $0.title == "Personal details" })
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.items.contains(where: { $0.label == "Given name" && $0.value == .text("Ada") })
+        }))
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.items.contains(where: { $0.label == "Resident address" })
+        }))
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.items.contains(where: { item in
+                guard case .image(_, let data, let mimeType, let byteCount) = item.value else {
+                    return false
+                }
+                return item.label == "Portrait" &&
+                    data == imageBytes &&
+                    mimeType == "image/png" &&
+                    byteCount == imageBytes.count
+            })
+        }))
+    }
+
+    func testNormalizesParameterizedDataURIImageMimeType() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "vc+sd-jwt",
+            issuer: nil,
+            subject: nil,
+            label: nil,
+            addedAt: nil,
+            credentialDataJSON: #"{"portrait":"DATA:image/PNG;charset=utf-8;base64,  \#(Self.tinyPngBase64)  "}"#
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+        let portrait = details.groups.flatMap(\.items).first { $0.path.id == "portrait" }
+
+        guard case .image(_, let data, let mimeType, let byteCount) = portrait?.value else {
+            return XCTFail("Expected data URI portrait to render as an image")
+        }
+
+        XCTAssertEqual(data, Self.tinyPngBytes)
+        XCTAssertEqual(mimeType, "image/png")
+        XCTAssertEqual(byteCount, Self.tinyPngBytes.count)
+    }
+
+    func testClassifiesPortraitByteArrayDataAsImage() {
+        let signedBytes = Self.tinyPngBytes.map { byte in
+            byte > 127 ? Int(byte) - 256 : Int(byte)
+        }
+        let credential = Credential(
+            id: "cred-1",
+            format: "mso_mdoc",
+            issuer: nil,
+            subject: nil,
+            label: nil,
+            addedAt: nil,
+            credentialDataJSON: #"{"portrait":\#(signedBytes)}"#
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.items.contains(where: { item in
+                guard case .image(_, let data, let mimeType, let byteCount) = item.value else {
+                    return false
+                }
+                return item.label == "Portrait" &&
+                    data == Self.tinyPngBytes &&
+                    mimeType == "image/png" &&
+                    byteCount == Self.tinyPngBytes.count
+            })
+        }))
+    }
+
+    func testClassifiesNestedPortraitByteArrayDataAsImageAndCardPortrait() {
+        let signedBytes = Self.tinyPngBytes.map { byte in
+            byte > 127 ? Int(byte) - 256 : Int(byte)
+        }
+        let credential = Credential(
+            id: "cred-1",
+            format: "mso_mdoc",
+            issuer: nil,
+            subject: nil,
+            label: nil,
+            addedAt: nil,
+            credentialDataJSON: #"{"portrait":{"elementValue":\#(signedBytes)}}"#
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.items.contains(where: { item in
+                guard item.label == "Portrait",
+                      case .object(let children) = item.value,
+                      let nested = children.first(where: { $0.path.id == "portrait.elementValue" }),
+                      case .image(_, let data, let mimeType, let byteCount) = nested.value else {
+                    return false
+                }
+                return data == Self.tinyPngBytes &&
+                    mimeType == "image/png" &&
+                    byteCount == Self.tinyPngBytes.count
+            })
+        }))
+        XCTAssertEqual(details.cardSummary.portraitData, Self.tinyPngBytes)
+        XCTAssertEqual(details.cardSummary.portraitMimeType, "image/png")
+    }
+
+    func testClassifiesPresentationDisclosureByteArrayDataAsImage() {
+        let signedBytes = Self.tinyPngBytes.map { byte in
+            byte > 127 ? Int(byte) - 256 : Int(byte)
+        }
+        let option = PresentationCredentialOption(
+            queryID: "pid",
+            credentialID: "cred-1",
+            format: "mso_mdoc",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "PID",
+            credentialDataJSON: nil,
+            disclosures: [
+                PresentationDisclosure(
+                    path: "$.portrait",
+                    name: "Portrait",
+                    valueJSON: "\(signedBytes)",
+                    displayValue: nil,
+                    selectivelyDisclosable: true
+                )
+            ]
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: option)
+        let disclosure = details.groups
+            .first { $0.title == CredentialDisplayVocabulary.requestedDisclosuresTitle }?
+            .items
+            .first
+
+        guard case .image(_, let data, let mimeType, let byteCount) = disclosure?.value else {
+            return XCTFail("Expected presentation disclosure to render as an image")
+        }
+
+        XCTAssertEqual(disclosure?.path.id, "disclosures[0].portrait")
+        XCTAssertEqual(disclosure?.path.sourcePath, "$.portrait")
+        XCTAssertEqual(data, Self.tinyPngBytes)
+        XCTAssertEqual(mimeType, "image/png")
+        XCTAssertEqual(byteCount, Self.tinyPngBytes.count)
+        XCTAssertEqual(disclosure?.rawValue, "\(signedBytes)")
+    }
+
+    func testClassifiesDisclosureSemanticsFromSdkPathWhenNameIsMissing() {
+        let signedBytes = Self.tinyPngBytes.map { byte in
+            byte > 127 ? Int(byte) - 256 : Int(byte)
+        }
+        let option = PresentationCredentialOption(
+            queryID: "pid",
+            credentialID: "cred-1",
+            format: "mso_mdoc",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "PID",
+            credentialDataJSON: nil,
+            disclosures: [
+                PresentationDisclosure(
+                    path: "$.portrait",
+                    name: nil,
+                    valueJSON: "\(signedBytes)",
+                    displayValue: nil,
+                    selectivelyDisclosable: true
+                )
+            ]
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: option)
+        let disclosure = details.groups
+            .first { $0.title == CredentialDisplayVocabulary.requestedDisclosuresTitle }?
+            .items
+            .first
+
+        XCTAssertEqual(disclosure?.label, "Portrait")
+        guard case .image(_, let data, let mimeType, _) = disclosure?.value else {
+            return XCTFail("Expected disclosure path to identify portrait image data")
+        }
+        XCTAssertEqual(data, Self.tinyPngBytes)
+        XCTAssertEqual(mimeType, "image/png")
+    }
+
+    func testBuildsReadableDisclosureLabelsFromSdkPath() {
+        XCTAssertEqual(CredentialDisplayVocabulary.disclosureLabel(name: nil, path: "$.portrait"), "Portrait")
+        XCTAssertEqual(CredentialDisplayVocabulary.disclosureLabel(name: nil, path: "$.given_name"), "Given name")
+        XCTAssertEqual(CredentialDisplayVocabulary.disclosureLabel(name: nil, path: "$.credentialSubject['family.name']"), "Family name")
+        XCTAssertEqual(CredentialDisplayVocabulary.disclosureLabel(name: nil, path: "$['credentialSubject']['resident.address']"), "Resident address")
+        XCTAssertEqual(CredentialDisplayVocabulary.disclosureLabel(name: "Visible name", path: "$.given_name"), "Visible name")
+        XCTAssertEqual(CredentialDisplayVocabulary.disclosureLabel(name: "   ", path: "$.given_name"), "Given name")
+    }
+
+    func testClassifiesHumanLabelledMdocClaimsForDetailsAndCards() {
+        let signedBytes = Self.tinyPngBytes.map { byte in
+            byte > 127 ? Int(byte) - 256 : Int(byte)
+        }
+        let credential = Credential(
+            id: "cred-1",
+            format: "mso_mdoc",
+            issuer: nil,
+            subject: nil,
+            label: nil,
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "Given name": "Ada",
+              "Family name": "Lovelace",
+              "Date of birth": "1815-12-10",
+              "Place of birth": "London",
+              "Valid to": 1781654400,
+              "Portrait": {
+                "elementValue": \(signedBytes)
+              }
+            }
+            """
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+        let summary = details.cardSummary
+
+        XCTAssertTrue(details.groups.contains { $0.title == "Personal details" })
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.title == "Personal details" &&
+                group.items.contains { $0.path.id == "Date of birth" && $0.value == .text("1815-12-10") } &&
+                group.items.contains { $0.path.id == "Place of birth" && $0.value == .text("London") }
+        }))
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.items.contains(where: { item in
+                guard item.path.id == "Portrait",
+                      case .object(let children) = item.value,
+                      let nested = children.first(where: { $0.path.id == "Portrait.elementValue" }),
+                      case .image(_, let data, let mimeType, _) = nested.value else {
+                    return false
+                }
+                return data == Self.tinyPngBytes && mimeType == "image/png"
+            })
+        }))
+        XCTAssertEqual(summary.holderName, "Ada Lovelace")
+        XCTAssertEqual(summary.dateText, "2026-06-17")
+        XCTAssertEqual(summary.validityText, "Expires 2026-06-17")
+        XCTAssertEqual(summary.portraitData, Self.tinyPngBytes)
+    }
+
+    func testDecodesBase64Text() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: nil,
+            subject: nil,
+            label: nil,
+            addedAt: nil,
+            credentialDataJSON: #"{"encoded_note":"SGVsbG8gd2FsbGV0"}"#
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+
+        XCTAssertTrue(details.groups.contains(where: { group in
+            group.items.contains(where: { $0.label == "Encoded note" && $0.value == .decodedText("Hello wallet") })
+        }))
+    }
+
+    func testBuildsCredentialCardSummaryFromReadableClaims() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "given_name": "Ada",
+              "family_name": "Lovelace",
+              "exp": "2026-06-17",
+              "portrait": "\(Self.tinyPngBase64)"
+            }
+            """
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.title, "Example Credential")
+        XCTAssertEqual(summary.holderName, "Ada Lovelace")
+        XCTAssertEqual(summary.dateText, "2026-06-17")
+        XCTAssertEqual(summary.portraitData, Self.tinyPngBytes)
+        XCTAssertEqual(summary.portraitMimeType, "image/png")
+    }
+
+    func testFormatsNumericTemporalClaimsAsReadableDatesForDetailsAndCards() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "given_name": "Ada",
+              "family_name": "Lovelace",
+              "exp": 1781654400,
+              "nbf": 1781568000000
+            }
+            """
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+        let items = details.groups.flatMap(\.items)
+
+        XCTAssertTrue(items.contains { $0.path.id == "exp" && $0.value == .text("2026-06-17") })
+        XCTAssertTrue(items.contains { $0.path.id == "nbf" && $0.value == .text("2026-06-16") })
+        XCTAssertEqual(details.cardSummary.dateText, "2026-06-17")
+        XCTAssertEqual(details.cardSummary.validityText, "Expires 2026-06-17")
+    }
+
+    func testBuildsCredentialCardSummaryFromValidToClaim() {
+        let addedAt = ISO8601DateFormatter().date(from: "2026-07-09T12:00:00Z")!
+        let credential = Credential(
+            id: "cred-1",
+            format: "mso_mdoc",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: addedAt,
+            credentialDataJSON: """
+            {
+              "given_name": "Ada",
+              "valid_to": 1781654400
+            }
+            """
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.dateText, "2026-06-17")
+    }
+
+    func testCredentialCardSummaryLabelsAddedAtFallbackWhenNoExpiryClaimExists() {
+        let addedAt = ISO8601DateFormatter().date(from: "2026-07-09T12:00:00Z")!
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: addedAt,
+            credentialDataJSON: #"{"given_name":"Ada"}"#
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.dateText, "2026-07-09")
+        XCTAssertEqual(summary.validityText, "Added 2026-07-09")
+    }
+
+    func testBuildsCredentialCardSummaryTypeFromReadableCredentialTypeClaim() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "vc+sd-jwt",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "PID",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "vct": "https://issuer.example/credential-types/mobile-driving-licence",
+              "given_name": "Ada"
+            }
+            """
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.credentialType, "Mobile driving licence")
+    }
+
+    func testBuildsCredentialCardSummaryTypeFromURLClaimWithoutQueryOrFragmentNoise() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "vc+sd-jwt",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "PID",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "vct": "https://issuer.example/credential-types/mobile-driving-licence?version=1#current",
+              "given_name": "Ada"
+            }
+            """
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.credentialType, "Mobile driving licence")
+    }
+
+    func testBuildsCredentialCardSummaryTypeFromVcTypeArray() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+              "given_name": "Ada"
+            }
+            """
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.credentialType, "University degree credential")
+    }
+
+    func testBuildsCredentialCardSummaryTypeFromURNTypeArray() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "type": ["VerifiableCredential", "urn:example:ExampleCredential"],
+              "given_name": "Ada"
+            }
+            """
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.credentialType, "Example credential")
+    }
+
+    func testCredentialCardSummaryIgnoresNestedTypeClaims() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "document": {
+                "type": "metadata"
+              },
+              "given_name": "Ada"
+            }
+            """
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertNil(summary.credentialType)
+    }
+
+    func testDoesNotInferClaimRolesFromPunctuationInsideClaimNames() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "vc+sd-jwt",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "PID",
+            addedAt: nil,
+            credentialDataJSON: """
+            {
+              "metadata.exp": 1781654400
+            }
+            """
+        )
+
+        let details = CredentialDisplayNormalizer.details(for: credential)
+        let metadataExpiry = details.groups.flatMap(\.items).first { $0.path.id == "metadata.exp" }
+
+        XCTAssertEqual(metadataExpiry?.value, .number("1781654400"))
+        XCTAssertNil(details.cardSummary.dateText)
+    }
+
+    func testCredentialCardSummaryFallsBackToAddedAtWhenNoExpiryClaimExists() {
+        let addedAt = ISO8601DateFormatter().date(from: "2026-07-09T12:00:00Z")!
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Example Credential",
+            addedAt: addedAt,
+            credentialDataJSON: #"{"given_name":"Ada"}"#
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.dateText, "2026-07-09")
+    }
+
+    func testCredentialCardSummaryFallsBackToSubjectWhenNameClaimsAreMissing() {
+        let credential = Credential(
+            id: "cred-1",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: "did:example:holder",
+            label: "Example Credential",
+            addedAt: nil,
+            credentialDataJSON: #"{"credential_role":"Member"}"#
+        )
+
+        let summary = CredentialDisplayNormalizer.details(for: credential).cardSummary
+
+        XCTAssertEqual(summary.holderName, "did:example:holder")
+    }
+
+    func testBuildsHumanReadableVerifierNamesWithoutDumpingRawIdentifiers() {
+        XCTAssertEqual(
+            VerifierDisplayName.value(
+                verifierName: "Example Verifier",
+                clientID: "decentralized_identifier:did:jwk:abc",
+                responseURI: nil
+            ),
+            "Example Verifier"
+        )
+        XCTAssertEqual(
+            VerifierDisplayName.value(
+                verifierName: nil,
+                clientID: "decentralized_identifier:did:jwk:abc",
+                responseURI: nil
+            ),
+            "DID verifier"
+        )
+        XCTAssertEqual(
+            VerifierDisplayName.value(
+                verifierName: nil,
+                clientID: "did:jwk:legacy-abc",
+                responseURI: nil
+            ),
+            "DID verifier"
+        )
+        XCTAssertEqual(
+            VerifierDisplayName.value(
+                verifierName: nil,
+                clientID: "https://verifier.example:8443/client?x=1#fragment",
+                responseURI: nil
+            ),
+            "verifier.example"
+        )
+        XCTAssertEqual(
+            VerifierDisplayName.value(
+                verifierName: nil,
+                clientID: "HTTPS://verifier.example/client",
+                responseURI: nil
+            ),
+            "verifier.example"
+        )
+        XCTAssertEqual(
+            VerifierDisplayName.value(
+                verifierName: nil,
+                clientID: "redirect_uri:https://verifier.example/callback",
+                responseURI: nil
+            ),
+            "verifier.example"
+        )
+        XCTAssertEqual(
+            VerifierDisplayName.value(
+                verifierName: nil,
+                clientID: "x509_san_dns:verifier.example",
+                responseURI: nil
+            ),
+            "verifier.example"
+        )
+    }
+
+    @MainActor
+    func testStartNewReceiveFlowClearsCompletedStateAndStatus() {
+        let viewModel = WalletViewModel(walletID: "reset-receive-\(UUID().uuidString)")
+        viewModel.offerUrl = "openid-credential-offer://example"
+        viewModel.lastReceivedCredentialIDs = ["cred-1"]
+        viewModel.receiveCompleted = true
+        viewModel.isLoading = true
+        viewModel.isError = true
+        viewModel.statusMessage = "Received 1 credential(s)"
+
+        let resetKeyBeforeNewFlow = viewModel.receiveNavigationResetKey
+        viewModel.startNewReceiveFlow()
+
+        XCTAssertEqual(viewModel.offerUrl, "")
+        XCTAssertEqual(viewModel.lastReceivedCredentialIDs, [])
+        XCTAssertFalse(viewModel.receiveCompleted)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isError)
+        XCTAssertEqual(viewModel.receiveNavigationResetKey, resetKeyBeforeNewFlow + 1)
+        XCTAssertEqual(viewModel.statusMessage, "Wallet ready")
+    }
+
+    @MainActor
+    func testReceiveFlowAvailabilityFollowsLoadingAndCompletionState() {
+        let viewModel = WalletViewModel(walletID: "receive-availability-\(UUID().uuidString)")
+        viewModel.isReady = true
+        viewModel.isLoading = false
+
+        XCTAssertTrue(viewModel.receiveUrlEntryEnabled)
+        XCTAssertFalse(viewModel.receiveActionEnabled)
+
+        viewModel.offerUrl = "openid-credential-offer://example"
+        XCTAssertTrue(viewModel.receiveActionEnabled)
+
+        viewModel.isLoading = true
+        XCTAssertFalse(viewModel.receiveUrlEntryEnabled)
+        XCTAssertFalse(viewModel.receiveActionEnabled)
+
+        viewModel.isLoading = false
+        viewModel.receiveCompleted = true
+        XCTAssertFalse(viewModel.receiveUrlEntryEnabled)
+        XCTAssertFalse(viewModel.receiveActionEnabled)
+
+        viewModel.startNewReceiveFlow()
+        XCTAssertTrue(viewModel.receiveUrlEntryEnabled)
+        XCTAssertFalse(viewModel.receiveActionEnabled)
+    }
+
+    @MainActor
+    func testReceiveCredentialRefreshesCredentialsAndLocksCompletedFlow() async throws {
+        let viewModel = WalletViewModel(
+            walletID: "receive-refresh-\(UUID().uuidString)",
+            walletClient: MockWalletClient()
+        )
+
+        try await waitUntil { viewModel.isReady }
+        XCTAssertTrue(viewModel.credentials.isEmpty)
+
+        viewModel.offerUrl = "openid-credential-offer://mock"
+        XCTAssertTrue(viewModel.receiveActionEnabled)
+
+        viewModel.receiveCredential()
+
+        try await waitUntil { viewModel.receiveCompleted }
+        XCTAssertEqual(viewModel.credentials.map(\.id), ["cred-1"])
+        XCTAssertEqual(viewModel.lastReceivedCredentialIDs, ["cred-1"])
+        XCTAssertFalse(viewModel.receiveUrlEntryEnabled)
+        XCTAssertFalse(viewModel.receiveActionEnabled)
+        XCTAssertEqual(viewModel.statusMessage, "Received 1 credential(s)")
+        XCTAssertFalse(viewModel.isError)
+    }
+
+    @MainActor
+    func testReceiveCredentialDerivesNewCredentialsWhenClientReturnsNoIds() async throws {
+        let existingCredential = Credential(
+            id: "old-cred",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "Existing Credential",
+            addedAt: nil,
+            credentialDataJSON: nil
+        )
+        let newCredential = Credential(
+            id: "new-cred",
+            format: "jwt_vc_json",
+            issuer: "Example Issuer",
+            subject: nil,
+            label: "New Credential",
+            addedAt: nil,
+            credentialDataJSON: nil
+        )
+        let viewModel = WalletViewModel(
+            walletID: "receive-derived-\(UUID().uuidString)",
+            walletClient: ReceiveFallbackWalletClient(
+                initialCredentials: [existingCredential],
+                credentialsAfterReceive: [existingCredential, newCredential],
+                receiveCredentialIDs: []
+            )
+        )
+
+        try await waitUntil { viewModel.isReady }
+        XCTAssertEqual(viewModel.credentials.map(\.id), ["old-cred"])
+
+        viewModel.offerUrl = "openid-credential-offer://mock"
+        viewModel.receiveCredential()
+
+        try await waitUntil { viewModel.receiveCompleted }
+        XCTAssertEqual(viewModel.credentials.map(\.id), ["old-cred", "new-cred"])
+        XCTAssertEqual(viewModel.lastReceivedCredentialIDs, ["new-cred"])
+        XCTAssertEqual(viewModel.receivedCredentials.map(\.id), ["new-cred"])
+        XCTAssertEqual(viewModel.statusMessage, "Received 1 credential(s)")
+    }
+
+    @MainActor
+    func testReceiveCredentialDoesNotCompleteWhenNoDisplayableCredentialIsAvailable() async throws {
+        let viewModel = WalletViewModel(
+            walletID: "receive-missing-\(UUID().uuidString)",
+            walletClient: ReceiveFallbackWalletClient(
+                initialCredentials: [],
+                credentialsAfterReceive: [],
+                receiveCredentialIDs: ["missing-cred"]
+            )
+        )
+
+        try await waitUntil { viewModel.isReady }
+        viewModel.offerUrl = "openid-credential-offer://mock"
+        viewModel.receiveCredential()
+
+        try await waitUntil { viewModel.isError }
+        XCTAssertFalse(viewModel.receiveCompleted)
+        XCTAssertEqual(viewModel.lastReceivedCredentialIDs, [])
+        XCTAssertTrue(viewModel.receiveUrlEntryEnabled)
+        XCTAssertEqual(viewModel.statusMessage, "Receive failed: received credentials are not available locally")
+    }
+
+    @MainActor
+    func testStartNewPresentationFlowClearsCompletedStateAndStatus() {
+        let viewModel = WalletViewModel(walletID: "reset-present-\(UUID().uuidString)")
+        viewModel.presentationRequestUrl = "openid4vp://example"
+        viewModel.selectedPresentationCredentialIDs = ["cred-1"]
+        viewModel.presentationCompleted = true
+        viewModel.isLoading = true
+        viewModel.isError = true
+        viewModel.statusMessage = "Presentation sent"
+
+        let resetKeyBeforeNewFlow = viewModel.presentationNavigationResetKey
+        viewModel.startNewPresentationFlow()
+
+        XCTAssertEqual(viewModel.presentationRequestUrl, "")
+        XCTAssertNil(viewModel.presentationPreview)
+        XCTAssertEqual(viewModel.selectedPresentationCredentialIDs, [])
+        XCTAssertFalse(viewModel.presentationCompleted)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isError)
+        XCTAssertEqual(viewModel.presentationNavigationResetKey, resetKeyBeforeNewFlow + 1)
+        XCTAssertEqual(viewModel.statusMessage, "Wallet ready")
+    }
+
+    @MainActor
+    func testPresentationFlowAvailabilityFollowsPreviewAndCompletionState() {
+        let viewModel = WalletViewModel(walletID: "present-availability-\(UUID().uuidString)")
+        viewModel.isReady = true
+        viewModel.isLoading = false
+        viewModel.credentials = [
+            Credential(
+                id: "cred-1",
+                format: "jwt_vc_json",
+                issuer: "Example Issuer",
+                subject: nil,
+                label: "Example Credential",
+                addedAt: nil,
+                credentialDataJSON: nil
+            )
+        ]
+
+        XCTAssertTrue(viewModel.presentationUrlEntryEnabled)
+        XCTAssertFalse(viewModel.presentationPreviewActionEnabled)
+
+        viewModel.presentationRequestUrl = "openid4vp://example"
+        XCTAssertTrue(viewModel.presentationPreviewActionEnabled)
+
+        viewModel.presentationPreview = PresentationPreview(
+            request: PresentationRequestInfo(
+                clientID: "https://verifier.example",
+                verifierName: "Example Verifier"
+            ),
+            credentialOptions: []
+        )
+        XCTAssertFalse(viewModel.presentationUrlEntryEnabled)
+        XCTAssertFalse(viewModel.presentationPreviewActionEnabled)
+
+        viewModel.presentationPreview = nil
+        viewModel.presentationCompleted = true
+        XCTAssertFalse(viewModel.presentationUrlEntryEnabled)
+        XCTAssertFalse(viewModel.presentationPreviewActionEnabled)
+
+        viewModel.startNewPresentationFlow()
+        XCTAssertTrue(viewModel.presentationUrlEntryEnabled)
+        XCTAssertFalse(viewModel.presentationPreviewActionEnabled)
+    }
+
+    @MainActor
+    func testSubmitPresentationKeepsCompletedPreviewAvailableUntilNewFlow() async throws {
+        let viewModel = WalletViewModel(
+            walletID: "present-completed-preview-\(UUID().uuidString)",
+            walletClient: MockWalletClient(storedCredentials: [
+                Credential(
+                    id: "cred-1",
+                    format: "jwt_vc_json",
+                    issuer: "Example Issuer",
+                    subject: nil,
+                    label: "Example Credential",
+                    addedAt: nil,
+                    credentialDataJSON: nil
+                )
+            ])
+        )
+
+        try await waitUntil { viewModel.isReady }
+        viewModel.presentationRequestUrl = "openid4vp://mock"
+        viewModel.previewPresentation()
+        try await waitUntil { viewModel.presentationPreview != nil }
+
+        viewModel.submitPresentation()
+        try await waitUntil { viewModel.presentationCompleted }
+
+        XCTAssertNotNil(viewModel.presentationPreview)
+        XCTAssertEqual(viewModel.selectedPresentationCredentialIDs, [])
+        XCTAssertFalse(viewModel.presentationReviewEnabled)
+        XCTAssertFalse(viewModel.presentationUrlEntryEnabled)
+        XCTAssertFalse(viewModel.presentationPreviewActionEnabled)
+        XCTAssertEqual(viewModel.statusMessage, "Presentation sent")
+        XCTAssertEqual(viewModel.statusMessage(for: .present), "Presentation sent")
+        XCTAssertEqual(viewModel.statusMessage(for: .credentials), "Wallet ready")
+        XCTAssertEqual(viewModel.statusMessage(for: .receive), "Wallet ready")
+
+        viewModel.startNewPresentationFlow()
+
+        XCTAssertNil(viewModel.presentationPreview)
+        XCTAssertFalse(viewModel.presentationCompleted)
+        XCTAssertTrue(viewModel.presentationUrlEntryEnabled)
+    }
+
+    @MainActor
+    func testCancelPresentationReviewClearsPreviewWithoutProtocolRejection() async throws {
+        let viewModel = WalletViewModel(
+            walletID: "present-cancel-preview-\(UUID().uuidString)",
+            walletClient: MockWalletClient(storedCredentials: [
+                Credential(
+                    id: "cred-1",
+                    format: "jwt_vc_json",
+                    issuer: "Example Issuer",
+                    subject: nil,
+                    label: "Example Credential",
+                    addedAt: nil,
+                    credentialDataJSON: nil
+                )
+            ])
+        )
+
+        try await waitUntil { viewModel.isReady }
+        viewModel.presentationRequestUrl = "openid4vp://mock"
+        viewModel.previewPresentation()
+        try await waitUntil { viewModel.presentationPreview != nil }
+
+        let resetKeyBeforeCancel = viewModel.presentationNavigationResetKey
+        viewModel.cancelPresentationReview()
+
+        XCTAssertNil(viewModel.presentationPreview)
+        XCTAssertEqual(viewModel.selectedPresentationCredentialIDs, [])
+        XCTAssertFalse(viewModel.presentationCompleted)
+        XCTAssertEqual(viewModel.presentationNavigationResetKey, resetKeyBeforeCancel + 1)
+        XCTAssertEqual(viewModel.statusMessage(for: .present), "Presentation review cancelled")
+        XCTAssertEqual(viewModel.statusMessage(for: .credentials), "Wallet ready")
+        XCTAssertEqual(viewModel.statusMessage(for: .receive), "Wallet ready")
+    }
+
+    @MainActor
+    func testDeepLinksRouteToMatchingTabsAndResetFlowState() throws {
+        let viewModel = WalletViewModel(walletID: "deeplink-\(UUID().uuidString)")
+        viewModel.lastReceivedCredentialIDs = ["old-credential"]
+        viewModel.receiveCompleted = true
+        viewModel.presentationPreview = PresentationPreview(
+            request: PresentationRequestInfo(
+                clientID: "https://verifier.example",
+                verifierName: "Example Verifier"
+            ),
+            credentialOptions: []
+        )
+        viewModel.selectedPresentationCredentialIDs = ["old-presentation"]
+        viewModel.presentationCompleted = true
+        viewModel.isReady = true
+        viewModel.isLoading = true
+        viewModel.isError = true
+        viewModel.statusMessage = "Receive failed: old error"
+
+        let offerUrl = try XCTUnwrap(URL(string: "openid-credential-offer://example"))
+        viewModel.handleDeepLink(offerUrl)
+
+        XCTAssertEqual(viewModel.selectedTab, .receive)
+        XCTAssertEqual(viewModel.offerUrl, offerUrl.absoluteString)
+        XCTAssertEqual(viewModel.receiveNavigationResetKey, 1)
+        XCTAssertEqual(viewModel.presentationNavigationResetKey, 0)
+        XCTAssertEqual(viewModel.lastReceivedCredentialIDs, [])
+        XCTAssertFalse(viewModel.receiveCompleted)
+        XCTAssertNil(viewModel.presentationPreview)
+        XCTAssertEqual(viewModel.selectedPresentationCredentialIDs, [])
+        XCTAssertFalse(viewModel.presentationCompleted)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isError)
+        XCTAssertEqual(viewModel.statusMessage, "Wallet ready")
+
+        viewModel.isLoading = true
+        viewModel.isError = true
+        viewModel.statusMessage = "Preview failed: old error"
+
+        let presentationUrl = try XCTUnwrap(URL(string: "openid4vp://example"))
+        viewModel.handleDeepLink(presentationUrl)
+
+        XCTAssertEqual(viewModel.selectedTab, .present)
+        XCTAssertEqual(viewModel.presentationRequestUrl, presentationUrl.absoluteString)
+        XCTAssertEqual(viewModel.receiveNavigationResetKey, 1)
+        XCTAssertEqual(viewModel.presentationNavigationResetKey, 1)
+        XCTAssertNil(viewModel.presentationPreview)
+        XCTAssertEqual(viewModel.selectedPresentationCredentialIDs, [])
+        XCTAssertFalse(viewModel.presentationCompleted)
+        XCTAssertFalse(viewModel.isLoading)
+        XCTAssertFalse(viewModel.isError)
+        XCTAssertEqual(viewModel.statusMessage, "Wallet ready")
+
+        viewModel.handleDeepLink(presentationUrl)
+
+        XCTAssertEqual(viewModel.presentationNavigationResetKey, 2)
+    }
+
+    private static let tinyPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII="
+    private static let tinyPngBytes = Data(base64Encoded: tinyPngBase64)!
+
+    @MainActor
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        while !condition() {
+            if ContinuousClock.now >= deadline {
+                XCTFail("Timed out waiting for condition")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}
+
+private actor ReceiveFallbackWalletClient: WalletClient {
+    private var storedCredentials: [Credential]
+    private let credentialsAfterReceive: [Credential]
+    private let receiveCredentialIDs: [String]
+
+    init(
+        initialCredentials: [Credential],
+        credentialsAfterReceive: [Credential],
+        receiveCredentialIDs: [String]
+    ) {
+        self.storedCredentials = initialCredentials
+        self.credentialsAfterReceive = credentialsAfterReceive
+        self.receiveCredentialIDs = receiveCredentialIDs
+    }
+
+    func bootstrap() async throws -> WalletBootstrapResult {
+        WalletBootstrapResult(keyID: "mock-key-1", did: "did:key:mock")
+    }
+
+    func credentials() async throws -> [Credential] {
+        storedCredentials
+    }
+
+    func receive(offer: URL) async throws -> [String] {
+        storedCredentials = credentialsAfterReceive
+        return receiveCredentialIDs
+    }
+
+    func present(request: URL, did: String?) async throws -> PresentationResult {
+        PresentationResult(success: true, redirectTo: nil, verifierResponseJSON: nil)
+    }
+
+    func previewPresentation(request: URL) async throws -> PresentationPreview {
+        PresentationPreview(
+            request: PresentationRequestInfo(clientID: nil, verifierName: nil),
+            credentialOptions: []
+        )
+    }
+
+    func submitPresentation(request: URL, selectedCredentialIDs: [String], did: String?) async throws -> PresentationResult {
+        PresentationResult(success: true, redirectTo: nil, verifierResponseJSON: nil)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -221,6 +221,52 @@ final class MobileWalletIntegrationTests: XCTestCase {
         try await receiveAndPresentDemoCredential(scenarioID: "eudi-pid-mdoc")
     }
 
+    func testPreviewAndSubmitEudiPidMdocAgainstDemoIssuer2AndVerifier2() async throws {
+        let scenario = try demoPresentationScenario("eudi-pid-mdoc")
+        let walletId = "ios-demo-preview-submit-\(scenario.id)-\(UUID().uuidString)"
+        await clearTestData(walletId: walletId)
+
+        let wallet = try await makeWallet(walletId: walletId)
+        let bootstrapResult = try await wallet.bootstrap()
+        let did = bootstrapResult.did
+
+        let offer = try await DemoBackend.shared.createOffer(scenario: scenario)
+        let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
+        let credentialIDs = try await wallet.receive(offer: offerURL)
+        XCTAssertFalse(
+            credentialIDs.isEmpty,
+            "Should receive \(scenario.displayName) from public demo issuer2"
+        )
+
+        let session = try await DemoBackend.shared.createVerifierSession(scenario: scenario)
+        let presentationURL = try XCTUnwrap(URL(string: session.authorizationRequestUri))
+        let preview = try await wallet.previewPresentation(request: presentationURL)
+        XCTAssertFalse(
+            preview.credentialOptions.isEmpty,
+            "Should preview at least one matching credential for \(scenario.displayName): \(preview)"
+        )
+        XCTAssertTrue(
+            preview.credentialOptions.allSatisfy { credentialIDs.contains($0.credentialID) },
+            "Preview should only offer credentials received in this test. Received: \(credentialIDs), Preview: \(preview)"
+        )
+
+        let result = try await wallet.submitPresentation(
+            request: presentationURL,
+            selectedCredentialIDs: preview.credentialOptions.map(\.credentialID),
+            did: did
+        )
+
+        XCTAssertTrue(
+            result.success,
+            "public demo verifier2 stepwise presentation should succeed for \(scenario.displayName). Preview: \(preview), Result: \(result)"
+        )
+
+        try await DemoBackend.shared.waitForVerifierSuccess(
+            sessionID: session.sessionID,
+            timeoutSeconds: verifierPollingTimeout
+        )
+    }
+
     func testReceiveAndPresentIsoMdlAgainstDemoIssuer2AndVerifier2() async throws {
         try await receiveAndPresentDemoCredential(scenarioID: "iso-mdl")
     }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/MockWalletUITests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/MockWalletUITests.swift
@@ -1,0 +1,639 @@
+import XCTest
+
+@MainActor
+final class MockWalletUITests: XCTestCase {
+    private static let didClientID = "decentralized_identifier:did:jwk:abc"
+    private static let x509SanDnsClientID = "x509_san_dns:verifier.example"
+
+    func testUrlEditorsAreTopControlsInReceiveAndPresentTabs() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        let offerInput = ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL")
+        XCTAssertTrue(offerInput.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["wallet.status"].waitForExistence(timeout: 10))
+        XCTAssertLessThan(
+            offerInput.frame.minY,
+            app.staticTexts["wallet.status"].frame.minY,
+            "Receive URL entry should be the first control in the tab"
+        )
+
+        ui.tapTab(label: "Present")
+        let presentationInput = ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL")
+        XCTAssertTrue(presentationInput.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["wallet.status"].waitForExistence(timeout: 10))
+        XCTAssertLessThan(
+            presentationInput.frame.minY,
+            app.staticTexts["wallet.status"].frame.minY,
+            "Presentation URL entry should be the first control in the tab"
+        )
+    }
+
+    func testDeepLinksRouteToReceiveAndPresentTabs() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        let offerUrl = "openid-credential-offer://mock"
+        ui.openDeepLink(offerUrl)
+        XCTAssertTrue(app.tabBars.buttons["Receive"].isSelected)
+        XCTAssertTrue(
+            ui.waitForTextInputValue(
+                identifier: "wallet.offerInput",
+                fallbackLabel: "Credential offer URL",
+                value: offerUrl,
+                timeout: 10
+            )
+        )
+        XCTAssertTrue(app.buttons["wallet.receiveButton"].isEnabled)
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+
+        let presentationUrl = "openid4vp://mock"
+        ui.openDeepLink(presentationUrl)
+        XCTAssertTrue(app.tabBars.buttons["Present"].isSelected)
+        XCTAssertTrue(
+            ui.waitForTextInputValue(
+                identifier: "wallet.presentationInput",
+                fallbackLabel: "OpenID4VP request URL",
+                value: presentationUrl,
+                timeout: 10
+            )
+        )
+    }
+
+    func testPresentTabExplainsWhyPreviewIsUnavailableWithoutCredentials() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: "openid4vp://mock"
+        )
+
+        XCTAssertFalse(app.buttons["wallet.presentButton"].isEnabled)
+        XCTAssertTrue(app.staticTexts["No credentials available"].waitForExistence(timeout: 10))
+    }
+
+    func testCredentialOfferDeepLinksResetReceiveDetailStackWhenUrlIsUnchanged() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        let offerUrl = "openid-credential-offer://mock"
+        ui.openDeepLink(offerUrl)
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+
+        ui.openDeepLink(offerUrl)
+        XCTAssertTrue(app.tabBars.buttons["Receive"].isSelected)
+        XCTAssertFalse(app.staticTexts["Credential details"].exists)
+        XCTAssertTrue(
+            ui.waitForTextInputValue(
+                identifier: "wallet.offerInput",
+                fallbackLabel: "Credential offer URL",
+                value: offerUrl,
+                timeout: 10
+            )
+        )
+        XCTAssertTrue(app.buttons["wallet.receiveButton"].isEnabled)
+    }
+
+    func testPresentationDeepLinksResetPresentDetailStackWhenUrlIsUnchanged() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        let presentationUrl = "openid4vp://mock"
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: presentationUrl
+        )
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Review presentation request", "Preview failed"], timeout: 10),
+            "Review presentation request"
+        )
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+
+        ui.openDeepLink(presentationUrl)
+        XCTAssertTrue(app.tabBars.buttons["Present"].isSelected)
+        XCTAssertFalse(app.staticTexts["Credential details"].exists)
+        XCTAssertTrue(
+            ui.waitForTextInputValue(
+                identifier: "wallet.presentationInput",
+                fallbackLabel: "OpenID4VP request URL",
+                value: presentationUrl,
+                timeout: 10
+            )
+        )
+    }
+
+    func testPresentationDisclosureImagesRenderAsImages() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: "openid4vp://mock"
+        )
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Review presentation request", "Preview failed"], timeout: 10),
+            "Review presentation request"
+        )
+
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Requested disclosures"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Portrait"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.staticTexts["$.portrait"].exists)
+        ui.assertExists(identifier: ui.claimImageIdentifier(path: "disclosures[1].portrait"), timeout: 10)
+    }
+
+    func testCredentialDetailsStayScopedToCredentialsTabNavigationStack() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+        XCTAssertTrue(app.tabBars.buttons["Credentials"].isSelected)
+        XCTAssertTrue(app.staticTexts["No credentials yet"].waitForExistence(timeout: 10))
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        ui.tapTab(label: "Credentials")
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Given name"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.tabBars.buttons["Credentials"].isSelected)
+
+        ui.tapTab(label: "Receive")
+        XCTAssertFalse(app.staticTexts["Credential details"].exists)
+
+        ui.tapTab(label: "Credentials")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Given name"].waitForExistence(timeout: 10))
+    }
+
+    func testReceiveAndPresentDisableUrlControlsWhileLoading() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: [
+            "E2E_MOCK_WALLET": "1",
+            "E2E_MOCK_WALLET_DELAY_MS": "1500",
+        ])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Receiving credential", "Receive failed"], timeout: 10),
+            "Receiving credential..."
+        )
+        XCTAssertFalse(app.textViews["wallet.offerInput"].isEnabled)
+        XCTAssertFalse(app.buttons["wallet.receiveButton"].isEnabled)
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: "openid4vp://mock"
+        )
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Resolving presentation", "Preview failed"], timeout: 10),
+            "Resolving presentation..."
+        )
+        XCTAssertFalse(app.textViews["wallet.presentationInput"].isEnabled)
+        XCTAssertFalse(app.buttons["wallet.presentButton"].isEnabled)
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Review presentation request", "Preview failed"], timeout: 10),
+            "Review presentation request"
+        )
+    }
+
+    func testCredentialCardsExposeStableTappableButtonIdentifier() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        let card = app.buttons["wallet.credentialCard.cred-1"]
+        XCTAssertTrue(card.waitForExistence(timeout: 10))
+        XCTAssertTrue(card.isHittable)
+        card.tap()
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+    }
+
+    func testTabbedReceiveAndPresentFlowUsesMockWallet() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Credentials")
+        XCTAssertTrue(app.staticTexts["No credentials yet"].waitForExistence(timeout: 10))
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+        XCTAssertFalse(app.textViews["wallet.offerInput"].isEnabled)
+        XCTAssertTrue(app.buttons["wallet.receiveNewButton"].waitForExistence(timeout: 10))
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Mobile driving licence"].waitForExistence(timeout: 10))
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Mobile driving licence"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Expires 2026-06-17"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Example Issuer"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["jwt_vc_json"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Given name"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.images["Credential image"].waitForExistence(timeout: 10))
+        ui.tapNavigationBack()
+        ui.tapButton(identifier: "wallet.receiveNewButton", fallbackLabel: "New receive")
+        let resetOfferInput = ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL")
+        XCTAssertTrue(resetOfferInput.isEnabled)
+        XCTAssertEqual(resetOfferInput.value as? String, "")
+        XCTAssertFalse(app.buttons["wallet.receiveButton"].isEnabled)
+
+        ui.tapTab(label: "Credentials")
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.images["Credential portrait"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Mobile driving licence"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Ada Lovelace"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Expires 2026-06-17"].waitForExistence(timeout: 10))
+
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: "openid4vp://mock"
+        )
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Review presentation request", "Preview failed"], timeout: 10),
+            "Review presentation request"
+        )
+        XCTAssertFalse(app.textViews["wallet.presentationInput"].isEnabled)
+        XCTAssertTrue(app.staticTexts["Example Verifier"].waitForExistence(timeout: 10))
+        assertVerifierTechnicalDetailsCollapsedUntilRequested(app: app, ui: ui)
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        assertPresentationActionsFollowReviewContent(app: app)
+
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Mobile driving licence"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Expires 2026-06-17"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Given name"].waitForExistence(timeout: 10))
+        ui.tapNavigationBack()
+
+        ui.tapButton(identifier: "wallet.presentationSubmitButton", fallbackLabel: "Share")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Presentation sent", "Present failed"], timeout: 10),
+            "Presentation sent"
+        )
+        ui.tapTab(label: "Credentials")
+        XCTAssertFalse(app.staticTexts["Presentation sent"].exists)
+        ui.tapTab(label: "Receive")
+        XCTAssertFalse(app.staticTexts["Presentation sent"].exists)
+        ui.tapTab(label: "Present")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Presentation sent", "Present failed"], timeout: 10),
+            "Presentation sent"
+        )
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertFalse(app.buttons["wallet.presentationSubmitButton"].exists)
+        XCTAssertFalse(app.buttons["wallet.presentationCancelButton"].exists)
+        XCTAssertTrue(app.buttons["wallet.presentationNewButton"].waitForExistence(timeout: 10))
+        assertPresentationNewActionPrecedesReadOnlyReview(app: app)
+        ui.tapButton(identifier: "wallet.presentationNewButton", fallbackLabel: "New presentation")
+        let resetPresentationInput = ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL")
+        XCTAssertTrue(resetPresentationInput.isEnabled)
+        XCTAssertEqual(resetPresentationInput.value as? String, "")
+        XCTAssertFalse(app.buttons["wallet.presentButton"].isEnabled)
+    }
+
+    func testPresentationShowsReadableVerifierFallbackForDidClientIDs() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: [
+            "E2E_MOCK_WALLET": "1",
+            "E2E_MOCK_DID_VERIFIER": "1",
+        ])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: "openid4vp://mock"
+        )
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Review presentation request", "Preview failed"], timeout: 10),
+            "Review presentation request"
+        )
+
+        XCTAssertTrue(app.staticTexts["DID verifier"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.staticTexts[Self.didClientID].exists)
+        ui.tapButton(identifier: "wallet.verifierTechnicalDetailsToggle", fallbackLabel: "Show technical details")
+        XCTAssertTrue(app.staticTexts[Self.didClientID].waitForExistence(timeout: 10))
+    }
+
+    func testPresentationShowsReadableVerifierFallbackForX509SanDnsClientIDs() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: [
+            "E2E_MOCK_WALLET": "1",
+            "E2E_MOCK_DNS_VERIFIER": "1",
+        ])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: "openid4vp://mock"
+        )
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Review presentation request", "Preview failed"], timeout: 10),
+            "Review presentation request"
+        )
+
+        XCTAssertTrue(app.staticTexts["verifier.example"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.staticTexts[Self.x509SanDnsClientID].exists)
+        ui.tapButton(identifier: "wallet.verifierTechnicalDetailsToggle", fallbackLabel: "Show technical details")
+        XCTAssertTrue(app.staticTexts[Self.x509SanDnsClientID].waitForExistence(timeout: 10))
+    }
+
+    func testCredentialDetailsStayScopedToReceiveTabNavigationStack() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+
+        ui.tapTab(label: "Credentials")
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertFalse(app.staticTexts["Credential details"].exists)
+
+        ui.tapTab(label: "Receive")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Given name"].waitForExistence(timeout: 10))
+    }
+
+    func testCredentialDetailsStayScopedToPresentTabNavigationStack() {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
+
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Wallet ready", "Bootstrap failed"], timeout: 10),
+            "Wallet ready"
+        )
+
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        ui.tapTab(label: "Present")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL"),
+            value: "openid4vp://mock"
+        )
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Review presentation request", "Preview failed"], timeout: 10),
+            "Review presentation request"
+        )
+
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Requested disclosures"].waitForExistence(timeout: 10))
+
+        ui.tapTab(label: "Credentials")
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        XCTAssertFalse(app.staticTexts["Credential details"].exists)
+
+        ui.tapTab(label: "Present")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Requested disclosures"].waitForExistence(timeout: 10))
+    }
+
+    private func assertPresentationActionsFollowReviewContent(app: XCUIApplication) {
+        let verifier = app.staticTexts["Example Verifier"]
+        let credential = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "wallet.credentialCard."))
+            .firstMatch
+        let share = app.buttons["wallet.presentationSubmitButton"]
+
+        XCTAssertTrue(verifier.waitForExistence(timeout: 10), "Verifier details are missing")
+        XCTAssertTrue(credential.waitForExistence(timeout: 10), "Shared credential card is missing")
+        XCTAssertTrue(share.waitForExistence(timeout: 10), "Share action is missing")
+        XCTAssertLessThan(
+            verifier.frame.minY,
+            share.frame.minY,
+            "Share action should be below verifier details so the verifier is reviewed before consent"
+        )
+        XCTAssertLessThan(
+            credential.frame.minY,
+            share.frame.minY,
+            "Share action should be below shared credential details so the credential is reviewed before consent"
+        )
+    }
+
+    private func assertVerifierTechnicalDetailsCollapsedUntilRequested(app: XCUIApplication, ui: WalletE2EUI) {
+        XCTAssertFalse(app.staticTexts["Client ID"].exists, "Technical verifier fields should not be expanded by default")
+        ui.tapButton(identifier: "wallet.verifierTechnicalDetailsToggle", fallbackLabel: "Show technical details")
+        XCTAssertTrue(app.staticTexts["Client ID"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["https://verifier.example/response"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["state-123"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["nonce-456"].waitForExistence(timeout: 10))
+    }
+
+    private func assertPresentationNewActionPrecedesReadOnlyReview(app: XCUIApplication) {
+        let elements = app.descendants(matching: .any).allElementsBoundByIndex
+        let newActionIndex = elements.firstIndex { $0.identifier == "wallet.presentationNewButton" }
+        let verifierIndex = elements.firstIndex { $0.label == "Example Verifier" }
+
+        XCTAssertNotNil(newActionIndex, "New presentation action is missing")
+        XCTAssertNotNil(verifierIndex, "Read-only presentation review is missing")
+        XCTAssertLessThan(
+            newActionIndex ?? Int.max,
+            verifierIndex ?? Int.min,
+            "New presentation action should precede the read-only review so starting over stays easy"
+        )
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
@@ -29,6 +29,7 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         )
         XCTAssertEqual(readyStatus, "Wallet ready", "Wallet did not become ready, status: \(readyStatus ?? "nil")")
 
+        ui.tapTab(label: "Receive")
         let offerInput = ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL")
         ui.replaceText(in: offerInput, value: offer.offerUrl)
         ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
@@ -39,10 +40,31 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         )
         XCTAssertTrue(receiveStatus?.starts(with: "Received") == true, "Receive failed, status: \(receiveStatus ?? "nil")")
 
+        ui.tapTab(label: "Credentials")
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        ui.assertExists(identifierPrefix: "wallet.credentialDetails.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 20))
+        ui.tapNavigationBack()
+
         let session = try await backend.createVerifierSession(scenario: scenario)
+        ui.tapTab(label: "Present")
         let presentInput = ui.textInput(identifier: "wallet.presentationInput", fallbackLabel: "OpenID4VP request URL")
         ui.replaceText(in: presentInput, value: session.authorizationRequestUri)
-        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Present")
+        ui.tapButton(identifier: "wallet.presentButton", fallbackLabel: "Preview")
+        let previewStatus = ui.waitForStatus(
+            prefixes: ["Review presentation request", "Preview failed", "Bootstrap failed"],
+            timeout: credentialOperationTimeout
+        )
+        XCTAssertEqual(previewStatus, "Review presentation request", "Preview failed, status: \(previewStatus ?? "nil")")
+
+        ui.assertExists(identifierPrefix: "wallet.credentialCard.")
+        ui.tapElement(identifierPrefix: "wallet.credentialCard.")
+        ui.assertExists(identifierPrefix: "wallet.credentialDetails.")
+        XCTAssertTrue(app.staticTexts["Credential details"].waitForExistence(timeout: 20))
+        ui.tapNavigationBack()
+
+        ui.tapButton(identifier: "wallet.presentationSubmitButton", fallbackLabel: "Share")
 
         let presentStatus = ui.waitForStatus(
             prefixes: ["Presentation sent", "Presentation finished", "Present failed", "Receive failed", "Bootstrap failed"],

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/WalletE2EHelpers.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/WalletE2EHelpers.swift
@@ -10,9 +10,12 @@ final class WalletE2EUI {
         self.app = app
     }
 
-    func launch(attestation: [String: String] = [:]) {
+    func launch(attestation: [String: String] = [:], environment: [String: String] = [:]) {
         app.launchEnvironment["E2E_WALLET_ID"] = app.launchEnvironment["E2E_WALLET_ID"] ?? "e2e-\(UUID().uuidString)"
         for (key, value) in attestation {
+            app.launchEnvironment[key] = value
+        }
+        for (key, value) in environment {
             app.launchEnvironment[key] = value
         }
         app.launch()
@@ -40,6 +43,33 @@ final class WalletE2EUI {
         return nil
     }
 
+    func openDeepLink(_ value: String) {
+        guard let url = URL(string: value) else {
+            XCTFail("Invalid deep link URL: \(value)")
+            return
+        }
+
+        guard #available(iOS 16.4, *) else {
+            XCTFail("Opening deep links from UI tests requires iOS 16.4 or newer")
+            return
+        }
+
+        app.open(url)
+        app.activate()
+    }
+
+    func waitForTextInputValue(identifier: String, fallbackLabel: String, value: String, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let input = textInput(identifier: identifier, fallbackLabel: fallbackLabel)
+            if input.exists, input.value as? String == value {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.4))
+        }
+        return false
+    }
+
     func textInput(identifier: String, fallbackLabel: String) -> XCUIElement {
         firstExisting([
             app.textFields[identifier],
@@ -60,6 +90,48 @@ final class WalletE2EUI {
         makeHittable(button)
         XCTAssertTrue(button.isHittable, "Button is not hittable: \(identifier)")
         button.tap()
+    }
+
+    func assertExists(identifierPrefix: String, timeout: TimeInterval = 20) {
+        let element = firstElement(identifierPrefix: identifierPrefix)
+        XCTAssertTrue(element.waitForExistence(timeout: timeout), "Element not found with identifier prefix: \(identifierPrefix)")
+    }
+
+    func assertExists(identifier: String, timeout: TimeInterval = 20) {
+        let element = app.descendants(matching: .any)[identifier]
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if element.exists || element.waitForExistence(timeout: 0.5) {
+                return
+            }
+            app.swipeUp()
+        }
+        XCTAssertTrue(element.exists, "Element not found with identifier: \(identifier)")
+    }
+
+    func tapElement(identifierPrefix: String, timeout: TimeInterval = 20) {
+        let element = firstElement(identifierPrefix: identifierPrefix)
+        XCTAssertTrue(element.waitForExistence(timeout: timeout), "Element not found with identifier prefix: \(identifierPrefix)")
+        makeHittable(element)
+        XCTAssertTrue(element.isHittable, "Element is not hittable with identifier prefix: \(identifierPrefix)")
+        element.tap()
+    }
+
+    func claimImageIdentifier(path: String) -> String {
+        "wallet.claimImage.\(path.identifierSegment)"
+    }
+
+    func tapNavigationBack() {
+        let button = app.navigationBars.buttons.firstMatch
+        XCTAssertTrue(button.waitForExistence(timeout: 20), "Navigation back button not found")
+        button.tap()
+    }
+
+    func tapTab(label: String) {
+        let tab = app.tabBars.buttons[label]
+        XCTAssertTrue(tab.waitForExistence(timeout: 20), "Tab not found: \(label)")
+        XCTAssertTrue(tab.isHittable, "Tab is not hittable: \(label)")
+        tab.tap()
     }
 
     func replaceText(in element: XCUIElement, value: String) {
@@ -89,10 +161,21 @@ final class WalletE2EUI {
         }
     }
 
+    private func firstElement(identifierPrefix: String) -> XCUIElement {
+        let predicate = NSPredicate(format: "identifier BEGINSWITH %@", identifierPrefix)
+        return app.descendants(matching: .any).matching(predicate).firstMatch
+    }
+
     private func firstExisting(_ elements: [XCUIElement]) -> XCUIElement {
         for element in elements where element.exists {
             return element
         }
         return elements[0]
+    }
+}
+
+private extension String {
+    var identifierSegment: String {
+        map { $0.isLetter || $0.isNumber ? String($0) : "_" }.joined()
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -371,7 +371,9 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge { // id.walt.wal
     final suspend fun credentials(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletCredential>> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.credentials|credentials(){}[0]
     final suspend fun deleteWallet(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<kotlin/Unit> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.deleteWallet|deleteWallet(){}[0]
     final suspend fun present(kotlin/String, kotlin/String? = ..., kotlin/Boolean? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletPresentationResult> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.present|present(kotlin.String;kotlin.String?;kotlin.Boolean?){}[0]
+    final suspend fun previewPresentation(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletPresentationPreview> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.previewPresentation|previewPresentation(kotlin.String){}[0]
     final suspend fun receive(kotlin/String, kotlin/String? = ..., kotlin/String = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<kotlin.collections/List<kotlin/String>> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.receive|receive(kotlin.String;kotlin.String?;kotlin.String){}[0]
+    final suspend fun submitPresentation(kotlin/String, kotlin.collections/List<kotlin/String>, kotlin/String? = ..., kotlin/Boolean? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletPresentationResult> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.submitPresentation|submitPresentation(kotlin.String;kotlin.collections.List<kotlin.String>;kotlin.String?;kotlin.Boolean?){}[0]
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletSdkBridgeFactory { // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridgeFactory|null[0]
@@ -388,7 +390,9 @@ final class id.walt.wallet2.mobile/MobileWallet { // id.walt.wallet2.mobile/Mobi
     final suspend fun credentials(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletCredential> // id.walt.wallet2.mobile/MobileWallet.credentials|credentials(){}[0]
     final suspend fun deleteWallet() // id.walt.wallet2.mobile/MobileWallet.deleteWallet|deleteWallet(){}[0]
     final suspend fun present(kotlin/String, kotlin/String? = ..., kotlin/Boolean? = ...): id.walt.wallet2.mobile/MobileWalletPresentationResult // id.walt.wallet2.mobile/MobileWallet.present|present(kotlin.String;kotlin.String?;kotlin.Boolean?){}[0]
+    final suspend fun previewPresentation(kotlin/String): id.walt.wallet2.mobile/MobileWalletPresentationPreview // id.walt.wallet2.mobile/MobileWallet.previewPresentation|previewPresentation(kotlin.String){}[0]
     final suspend fun receive(kotlin/String, kotlin/String? = ..., kotlin/String = ...): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile/MobileWallet.receive|receive(kotlin.String;kotlin.String?;kotlin.String){}[0]
+    final suspend fun submitPresentation(kotlin/String, kotlin.collections/List<kotlin/String>, kotlin/String? = ..., kotlin/Boolean? = ...): id.walt.wallet2.mobile/MobileWalletPresentationResult // id.walt.wallet2.mobile/MobileWallet.submitPresentation|submitPresentation(kotlin.String;kotlin.collections.List<kotlin.String>;kotlin.String?;kotlin.Boolean?){}[0]
 }
 
 final class id.walt.wallet2.mobile/MobileWalletBootstrapResult { // id.walt.wallet2.mobile/MobileWalletBootstrapResult|null[0]
@@ -433,10 +437,12 @@ final class id.walt.wallet2.mobile/MobileWalletConfig { // id.walt.wallet2.mobil
 }
 
 final class id.walt.wallet2.mobile/MobileWalletCredential { // id.walt.wallet2.mobile/MobileWalletCredential|null[0]
-    constructor <init>(kotlin/String, kotlin/String, kotlin/String?, kotlin/String?, kotlin/String?, kotlin/String?) // id.walt.wallet2.mobile/MobileWalletCredential.<init>|<init>(kotlin.String;kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String?, kotlin/String?, kotlin/String?, kotlin/String?, kotlin/String? = ...) // id.walt.wallet2.mobile/MobileWalletCredential.<init>|<init>(kotlin.String;kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
 
     final val addedAt // id.walt.wallet2.mobile/MobileWalletCredential.addedAt|{}addedAt[0]
         final fun <get-addedAt>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletCredential.addedAt.<get-addedAt>|<get-addedAt>(){}[0]
+    final val credentialDataJson // id.walt.wallet2.mobile/MobileWalletCredential.credentialDataJson|{}credentialDataJson[0]
+        final fun <get-credentialDataJson>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletCredential.credentialDataJson.<get-credentialDataJson>|<get-credentialDataJson>(){}[0]
     final val format // id.walt.wallet2.mobile/MobileWalletCredential.format|{}format[0]
         final fun <get-format>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletCredential.format.<get-format>|<get-format>(){}[0]
     final val id // id.walt.wallet2.mobile/MobileWalletCredential.id|{}id[0]
@@ -454,7 +460,8 @@ final class id.walt.wallet2.mobile/MobileWalletCredential { // id.walt.wallet2.m
     final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletCredential.component4|component4(){}[0]
     final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletCredential.component5|component5(){}[0]
     final fun component6(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletCredential.component6|component6(){}[0]
-    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...): id.walt.wallet2.mobile/MobileWalletCredential // id.walt.wallet2.mobile/MobileWalletCredential.copy|copy(kotlin.String;kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+    final fun component7(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletCredential.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...): id.walt.wallet2.mobile/MobileWalletCredential // id.walt.wallet2.mobile/MobileWalletCredential.copy|copy(kotlin.String;kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletCredential.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletCredential.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletCredential.toString|toString(){}[0]
@@ -515,6 +522,106 @@ final class id.walt.wallet2.mobile/MobileWalletPersistence { // id.walt.wallet2.
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPersistence.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPersistence.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPersistence.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption { // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption|null[0]
+    constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin/String?, kotlin/String?, kotlin/String?, kotlin/String?, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationDisclosure> = ...) // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletPresentationDisclosure>){}[0]
+
+    final val credentialDataJson // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.credentialDataJson|{}credentialDataJson[0]
+        final fun <get-credentialDataJson>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.credentialDataJson.<get-credentialDataJson>|<get-credentialDataJson>(){}[0]
+    final val credentialId // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.credentialId|{}credentialId[0]
+        final fun <get-credentialId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.credentialId.<get-credentialId>|<get-credentialId>(){}[0]
+    final val disclosures // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.disclosures|{}disclosures[0]
+        final fun <get-disclosures>(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationDisclosure> // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.disclosures.<get-disclosures>|<get-disclosures>(){}[0]
+    final val format // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.format|{}format[0]
+        final fun <get-format>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.format.<get-format>|<get-format>(){}[0]
+    final val issuer // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.issuer|{}issuer[0]
+        final fun <get-issuer>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.issuer.<get-issuer>|<get-issuer>(){}[0]
+    final val label // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.label|{}label[0]
+        final fun <get-label>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.label.<get-label>|<get-label>(){}[0]
+    final val queryId // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.queryId|{}queryId[0]
+        final fun <get-queryId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.queryId.<get-queryId>|<get-queryId>(){}[0]
+    final val subject // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.subject|{}subject[0]
+        final fun <get-subject>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.subject.<get-subject>|<get-subject>(){}[0]
+
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component1|component1(){}[0]
+    final fun component2(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component2|component2(){}[0]
+    final fun component3(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component5|component5(){}[0]
+    final fun component6(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component6|component6(){}[0]
+    final fun component7(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationDisclosure> // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.component8|component8(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationDisclosure> = ...): id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.copy|copy(kotlin.String;kotlin.String;kotlin.String;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletPresentationDisclosure>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletPresentationDisclosure { // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure|null[0]
+    constructor <init>(kotlin/String, kotlin/String?, kotlin/String, kotlin/String?, kotlin/Boolean) // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.<init>|<init>(kotlin.String;kotlin.String?;kotlin.String;kotlin.String?;kotlin.Boolean){}[0]
+
+    final val displayValue // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.displayValue|{}displayValue[0]
+        final fun <get-displayValue>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.displayValue.<get-displayValue>|<get-displayValue>(){}[0]
+    final val name // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.name.<get-name>|<get-name>(){}[0]
+    final val path // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.path|{}path[0]
+        final fun <get-path>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.path.<get-path>|<get-path>(){}[0]
+    final val selectivelyDisclosable // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.selectivelyDisclosable|{}selectivelyDisclosable[0]
+        final fun <get-selectivelyDisclosable>(): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.selectivelyDisclosable.<get-selectivelyDisclosable>|<get-selectivelyDisclosable>(){}[0]
+    final val valueJson // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.valueJson|{}valueJson[0]
+        final fun <get-valueJson>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.valueJson.<get-valueJson>|<get-valueJson>(){}[0]
+
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.component2|component2(){}[0]
+    final fun component3(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.component4|component4(){}[0]
+    final fun component5(): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.component5|component5(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String? = ..., kotlin/String = ..., kotlin/String? = ..., kotlin/Boolean = ...): id.walt.wallet2.mobile/MobileWalletPresentationDisclosure // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.copy|copy(kotlin.String;kotlin.String?;kotlin.String;kotlin.String?;kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationDisclosure.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletPresentationPreview { // id.walt.wallet2.mobile/MobileWalletPresentationPreview|null[0]
+    constructor <init>(id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption>) // id.walt.wallet2.mobile/MobileWalletPresentationPreview.<init>|<init>(id.walt.wallet2.mobile.MobileWalletPresentationRequestInfo;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletPresentationCredentialOption>){}[0]
+
+    final val credentialOptions // id.walt.wallet2.mobile/MobileWalletPresentationPreview.credentialOptions|{}credentialOptions[0]
+        final fun <get-credentialOptions>(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption> // id.walt.wallet2.mobile/MobileWalletPresentationPreview.credentialOptions.<get-credentialOptions>|<get-credentialOptions>(){}[0]
+    final val request // id.walt.wallet2.mobile/MobileWalletPresentationPreview.request|{}request[0]
+        final fun <get-request>(): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationPreview.request.<get-request>|<get-request>(){}[0]
+
+    final fun component1(): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationPreview.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption> // id.walt.wallet2.mobile/MobileWalletPresentationPreview.component2|component2(){}[0]
+    final fun copy(id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletPresentationCredentialOption> = ...): id.walt.wallet2.mobile/MobileWalletPresentationPreview // id.walt.wallet2.mobile/MobileWalletPresentationPreview.copy|copy(id.walt.wallet2.mobile.MobileWalletPresentationRequestInfo;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletPresentationCredentialOption>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationPreview.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationPreview.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationPreview.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo { // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo|null[0]
+    constructor <init>(kotlin/String?, kotlin/String?, kotlin/String?, kotlin/String?, kotlin/String?) // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+
+    final val clientId // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId|{}clientId[0]
+        final fun <get-clientId>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId.<get-clientId>|<get-clientId>(){}[0]
+    final val nonce // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce|{}nonce[0]
+        final fun <get-nonce>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce.<get-nonce>|<get-nonce>(){}[0]
+    final val responseUri // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseUri|{}responseUri[0]
+        final fun <get-responseUri>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseUri.<get-responseUri>|<get-responseUri>(){}[0]
+    final val state // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.state|{}state[0]
+        final fun <get-state>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.state.<get-state>|<get-state>(){}[0]
+    final val verifierName // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.verifierName|{}verifierName[0]
+        final fun <get-verifierName>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.verifierName.<get-verifierName>|<get-verifierName>(){}[0]
+
+    final fun component1(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component2|component2(){}[0]
+    final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component5|component5(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.copy|copy(kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.toString|toString(){}[0]
 }
 
 final class id.walt.wallet2.mobile/MobileWalletPresentationResult { // id.walt.wallet2.mobile/MobileWalletPresentationResult|null[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -100,6 +100,43 @@ class MobileWalletIntegrationTest {
     }
 
     @Test
+    fun previewAndSubmitEudiPidMdocAgainstDemoIssuer2AndVerifier2() = runBlocking {
+        val scenario = demoPresentationScenario("eudi-pid-mdoc")
+        val client = MobileWalletFactory(context).create(walletConfig("preview-submit-${scenario.id}"))
+        val bootstrapResult = client.bootstrap()
+
+        val offer = DemoTestBackend.createOffer(scenario)
+        val credentialIds = client.receive(offer.offerUrl, txCode = offer.txCode)
+        assertTrue(
+            credentialIds.isNotEmpty(),
+            "Should receive ${scenario.displayName} from public demo issuer2",
+        )
+
+        val session = DemoTestBackend.createVerifierSession(scenario)
+        val preview = client.previewPresentation(session.authorizationRequestUri)
+        assertTrue(
+            preview.credentialOptions.isNotEmpty(),
+            "Should preview at least one matching credential for ${scenario.displayName}: preview=$preview",
+        )
+        assertTrue(
+            preview.credentialOptions.all { it.credentialId in credentialIds },
+            "Preview should only offer credentials received in this test: received=$credentialIds, preview=$preview",
+        )
+
+        val result = client.submitPresentation(
+            requestUrl = session.authorizationRequestUri,
+            selectedCredentialIds = preview.credentialOptions.map { it.credentialId },
+            did = bootstrapResult.did,
+        )
+        assertTrue(
+            result.success,
+            "public demo verifier2 stepwise presentation should succeed for ${scenario.displayName}: preview=$preview, result=$result",
+        )
+
+        DemoTestBackend.waitForVerifierSuccess(session.sessionId)
+    }
+
+    @Test
     fun receiveAndPresentIsoMdlAgainstDemoIssuer2AndVerifier2() = runBlocking {
         receiveAndPresentDemoCredential("iso-mdl")
     }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
 package id.walt.wallet2.mobile
 
 import id.walt.crypto.keys.Key
@@ -12,16 +14,23 @@ import id.walt.wallet2.data.WalletDidStore
 import id.walt.wallet2.data.WalletKeyStore
 import id.walt.wallet2.data.WalletSessionEvent
 import id.walt.wallet2.handlers.PresentCredentialRequest
+import id.walt.wallet2.handlers.PresentationCredentialOption
+import id.walt.wallet2.handlers.PreviewPresentationRequest
 import id.walt.wallet2.handlers.ReceiveCredentialRequest
+import id.walt.wallet2.handlers.SubmitPresentationRequest
 import id.walt.wallet2.handlers.WalletIssuanceHandler
 import id.walt.wallet2.handlers.WalletPresentationHandler
 import id.waltid.openid4vci.wallet.attestation.ClientAttestationAssembler
 import id.waltid.openid4vci.wallet.attestation.HttpWalletAttestationProvider
+import id.waltid.openid4vp.wallet.WalletPresentFunctionality2.WalletPresentResult
 import io.ktor.http.Url
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Result returned after a mobile wallet has been initialized with signing material and a DID.
@@ -43,6 +52,7 @@ public data class MobileWalletBootstrapResult(
  * @property subject Subject identifier extracted from the credential when available.
  * @property label Optional display label stored with the credential.
  * @property addedAt ISO-8601 timestamp string for when the credential was added, when known.
+ * @property credentialDataJson Parsed credential data encoded as JSON for app-side display, when available.
  */
 public data class MobileWalletCredential(
     public val id: String,
@@ -51,6 +61,7 @@ public data class MobileWalletCredential(
     public val subject: String?,
     public val label: String?,
     public val addedAt: String?,
+    public val credentialDataJson: String? = null,
 )
 
 /**
@@ -219,6 +230,7 @@ public class MobileWallet internal constructor(
                 subject = meta.subject,
                 label = meta.label,
                 addedAt = meta.addedAt?.toString(),
+                credentialDataJson = credential.credential.credentialData.encodeJsonObject(),
             )
         }
 
@@ -255,6 +267,50 @@ public class MobileWallet internal constructor(
     }
 
     /**
+     * Resolves and previews an OpenID4VP presentation request without submitting credentials.
+     */
+    public suspend fun previewPresentation(requestUrl: String): MobileWalletPresentationPreview {
+        val result = WalletPresentationHandler.previewPresentation(
+            wallet = wallet,
+            request = PreviewPresentationRequest(
+                requestUrl = Url(requestUrl.trim()),
+            ),
+            onEvent = ::emitSessionEvent,
+        )
+
+        return MobileWalletPresentationPreview(
+            request = MobileWalletPresentationRequestInfo(
+                clientId = result.authorizationRequest.clientId,
+                verifierName = result.authorizationRequest.clientMetadata?.clientName,
+                responseUri = result.authorizationRequest.responseUri,
+                state = result.authorizationRequest.state,
+                nonce = result.authorizationRequest.nonce,
+            ),
+            credentialOptions = result.credentialOptions.map { it.toMobileCredentialOption() },
+        )
+    }
+
+    /**
+     * Submits a presentation using the credential IDs selected by the user from [previewPresentation].
+     */
+    public suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String? = null,
+        runPolicies: Boolean? = null,
+    ): MobileWalletPresentationResult =
+        WalletPresentationHandler.submitPresentation(
+            wallet = wallet,
+            request = SubmitPresentationRequest(
+                requestUrl = Url(requestUrl.trim()),
+                selectedCredentialIds = selectedCredentialIds,
+                did = did,
+                runPolicies = runPolicies,
+            ),
+            onEvent = ::emitSessionEvent,
+        ).toMobilePresentationResult()
+
+    /**
      * Deletes local wallet material owned by this mobile wallet instance.
      *
      * The active key, credential, and DID stores receive store-level remove calls. The wallet then closes
@@ -278,4 +334,42 @@ public class MobileWallet internal constructor(
         eventStream.tryEmit(mobileEvent)
         onEvent(mobileEvent)
     }
+
+    private fun PresentationCredentialOption.toMobileCredentialOption(): MobileWalletPresentationCredentialOption =
+        MobileWalletPresentationCredentialOption(
+            queryId = queryId,
+            credentialId = credentialId,
+            format = format,
+            issuer = issuer,
+            subject = subject,
+            label = label,
+            credentialDataJson = credentialData.encodeJsonObject(),
+            disclosures = disclosures.map { disclosure ->
+                MobileWalletPresentationDisclosure(
+                    path = disclosure.path,
+                    name = disclosure.name,
+                    valueJson = Json.encodeToString(JsonElement.serializer(), disclosure.value),
+                    displayValue = disclosure.value.displayValue(),
+                    selectivelyDisclosable = disclosure.selectivelyDisclosable,
+                )
+            },
+        )
+
+    private fun WalletPresentResult.toMobilePresentationResult(): MobileWalletPresentationResult =
+        MobileWalletPresentationResult(
+            success = transmissionSuccess ?: false,
+            redirectTo = redirectTo,
+            verifierResponseJson = verifierResponse?.let {
+                Json.encodeToString(JsonElement.serializer(), it)
+            },
+        )
+
+    private fun JsonObject.encodeJsonObject(): String =
+        Json.encodeToString(JsonObject.serializer(), this)
+
+    private fun JsonElement.displayValue(): String? =
+        when (this) {
+            is JsonPrimitive -> contentOrNull
+            else -> toString()
+        }
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
@@ -1,0 +1,69 @@
+package id.walt.wallet2.mobile
+
+/**
+ * Preview of an OpenID4VP presentation request before the wallet submits a VP token.
+ *
+ * @property request Verifier and protocol metadata extracted from the request.
+ * @property credentialOptions Wallet-local credentials that can satisfy the presentation request.
+ */
+public data class MobileWalletPresentationPreview(
+    val request: MobileWalletPresentationRequestInfo,
+    val credentialOptions: List<MobileWalletPresentationCredentialOption>,
+)
+
+/**
+ * Verifier metadata extracted from a presentation request.
+ *
+ * @property clientId Raw OpenID4VP `client_id` value, when available.
+ * @property verifierName Human-readable verifier name derived from request metadata or the client identifier.
+ * @property responseUri Verifier response URI to which the wallet will submit the presentation, when provided.
+ * @property state OpenID4VP state value supplied by the verifier, when provided.
+ * @property nonce OpenID4VP nonce value supplied by the verifier, when provided.
+ */
+public data class MobileWalletPresentationRequestInfo(
+    val clientId: String?,
+    val verifierName: String?,
+    val responseUri: String?,
+    val state: String?,
+    val nonce: String?,
+)
+
+/**
+ * A wallet credential that satisfies one DCQL credential query in the presentation request.
+ *
+ * @property queryId DCQL credential query identifier this credential can satisfy.
+ * @property credentialId Wallet-local credential identifier to submit when this option is selected.
+ * @property format Credential format, such as `jwt_vc_json`, `vc+sd-jwt`, or `mso_mdoc`.
+ * @property issuer Issuer identifier extracted from the credential when available.
+ * @property subject Subject identifier extracted from the credential when available.
+ * @property label Optional display label stored with the credential.
+ * @property credentialDataJson Parsed credential data encoded as JSON for app-side display, when available.
+ * @property disclosures Claim values requested by the verifier for this credential option.
+ */
+public data class MobileWalletPresentationCredentialOption(
+    val queryId: String,
+    val credentialId: String,
+    val format: String,
+    val issuer: String?,
+    val subject: String?,
+    val label: String?,
+    val credentialDataJson: String?,
+    val disclosures: List<MobileWalletPresentationDisclosure> = emptyList(),
+)
+
+/**
+ * Claim or selective-disclosure value that may be shared for a matched credential.
+ *
+ * @property path JSONPath-like claim path supplied by the presentation engine.
+ * @property name Optional human-readable claim name supplied by the presentation engine.
+ * @property valueJson Claim value encoded as JSON.
+ * @property displayValue Optional presentation-engine display value for the claim.
+ * @property selectivelyDisclosable `true` when the claim can be selectively disclosed.
+ */
+public data class MobileWalletPresentationDisclosure(
+    val path: String,
+    val name: String?,
+    val valueJson: String,
+    val displayValue: String?,
+    val selectivelyDisclosable: Boolean,
+)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
@@ -153,6 +153,58 @@ class MobileWalletTest {
         assertEquals("""{"accepted":true}""", result.verifierResponseJson)
     }
 
+    @Test
+    fun credentialSummaryCanExposeParsedCredentialDataJson() {
+        val credential = MobileWalletCredential(
+            id = "credential-1",
+            format = "vc+sd-jwt",
+            issuer = "https://issuer.example",
+            subject = "did:key:subject",
+            label = "PID",
+            addedAt = null,
+            credentialDataJson = """{"given_name":"Ada"}""",
+        )
+
+        assertEquals("""{"given_name":"Ada"}""", credential.credentialDataJson)
+    }
+
+    @Test
+    fun presentationPreviewUsesSwiftFriendlyCredentialAndClaimDtos() {
+        val preview = MobileWalletPresentationPreview(
+            request = MobileWalletPresentationRequestInfo(
+                clientId = "https://verifier.example",
+                verifierName = "Example Verifier",
+                responseUri = "https://verifier.example/direct-post",
+                state = "state-1",
+                nonce = "nonce-1",
+            ),
+            credentialOptions = listOf(
+                MobileWalletPresentationCredentialOption(
+                    queryId = "pid",
+                    credentialId = "credential-1",
+                    format = "vc+sd-jwt",
+                    issuer = "https://issuer.example",
+                    subject = "did:key:subject",
+                    label = "PID",
+                    credentialDataJson = """{"given_name":"Ada"}""",
+                    disclosures = listOf(
+                        MobileWalletPresentationDisclosure(
+                            path = "$.given_name",
+                            name = "given_name",
+                            valueJson = """"Ada"""",
+                            displayValue = "Ada",
+                            selectivelyDisclosable = true,
+                        )
+                    ),
+                )
+            ),
+        )
+
+        assertEquals("https://verifier.example", preview.request.clientId)
+        assertEquals("credential-1", preview.credentialOptions.single().credentialId)
+        assertEquals("Ada", preview.credentialOptions.single().disclosures.single().displayValue)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun mobileWalletEventStreamDoesNotBackpressureSlowCollectors() = runTest {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridge.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridge.kt
@@ -5,6 +5,7 @@ import id.walt.wallet2.mobile.MobileWalletBootstrapResult
 import id.walt.wallet2.mobile.MobileWalletCredential
 import id.walt.wallet2.mobile.MobileWalletEvent
 import id.walt.wallet2.mobile.MobileWalletKeyType
+import id.walt.wallet2.mobile.MobileWalletPresentationPreview
 import id.walt.wallet2.mobile.MobileWalletPresentationResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -104,6 +105,34 @@ public class WalletSdkBridge private constructor(
             )
         }
 
+    /**
+     * Resolves and previews an OpenID4VP presentation request without submitting credentials.
+     */
+    public suspend fun previewPresentation(
+        requestUrl: String,
+    ): WalletBridgeResult<MobileWalletPresentationPreview> =
+        walletBridgeCall {
+            operations.previewPresentation(requestUrl = requestUrl)
+        }
+
+    /**
+     * Submits a presentation using user-selected wallet credential IDs.
+     */
+    public suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String? = null,
+        runPolicies: Boolean? = null,
+    ): WalletBridgeResult<MobileWalletPresentationResult> =
+        walletBridgeCall {
+            operations.submitPresentation(
+                requestUrl = requestUrl,
+                selectedCredentialIds = selectedCredentialIds,
+                did = did,
+                runPolicies = runPolicies,
+            )
+        }
+
     internal companion object {
         internal fun forOperations(
             operations: WalletSdkBridgeOperations,
@@ -136,6 +165,18 @@ internal interface WalletSdkBridgeOperations {
         did: String?,
         runPolicies: Boolean?,
     ): MobileWalletPresentationResult
+
+    suspend fun previewPresentation(
+        requestUrl: String,
+    ): MobileWalletPresentationPreview
+
+    suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String?,
+        runPolicies: Boolean?,
+    ): MobileWalletPresentationResult
+
 }
 
 internal class MobileWalletSdkBridgeOperations(
@@ -177,4 +218,23 @@ internal class MobileWalletSdkBridgeOperations(
             did = did,
             runPolicies = runPolicies,
         )
+
+    override suspend fun previewPresentation(
+        requestUrl: String,
+    ): MobileWalletPresentationPreview =
+        wallet.previewPresentation(requestUrl = requestUrl)
+
+    override suspend fun submitPresentation(
+        requestUrl: String,
+        selectedCredentialIds: List<String>,
+        did: String?,
+        runPolicies: Boolean?,
+    ): MobileWalletPresentationResult =
+        wallet.submitPresentation(
+            requestUrl = requestUrl,
+            selectedCredentialIds = selectedCredentialIds,
+            did = did,
+            runPolicies = runPolicies,
+        )
+
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -12,6 +12,9 @@ import id.walt.wallet2.mobile.MobileWalletBootstrapResult
 import id.walt.wallet2.mobile.MobileWalletConfig
 import id.walt.wallet2.mobile.MobileWalletCredential
 import id.walt.wallet2.mobile.MobileWalletDatabaseKey
+import id.walt.wallet2.mobile.MobileWalletPresentationCredentialOption
+import id.walt.wallet2.mobile.MobileWalletPresentationPreview
+import id.walt.wallet2.mobile.MobileWalletPresentationRequestInfo
 import id.walt.wallet2.mobile.MobileWalletPresentationResult
 import id.walt.wallet2.mobile.MobileWalletPersistence
 import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKey
@@ -108,6 +111,7 @@ class WalletSdkBridgeTest {
         assertIs<WalletBridgeResult.Success<List<MobileWalletCredential>>>(result)
         assertEquals("credential-1", result.value.single().id)
         assertEquals("https://issuer.example", result.value.single().issuer)
+        assertEquals("""{"given_name":"Ada"}""", result.value.single().credentialDataJson)
     }
 
     @Test
@@ -139,6 +143,38 @@ class WalletSdkBridgeTest {
         assertEquals("openid4vp://request", operations.presentationRequestUrl)
         assertEquals("did:jwk:issuer", operations.presentationDid)
         assertEquals(true, operations.presentationRunPolicies)
+    }
+
+    @Test
+    fun bridgePresentationPreviewReturnsSwiftSafeDtos() = runTest {
+        val operations = FakeWalletSdkBridgeOperations()
+        val bridge = WalletSdkBridge.forOperations(operations)
+
+        val result = bridge.previewPresentation("openid4vp://request")
+
+        assertIs<WalletBridgeResult.Success<MobileWalletPresentationPreview>>(result)
+        assertEquals("https://verifier.example", result.value.request.clientId)
+        assertEquals("credential-1", result.value.credentialOptions.single().credentialId)
+        assertEquals("openid4vp://request", operations.previewRequestUrl)
+    }
+
+    @Test
+    fun bridgeSubmitPresentationForwardsSelectedCredentialIds() = runTest {
+        val operations = FakeWalletSdkBridgeOperations()
+        val bridge = WalletSdkBridge.forOperations(operations)
+
+        val result = bridge.submitPresentation(
+            requestUrl = "openid4vp://request",
+            selectedCredentialIds = listOf("credential-1"),
+            did = "did:jwk:issuer",
+            runPolicies = false,
+        )
+
+        assertIs<WalletBridgeResult.Success<MobileWalletPresentationResult>>(result)
+        assertEquals(listOf("credential-1"), operations.submittedCredentialIds)
+        assertEquals("openid4vp://request", operations.submittedRequestUrl)
+        assertEquals("did:jwk:issuer", operations.submittedDid)
+        assertEquals(false, operations.submittedRunPolicies)
     }
 
     @Test
@@ -428,7 +464,16 @@ class WalletSdkBridgeTest {
             private set
         var deleteWalletCalls = 0
             private set
-
+        var previewRequestUrl: String? = null
+            private set
+        var submittedRequestUrl: String? = null
+            private set
+        var submittedCredentialIds: List<String>? = null
+            private set
+        var submittedDid: String? = null
+            private set
+        var submittedRunPolicies: Boolean? = null
+            private set
         override suspend fun bootstrap(
             keyType: MobileWalletKeyType?,
             didMethod: String,
@@ -459,6 +504,7 @@ class WalletSdkBridgeTest {
                     subject = null,
                     label = "PID",
                     addedAt = null,
+                    credentialDataJson = """{"given_name":"Ada"}""",
                 )
             )
 
@@ -474,6 +520,48 @@ class WalletSdkBridgeTest {
             presentationRequestUrl = requestUrl
             presentationDid = did
             presentationRunPolicies = runPolicies
+            return MobileWalletPresentationResult(
+                success = true,
+                redirectTo = "wallet://return",
+                verifierResponseJson = """{"accepted":true}""",
+            )
+        }
+
+        override suspend fun previewPresentation(requestUrl: String): MobileWalletPresentationPreview {
+            previewRequestUrl = requestUrl
+            return MobileWalletPresentationPreview(
+                request = MobileWalletPresentationRequestInfo(
+                    clientId = "https://verifier.example",
+                    verifierName = "Example Verifier",
+                    responseUri = "https://verifier.example/direct-post",
+                    state = "state-1",
+                    nonce = "nonce-1",
+                ),
+                credentialOptions = listOf(
+                    MobileWalletPresentationCredentialOption(
+                        queryId = "pid",
+                        credentialId = "credential-1",
+                        format = "vc+sd-jwt",
+                        issuer = "https://issuer.example",
+                        subject = null,
+                        label = "PID",
+                        credentialDataJson = """{"given_name":"Ada"}""",
+                        disclosures = emptyList(),
+                    )
+                ),
+            )
+        }
+
+        override suspend fun submitPresentation(
+            requestUrl: String,
+            selectedCredentialIds: List<String>,
+            did: String?,
+            runPolicies: Boolean?,
+        ): MobileWalletPresentationResult {
+            submittedRequestUrl = requestUrl
+            submittedCredentialIds = selectedCredentialIds
+            submittedDid = did
+            submittedRunPolicies = runPolicies
             return MobileWalletPresentationResult(
                 success = true,
                 redirectTo = "wallet://return",

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletPresentationHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletPresentationHandler.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
 package id.walt.wallet2.handlers
 
 import id.walt.credentials.formats.DigitalCredential
@@ -14,12 +16,17 @@ import id.walt.webdatafetching.WebDataFetcherId
 import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
 import id.waltid.openid4vp.wallet.WalletPresentFunctionality2
 import id.waltid.openid4vp.wallet.WalletPresentFunctionality2.WalletPresentResult
+import id.waltid.openid4vp.wallet.request.AuthorizationRequestResolver
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import kotlinx.coroutines.flow.toList
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.put
@@ -138,6 +145,42 @@ data class MatchCredentialsResult(
     val matchedCredentialIds: Map<String, List<String>>
 )
 
+@Serializable
+data class PreviewPresentationRequest(
+    val requestUrl: Url
+)
+
+data class PreviewPresentationResult(
+    val authorizationRequest: AuthorizationRequest,
+    val credentialOptions: List<PresentationCredentialOption>,
+)
+
+data class PresentationCredentialOption(
+    val queryId: String,
+    val credentialId: String,
+    val format: String,
+    val issuer: String?,
+    val subject: String?,
+    val label: String?,
+    val credentialData: JsonObject,
+    val disclosures: List<PresentationDisclosure>,
+)
+
+data class PresentationDisclosure(
+    val path: String,
+    val name: String?,
+    val value: JsonElement,
+    val selectivelyDisclosable: Boolean,
+)
+
+@Serializable
+data class SubmitPresentationRequest(
+    val requestUrl: Url,
+    val selectedCredentialIds: List<String>,
+    val did: String? = null,
+    val runPolicies: Boolean? = null,
+)
+
 // ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
@@ -239,6 +282,81 @@ object WalletPresentationHandler {
         return result.getOrThrow()
     }
 
+    suspend fun previewPresentation(
+        wallet: Wallet,
+        request: PreviewPresentationRequest,
+        onEvent: suspend (WalletSessionEvent) -> Unit = {}
+    ): PreviewPresentationResult {
+        onEvent(WalletSessionEvent.presentation_request_parsed)
+        val authorizationRequest = resolveAuthorizationRequest(request.requestUrl)
+        val query = authorizationRequest.dcqlQuery ?: error("Missing dcql_query for AuthorizationRequest")
+        val storedById = wallet.streamAllCredentials().toList().associateBy { it.id }
+        val matched = selectFromStores(wallet, query, useWalletCredentialIds = true)
+        onEvent(WalletSessionEvent.presentation_credentials_selected)
+
+        return PreviewPresentationResult(
+            authorizationRequest = authorizationRequest,
+            credentialOptions = matched.flatMap { (queryId, results) ->
+                results.map { result ->
+                    val raw = result.credential as RawDcqlCredential
+                    val stored = storedById[raw.id] ?: error("Credential '${raw.id}' disappeared while building presentation preview")
+                    val credential = stored.credential
+                    PresentationCredentialOption(
+                        queryId = queryId,
+                        credentialId = stored.id,
+                        format = credential.format,
+                        issuer = credential.issuer,
+                        subject = credential.subject,
+                        label = stored.label,
+                        credentialData = credential.credentialData,
+                        disclosures = result.toPresentationDisclosures(),
+                    )
+                }
+            },
+        )
+    }
+
+    suspend fun submitPresentation(
+        wallet: Wallet,
+        request: SubmitPresentationRequest,
+        onEvent: suspend (WalletSessionEvent) -> Unit = {}
+    ): WalletPresentResult {
+        require(request.selectedCredentialIds.isNotEmpty()) {
+            "At least one credential must be selected for presentation"
+        }
+        val key = resolveKey(wallet, null)
+            ?: error("No key available: wallet has no keyStores, no staticKey, and no keyId was specified")
+        val did = request.did ?: wallet.defaultDid()
+        val selectedCredentialIds = request.selectedCredentialIds.toSet()
+
+        onEvent(WalletSessionEvent.presentation_request_parsed)
+
+        val result = WalletPresentFunctionality2.walletPresentHandling(
+            holderKey = key,
+            holderDid = did,
+            presentationRequestUrl = request.requestUrl,
+            selectCredentialsForQuery = { query ->
+                selectFromStores(
+                    wallet = wallet,
+                    query = query,
+                    walletCredentialIds = selectedCredentialIds,
+                    useWalletCredentialIds = true,
+                ).also {
+                    onEvent(WalletSessionEvent.presentation_credentials_selected)
+                }
+            },
+            holderPoliciesToRun = null,
+            runPolicies = request.runPolicies,
+        )
+
+        if (result.isSuccess) {
+            onEvent(WalletSessionEvent.presentation_completed)
+        } else {
+            onEvent(WalletSessionEvent.presentation_failed)
+        }
+
+        return result.getOrThrow()
+    }
     // ---------------------------------------------------------------------------
     // Isolated step handlers
     // ---------------------------------------------------------------------------
@@ -362,7 +480,9 @@ object WalletPresentationHandler {
      */
     internal suspend fun selectFromStores(
         wallet: Wallet,
-        query: DcqlQuery
+        query: DcqlQuery,
+        walletCredentialIds: Set<String>? = null,
+        useWalletCredentialIds: Boolean = false,
     ): Map<String, List<DcqlMatcher.DcqlMatchResult>> {
         if (wallet.credentialStores.isEmpty()) {
             error("Wallet has no credential stores — use presentCredentialIsolated to present inline credentials")
@@ -371,8 +491,12 @@ object WalletPresentationHandler {
         val rawCredentials = mutableListOf<RawDcqlCredential>()
         var idx = 0
         wallet.streamAllCredentials().collect { stored ->
-            log.trace { "  credential[$idx]: id=${stored.id}, format=${stored.credential.format}, issuer=${stored.credential.issuer}" }
-            rawCredentials += stored.credential.toRawDcqlCredential(idx.toString())
+            if (walletCredentialIds == null || stored.id in walletCredentialIds) {
+                log.trace { "  credential[$idx]: id=${stored.id}, format=${stored.credential.format}, issuer=${stored.credential.issuer}" }
+                rawCredentials += stored.credential.toRawDcqlCredential(
+                    id = if (useWalletCredentialIds) stored.id else idx.toString(),
+                )
+            }
             idx++
         }
 
@@ -381,6 +505,45 @@ object WalletPresentationHandler {
         log.trace { "DCQL match result: matchedQueryIds=${matched.keys}, matchCounts=${matched.mapValues { it.value.size }}" }
         return matched
     }
+
+    private suspend fun resolveAuthorizationRequest(requestUrl: Url): AuthorizationRequest {
+        val fetcher = WebDataFetcher(WebDataFetcherId.OPENID4VP_WALLET_RESOLVE_AUTHORIZATIONREQUEST)
+        return AuthorizationRequestResolver.resolve(
+            requestUrl = requestUrl,
+            unsignedRequestObjectPolicy = AuthorizationRequestResolver.UnsignedRequestObjectPolicy.REQUIRE_SIGNED,
+            fetchRequestUri = { requestUri, requestUriMethod ->
+                AuthorizationRequestResolver.fetchRequestUriWithWebDataFetcher(
+                    webResolveAuthReq = fetcher,
+                    requestUri = requestUri,
+                    requestUriMethod = requestUriMethod,
+                )
+            },
+        ).authorizationRequest
+    }
+
+    private fun DcqlMatcher.DcqlMatchResult.toPresentationDisclosures(): List<PresentationDisclosure> =
+        selectedDisclosures.orEmpty().map { (path, value) ->
+            when (value) {
+                is DcqlDisclosure -> PresentationDisclosure(
+                    path = path,
+                    name = value.name,
+                    value = value.value,
+                    selectivelyDisclosable = true,
+                )
+                is JsonElement -> PresentationDisclosure(
+                    path = path,
+                    name = path.substringAfterLast('.', path),
+                    value = value,
+                    selectivelyDisclosable = false,
+                )
+                else -> PresentationDisclosure(
+                    path = path,
+                    name = path.substringAfterLast('.', path),
+                    value = JsonPrimitive(value.toString()),
+                    selectivelyDisclosable = false,
+                )
+            }
+        }
 
     private fun DigitalCredential.toRawDcqlCredential(id: String): RawDcqlCredential {
         val sdvc = this as? id.walt.credentials.signatures.sdjwt.SelectivelyDisclosableVerifiableCredential

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -103,6 +103,42 @@ final class KMPWalletCoreBridge: WalletCoreBridge, @unchecked Sendable {
         )
     }
 
+    func previewPresentation(request: URL) async throws -> PresentationPreview {
+        let result = try await bridge.previewPresentation(requestUrl: request.absoluteString)
+        let value = try Self.successValue(
+            result,
+            as: MobileWalletPresentationPreview.self,
+            operation: "preview presentation"
+        )
+
+        return value.toSwiftPreview()
+    }
+
+    func submitPresentation(
+        request: URL,
+        selectedCredentialIDs: [String],
+        did: String?,
+        runPolicies: Bool?
+    ) async throws -> PresentationResult {
+        let result = try await bridge.submitPresentation(
+            requestUrl: request.absoluteString,
+            selectedCredentialIds: selectedCredentialIDs,
+            did: did,
+            runPolicies: runPolicies.map { KotlinBoolean(bool: $0) }
+        )
+        let value = try Self.successValue(
+            result,
+            as: MobileWalletPresentationResult.self,
+            operation: "submit presentation"
+        )
+
+        return .init(
+            success: value.success,
+            redirectTo: value.redirectTo.flatMap(URL.init(string:)),
+            verifierResponseJSON: value.verifierResponseJson
+        )
+    }
+
     private static func successValue<T>(
         _ result: any WalletBridgeResult,
         as type: T.Type,
@@ -496,9 +532,70 @@ private extension MobileWalletCredential {
             issuer: issuer,
             subject: subject,
             label: label,
-            addedAt: addedAt.flatMap { ISO8601DateFormatter().date(from: $0) }
+            addedAt: addedAt.flatMap { ISO8601DateFormatter().date(from: $0) },
+            credentialDataJSON: credentialDataJson
         )
     }
+}
+
+private extension MobileWalletPresentationPreview {
+    func toSwiftPreview() -> PresentationPreview {
+        PresentationPreview(
+            request: request.toSwiftRequestInfo(),
+            credentialOptions: swiftArray(credentialOptions, of: MobileWalletPresentationCredentialOption.self)
+                .map { $0.toSwiftCredentialOption() }
+        )
+    }
+}
+
+private extension MobileWalletPresentationRequestInfo {
+    func toSwiftRequestInfo() -> PresentationRequestInfo {
+        PresentationRequestInfo(
+            clientID: clientId,
+            verifierName: verifierName,
+            responseURI: responseUri.flatMap(URL.init(string:)),
+            state: state,
+            nonce: nonce
+        )
+    }
+}
+
+private extension MobileWalletPresentationCredentialOption {
+    func toSwiftCredentialOption() -> PresentationCredentialOption {
+        PresentationCredentialOption(
+            queryID: queryId,
+            credentialID: credentialId,
+            format: format,
+            issuer: issuer,
+            subject: subject,
+            label: label,
+            credentialDataJSON: credentialDataJson,
+            disclosures: swiftArray(disclosures, of: MobileWalletPresentationDisclosure.self)
+                .map { $0.toSwiftDisclosure() }
+        )
+    }
+}
+
+private extension MobileWalletPresentationDisclosure {
+    func toSwiftDisclosure() -> PresentationDisclosure {
+        PresentationDisclosure(
+            path: path,
+            name: name,
+            valueJSON: valueJson,
+            displayValue: displayValue,
+            selectivelyDisclosable: selectivelyDisclosable
+        )
+    }
+}
+
+private func swiftArray<T>(_ value: Any, of type: T.Type) -> [T] {
+    if let values = value as? [T] {
+        return values
+    }
+    if let values = value as? NSArray {
+        return values.compactMap { $0 as? T }
+    }
+    return []
 }
 
 private extension MobileWalletEvent {

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Wallet.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Wallet.swift
@@ -108,4 +108,38 @@ public actor Wallet {
     ) async throws -> PresentationResult {
         try await bridge.present(request: request, did: did, runPolicies: runPolicies)
     }
+
+    /// Resolves and previews an OpenID4VP presentation request without submitting credentials.
+    ///
+    /// - Parameter request: OpenID4VP authorization request URL received by the app.
+    /// - Returns: Verifier metadata and matching credential options.
+    /// - Throws: ``WalletError`` when the request cannot be resolved or matched.
+    public func previewPresentation(request: URL) async throws -> PresentationPreview {
+        try await bridge.previewPresentation(request: request)
+    }
+
+    /// Submits a presentation with user-selected credential identifiers.
+    ///
+    /// - Parameters:
+    ///   - request: OpenID4VP authorization request URL received by the app.
+    ///   - selectedCredentialIDs: Wallet credential identifiers selected from
+    ///     ``previewPresentation(request:)``.
+    ///   - did: Optional wallet DID to use for presentation.
+    ///   - runPolicies: Optional policy execution override for presentation.
+    /// - Returns: Presentation outcome.
+    /// - Throws: ``WalletError`` when selection, signing, or verifier communication fails.
+    public func submitPresentation(
+        request: URL,
+        selectedCredentialIDs: [String],
+        did: String? = nil,
+        runPolicies: Bool? = nil
+    ) async throws -> PresentationResult {
+        try await bridge.submitPresentation(
+            request: request,
+            selectedCredentialIDs: selectedCredentialIDs,
+            did: did,
+            runPolicies: runPolicies
+        )
+    }
+
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletCoreBridge.swift
@@ -9,6 +9,13 @@ protocol WalletCoreBridge: Sendable {
     func credentials() async throws -> [Credential]
     func deleteLocalData() async throws
     func present(request: URL, did: String?, runPolicies: Bool?) async throws -> PresentationResult
+    func previewPresentation(request: URL) async throws -> PresentationPreview
+    func submitPresentation(
+        request: URL,
+        selectedCredentialIDs: [String],
+        did: String?,
+        runPolicies: Bool?
+    ) async throws -> PresentationResult
 }
 
 @available(macOS 10.15, *)
@@ -47,6 +54,19 @@ struct UnavailableWalletCoreBridge: WalletCoreBridge {
     }
 
     func present(request: URL, did: String?, runPolicies: Bool?) async throws -> PresentationResult {
+        throw unavailableError()
+    }
+
+    func previewPresentation(request: URL) async throws -> PresentationPreview {
+        throw unavailableError()
+    }
+
+    func submitPresentation(
+        request: URL,
+        selectedCredentialIDs: [String],
+        did: String?,
+        runPolicies: Bool?
+    ) async throws -> PresentationResult {
         throw unavailableError()
     }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -468,6 +468,9 @@ public struct Credential: Equatable, Identifiable, Sendable {
     /// Date the credential was added to the wallet when available.
     public let addedAt: Date?
 
+    /// Raw parsed credential data encoded as JSON, when available.
+    public let credentialDataJSON: String?
+
     /// Creates credential metadata visible to SDK consumers.
     ///
     /// - Parameters:
@@ -479,13 +482,16 @@ public struct Credential: Equatable, Identifiable, Sendable {
     ///   - label: User-facing credential label when available.
     ///   - addedAt: Date the credential was added to the wallet when
     ///     available.
+    ///   - credentialDataJSON: Raw parsed credential data encoded as JSON,
+    ///     when available.
     public init(
         id: String,
         format: String,
         issuer: String?,
         subject: String?,
         label: String?,
-        addedAt: Date?
+        addedAt: Date?,
+        credentialDataJSON: String? = nil
     ) {
         self.id = id
         self.format = format
@@ -493,6 +499,7 @@ public struct Credential: Equatable, Identifiable, Sendable {
         self.subject = subject
         self.label = label
         self.addedAt = addedAt
+        self.credentialDataJSON = credentialDataJSON
     }
 }
 
@@ -541,6 +548,177 @@ public struct PresentationResult: Equatable, Sendable {
         self.success = success
         self.redirectTo = redirectTo
         self.verifierResponseJSON = verifierResponseJSON
+    }
+}
+
+/// Preview of an OpenID4VP presentation request before the wallet submits a VP token.
+public struct PresentationPreview: Equatable, Sendable {
+    /// Verifier/request information shown to the user.
+    public let request: PresentationRequestInfo
+
+    /// Credentials that satisfy the request's DCQL queries.
+    public let credentialOptions: [PresentationCredentialOption]
+
+    /// Creates a presentation preview.
+    ///
+    /// - Parameters:
+    ///   - request: Verifier and request metadata extracted from the
+    ///     presentation request.
+    ///   - credentialOptions: Wallet credentials that can satisfy the
+    ///     requested credential queries.
+    public init(
+        request: PresentationRequestInfo,
+        credentialOptions: [PresentationCredentialOption]
+    ) {
+        self.request = request
+        self.credentialOptions = credentialOptions
+    }
+}
+
+/// Verifier metadata extracted from a presentation request.
+public struct PresentationRequestInfo: Equatable, Sendable {
+    /// OpenID4VP client identifier.
+    public let clientID: String?
+
+    /// Human-readable verifier name from client metadata when available.
+    public let verifierName: String?
+
+    /// Response URI used for direct-post responses when available.
+    public let responseURI: URL?
+
+    /// OpenID state value.
+    public let state: String?
+
+    /// OpenID nonce value.
+    public let nonce: String?
+
+    /// Creates presentation request information.
+    ///
+    /// - Parameters:
+    ///   - clientID: OpenID4VP client identifier from the request.
+    ///   - verifierName: Human-readable verifier name from client metadata
+    ///     when available.
+    ///   - responseURI: Direct-post response URI when available.
+    ///   - state: OpenID state value from the request.
+    ///   - nonce: OpenID nonce value from the request.
+    public init(
+        clientID: String? = nil,
+        verifierName: String? = nil,
+        responseURI: URL? = nil,
+        state: String? = nil,
+        nonce: String? = nil
+    ) {
+        self.clientID = clientID
+        self.verifierName = verifierName
+        self.responseURI = responseURI
+        self.state = state
+        self.nonce = nonce
+    }
+}
+
+/// A wallet credential that satisfies one presentation credential query.
+public struct PresentationCredentialOption: Equatable, Identifiable, Sendable {
+    /// Stable UI identifier made from query and credential IDs.
+    public var id: String { "\(queryID):\(credentialID)" }
+
+    /// DCQL credential query identifier.
+    public let queryID: String
+
+    /// Wallet-local credential identifier.
+    public let credentialID: String
+
+    /// Credential format.
+    public let format: String
+
+    /// Issuer identifier when available.
+    public let issuer: String?
+
+    /// Subject identifier when available.
+    public let subject: String?
+
+    /// User-facing label when available.
+    public let label: String?
+
+    /// Raw credential data encoded as JSON, when available.
+    public let credentialDataJSON: String?
+
+    /// Requested credential values shown for informed consent.
+    public let disclosures: [PresentationDisclosure]
+
+    /// Creates a presentation credential option.
+    ///
+    /// - Parameters:
+    ///   - queryID: DCQL credential query identifier this option satisfies.
+    ///   - credentialID: Wallet-local credential identifier.
+    ///   - format: Credential format.
+    ///   - issuer: Issuer identifier when available.
+    ///   - subject: Subject identifier when available.
+    ///   - label: User-facing credential label when available.
+    ///   - credentialDataJSON: Raw credential data encoded as JSON, when
+    ///     available.
+    ///   - disclosures: Credential values requested from this credential.
+    public init(
+        queryID: String,
+        credentialID: String,
+        format: String,
+        issuer: String?,
+        subject: String?,
+        label: String?,
+        credentialDataJSON: String?,
+        disclosures: [PresentationDisclosure] = []
+    ) {
+        self.queryID = queryID
+        self.credentialID = credentialID
+        self.format = format
+        self.issuer = issuer
+        self.subject = subject
+        self.label = label
+        self.credentialDataJSON = credentialDataJSON
+        self.disclosures = disclosures
+    }
+}
+
+/// Credential value that may be shared.
+public struct PresentationDisclosure: Equatable, Identifiable, Sendable {
+    /// Stable display identifier.
+    public var id: String { path }
+
+    /// JSON-path-like claim path.
+    public let path: String
+
+    /// Claim name when known.
+    public let name: String?
+
+    /// Raw claim value encoded as JSON.
+    public let valueJSON: String
+
+    /// Human-readable value when trivially available.
+    public let displayValue: String?
+
+    /// Whether this value comes from a selectively disclosable claim.
+    public let selectivelyDisclosable: Bool
+
+    /// Creates a presentation disclosure.
+    ///
+    /// - Parameters:
+    ///   - path: JSON-path-like claim path.
+    ///   - name: Claim name when known.
+    ///   - valueJSON: Raw claim value encoded as JSON.
+    ///   - displayValue: Human-readable value when trivially available.
+    ///   - selectivelyDisclosable: Whether this value comes from a
+    ///     selectively disclosable claim.
+    public init(
+        path: String,
+        name: String?,
+        valueJSON: String,
+        displayValue: String?,
+        selectivelyDisclosable: Bool
+    ) {
+        self.path = path
+        self.name = name
+        self.valueJSON = valueJSON
+        self.displayValue = displayValue
+        self.selectivelyDisclosable = selectivelyDisclosable
     }
 }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -120,11 +120,13 @@ final class WalletAPITests: XCTestCase {
             issuer: "https://issuer.example",
             subject: "did:key:subject",
             label: "PID",
-            addedAt: nil
+            addedAt: nil,
+            credentialDataJSON: #"{"given_name":"Ada"}"#
         )
 
         acceptsSendable(credential)
         XCTAssertEqual(credential.id, "credential-1")
+        XCTAssertEqual(credential.credentialDataJSON, #"{"given_name":"Ada"}"#)
         XCTAssertEqual(credential, credential)
 
         let storedCredential = StoredCredential(
@@ -154,6 +156,41 @@ final class WalletAPITests: XCTestCase {
         acceptsSendable(storedKey)
         XCTAssertEqual(storedKey.id, "key-1")
         XCTAssertEqual(storedKey, storedKey)
+    }
+
+    func testPresentationPreviewModelsAreValueTypesAndEquatable() {
+        let preview = PresentationPreview(
+            request: .init(
+                clientID: "https://verifier.example",
+                verifierName: "Example Verifier",
+                responseURI: URL(string: "https://verifier.example/direct-post"),
+                state: "state-1",
+                nonce: "nonce-1"
+            ),
+            credentialOptions: [
+                .init(
+                    queryID: "pid",
+                    credentialID: "credential-1",
+                    format: "vc+sd-jwt",
+                    issuer: "https://issuer.example",
+                    subject: "did:key:subject",
+                    label: "PID",
+                    credentialDataJSON: #"{"given_name":"Ada"}"#,
+                    disclosures: [
+                        .init(
+                            path: "$.given_name",
+                            name: "given_name",
+                            valueJSON: #""Ada""#,
+                            displayValue: "Ada",
+                            selectivelyDisclosable: true
+                        )
+                    ]
+                )
+            ]
+        )
+
+        acceptsSendable(preview)
+        XCTAssertEqual(preview.credentialOptions.single?.credentialID, "credential-1")
     }
 
     func testWalletHasAsyncFacadeShape() async {
@@ -260,6 +297,58 @@ final class WalletAPITests: XCTestCase {
         XCTAssertEqual(bridge.presentCalls.first?.request, request)
         XCTAssertEqual(bridge.presentCalls.first?.did, "did:key:wallet")
         XCTAssertEqual(bridge.presentCalls.first?.runPolicies, true)
+    }
+
+    func testPreviewPresentationForwardsRequestAndReturnsPreview() async throws {
+        let request = URL(string: "openid4vp://verifier.example?request_uri=abc")!
+        let bridge = FakeWalletCoreBridge()
+        bridge.previewResult = .init(
+            request: .init(
+                clientID: "https://verifier.example",
+                verifierName: "Example Verifier",
+                responseURI: nil,
+                state: nil,
+                nonce: "nonce-1"
+            ),
+            credentialOptions: [
+                .init(
+                    queryID: "pid",
+                    credentialID: "credential-1",
+                    format: "vc+sd-jwt",
+                    issuer: nil,
+                    subject: nil,
+                    label: "PID",
+                    credentialDataJSON: nil,
+                    disclosures: []
+                )
+            ]
+        )
+        let wallet = Wallet(bridge: bridge)
+
+        let result = try await wallet.previewPresentation(request: request)
+
+        XCTAssertEqual(result.request.clientID, "https://verifier.example")
+        XCTAssertEqual(result.credentialOptions.single?.credentialID, "credential-1")
+        XCTAssertEqual(bridge.previewCalls, [request])
+    }
+
+    func testSubmitPresentationForwardsSelectionAndReturnsResult() async throws {
+        let request = URL(string: "openid4vp://verifier.example?request_uri=abc")!
+        let bridge = FakeWalletCoreBridge()
+        let wallet = Wallet(bridge: bridge)
+
+        _ = try await wallet.submitPresentation(
+            request: request,
+            selectedCredentialIDs: ["credential-1"],
+            did: "did:key:wallet",
+            runPolicies: false
+        )
+
+        XCTAssertEqual(bridge.submitCalls.count, 1)
+        XCTAssertEqual(bridge.submitCalls.first?.request, request)
+        XCTAssertEqual(bridge.submitCalls.first?.selectedCredentialIDs, ["credential-1"])
+        XCTAssertEqual(bridge.submitCalls.first?.did, "did:key:wallet")
+        XCTAssertEqual(bridge.submitCalls.first?.runPolicies, false)
     }
 
     func testBridgeErrorsSurfaceAsWalletErrors() async {
@@ -399,6 +488,12 @@ private final class FakeKeyStore: WalletKeyStore, @unchecked Sendable {
     }
 }
 
+private extension Array {
+    var single: Element? {
+        count == 1 ? first : nil
+    }
+}
+
 private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable {
     struct BootstrapCall {
         let keyType: WalletKeyType
@@ -417,17 +512,28 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
         let runPolicies: Bool?
     }
 
+    struct SubmitCall {
+        let request: URL
+        let selectedCredentialIDs: [String]
+        let did: String?
+        let runPolicies: Bool?
+    }
+
     var events: AsyncStream<WalletEvent>
     var error: WalletError?
     var bootstrapResult = WalletBootstrapResult(keyID: "key", did: "did:key:wallet")
     var receiveResult: [String] = []
     var credentialsResult: [Credential] = []
     var presentResult = PresentationResult(success: true, redirectTo: nil, verifierResponseJSON: nil)
+    var previewResult = PresentationPreview(request: .init(clientID: nil), credentialOptions: [])
+    var submitResult = PresentationResult(success: true, redirectTo: nil, verifierResponseJSON: nil)
     private(set) var bootstrapCalls: [BootstrapCall] = []
     private(set) var receiveCalls: [ReceiveCall] = []
     private(set) var credentialsCallCount = 0
     private(set) var deleteLocalDataCallCount = 0
     private(set) var presentCalls: [PresentCall] = []
+    private(set) var previewCalls: [URL] = []
+    private(set) var submitCalls: [SubmitCall] = []
 
     init(events: [WalletEvent] = []) {
         self.events = AsyncStream { continuation in
@@ -480,5 +586,35 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
 
         presentCalls.append(.init(request: request, did: did, runPolicies: runPolicies))
         return presentResult
+    }
+
+    func previewPresentation(request: URL) async throws -> PresentationPreview {
+        if let error {
+            throw error
+        }
+
+        previewCalls.append(request)
+        return previewResult
+    }
+
+    func submitPresentation(
+        request: URL,
+        selectedCredentialIDs: [String],
+        did: String?,
+        runPolicies: Bool?
+    ) async throws -> PresentationResult {
+        if let error {
+            throw error
+        }
+
+        submitCalls.append(
+            .init(
+                request: request,
+                selectedCredentialIDs: selectedCredentialIDs,
+                did: did,
+                runPolicies: runPolicies
+            )
+        )
+        return submitResult
     }
 }


### PR DESCRIPTION
## Summary

Stub follow-up for claim-level selective disclosure in the WAL-751 mobile OpenID4VP flow. There is no separate Linear ticket for this yet, so this stays under WAL-751 while remaining split from [#1882](https://github.com/walt-id/waltid-identity/pull/1882).

I re-checked the pre-rescope branch and did not find a real claim-level selection implementation worth moving here. The recovered code only exposed and displayed requested disclosure metadata, which belongs in the base WAL-751 consent preview; it did not add selectable-claim DTOs, required-vs-optional modeling, or submission filtering.

This PR therefore intentionally remains an empty marker branch so the follow-up scope is visible without adding misleading placeholder implementation code.

## Intended Scope

- Add an explicit selected-disclosure / selected-claim API shape instead of overloading `selectedCredentialIds`.
- Model required vs optional disclosures based on DCQL/query semantics.
- Let the user deselect only optional/selectively-disclosable claims in Compose and native iOS demo apps.
- Clearly mark required claims and explain why they cannot be deselected.
- Ensure submission passes selected claims into the presentation engine and prove the generated VP contains only allowed disclosures.

## Non-Goals

- No transaction-data rendering; that is [#1893](https://github.com/walt-id/waltid-identity/pull/1893) / WAL-1077.
- No verifier rejection / Decline response implementation; that is [#1892](https://github.com/walt-id/waltid-identity/pull/1892) / WAL-1078.
- No weakening of the existing credential-option submit flow from [#1882](https://github.com/walt-id/waltid-identity/pull/1882).

## First Implementation Steps

1. Audit current DCQL selection semantics and presenter support for claim/disclosure filtering.
2. Design Swift-friendly SDK DTOs for selectable disclosures and required/optional state.
3. Add sharedLogic selection state and tests before UI.
4. Add Compose and native iOS review UI for optional claim toggles.
5. Add SDK, UI, and smoke tests proving only selected optional disclosures are presented.

## Validation

- Not run for this marker branch; there are currently no implementation changes beyond the empty scope marker commit.
