### PR TITLE
Harden Android emulator SDK installs

### DIFF
--- a/.github/workflows/android-device-tests.yml
+++ b/.github/workflows/android-device-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   android-device-test-phase:
     name: android-device-tests (${{ matrix.phase }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -46,6 +46,32 @@ jobs:
         id: android-device-phase
         run: ./waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh "${{ matrix.phase }}"
 
+      - name: Preinstall Android emulator SDK packages
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          retry_sdkmanager_install() {
+            local attempt
+            for attempt in 1 2 3; do
+              echo "sdkmanager install attempt ${attempt}: $*"
+              if "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install "$@" --channel=0; then
+                return 0
+              fi
+
+              if [ "$attempt" -eq 3 ]; then
+                return 1
+              fi
+
+              sleep $((attempt * 20))
+            done
+          }
+
+          yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true
+          retry_sdkmanager_install 'build-tools;37.0.0' platform-tools 'platforms;android-34'
+          retry_sdkmanager_install emulator
+          retry_sdkmanager_install 'system-images;android-34;default;x86_64'
+
       - name: Build Enterprise Android mobile test artifacts
         if: matrix.phase == 'enterprise-mobile'
         run: ./waltid-identity/.github/scripts/mobile-ci/prepare-enterprise-android-mobile-tests.sh
@@ -81,7 +107,7 @@ jobs:
           retention-days: 30
 
   android-device-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: android-device-test-phase
     if: always()
     steps:


### PR DESCRIPTION
## Summary

This hardens the Android device-test workflow against the recurring GitHub-hosted runner failure where `sdkmanager` reports `Error on ZipFile unknown archive` while installing the Android Emulator or the API 34 system image.

## What Changed

- Pin the Android device-test jobs to `ubuntu-24.04` instead of the floating `ubuntu-latest` label.
- Preinstall the emulator SDK dependencies before `reactivecircus/android-emulator-runner@v2` runs:
  - `build-tools;37.0.0`
  - `platform-tools`
  - `platforms;android-34`
  - `emulator`
  - `system-images;android-34;default;x86_64`
- Wrap each `sdkmanager --install` call in a three-attempt retry loop with visible install output.

## Root Cause

Recent `main` Android failures happened before any Android tests executed. The enterprise-mobile phase built its test artifacts, then failed while the emulator runner was preparing SDK packages. Once that install failed, cleanup tried to kill `emulator-5554`, but no emulator had started yet.

Representative failing `main` run: [`Android device tests` run `29085404797`, job `86337815461`](https://github.com/walt-id/waltid-identity/actions/runs/29085404797/job/86337815461).

`reactivecircus/android-emulator-runner@v2` performs these SDK installs internally with output redirected to `/dev/null` and without repo-level retry control. Preinstalling the same packages with retries lets transient SDK download/archive failures recover before the action starts the emulator.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/android-device-tests.yml"); puts "workflow yaml ok"'`
- `Android device tests` run `29093709740` passed on GitHub Actions:
  - `android-device-tests (compose-demo)` passed, including `Preinstall Android emulator SDK packages`
  - `android-device-tests (wallet-mobile)` passed, including `Preinstall Android emulator SDK packages`
  - `android-device-tests (enterprise-mobile)` passed, including `Preinstall Android emulator SDK packages`
  - aggregate `android-device-tests` passed

## Caveats and Follow-Ups

- This keeps the existing emulator runner action and test commands intact; it only hardens SDK setup around it.
- Most existing Ubuntu jobs in this repo use `ubuntu-latest`; this PR intentionally pins only the Android device-test workflow to reduce hosted-image drift for emulator setup.
