### PR TITLE
chore(mobile): ignore SwiftPM lock scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ playground.xcworkspace
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm
+.swiftpm-locks/
 
 .build/
 


### PR DESCRIPTION
Ignores the generated `.swiftpm-locks/` directory in the identity repo.
