### PR TITLE
[WAL-1077] feat(mobile): fetch demo transaction data profiles

### DIFF
--- a/.github/scripts/mobile-ci/run-android-compose-demo-tests.sh
+++ b/.github/scripts/mobile-ci/run-android-compose-demo-tests.sh
@@ -6,4 +6,5 @@ identity_dir="$(cd "$script_dir/../../.." && pwd -P)"
 
 "$identity_dir/gradlew" -p "$identity_dir" \
   :waltid-applications:waltid-wallet-demo-compose:androidApp:connectedDebugAndroidTest \
+  -PtransactionDataProfiles.url=https://wallet.demo.walt.id/wallet-api/transaction-data-profiles \
   --info

--- a/docker-compose/verifier-api2/config/transaction-data-profiles.conf
+++ b/docker-compose/verifier-api2/config/transaction-data-profiles.conf
@@ -2,7 +2,7 @@ transactionDataProfiles = [
   {
     type = "org.waltid.transaction-data.payment-authorization"
     displayName = "Payment Authorization"
-    fields = ["amount", "currency", "payee"]
+    fields = ["amount", "currency", "payee", "reference"]
   },
   {
     type = "org.waltid.transaction-data.account-access"

--- a/docker-compose/wallet-api/config/transaction-data-profiles.conf
+++ b/docker-compose/wallet-api/config/transaction-data-profiles.conf
@@ -2,7 +2,7 @@ transactionDataProfiles = [
   {
     type = "org.waltid.transaction-data.payment-authorization"
     displayName = "Payment Authorization"
-    fields = ["amount", "currency", "payee"]
+    fields = ["amount", "currency", "payee", "reference"]
   },
   {
     type = "org.waltid.transaction-data.account-access"

--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
@@ -21,6 +21,9 @@ public struct DemoVerifierSession {
 public final class DemoBackend {
     public static let shared = DemoBackend()
     private static let eudiPidSdJwtVct = "https://issuer2.demo.walt.id/openid4vci/urn:eudi:pid:1"
+    public static let transactionDataProfilesURL = URL(string: "https://wallet.demo.walt.id/wallet-api/transaction-data-profiles")!
+    private static let paymentAuthorizationType = "org.waltid.transaction-data.payment-authorization"
+    private static let requiredPaymentAuthorizationFields: Set<String> = ["amount", "currency", "payee"]
 
     public static let scenarios: [DemoCredentialScenario] = [
         DemoCredentialScenario(
@@ -113,10 +116,37 @@ public final class DemoBackend {
     public func createTransactionDataVerifierSession(
         scenario: DemoCredentialScenario = DemoBackend.transactionDataPresentationScenario
     ) async throws -> DemoVerifierSession {
-        try await createVerifierSession(
+        let fields = try await transactionDataProfileFields(type: Self.paymentAuthorizationType)
+        let missingFields = Self.requiredPaymentAuthorizationFields.subtracting(fields)
+        guard missingFields.isEmpty else {
+            throw NSError(
+                domain: "WalletE2E",
+                code: 305,
+                userInfo: [NSLocalizedDescriptionKey: "Public demo transaction data profile '\(Self.paymentAuthorizationType)' is missing required fields: \(missingFields.sorted().joined(separator: ", "))"]
+            )
+        }
+        return try await createVerifierSession(
             scenario: scenario,
-            transactionData: [Self.paymentAuthorizationTransactionData(credentialID: "pid")]
+            transactionData: [Self.paymentAuthorizationTransactionData(credentialID: "pid", fields: fields)]
         )
+    }
+
+    public func transactionDataProfileFields(type: String) async throws -> Set<String> {
+        let response = try await client.textRequest(
+            url: Self.transactionDataProfilesURL,
+            retryTransientFailures: true
+        )
+        let json = try JSONSerialization.jsonObject(with: Data(response.body.utf8), options: [])
+        guard let profiles = json as? [[String: Any]],
+              let profile = profiles.first(where: { $0["type"] as? String == type }),
+              let fields = profile["fields"] as? [String] else {
+            throw NSError(
+                domain: "WalletE2E",
+                code: 306,
+                userInfo: [NSLocalizedDescriptionKey: "Missing public demo transaction data profile: \(type)"]
+            )
+        }
+        return Set(fields)
     }
 
     private func createVerifierSession(
@@ -229,16 +259,25 @@ public final class DemoBackend {
         ]
     }
 
-    private static func paymentAuthorizationTransactionData(credentialID: String) -> [String: Any] {
-        [
-            "type": "org.waltid.transaction-data.payment-authorization",
+    private static func paymentAuthorizationTransactionData(credentialID: String, fields: Set<String>) -> [String: Any] {
+        var payload: [String: Any] = [
+            "type": paymentAuthorizationType,
             "credential_ids": [credentialID],
             "require_cryptographic_holder_binding": true,
             "transaction_data_hashes_alg": ["sha-256"],
-            "amount": "42.00",
-            "currency": "EUR",
-            "payee": "ACME Corp",
-            "reference": "INV-2026-042",
         ]
+        payload.putProfileField(fields: fields, key: "amount", value: "42.00")
+        payload.putProfileField(fields: fields, key: "currency", value: "EUR")
+        payload.putProfileField(fields: fields, key: "payee", value: "ACME Corp")
+        payload.putProfileField(fields: fields, key: "reference", value: "INV-2026-042")
+        return payload
+    }
+}
+
+private extension Dictionary where Key == String, Value == Any {
+    mutating func putProfileField(fields: Set<String>, key: String, value: String) {
+        if fields.contains(key) {
+            self[key] = value
+        }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/build.gradle.kts
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/build.gradle.kts
@@ -23,6 +23,7 @@ android {
         buildConfigField("String", "ATTESTATION_ATTESTER_PATH", "\"${findProperty("attestation.attesterPath") ?: ""}\"")
         buildConfigField("String", "ATTESTATION_BEARER_TOKEN", "\"${findProperty("attestation.bearerToken") ?: ""}\"")
         buildConfigField("String", "ATTESTATION_HOST_HEADER", "\"${findProperty("attestation.hostHeader") ?: ""}\"")
+        buildConfigField("String", "TRANSACTION_DATA_PROFILES_URL", "\"${findProperty("transactionDataProfiles.url") ?: ""}\"")
     }
 
     buildFeatures {

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PublicDemoBackendE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PublicDemoBackendE2ETest.kt
@@ -179,12 +179,16 @@ class PublicDemoBackendE2ETest {
             expectedValues = listOf("ACME Corp"),
             message = "Payment payee missing",
         )
-        assertClaimValueVisibleAfterScrolling(
-            device = device,
-            path = "transactionData[0].details.reference",
-            label = "Reference",
-            expectedValues = listOf("INV-2026-042"),
-            message = "Payment reference missing",
-        )
+        val transactionDataFields =
+            DemoTestBackend.transactionDataProfileFields("org.waltid.transaction-data.payment-authorization")
+        if ("reference" in transactionDataFields) {
+            assertClaimValueVisibleAfterScrolling(
+                device = device,
+                path = "transactionData[0].details.reference",
+                label = "Reference",
+                expectedValues = listOf("INV-2026-042"),
+                message = "Payment reference missing",
+            )
+        }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/main/java/id/walt/walletdemo/compose/android/MainActivity.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/main/java/id/walt/walletdemo/compose/android/MainActivity.kt
@@ -25,6 +25,7 @@ class MainActivity : ComponentActivity() {
                     attestationAttesterPath = BuildConfig.ATTESTATION_ATTESTER_PATH,
                     attestationBearerToken = BuildConfig.ATTESTATION_BEARER_TOKEN,
                     attestationHostHeader = BuildConfig.ATTESTATION_HOST_HEADER,
+                    transactionDataProfilesUrl = BuildConfig.TRANSACTION_DATA_PROFILES_URL,
                 )
             )
         )

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosApp/ComposeWalletDemoApp.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosApp/ComposeWalletDemoApp.swift
@@ -8,6 +8,7 @@ struct ComposeWalletDemoApp: App {
     private let attestationAttesterPath: String
     private let attestationBearerToken: String
     private let attestationHostHeader: String
+    private let transactionDataProfilesUrl: String
 
     init() {
         let env = ProcessInfo.processInfo.environment
@@ -17,6 +18,7 @@ struct ComposeWalletDemoApp: App {
         attestationAttesterPath = env["ATTESTATION_ATTESTER_PATH"] ?? defaults.string(forKey: "ATTESTATION_ATTESTER_PATH") ?? ""
         attestationBearerToken = env["ATTESTATION_BEARER_TOKEN"] ?? defaults.string(forKey: "ATTESTATION_BEARER_TOKEN") ?? ""
         attestationHostHeader = env["ATTESTATION_HOST_HEADER"] ?? defaults.string(forKey: "ATTESTATION_HOST_HEADER") ?? ""
+        transactionDataProfilesUrl = env["TRANSACTION_DATA_PROFILES_URL"] ?? defaults.string(forKey: "TRANSACTION_DATA_PROFILES_URL") ?? ""
     }
 
     var body: some Scene {
@@ -26,7 +28,8 @@ struct ComposeWalletDemoApp: App {
                 attestationBaseUrl: attestationBaseUrl,
                 attestationAttesterPath: attestationAttesterPath,
                 attestationBearerToken: attestationBearerToken,
-                attestationHostHeader: attestationHostHeader
+                attestationHostHeader: attestationHostHeader,
+                transactionDataProfilesUrl: transactionDataProfilesUrl
             )
             .ignoresSafeArea()
             .onOpenURL { url in

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosApp/ContentView.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosApp/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: UIViewControllerRepresentable {
     let attestationAttesterPath: String
     let attestationBearerToken: String
     let attestationHostHeader: String
+    let transactionDataProfilesUrl: String
 
     func makeUIViewController(context: Context) -> UIViewController {
         sharedUI.WalletDemoIosKt.walletDemoViewController(
@@ -15,7 +16,8 @@ struct ContentView: UIViewControllerRepresentable {
             attestationBaseUrl: attestationBaseUrl,
             attestationAttesterPath: attestationAttesterPath,
             attestationBearerToken: attestationBearerToken,
-            attestationHostHeader: attestationHostHeader
+            attestationHostHeader: attestationHostHeader,
+            transactionDataProfilesUrl: transactionDataProfilesUrl
         )
     }
 
@@ -29,6 +31,7 @@ struct ContentView: UIViewControllerRepresentable {
         attestationBaseUrl: "",
         attestationAttesterPath: "",
         attestationBearerToken: "",
-        attestationHostHeader: ""
+        attestationHostHeader: "",
+        transactionDataProfilesUrl: ""
     )
 }

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
@@ -174,7 +174,10 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         XCTAssertTrue(app.staticTexts["42.00"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["EUR"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["ACME Corp"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.staticTexts["INV-2026-042"].waitForExistence(timeout: 10))
+        let transactionDataFields = try await backend.transactionDataProfileFields(type: "org.waltid.transaction-data.payment-authorization")
+        if transactionDataFields.contains("reference") {
+            XCTAssertTrue(app.staticTexts["INV-2026-042"].waitForExistence(timeout: 10))
+        }
 
         let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
         screenshot.name = "WAL-1077 Compose iOS transaction data preview"
@@ -231,6 +234,9 @@ final class PublicDemoBackendE2ETests: XCTestCase {
     }
 
     private func isolatedWalletEnvironment() -> [String: String] {
-        ["WALLET_ID": "compose-ios-public-demo-\(UUID().uuidString)"]
+        [
+            "WALLET_ID": "compose-ios-public-demo-\(UUID().uuidString)",
+            "TRANSACTION_DATA_PROFILES_URL": DemoBackend.transactionDataProfilesURL.absoluteString,
+        ]
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/build.gradle.kts
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/build.gradle.kts
@@ -35,6 +35,9 @@ kotlin {
                 dependsOn(commonMain.get())
                 dependencies {
                     implementation(project(":waltid-libraries:protocols:waltid-openid4vc-wallet-mobile"))
+                    implementation(identityLibs.ktor.client.core)
+                    implementation(identityLibs.ktor.client.content.negotiation)
+                    implementation(identityLibs.ktor.serialization.kotlinx.json)
                 }
             }
 

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidMain/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidMain/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoWallet.kt
@@ -10,14 +10,16 @@ fun createAndroidDemoWallet(
 ): DemoWallet {
 
     return LazyDemoWallet {
+        val transactionDataProfiles = config.resolveDemoTransactionDataProfiles()
         MobileDemoWallet(
             MobileWalletFactory(context).create(
                 MobileWalletConfig(
                     walletId = config.walletId,
                     attestationConfig = config.toWalletAttestationConfig(),
-                    transactionDataProfiles = DemoTransactionDataProfiles,
+                    transactionDataProfiles = transactionDataProfiles.profiles,
                 )
-            )
+            ),
+            warning = transactionDataProfiles.warning,
         )
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/DemoWalletConfig.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/DemoWalletConfig.kt
@@ -6,4 +6,5 @@ data class DemoWalletConfig(
     val attestationAttesterPath: String = "",
     val attestationBearerToken: String = "",
     val attestationHostHeader: String = "",
+    val transactionDataProfilesUrl: String = "",
 )

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoBootstrapResult.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoBootstrapResult.kt
@@ -3,4 +3,5 @@ package id.walt.walletdemo.compose.logic
 data class WalletDemoBootstrapResult(
     val keyId: String,
     val did: String,
+    val warning: String? = null,
 )

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
@@ -437,6 +437,7 @@ class WalletDemoController(
                             credentials = credentials,
                         ),
                         operation = WalletOperationState.Idle,
+                        warning = result.warning,
                     )
                 }
             }.onFailure { error ->

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiState.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiState.kt
@@ -14,6 +14,7 @@ data class WalletDemoUiState(
     val selectedPresentationDisclosureOptions: Set<WalletDemoPresentationDisclosureSelection> = emptySet(),
     val presentationCompleted: Boolean = false,
     val presentationNavigationResetKey: Int = 0,
+    val warning: String? = null,
 )
 
 fun WalletDemoUiState.receivedCredentials(): List<WalletDemoCredential> {

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/iosMain/kotlin/id/walt/walletdemo/compose/logic/IosDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/iosMain/kotlin/id/walt/walletdemo/compose/logic/IosDemoWallet.kt
@@ -8,14 +8,16 @@ fun createIosDemoWallet(
 ): DemoWallet {
 
     return LazyDemoWallet {
+        val transactionDataProfiles = config.resolveDemoTransactionDataProfiles()
         MobileDemoWallet(
             MobileWalletFactory().create(
                 MobileWalletConfig(
                     walletId = config.walletId,
                     attestationConfig = config.toWalletAttestationConfig(),
-                    transactionDataProfiles = DemoTransactionDataProfiles,
+                    transactionDataProfiles = transactionDataProfiles.profiles,
                 )
-            )
+            ),
+            warning = transactionDataProfiles.warning,
         )
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/DemoTransactionDataProfiles.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/DemoTransactionDataProfiles.kt
@@ -1,16 +1,67 @@
 package id.walt.walletdemo.compose.logic
 
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
-internal val DemoTransactionDataProfiles = listOf(
-    MobileWalletTransactionDataProfile(
-        type = "org.waltid.transaction-data.payment-authorization",
-        displayName = "Payment Authorization",
-        fields = listOf("amount", "currency", "payee", "reference"),
-    ),
-    MobileWalletTransactionDataProfile(
-        type = "org.waltid.transaction-data.account-access",
-        displayName = "Account Access",
-        fields = listOf("account_identifier", "access_scope"),
-    ),
+internal data class DemoTransactionDataProfilesResult(
+    val profiles: List<MobileWalletTransactionDataProfile>,
+    val warning: String? = null,
+)
+
+internal suspend fun DemoWalletConfig.resolveDemoTransactionDataProfiles(): DemoTransactionDataProfilesResult {
+    val url = transactionDataProfilesUrl.trim()
+    if (url.isEmpty()) {
+        return transactionDataProfilesUnavailable("transactionDataProfiles.url is not configured")
+    }
+
+    return runCatching {
+        fetchTransactionDataProfiles(url)
+    }.fold(
+        onSuccess = { profiles -> DemoTransactionDataProfilesResult(profiles = profiles) },
+        onFailure = { error -> transactionDataProfilesUnavailable(error.message ?: error::class.simpleName.orEmpty()) },
+    )
+}
+
+private suspend fun fetchTransactionDataProfiles(url: String) =
+    transactionDataProfilesClient.use { client ->
+        client.get(url).body<List<TransactionDataProfileDto>>().map {
+            MobileWalletTransactionDataProfile(
+                type = it.type,
+                displayName = it.displayName,
+                fields = it.fields,
+            )
+        }
+    }.takeIf { it.isNotEmpty() } ?: error("No transaction data profiles returned from $url")
+
+private fun transactionDataProfilesUnavailable(reason: String): DemoTransactionDataProfilesResult {
+    println("Transaction data profiles unavailable: $reason")
+    return DemoTransactionDataProfilesResult(
+        profiles = emptyList(),
+        warning = "Transaction data profiles could not be loaded; transaction-data presentation requests will be rejected.",
+    )
+}
+
+private val transactionDataProfilesClient: HttpClient
+    get() = HttpClient {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = false
+                }
+            )
+        }
+    }
+
+@Serializable
+private data class TransactionDataProfileDto(
+    val type: String,
+    val displayName: String,
+    val fields: List<String> = emptyList(),
 )

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileDemoWallet.kt
@@ -8,12 +8,14 @@ import id.walt.wallet2.mobile.WalletAttestationConfig
 
 internal class MobileDemoWallet(
     private val mobileWallet: MobileWallet,
+    private val warning: String? = null,
 ) : DemoWallet {
     override suspend fun bootstrap(): WalletDemoBootstrapResult =
         mobileWallet.bootstrap().let { result ->
             WalletDemoBootstrapResult(
                 keyId = result.keyId,
                 did = result.did,
+                warning = warning,
             )
         }
 

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletHeader.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/WalletHeader.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,5 +50,26 @@ internal fun WalletHeader(did: String?, state: WalletDemoUiState, onLock: () -> 
             }
         }
         StatusCard(state)
+        state.warning?.let { warning ->
+            WarningCard(warning)
+        }
+    }
+}
+
+@Composable
+private fun WarningCard(message: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+    ) {
+        Text(
+            text = message,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            style = MaterialTheme.typography.bodyMedium,
+        )
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoIos.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoIos.kt
@@ -15,6 +15,7 @@ fun walletDemoViewController(
     attestationAttesterPath: String = "",
     attestationBearerToken: String = "",
     attestationHostHeader: String = "",
+    transactionDataProfilesUrl: String = "",
 ): UIViewController {
     val controller = WalletDemoController(
         createIosDemoWallet(
@@ -24,6 +25,7 @@ fun walletDemoViewController(
                 attestationAttesterPath = attestationAttesterPath,
                 attestationBearerToken = attestationBearerToken,
                 attestationHostHeader = attestationHostHeader,
+                transactionDataProfilesUrl = transactionDataProfilesUrl,
             )
         )
     )

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/StatusBannerView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/StatusBannerView.swift
@@ -36,3 +36,20 @@ struct StatusBannerView: View {
         return .waltBlueDark
     }
 }
+
+struct WarningBannerView: View {
+    let message: String
+
+    var body: some View {
+        Text(message)
+            .font(.subheadline)
+            .lineLimit(3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(Color.orange.opacity(0.16))
+            .foregroundColor(.orange)
+            .cornerRadius(8)
+            .accessibilityIdentifier(WalletAccessibilityID.transactionDataProfilesWarning)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ContentView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ContentView.swift
@@ -9,5 +9,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(viewModel: WalletViewModel())
+    ContentView(viewModel: WalletViewModel.mockForUITests())
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletViewModel.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletViewModel.swift
@@ -31,6 +31,7 @@ private enum WalletStatusText {
     static let invalidRequestURL = "invalid request URL"
     static let selectCredentialForEveryRequest = "select a credential for every requested credential"
     static let receivedCredentialsUnavailable = "received credentials are not available locally"
+    static let transactionDataProfilesUnavailable = "Transaction data profiles could not be loaded; transaction-data presentation requests will be rejected."
 
     static func receivedCredentials(_ count: Int) -> String {
         "Received \(count) credential(s)"
@@ -65,6 +66,7 @@ class WalletViewModel: ObservableObject {
     @Published var receiveNavigationResetKey = 0
     @Published var presentationNavigationResetKey = 0
     @Published var inputFocusResetKey = 0
+    @Published var transactionDataProfilesWarning: String?
     private var statusTab: WalletTab?
 
     var receiveUrlEntryEnabled: Bool {
@@ -124,8 +126,15 @@ class WalletViewModel: ObservableObject {
         attestationAttesterPath: String? = nil,
         attestationBearerToken: String? = nil,
         attestationHostHeader: String? = nil,
+        transactionDataProfilesUrl: String? = nil,
         walletClient: (any WalletClient)? = nil
     ) {
+        let transactionDataProfiles: TransactionDataProfilesConfiguration
+        if walletClient == nil {
+            transactionDataProfiles = Self.resolveTransactionDataProfiles(from: transactionDataProfilesUrl)
+        } else {
+            transactionDataProfiles = TransactionDataProfilesConfiguration(profiles: [])
+        }
         let configuration = WalletConfiguration(
             walletID: walletID,
             attestation: Self.attestationConfiguration(
@@ -134,24 +143,106 @@ class WalletViewModel: ObservableObject {
                 bearerToken: attestationBearerToken,
                 hostHeader: attestationHostHeader
             ),
-            transactionDataProfiles: Self.demoTransactionDataProfiles
+            transactionDataProfiles: transactionDataProfiles.profiles
         )
         self.walletClient = walletClient ?? SDKWalletClient(configuration: configuration)
+        transactionDataProfilesWarning = transactionDataProfiles.warning
         bootstrap()
     }
 
-    private static let demoTransactionDataProfiles: [WalletTransactionDataProfile] = [
-        WalletTransactionDataProfile(
-            type: "org.waltid.transaction-data.payment-authorization",
-            displayName: "Payment Authorization",
-            fields: ["amount", "currency", "payee", "reference"]
-        ),
-        WalletTransactionDataProfile(
-            type: "org.waltid.transaction-data.account-access",
-            displayName: "Account Access",
-            fields: ["account_identifier", "access_scope"]
+    private static func resolveTransactionDataProfiles(from urlString: String?) -> TransactionDataProfilesConfiguration {
+        guard let trimmed = urlString?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty,
+              let url = URL(string: trimmed) else {
+            return transactionDataProfilesUnavailable("TRANSACTION_DATA_PROFILES_URL is not configured")
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var fetchResult: Result<[WalletTransactionDataProfile], Error>?
+        URLSession.shared.dataTask(with: url) { data, response, error in
+            defer { semaphore.signal() }
+            if let error {
+                fetchResult = .failure(error)
+                return
+            }
+
+            guard let status = (response as? HTTPURLResponse)?.statusCode else {
+                fetchResult = .failure(TransactionDataProfileFetchError.missingResponse)
+                return
+            }
+            guard (200..<300).contains(status) else {
+                fetchResult = .failure(TransactionDataProfileFetchError.httpStatus(status))
+                return
+            }
+            guard let data else {
+                fetchResult = .failure(TransactionDataProfileFetchError.missingBody)
+                return
+            }
+
+            do {
+                let profiles = try JSONDecoder().decode([RemoteTransactionDataProfile].self, from: data)
+                guard !profiles.isEmpty else {
+                    fetchResult = .failure(TransactionDataProfileFetchError.emptyProfiles)
+                    return
+                }
+                fetchResult = .success(
+                    profiles.map {
+                        WalletTransactionDataProfile(
+                            type: $0.type,
+                            displayName: $0.displayName,
+                            fields: $0.fields
+                        )
+                    }
+                )
+            } catch {
+                fetchResult = .failure(error)
+            }
+        }.resume()
+
+        guard semaphore.wait(timeout: .now() + 3) == .success else {
+            return transactionDataProfilesUnavailable("Timed out fetching transaction data profiles from \(url.absoluteString)")
+        }
+
+        switch fetchResult {
+        case .success(let profiles):
+            return TransactionDataProfilesConfiguration(profiles: profiles)
+        case .failure(let error):
+            return transactionDataProfilesUnavailable("Could not fetch transaction data profiles from \(url.absoluteString): \(error)")
+        case nil:
+            return transactionDataProfilesUnavailable("Could not fetch transaction data profiles from \(url.absoluteString)")
+        }
+    }
+
+    private static func transactionDataProfilesUnavailable(_ reason: String) -> TransactionDataProfilesConfiguration {
+        NSLog("[WalletE2E] Transaction data profiles unavailable: \(reason)")
+        return TransactionDataProfilesConfiguration(
+            profiles: [],
+            warning: WalletStatusText.transactionDataProfilesUnavailable
         )
-    ]
+    }
+
+    private struct TransactionDataProfilesConfiguration {
+        let profiles: [WalletTransactionDataProfile]
+        let warning: String?
+
+        init(profiles: [WalletTransactionDataProfile], warning: String? = nil) {
+            self.profiles = profiles
+            self.warning = warning
+        }
+    }
+
+    private struct RemoteTransactionDataProfile: Decodable {
+        let type: String
+        let displayName: String
+        let fields: [String]
+    }
+
+    private enum TransactionDataProfileFetchError: Error {
+        case emptyProfiles
+        case httpStatus(Int)
+        case missingBody
+        case missingResponse
+    }
 
     func handleDeepLink(_ url: URL) {
         resetInputFocus()

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialsTabView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/CredentialsTabView.swift
@@ -19,6 +19,10 @@ struct CredentialsTabView: View {
                         isError: viewModel.statusIsError(for: .credentials)
                     )
 
+                    if let warning = viewModel.transactionDataProfilesWarning {
+                        WarningBannerView(message: warning)
+                    }
+
                     if details.isEmpty {
                         EmptyCredentialsView()
                     } else {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/PresentView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/PresentView.swift
@@ -41,6 +41,10 @@ struct PresentView: View {
                         isError: viewModel.statusIsError(for: .present)
                     )
 
+                    if let warning = viewModel.transactionDataProfilesWarning {
+                        WarningBannerView(message: warning)
+                    }
+
                     if viewModel.presentationCompleted {
                         Button("New presentation", action: viewModel.startNewPresentationFlow)
                             .buttonStyle(.bordered)

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/ReceiveView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/ReceiveView.swift
@@ -35,6 +35,10 @@ struct ReceiveView: View {
                         isError: viewModel.statusIsError(for: .receive)
                     )
 
+                    if let warning = viewModel.transactionDataProfilesWarning {
+                        WarningBannerView(message: warning)
+                    }
+
                     if viewModel.receiveCompleted {
                         Button("New receive", action: viewModel.startNewReceiveFlow)
                             .buttonStyle(.bordered)

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletAccessibilityID.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletAccessibilityID.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum WalletAccessibilityID {
     static let status = identifier("status")
+    static let transactionDataProfilesWarning = identifier("transactionDataProfilesWarning")
     static let credentialsEmpty = identifier("credentials", "empty")
     static let credentialsTabContent = identifier("credentialsTabContent")
     static let offerInput = identifier("offerInput")

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletDemoApp.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/WalletDemoApp.swift
@@ -23,16 +23,21 @@ struct WalletDemoApp: App {
             )
         }
         let baseUrl = env["ATTESTATION_BASE_URL"] ?? defaults.string(forKey: "ATTESTATION_BASE_URL")
+        let transactionDataProfilesUrl = env["TRANSACTION_DATA_PROFILES_URL"] ?? defaults.string(forKey: "TRANSACTION_DATA_PROFILES_URL")
         if let baseUrl, !baseUrl.isEmpty {
             return WalletViewModel(
                 walletID: walletID,
                 attestationBaseUrl: baseUrl,
                 attestationAttesterPath: env["ATTESTATION_ATTESTER_PATH"] ?? defaults.string(forKey: "ATTESTATION_ATTESTER_PATH"),
                 attestationBearerToken: env["ATTESTATION_BEARER_TOKEN"] ?? defaults.string(forKey: "ATTESTATION_BEARER_TOKEN"),
-                attestationHostHeader: env["ATTESTATION_HOST_HEADER"] ?? defaults.string(forKey: "ATTESTATION_HOST_HEADER")
+                attestationHostHeader: env["ATTESTATION_HOST_HEADER"] ?? defaults.string(forKey: "ATTESTATION_HOST_HEADER"),
+                transactionDataProfilesUrl: transactionDataProfilesUrl
             )
         }
-        return WalletViewModel(walletID: walletID)
+        return WalletViewModel(
+            walletID: walletID,
+            transactionDataProfilesUrl: transactionDataProfilesUrl
+        )
     }()
 
     var body: some Scene {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
@@ -21,7 +21,7 @@ final class PublicDemoBackendE2ETests: XCTestCase {
 
         let app = XCUIApplication()
         let ui = WalletE2EUI(app: app)
-        ui.launch()
+        ui.launch(environment: publicDemoEnvironment())
 
         let readyStatus = ui.waitForStatus(
             prefixes: ["Wallet ready", "Bootstrap failed"],
@@ -84,7 +84,7 @@ final class PublicDemoBackendE2ETests: XCTestCase {
 
         let app = XCUIApplication()
         let ui = WalletE2EUI(app: app)
-        ui.launch()
+        ui.launch(environment: publicDemoEnvironment())
 
         let readyStatus = ui.waitForStatus(
             prefixes: ["Wallet ready", "Bootstrap failed"],
@@ -118,7 +118,10 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         XCTAssertTrue(app.staticTexts["42.00"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["EUR"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["ACME Corp"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.staticTexts["INV-2026-042"].waitForExistence(timeout: 10))
+        let transactionDataFields = try await backend.transactionDataProfileFields(type: "org.waltid.transaction-data.payment-authorization")
+        if transactionDataFields.contains("reference") {
+            XCTAssertTrue(app.staticTexts["INV-2026-042"].waitForExistence(timeout: 10))
+        }
 
         let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
         screenshot.name = "WAL-1077 native iOS transaction data preview"
@@ -129,6 +132,10 @@ final class PublicDemoBackendE2ETests: XCTestCase {
     private func publicDemoScenario() throws -> DemoCredentialScenario {
         try XCTUnwrap(DemoBackend.presentationScenarios.first { $0.id == "eudi-pid-mdoc" })
     }
+
+    private func publicDemoEnvironment() -> [String: String] {
+        ["TRANSACTION_DATA_PROFILES_URL": DemoBackend.transactionDataProfilesURL.absoluteString]
+    }
 }
 
 @MainActor
@@ -136,9 +143,8 @@ final class MockCredentialDisplayUITests: XCTestCase {
 
     func testMockCredentialDetailsRenderPortraitAndCredentialInfo() {
         let app = XCUIApplication()
-        app.launchEnvironment["E2E_USE_MOCK_WALLET"] = "1"
         let ui = WalletE2EUI(app: app)
-        ui.launch()
+        ui.launch(environment: ["E2E_MOCK_WALLET": "1"])
 
         let readyStatus = ui.waitForStatus(
             prefixes: ["Wallet ready", "Bootstrap failed"],
@@ -146,13 +152,24 @@ final class MockCredentialDisplayUITests: XCTestCase {
         )
         XCTAssertEqual(readyStatus, "Wallet ready", "Wallet did not become ready, status: \(readyStatus ?? "nil")")
 
-        let credentialCard = app.buttons["wallet.credentialCard.mock-credential"]
+        ui.tapTab(label: "Receive")
+        ui.replaceText(
+            in: ui.textInput(identifier: "wallet.offerInput", fallbackLabel: "Credential offer URL"),
+            value: "openid-credential-offer://mock"
+        )
+        ui.tapButton(identifier: "wallet.receiveButton", fallbackLabel: "Receive")
+        XCTAssertEqual(
+            ui.waitForStatus(prefixes: ["Received", "Receive failed"], timeout: 10),
+            "Received 1 credential(s)"
+        )
+
+        let credentialCard = app.buttons["wallet.credentialCard.cred-1"]
         XCTAssertTrue(credentialCard.waitForExistence(timeout: 10), "Mock credential card was not shown")
         credentialCard.tap()
 
-        XCTAssertTrue(app.descendants(matching: .any)["wallet.credentialOverview.mock-credential"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.descendants(matching: .any)["wallet.credentialOverview.cred-1"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["wallet.claimGroup.Personal_details"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.images["wallet.claimImage.portrait"].waitForExistence(timeout: 10))
+        ui.assertExists(identifier: ui.claimImageIdentifier(path: "portrait.elementValue"), timeout: 10)
         XCTAssertTrue(app.staticTexts["wallet.claimGroup.About_this_credential"].waitForExistence(timeout: 10))
         XCTAssertFalse(app.staticTexts["No credential details available"].exists)
     }

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -10,9 +10,11 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -28,7 +30,10 @@ object DemoTestBackend {
 
     private const val ISSUER_BASE_URL = "https://issuer2.demo.walt.id"
     private const val VERIFIER_BASE_URL = "https://verifier2.demo.walt.id"
+    const val TRANSACTION_DATA_PROFILES_URL = "https://wallet.demo.walt.id/wallet-api/transaction-data-profiles"
     private const val EUDI_PID_SD_JWT_VCT = "$ISSUER_BASE_URL/openid4vci/urn:eudi:pid:1"
+    private const val PAYMENT_AUTHORIZATION_TYPE = "org.waltid.transaction-data.payment-authorization"
+    private val requiredPaymentAuthorizationFields = setOf("amount", "currency", "payee")
 
     val scenarios = listOf(
         CredentialScenario(
@@ -138,10 +143,34 @@ object DemoTestBackend {
     suspend fun createTransactionDataVerifierSession(
         scenario: CredentialScenario = transactionDataPresentationScenario,
     ): VerifierSession {
+        val paymentAuthorizationFields = transactionDataProfileFields(PAYMENT_AUTHORIZATION_TYPE)
+        check(paymentAuthorizationFields.containsAll(requiredPaymentAuthorizationFields)) {
+            "Public demo transaction data profile '$PAYMENT_AUTHORIZATION_TYPE' is missing required fields: " +
+                (requiredPaymentAuthorizationFields - paymentAuthorizationFields).joinToString()
+        }
         return createVerifierSession(
             credentialQuery = scenario.verifierCredentialQuery,
-            transactionData = listOf(paymentAuthorizationTransactionData("pid")),
+            transactionData = listOf(paymentAuthorizationTransactionData("pid", paymentAuthorizationFields)),
         )
+    }
+
+    suspend fun transactionDataProfileFields(type: String): Set<String> {
+        val response = client.get(TRANSACTION_DATA_PROFILES_URL) {
+            accept(ContentType.Application.Json)
+        }
+        val body = response.bodyAsText()
+        if (!response.status.isSuccess()) {
+            error("HTTP ${response.status.value} from public demo transaction data profiles endpoint: $body")
+        }
+        return json.parseToJsonElement(body)
+            .jsonArray
+            .firstOrNull { profile -> profile.jsonObject["type"]?.jsonPrimitive?.content == type }
+            ?.jsonObject
+            ?.get("fields")
+            ?.jsonArray
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+            ?.toSet()
+            ?: error("Missing public demo transaction data profile: $type")
     }
 
     private suspend fun createVerifierSession(
@@ -180,8 +209,11 @@ object DemoTestBackend {
         return VerifierSession(sessionId, authorizationRequestUri)
     }
 
-    private fun paymentAuthorizationTransactionData(credentialId: String): JsonObject = buildJsonObject {
-        put("type", JsonPrimitive("org.waltid.transaction-data.payment-authorization"))
+    private fun paymentAuthorizationTransactionData(
+        credentialId: String,
+        fields: Set<String>,
+    ): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive(PAYMENT_AUTHORIZATION_TYPE))
         putJsonArray("credential_ids") {
             add(JsonPrimitive(credentialId))
         }
@@ -189,10 +221,10 @@ object DemoTestBackend {
         putJsonArray("transaction_data_hashes_alg") {
             add(JsonPrimitive("sha-256"))
         }
-        put("amount", JsonPrimitive("42.00"))
-        put("currency", JsonPrimitive("EUR"))
-        put("payee", JsonPrimitive("ACME Corp"))
-        put("reference", JsonPrimitive("INV-2026-042"))
+        putProfileField(fields, "amount", "42.00")
+        putProfileField(fields, "currency", "EUR")
+        putProfileField(fields, "payee", "ACME Corp")
+        putProfileField(fields, "reference", "INV-2026-042")
     }
 
     suspend fun verifierSessionInfo(sessionId: String): JsonObject {
@@ -332,6 +364,12 @@ object DemoTestBackend {
 
     private fun claimSet(vararg claimIds: String) = kotlinx.serialization.json.buildJsonArray {
         claimIds.forEach { add(JsonPrimitive(it)) }
+    }
+
+    private fun JsonObjectBuilder.putProfileField(fields: Set<String>, key: String, value: String) {
+        if (key in fields) {
+            put(key, JsonPrimitive(value))
+        }
     }
 
     private val json = kotlinx.serialization.json.Json {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -42,12 +42,19 @@ class MobileWalletIntegrationTest {
 
     companion object {
         private const val TEST_WALLET_ID = "android-device-test-wallet"
+        private const val PAYMENT_AUTHORIZATION_TYPE = "org.waltid.transaction-data.payment-authorization"
 
-        private val DEMO_TRANSACTION_DATA_PROFILES = listOf(
+        private val DEMO_TRANSACTION_DATA_PROFILES = demoTransactionDataProfiles(
+            paymentAuthorizationFields = listOf("amount", "currency", "payee", "reference"),
+        )
+
+        private fun demoTransactionDataProfiles(
+            paymentAuthorizationFields: Iterable<String>,
+        ) = listOf(
             MobileWalletTransactionDataProfile(
-                type = "org.waltid.transaction-data.payment-authorization",
+                type = PAYMENT_AUTHORIZATION_TYPE,
                 displayName = "Payment Authorization",
-                fields = listOf("amount", "currency", "payee", "reference"),
+                fields = paymentAuthorizationFields.toList(),
             ),
             MobileWalletTransactionDataProfile(
                 type = "org.waltid.transaction-data.account-access",
@@ -178,7 +185,13 @@ class MobileWalletIntegrationTest {
     @Test
     fun previewAndSubmitTransactionDataAgainstDemoIssuer2AndVerifier2() = runBlocking {
         val scenario = DemoTestBackend.transactionDataPresentationScenario
-        val client = MobileWalletFactory(context).create(walletConfig("transaction-data-${scenario.id}"))
+        val paymentAuthorizationFields = DemoTestBackend.transactionDataProfileFields(PAYMENT_AUTHORIZATION_TYPE)
+        val client = MobileWalletFactory(context).create(
+            walletConfig(
+                prefix = "transaction-data-${scenario.id}",
+                transactionDataProfiles = demoTransactionDataProfiles(paymentAuthorizationFields),
+            ),
+        )
         val bootstrapResult = client.bootstrap()
 
         val offer = DemoTestBackend.createOffer(scenario)
@@ -197,10 +210,15 @@ class MobileWalletIntegrationTest {
         assertTrue(
             transactionData.detailsJson.contains("\"amount\":\"42.00\"") &&
                 transactionData.detailsJson.contains("\"currency\":\"EUR\"") &&
-                transactionData.detailsJson.contains("\"payee\":\"ACME Corp\"") &&
-                transactionData.detailsJson.contains("\"reference\":\"INV-2026-042\""),
+                transactionData.detailsJson.contains("\"payee\":\"ACME Corp\""),
             "Preview should expose readable payment details: ${transactionData.detailsJson}",
         )
+        if (paymentAuthorizationFields.contains("reference")) {
+            assertTrue(
+                transactionData.detailsJson.contains("\"reference\":\"INV-2026-042\""),
+                "Preview should expose advertised reference details: ${transactionData.detailsJson}",
+            )
+        }
 
         val result = client.submitPresentation(
             requestUrl = session.authorizationRequestUri,
@@ -364,10 +382,13 @@ class MobileWalletIntegrationTest {
         DemoTestBackend.waitForVerifierSuccess(session.sessionId)
     }
 
-    private fun walletConfig(prefix: String) = MobileWalletConfig(
+    private fun walletConfig(
+        prefix: String,
+        transactionDataProfiles: List<MobileWalletTransactionDataProfile> = DEMO_TRANSACTION_DATA_PROFILES,
+    ) = MobileWalletConfig(
         walletId = "android-demo-$prefix-${UUID.randomUUID()}",
         onEvent = { event -> println("WALLET EVENT: $event") },
-        transactionDataProfiles = DEMO_TRANSACTION_DATA_PROFILES,
+        transactionDataProfiles = transactionDataProfiles,
     )
 
     private suspend fun receiveCredentialFromDemoIssuer2(scenarioId: String) {


### PR DESCRIPTION
## Summary

This follow-up lets the mobile demo apps load transaction-data profile support from the wallet API instead of carrying production demo profile definitions in each app. It stacks on [walt-id/waltid-identity#1893](https://github.com/walt-id/waltid-identity/pull/1893), which keeps the mobile SDK profile registry app-owned and empty by default.

The goal is to make profile support an app/runtime concern for the demo apps too: Android Compose, iOS Compose, and native iOS can point at a transaction-data profile endpoint, pass the fetched profiles into the SDK, and keep ordinary wallet flows usable if that endpoint is not configured or fails.

## What Changed

### Compose Demo Apps
- Adds a `transactionDataProfiles.url` Gradle property for the Android Compose demo app.
- Threads `TRANSACTION_DATA_PROFILES_URL` through the iOS Compose demo app.
- Fetches transaction-data profiles in shared mobile demo logic using Ktor JSON decoding.
- Passes fetched profiles into `MobileWalletConfig` on Android and iOS.

### Native iOS Demo App
- Reads `TRANSACTION_DATA_PROFILES_URL` from environment or user defaults.
- Fetches and decodes the same transaction-data profile payload before constructing `WalletConfiguration`.
- Uses an empty profile list when the endpoint is missing or unavailable, preserving the rest of the wallet demo.

### User Feedback
- Shows a persistent warning when transaction-data profiles could not be loaded.
- Logs the underlying fetch/configuration reason for debugging.
- Avoids silently falling back to bundled demo profiles, so stale local profile definitions cannot mask endpoint drift.

## Architecture Notes

- The SDK remains clean of demo profile defaults. The endpoint is consumed only by demo app wiring.
- Failed profile loading does not prevent credential receive, credential listing, or non-transaction-data presentation flows from working.
- Transaction-data presentation requests are rejected when the fetched profile list is empty, which is preferable to accepting requests with stale built-in demo profiles.

## Caveats and Follow-Ups

- The configured profile endpoint must stay aligned with the transaction-data demo requests. If the endpoint omits a field used by a demo request, the demo will surface the profile warning or reject that transaction-data request rather than substituting local definitions.
- This is intentionally a demo-app integration follow-up, not a mobile SDK endpoint client.

## Breaking

- Demo apps that want transaction-data request support now need to provide `transactionDataProfiles.url` / `TRANSACTION_DATA_PROFILES_URL`. Other wallet demo flows continue without it.