### PR TITLE
[WAL-1184] fix(mobile) Compose demo PIN persistence

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/README.md
+++ b/waltid-applications/waltid-wallet-demo-compose/README.md
@@ -30,6 +30,8 @@ The Compose iOS demo uses Kotlin direct Xcode integration and a local SwiftPM li
 
 Android and iOS demo targets use the default managed encrypted local persistence. Wallet database files are SQLCipher-encrypted, and managed database keys live in platform-protected storage. During local development, reset wallet state through `MobileWallet.deleteWallet()`, by uninstalling the app, or by deleting the app's local data.
 
+The demo unlock PIN is stored separately as a salted PBKDF2-SHA256 verifier in app-private preferences. The PIN itself is never persisted. Clearing app data or uninstalling the app resets the PIN setup flow together with the local wallet data.
+
 The UI stays focused on the production default. Non-default persistence options, including provided database keys and custom stores, are documented and tested at the SDK layer.
 
 ## Public demo backend defaults

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PinPersistenceTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PinPersistenceTest.kt
@@ -1,0 +1,22 @@
+package id.walt.walletdemo.compose.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.launchAndUnlock
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.relaunchAndUnlock
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PinPersistenceTest {
+    @Test
+    fun relaunchShowsLoginAndAcceptsOriginalPin() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val device = UiDevice.getInstance(instrumentation)
+
+        launchAndUnlock(context, device)
+        relaunchAndUnlock(context, device)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PinPersistenceTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PinPersistenceTest.kt
@@ -3,20 +3,41 @@ package id.walt.walletdemo.compose.android
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.launchAndUnlock
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.launchExpectingSetupAndUnlock
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.relaunchAndUnlock
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class PinPersistenceTest {
+    @Before
+    fun clearPinBeforeTest() = clearPersistedPin()
+
+    @After
+    fun clearPinAfterTest() = clearPersistedPin()
+
     @Test
     fun relaunchShowsLoginAndAcceptsOriginalPin() {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
         val device = UiDevice.getInstance(instrumentation)
 
-        launchAndUnlock(context, device)
+        launchExpectingSetupAndUnlock(context, device)
         relaunchAndUnlock(context, device)
+    }
+
+    private fun clearPersistedPin() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        assertTrue(
+            "PIN verifier preferences could not be cleared",
+            context.getSharedPreferences(PIN_PREFERENCES_NAME, 0).edit().clear().commit(),
+        )
+    }
+
+    private companion object {
+        const val PIN_PREFERENCES_NAME = "walt_wallet_demo_pin_verifiers"
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
@@ -38,18 +38,23 @@ internal object WalletComposeE2EHelper {
     )
 
     fun launchAndUnlock(context: Context, device: UiDevice) {
-        val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
-            ?.apply { addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) }
-            ?: error("Cannot resolve launch intent for ${context.packageName}")
-        context.startActivity(launchIntent)
+        launch(context)
+        unlock(device)
+    }
+
+    fun launchExpectingSetupAndUnlock(context: Context, device: UiDevice) {
+        launch(context)
+
+        assertNotNull("PIN input not found on initial launch", waitForResource(device, "wallet.pinInput", UI_ELEMENT_TIMEOUT))
+        assertNotNull(
+            "PIN setup was not shown on initial launch",
+            waitForResource(device, "wallet.pinConfirmationInput", UI_ELEMENT_TIMEOUT),
+        )
         unlock(device)
     }
 
     fun relaunchAndUnlock(context: Context, device: UiDevice) {
-        val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
-            ?.apply { addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) }
-            ?: error("Cannot resolve launch intent for ${context.packageName}")
-        context.startActivity(launchIntent)
+        launch(context)
 
         assertNotNull("PIN input not found after relaunch", waitForResource(device, "wallet.pinInput", UI_ELEMENT_TIMEOUT))
         assertNull(
@@ -57,6 +62,13 @@ internal object WalletComposeE2EHelper {
             waitForResource(device, "wallet.pinConfirmationInput", 2_000L),
         )
         unlock(device)
+    }
+
+    private fun launch(context: Context) {
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            ?.apply { addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) }
+            ?: error("Cannot resolve launch intent for ${context.packageName}")
+        context.startActivity(launchIntent)
     }
 
     fun unlock(device: UiDevice) {

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
@@ -8,6 +8,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import org.junit.Assert.fail
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 
 internal object WalletComposeE2EHelper {
@@ -41,6 +42,20 @@ internal object WalletComposeE2EHelper {
             ?.apply { addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) }
             ?: error("Cannot resolve launch intent for ${context.packageName}")
         context.startActivity(launchIntent)
+        unlock(device)
+    }
+
+    fun relaunchAndUnlock(context: Context, device: UiDevice) {
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            ?.apply { addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK) }
+            ?: error("Cannot resolve launch intent for ${context.packageName}")
+        context.startActivity(launchIntent)
+
+        assertNotNull("PIN input not found after relaunch", waitForResource(device, "wallet.pinInput", UI_ELEMENT_TIMEOUT))
+        assertNull(
+            "PIN setup was shown after relaunch",
+            waitForResource(device, "wallet.pinConfirmationInput", 2_000L),
+        )
         unlock(device)
     }
 

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/main/java/id/walt/walletdemo/compose/android/MainActivity.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/main/java/id/walt/walletdemo/compose/android/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.enableEdgeToEdge
 import id.walt.walletdemo.compose.logic.DemoWalletConfig
 import id.walt.walletdemo.compose.logic.WalletDemoController
 import id.walt.walletdemo.compose.logic.createAndroidDemoWallet
+import id.walt.walletdemo.compose.logic.createAndroidDemoPinStore
 import id.walt.walletdemo.compose.ui.WalletDemoApp
 
 class MainActivity : ComponentActivity() {
@@ -17,17 +18,19 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
+        val config = DemoWalletConfig(
+            attestationBaseUrl = BuildConfig.ATTESTATION_BASE_URL,
+            attestationAttesterPath = BuildConfig.ATTESTATION_ATTESTER_PATH,
+            attestationBearerToken = BuildConfig.ATTESTATION_BEARER_TOKEN,
+            attestationHostHeader = BuildConfig.ATTESTATION_HOST_HEADER,
+            transactionDataProfilesUrl = BuildConfig.TRANSACTION_DATA_PROFILES_URL,
+        )
         controller = WalletDemoController(
-            createAndroidDemoWallet(
+            wallet = createAndroidDemoWallet(
                 context = applicationContext,
-                config = DemoWalletConfig(
-                    attestationBaseUrl = BuildConfig.ATTESTATION_BASE_URL,
-                    attestationAttesterPath = BuildConfig.ATTESTATION_ATTESTER_PATH,
-                    attestationBearerToken = BuildConfig.ATTESTATION_BEARER_TOKEN,
-                    attestationHostHeader = BuildConfig.ATTESTATION_HOST_HEADER,
-                    transactionDataProfilesUrl = BuildConfig.TRANSACTION_DATA_PROFILES_URL,
-                )
-            )
+                config = config,
+            ),
+            pinStore = createAndroidDemoPinStore(applicationContext, config.walletId),
         )
         handleIntent(intent)
 

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
@@ -28,7 +28,7 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         XCTAssertEqual(readyStatus, "Wallet ready", "Wallet did not become ready, status: \(readyStatus ?? "nil")")
 
         app.terminate()
-        ui.launchExpectingLogin(environment: environment)
+        ui.launchExpectingLoginAndUnlock(environment: environment, walletReadyTimeout: walletReadyTimeout)
     }
 
     func testBootstrapCreatesDid() async throws {
@@ -294,12 +294,7 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         app.terminate()
         try await Task.sleep(nanoseconds: 2_000_000_000)
 
-        ui.launchExpectingLogin(environment: environment)
-        let readyAfterRestart = ui.waitForStatus(
-            prefixes: ["Wallet ready", "Bootstrap failed"],
-            timeout: walletReadyTimeout
-        )
-        XCTAssertEqual(readyAfterRestart, "Wallet ready", "Wallet did not become ready after restart, status: \(readyAfterRestart ?? "nil")")
+        ui.launchExpectingLoginAndUnlock(environment: environment, walletReadyTimeout: walletReadyTimeout)
         XCTAssertFalse(app.staticTexts["No credentials"].exists, "Credentials did not persist across app restart")
     }
 

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/PublicDemoBackendE2ETests.swift
@@ -15,6 +15,22 @@ final class PublicDemoBackendE2ETests: XCTestCase {
     private let presentationOperationTimeout: TimeInterval = 180
     private let verifierPollingTimeout: TimeInterval = 30
 
+    func testPinPersistsAcrossAppRestart() throws {
+        let app = XCUIApplication()
+        let ui = WalletE2EUI(app: app)
+        let environment = isolatedWalletEnvironment()
+
+        ui.launch(environment: environment)
+        let readyStatus = ui.waitForStatus(
+            prefixes: ["Wallet ready", "Bootstrap failed"],
+            timeout: walletReadyTimeout
+        )
+        XCTAssertEqual(readyStatus, "Wallet ready", "Wallet did not become ready, status: \(readyStatus ?? "nil")")
+
+        app.terminate()
+        ui.launchExpectingLogin(environment: environment)
+    }
+
     func testBootstrapCreatesDid() async throws {
         let app = XCUIApplication()
         let ui = WalletE2EUI(app: app)
@@ -278,7 +294,7 @@ final class PublicDemoBackendE2ETests: XCTestCase {
         app.terminate()
         try await Task.sleep(nanoseconds: 2_000_000_000)
 
-        ui.launch(environment: environment)
+        ui.launchExpectingLogin(environment: environment)
         let readyAfterRestart = ui.waitForStatus(
             prefixes: ["Wallet ready", "Bootstrap failed"],
             timeout: walletReadyTimeout

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/WalletE2EHelpers.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/WalletE2EHelpers.swift
@@ -22,6 +22,19 @@ final class WalletE2EUI {
         launch(environment: attestation)
     }
 
+    func launchExpectingLogin(environment: [String: String]) {
+        for (key, value) in environment {
+            app.launchEnvironment[key] = value
+        }
+        app.launch()
+
+        let pinInput = textInput(identifier: "wallet.pinInput", fallbackLabel: "PIN")
+        XCTAssertTrue(pinInput.waitForExistence(timeout: 10), "PIN input not found after relaunch")
+        let confirmation = textInput(identifier: "wallet.pinConfirmationInput", fallbackLabel: "Confirm PIN")
+        XCTAssertFalse(confirmation.waitForExistence(timeout: 2), "PIN setup was shown after relaunch")
+        unlockWallet()
+    }
+
     func textInput(identifier: String, fallbackLabel: String) -> XCUIElement {
         firstExisting([
             app.textFields[identifier],

--- a/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/WalletE2EHelpers.swift
+++ b/waltid-applications/waltid-wallet-demo-compose/iosApp/iosAppUITests/WalletE2EHelpers.swift
@@ -22,7 +22,10 @@ final class WalletE2EUI {
         launch(environment: attestation)
     }
 
-    func launchExpectingLogin(environment: [String: String]) {
+    func launchExpectingLoginAndUnlock(
+        environment: [String: String],
+        walletReadyTimeout: TimeInterval = 60
+    ) {
         for (key, value) in environment {
             app.launchEnvironment[key] = value
         }
@@ -33,6 +36,16 @@ final class WalletE2EUI {
         let confirmation = textInput(identifier: "wallet.pinConfirmationInput", fallbackLabel: "Confirm PIN")
         XCTAssertFalse(confirmation.waitForExistence(timeout: 2), "PIN setup was shown after relaunch")
         unlockWallet()
+
+        let readyStatus = waitForStatus(
+            prefixes: ["Wallet ready", "Bootstrap failed"],
+            timeout: walletReadyTimeout
+        )
+        XCTAssertEqual(
+            readyStatus,
+            "Wallet ready",
+            "Persisted PIN did not unlock the wallet, status: \(readyStatus ?? "nil")"
+        )
     }
 
     func textInput(identifier: String, fallbackLabel: String) -> XCUIElement {

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/build.gradle.kts
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/build.gradle.kts
@@ -38,6 +38,8 @@ kotlin {
                     implementation(identityLibs.ktor.client.core)
                     implementation(identityLibs.ktor.client.content.negotiation)
                     implementation(identityLibs.ktor.serialization.kotlinx.json)
+                    implementation(identityLibs.cryptography.core)
+                    implementation(identityLibs.whyoleg.cryptography.random)
                 }
             }
 
@@ -48,6 +50,13 @@ kotlin {
 
                 androidMain.dependencies {
                     implementation(identityLibs.ktor.client.android)
+                }
+
+                getByName("androidDeviceTest").dependencies {
+                    implementation(kotlin("test"))
+                    implementation(identityLibs.kotlinx.coroutines.test)
+                    implementation(identityLibs.androidx.test.ext.junit)
+                    implementation(identityLibs.androidx.test.runner)
                 }
             }
 

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidDeviceTest/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoPinStoreTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidDeviceTest/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoPinStoreTest.kt
@@ -1,0 +1,34 @@
+package id.walt.walletdemo.compose.logic
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class AndroidDemoPinStoreTest {
+    @Test
+    fun verifierPersistsAcrossStoreRecreationWithoutStoringPin() = runTest {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val walletId = "pin-store-test-${System.nanoTime()}"
+        val firstStore = createAndroidDemoPinStore(context, walletId)
+
+        assertFalse(firstStore.hasPin())
+        firstStore.setPin("1234")
+
+        val recreatedStore = createAndroidDemoPinStore(context, walletId)
+        assertTrue(recreatedStore.hasPin())
+        assertTrue(recreatedStore.verifyPin("1234"))
+        assertFalse(recreatedStore.verifyPin("9999"))
+
+        val storedRecord = context
+            .getSharedPreferences("walt_wallet_demo_pin_verifiers", 0)
+            .getString("pin.$walletId", null)
+        assertTrue(storedRecord?.startsWith("1:210000:") == true)
+        assertNotEquals("1234", storedRecord)
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidMain/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoPinStore.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidMain/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoPinStore.kt
@@ -1,0 +1,22 @@
+package id.walt.walletdemo.compose.logic
+
+import android.content.Context
+
+fun createAndroidDemoPinStore(
+    context: Context,
+    walletId: String,
+): DemoPinStore {
+    val preferences = context.applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    val recordKey = "$RECORD_KEY_PREFIX$walletId"
+    return PersistentDemoPinStore(
+        readRecord = { preferences.getString(recordKey, null) },
+        writeRecord = { record ->
+            check(preferences.edit().putString(recordKey, record).commit()) {
+                "PIN verifier could not be persisted"
+            }
+        },
+    )
+}
+
+private const val PREFERENCES_NAME = "walt_wallet_demo_pin_verifiers"
+private const val RECORD_KEY_PREFIX = "pin."

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/DemoPinStore.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/DemoPinStore.kt
@@ -1,0 +1,19 @@
+package id.walt.walletdemo.compose.logic
+
+interface DemoPinStore {
+    fun hasPin(): Boolean
+    suspend fun setPin(pin: String)
+    suspend fun verifyPin(pin: String): Boolean
+}
+
+class InMemoryDemoPinStore : DemoPinStore {
+    private var configuredPin: String? = null
+
+    override fun hasPin(): Boolean = configuredPin != null
+
+    override suspend fun setPin(pin: String) {
+        configuredPin = pin
+    }
+
+    override suspend fun verifyPin(pin: String): Boolean = configuredPin == pin
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletAuthState.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletAuthState.kt
@@ -1,15 +1,21 @@
 package id.walt.walletdemo.compose.logic
 
 sealed interface WalletAuthState {
+    sealed interface PinEntry : WalletAuthState
+
     data class Setup(
         val pin: String = "",
         val confirmation: String = "",
         val error: String? = null,
-    ) : WalletAuthState
+    ) : PinEntry
 
     data class Login(
         val pin: String = "",
         val error: String? = null,
+    ) : PinEntry
+
+    data class StorageUnavailable(
+        val message: String = "PIN storage is unavailable",
     ) : WalletAuthState
 
     data object Unlocked : WalletAuthState

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
@@ -16,12 +16,20 @@ import kotlinx.coroutines.launch
 
 class WalletDemoController(
     private val wallet: DemoWallet,
+    private val pinStore: DemoPinStore,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
-    private var configuredPin: String? = null
     private var receiveJob: Job? = null
-    private val _state = MutableStateFlow(WalletDemoUiState())
+    private val _state = MutableStateFlow(
+        WalletDemoUiState(
+            auth = runCatching {
+                if (pinStore.hasPin()) WalletAuthState.Login() else WalletAuthState.Setup()
+            }.getOrElse {
+                WalletAuthState.Setup(error = "PIN storage is unavailable")
+            },
+        ),
+    )
     val state: StateFlow<WalletDemoUiState> = _state.asStateFlow()
 
     fun updatePin(value: String) {
@@ -46,6 +54,7 @@ class WalletDemoController(
     }
 
     fun submitPin() {
+        if (_state.value.isAuthenticating) return
         when (val auth = _state.value.auth) {
             is WalletAuthState.Setup -> submitSetupPin(auth)
             is WalletAuthState.Login -> submitLoginPin(auth)
@@ -498,9 +507,22 @@ class WalletDemoController(
             return
         }
 
-        configuredPin = pin
-        _state.update { it.copy(auth = WalletAuthState.Unlocked) }
-        bootstrapIfNeeded()
+        _state.update { it.copy(isAuthenticating = true) }
+        scope.launch(dispatcher) {
+            runCatching { pinStore.setPin(pin) }
+                .onSuccess {
+                    _state.update {
+                        it.copy(
+                            auth = WalletAuthState.Unlocked,
+                            isAuthenticating = false,
+                        )
+                    }
+                    bootstrapIfNeeded()
+                }
+                .onFailure {
+                    setSetupPinError("PIN could not be saved")
+                }
+        }
     }
 
     private fun submitLoginPin(auth: WalletAuthState.Login) {
@@ -510,13 +532,26 @@ class WalletDemoController(
             return
         }
 
-        if (configuredPin != pin) {
-            setLoginPinError(WalletDisplayText.WrongPin)
-            return
+        _state.update { it.copy(isAuthenticating = true) }
+        scope.launch(dispatcher) {
+            runCatching { pinStore.verifyPin(pin) }
+                .onSuccess { matches ->
+                    if (!matches) {
+                        setLoginPinError(WalletDisplayText.WrongPin)
+                        return@onSuccess
+                    }
+                    _state.update {
+                        it.copy(
+                            auth = WalletAuthState.Unlocked,
+                            isAuthenticating = false,
+                        )
+                    }
+                    bootstrapIfNeeded()
+                }
+                .onFailure {
+                    setLoginPinError("PIN could not be verified")
+                }
         }
-
-        _state.update { it.copy(auth = WalletAuthState.Unlocked) }
-        bootstrapIfNeeded()
     }
 
     private fun bootstrapIfNeeded() {
@@ -562,14 +597,20 @@ class WalletDemoController(
     private fun setSetupPinError(message: String) {
         _state.update { state ->
             val auth = state.auth as? WalletAuthState.Setup ?: return@update state
-            state.copy(auth = auth.copy(error = message))
+            state.copy(
+                auth = auth.copy(error = message),
+                isAuthenticating = false,
+            )
         }
     }
 
     private fun setLoginPinError(message: String) {
         _state.update { state ->
             val auth = state.auth as? WalletAuthState.Login ?: return@update state
-            state.copy(auth = auth.copy(error = message))
+            state.copy(
+                auth = auth.copy(error = message),
+                isAuthenticating = false,
+            )
         }
     }
 

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoController.kt
@@ -23,11 +23,7 @@ class WalletDemoController(
     private var receiveJob: Job? = null
     private val _state = MutableStateFlow(
         WalletDemoUiState(
-            auth = runCatching {
-                if (pinStore.hasPin()) WalletAuthState.Login() else WalletAuthState.Setup()
-            }.getOrElse {
-                WalletAuthState.Setup(error = "PIN storage is unavailable")
-            },
+            auth = readInitialAuthState(),
         ),
     )
     val state: StateFlow<WalletDemoUiState> = _state.asStateFlow()
@@ -37,6 +33,7 @@ class WalletDemoController(
             when (val auth = state.auth) {
                 is WalletAuthState.Setup -> state.copy(auth = auth.copy(pin = value, error = null))
                 is WalletAuthState.Login -> state.copy(auth = auth.copy(pin = value, error = null))
+                is WalletAuthState.StorageUnavailable,
                 WalletAuthState.Unlocked -> state
             }
         }
@@ -47,6 +44,7 @@ class WalletDemoController(
             when (val auth = state.auth) {
                 is WalletAuthState.Setup -> state.copy(auth = auth.copy(confirmation = value, error = null))
                 is WalletAuthState.Login,
+                is WalletAuthState.StorageUnavailable,
                 WalletAuthState.Unlocked,
                 -> state
             }
@@ -58,7 +56,18 @@ class WalletDemoController(
         when (val auth = _state.value.auth) {
             is WalletAuthState.Setup -> submitSetupPin(auth)
             is WalletAuthState.Login -> submitLoginPin(auth)
+            is WalletAuthState.StorageUnavailable,
             WalletAuthState.Unlocked -> Unit
+        }
+    }
+
+    fun retryPinStorage() {
+        _state.update { state ->
+            if (state.auth is WalletAuthState.StorageUnavailable) {
+                state.copy(auth = readInitialAuthState())
+            } else {
+                state
+            }
         }
     }
 
@@ -624,6 +633,13 @@ class WalletDemoController(
             )
         }
     }
+
+    private fun readInitialAuthState(): WalletAuthState =
+        runCatching {
+            if (pinStore.hasPin()) WalletAuthState.Login() else WalletAuthState.Setup()
+        }.getOrElse {
+            WalletAuthState.StorageUnavailable()
+        }
 
     private companion object {
         val pinPattern = Regex("\\d{4,8}")

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiState.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiState.kt
@@ -2,6 +2,7 @@ package id.walt.walletdemo.compose.logic
 
 data class WalletDemoUiState(
     val auth: WalletAuthState = WalletAuthState.Setup(),
+    val isAuthenticating: Boolean = false,
     val session: WalletSessionState = WalletSessionState.NotBootstrapped,
     val operation: WalletOperationState = WalletOperationState.Idle,
     val selectedTab: WalletDemoTab = WalletDemoTab.Credentials,

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiStateDerivedProperties.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiStateDerivedProperties.kt
@@ -1,7 +1,8 @@
 package id.walt.walletdemo.compose.logic
 
 val WalletDemoUiState.isBusy: Boolean
-    get() = session is WalletSessionState.Bootstrapping ||
+    get() = isAuthenticating ||
+        session is WalletSessionState.Bootstrapping ||
         operation is WalletOperationState.ResolvingOffer ||
         operation is WalletOperationState.Receiving ||
         operation is WalletOperationState.ResolvingPresentation ||

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiStateDerivedProperties.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonMain/kotlin/id/walt/walletdemo/compose/logic/WalletDemoUiStateDerivedProperties.kt
@@ -70,6 +70,7 @@ private fun WalletSessionState.statusText(auth: WalletAuthState): String =
         WalletSessionState.NotBootstrapped -> when (auth) {
             is WalletAuthState.Setup -> WalletDisplayText.SetupPin
             is WalletAuthState.Login -> WalletDisplayText.UnlockPin
+            is WalletAuthState.StorageUnavailable -> auth.message
             WalletAuthState.Unlocked -> WalletDisplayText.WalletNotReady
         }
         WalletSessionState.Bootstrapping -> WalletDisplayText.BootstrappingWallet

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/WalletDemoControllerTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/WalletDemoControllerTest.kt
@@ -45,7 +45,8 @@ class WalletDemoControllerTest {
     @Test
     fun setupPinUnlocksAndBootstrapsWallet() = runTest {
         val wallet = FakeDemoWallet(credentials = listOf(sampleCredential))
-        val controller = controllerWith(wallet, this)
+        val pinStore = InMemoryDemoPinStore()
+        val controller = controllerWith(wallet, this, pinStore)
 
         controller.updatePin("1234")
         controller.updatePinConfirmation("1234")
@@ -59,6 +60,44 @@ class WalletDemoControllerTest {
         assertEquals("did:key:test", session.did)
         assertEquals(listOf(sampleCredential), session.credentials)
         assertEquals(1, wallet.bootstrapCalls)
+        assertTrue(pinStore.hasPin())
+    }
+
+    @Test
+    fun configuredPinStartsRecreatedControllerInLoginAndUnlocksWithOriginalPin() = runTest {
+        val pinStore = InMemoryDemoPinStore()
+        val firstController = controllerWith(FakeDemoWallet(), this, pinStore)
+        firstController.updatePin("1234")
+        firstController.updatePinConfirmation("1234")
+        firstController.submitPin()
+        runCurrent()
+
+        val recreatedWallet = FakeDemoWallet()
+        val recreatedController = controllerWith(recreatedWallet, this, pinStore)
+
+        assertTrue(recreatedController.state.value.auth is WalletAuthState.Login)
+        recreatedController.updatePin("1234")
+        recreatedController.submitPin()
+        runCurrent()
+
+        assertTrue(recreatedController.state.value.auth is WalletAuthState.Unlocked)
+        assertTrue(recreatedController.state.value.session is WalletSessionState.Ready)
+        assertEquals(1, recreatedWallet.bootstrapCalls)
+    }
+
+    @Test
+    fun recreatedControllerRejectsWrongPin() = runTest {
+        val pinStore = InMemoryDemoPinStore().also { it.setPin("1234") }
+        val controller = controllerWith(FakeDemoWallet(), this, pinStore)
+
+        controller.updatePin("9999")
+        controller.submitPin()
+        runCurrent()
+
+        val auth = controller.state.value.auth as WalletAuthState.Login
+        assertEquals("Wrong PIN", auth.error)
+        assertFalse(controller.state.value.isAuthenticating)
+        assertTrue(controller.state.value.session is WalletSessionState.NotBootstrapped)
     }
 
     @Test
@@ -68,6 +107,7 @@ class WalletDemoControllerTest {
         controller.lock()
         controller.updatePin("9999")
         controller.submitPin()
+        runCurrent()
 
         val auth = controller.state.value.auth as WalletAuthState.Login
         assertEquals("Wrong PIN", auth.error)
@@ -1002,9 +1042,14 @@ class WalletDemoControllerTest {
         assertEquals("Wallet ready", controller.state.value.statusText)
     }
 
-    private fun controllerWith(wallet: DemoWallet, scope: TestScope): WalletDemoController =
+    private fun controllerWith(
+        wallet: DemoWallet,
+        scope: TestScope,
+        pinStore: DemoPinStore = InMemoryDemoPinStore(),
+    ): WalletDemoController =
         WalletDemoController(
             wallet = wallet,
+            pinStore = pinStore,
             scope = scope.backgroundScope,
             dispatcher = StandardTestDispatcher(scope.testScheduler),
         )

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/WalletDemoControllerTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/WalletDemoControllerTest.kt
@@ -17,6 +17,29 @@ import kotlin.test.assertTrue
 class WalletDemoControllerTest {
 
     @Test
+    fun pinStorageReadFailureStaysLockedUntilRetrySucceeds() = runTest {
+        val pinStore = RecoverableDemoPinStore()
+        val wallet = FakeDemoWallet()
+        val controller = controllerWith(wallet, this, pinStore)
+
+        assertTrue(controller.state.value.auth is WalletAuthState.StorageUnavailable)
+
+        controller.updatePin("1234")
+        controller.updatePinConfirmation("1234")
+        controller.submitPin()
+        runCurrent()
+
+        assertTrue(controller.state.value.auth is WalletAuthState.StorageUnavailable)
+        assertEquals(0, pinStore.setPinCalls)
+        assertEquals(0, wallet.bootstrapCalls)
+
+        pinStore.isAvailable = true
+        controller.retryPinStorage()
+
+        assertTrue(controller.state.value.auth is WalletAuthState.Login)
+    }
+
+    @Test
     fun setupPinRejectsInvalidLengthAndNonDigits() = runTest {
         val controller = controllerWith(FakeDemoWallet(), this)
 
@@ -1074,6 +1097,22 @@ class WalletDemoControllerTest {
             credentialDataJson = WalletDemoSampleCredentialData.credentialDataJsonWithPortrait,
         )
     }
+}
+
+private class RecoverableDemoPinStore : DemoPinStore {
+    var isAvailable = false
+    var setPinCalls = 0
+
+    override fun hasPin(): Boolean {
+        check(isAvailable) { "PIN storage is unavailable" }
+        return true
+    }
+
+    override suspend fun setPin(pin: String) {
+        setPinCalls += 1
+    }
+
+    override suspend fun verifyPin(pin: String): Boolean = true
 }
 
 private class FakeDemoWallet(

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/iosMain/kotlin/id/walt/walletdemo/compose/logic/IosDemoPinStore.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/iosMain/kotlin/id/walt/walletdemo/compose/logic/IosDemoPinStore.kt
@@ -1,0 +1,14 @@
+package id.walt.walletdemo.compose.logic
+
+import platform.Foundation.NSUserDefaults
+
+fun createIosDemoPinStore(walletId: String): DemoPinStore {
+    val defaults = NSUserDefaults.standardUserDefaults
+    val recordKey = "$RECORD_KEY_PREFIX$walletId"
+    return PersistentDemoPinStore(
+        readRecord = { defaults.stringForKey(recordKey) },
+        writeRecord = { record -> defaults.setObject(record, forKey = recordKey) },
+    )
+}
+
+private const val RECORD_KEY_PREFIX = "id.walt.walletdemo.pin."

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/PersistentDemoPinStore.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/PersistentDemoPinStore.kt
@@ -1,0 +1,74 @@
+package id.walt.walletdemo.compose.logic
+
+import dev.whyoleg.cryptography.BinarySize.Companion.bytes
+import dev.whyoleg.cryptography.CryptographyProvider
+import dev.whyoleg.cryptography.CryptographyProviderApi
+import dev.whyoleg.cryptography.algorithms.PBKDF2
+import dev.whyoleg.cryptography.algorithms.SHA256
+import dev.whyoleg.cryptography.random.CryptographyRandom
+import kotlin.io.encoding.Base64
+
+@OptIn(CryptographyProviderApi::class)
+internal class PersistentDemoPinStore(
+    private val readRecord: () -> String?,
+    private val writeRecord: (String) -> Unit,
+    private val provider: CryptographyProvider = CryptographyProvider.Default,
+) : DemoPinStore {
+    private val pbkdf2 by lazy { provider.get(PBKDF2) }
+
+    override fun hasPin(): Boolean = readRecord() != null
+
+    override suspend fun setPin(pin: String) {
+        val salt = CryptographyRandom.nextBytes(SALT_SIZE_BYTES)
+        val verifier = derive(pin, salt, ITERATIONS)
+        writeRecord(
+            listOf(
+                RECORD_VERSION,
+                ITERATIONS.toString(),
+                Base64.encode(salt),
+                Base64.encode(verifier),
+            ).joinToString(RECORD_SEPARATOR),
+        )
+    }
+
+    override suspend fun verifyPin(pin: String): Boolean {
+        val record = readRecord() ?: return false
+        val parts = record.split(RECORD_SEPARATOR, limit = 4)
+        require(parts.size == 4 && parts[0] == RECORD_VERSION) { "Unsupported PIN verifier record" }
+
+        val iterations = parts[1].toInt()
+        require(iterations in 1..MAX_ITERATIONS) { "Invalid PIN verifier iteration count" }
+        val salt = Base64.decode(parts[2])
+        val expected = Base64.decode(parts[3])
+        require(salt.size == SALT_SIZE_BYTES && expected.size == VERIFIER_SIZE_BYTES) {
+            "Invalid PIN verifier record"
+        }
+
+        return derive(pin, salt, iterations).constantTimeEquals(expected)
+    }
+
+    private suspend fun derive(pin: String, salt: ByteArray, iterations: Int): ByteArray =
+        pbkdf2.secretDerivation(
+            digest = SHA256,
+            iterations = iterations,
+            outputSize = VERIFIER_SIZE_BYTES.bytes,
+            salt = salt,
+        ).deriveSecretToByteArray(pin.encodeToByteArray())
+
+    private fun ByteArray.constantTimeEquals(other: ByteArray): Boolean {
+        var difference = size xor other.size
+        for (index in indices) {
+            difference = difference or (this[index].toInt() xor other[index].toInt())
+        }
+        return difference == 0
+    }
+
+    private companion object {
+        const val RECORD_VERSION = "1"
+        const val RECORD_SEPARATOR = ":"
+        const val ITERATIONS = 210_000
+        const val MAX_ITERATIONS = 1_000_000
+        const val SALT_SIZE_BYTES = 16
+        const val VERIFIER_SIZE_BYTES = 32
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/androidHostTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppAndroidTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/androidHostTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppAndroidTest.kt
@@ -11,6 +11,10 @@ class WalletDemoAppAndroidTest {
     private val scenarios = WalletDemoAppTestScenarios()
 
     @Test
+    fun pinStorageFailureStaysLockedUntilRetrySucceeds() =
+        scenarios.pinStorageFailureStaysLockedUntilRetrySucceeds()
+
+    @Test
     fun credentialsTabShowsCompactCardsAndNavigatesToDetails() =
         scenarios.credentialsTabShowsCompactCardsAndNavigatesToDetails()
 

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoApp.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoApp.kt
@@ -13,6 +13,7 @@ import id.walt.walletdemo.compose.logic.WalletAuthState
 import id.walt.walletdemo.compose.logic.WalletDemoController
 import id.walt.walletdemo.compose.logic.isBusy
 import id.walt.walletdemo.compose.ui.screens.PinScreen
+import id.walt.walletdemo.compose.ui.screens.PinStorageUnavailableScreen
 import id.walt.walletdemo.compose.ui.screens.WalletScreen
 
 @Composable
@@ -32,12 +33,14 @@ fun WalletDemoApp(controller: WalletDemoController) {
                     .safeDrawingPadding(),
             ) {
                 when (val auth = state.auth) {
-                    is WalletAuthState.Setup,
-                    is WalletAuthState.Login,
-                    -> PinScreen(
+                    is WalletAuthState.PinEntry -> PinScreen(
                         controller = controller,
                         auth = auth,
                         isBusy = state.isBusy,
+                    )
+                    is WalletAuthState.StorageUnavailable -> PinStorageUnavailableScreen(
+                        controller = controller,
+                        message = auth.message,
                     )
                     WalletAuthState.Unlocked -> WalletScreen(controller, state)
                 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/PinScreen.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/screens/PinScreen.kt
@@ -26,19 +26,17 @@ import id.walt.walletdemo.compose.ui.WalletUiTestTags
 @Composable
 internal fun PinScreen(
     controller: WalletDemoController,
-    auth: WalletAuthState,
+    auth: WalletAuthState.PinEntry,
     isBusy: Boolean,
 ) {
     val setup = auth as? WalletAuthState.Setup
     val pin = when (auth) {
         is WalletAuthState.Setup -> auth.pin
         is WalletAuthState.Login -> auth.pin
-        WalletAuthState.Unlocked -> ""
     }
     val error = when (auth) {
         is WalletAuthState.Setup -> auth.error
         is WalletAuthState.Login -> auth.error
-        WalletAuthState.Unlocked -> null
     }
 
     Column(
@@ -103,6 +101,36 @@ internal fun PinScreen(
                 .testTag(WalletUiTestTags.PinSubmitButton),
         ) {
             Text(if (setup != null) "Set PIN" else "Unlock")
+        }
+    }
+}
+
+@Composable
+internal fun PinStorageUnavailableScreen(
+    controller: WalletDemoController,
+    message: String,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Spacer(Modifier.height(12.dp))
+        Text("walt.id Wallet", style = MaterialTheme.typography.headlineMedium, fontWeight = FontWeight.Bold)
+        Text("PIN storage unavailable", style = MaterialTheme.typography.titleMedium)
+        Text(
+            "$message. The wallet remains locked.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+        )
+        Button(
+            onClick = controller::retryPinStorage,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("wallet.pinStorageRetryButton"),
+        ) {
+            Text("Retry")
         }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoIos.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoIos.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.window.ComposeUIViewController
 import id.walt.walletdemo.compose.logic.DemoWalletConfig
 import id.walt.walletdemo.compose.logic.WalletDemoController
 import id.walt.walletdemo.compose.logic.createIosDemoWallet
+import id.walt.walletdemo.compose.logic.createIosDemoPinStore
 import platform.UIKit.UIViewController
 
 private var iosController: WalletDemoController? = null
@@ -17,17 +18,17 @@ fun walletDemoViewController(
     attestationHostHeader: String = "",
     transactionDataProfilesUrl: String = "",
 ): UIViewController {
+    val config = DemoWalletConfig(
+        walletId = walletId,
+        attestationBaseUrl = attestationBaseUrl,
+        attestationAttesterPath = attestationAttesterPath,
+        attestationBearerToken = attestationBearerToken,
+        attestationHostHeader = attestationHostHeader,
+        transactionDataProfilesUrl = transactionDataProfilesUrl,
+    )
     val controller = WalletDemoController(
-        createIosDemoWallet(
-            DemoWalletConfig(
-                walletId = walletId,
-                attestationBaseUrl = attestationBaseUrl,
-                attestationAttesterPath = attestationAttesterPath,
-                attestationBearerToken = attestationBearerToken,
-                attestationHostHeader = attestationHostHeader,
-                transactionDataProfilesUrl = transactionDataProfilesUrl,
-            )
-        )
+        wallet = createIosDemoWallet(config),
+        pinStore = createIosDemoPinStore(config.walletId),
     )
     iosController = controller
     pendingDeepLink?.let(controller::handleDeepLink)

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppIosTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/iosTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppIosTest.kt
@@ -6,6 +6,10 @@ class WalletDemoAppIosTest {
     private val scenarios = WalletDemoAppTestScenarios()
 
     @Test
+    fun pinStorageFailureStaysLockedUntilRetrySucceeds() =
+        scenarios.pinStorageFailureStaysLockedUntilRetrySucceeds()
+
+    @Test
     fun credentialsTabShowsCompactCardsAndNavigatesToDetails() =
         scenarios.credentialsTabShowsCompactCardsAndNavigatesToDetails()
 

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import id.walt.walletdemo.compose.logic.WalletDemoBootstrapResult
 import id.walt.walletdemo.compose.logic.DemoWallet
+import id.walt.walletdemo.compose.logic.InMemoryDemoPinStore
 import id.walt.walletdemo.compose.logic.WalletDemoController
 import id.walt.walletdemo.compose.logic.WalletDemoCredential
 import id.walt.walletdemo.compose.logic.WalletDemoOperationResult
@@ -49,7 +50,7 @@ class WalletDemoAppTestScenarios {
 
     fun credentialsTabShowsCompactCardsAndNavigatesToDetails() = runComposeUiTest {
         val wallet = FakeDemoWallet(credentials = listOf(sampleCredential))
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
 
@@ -92,7 +93,7 @@ class WalletDemoAppTestScenarios {
 
     fun credentialsTabShowsEmptyStateAndUpdatesAfterReceive() = runComposeUiTest {
         val wallet = FakeDemoWallet(receivedCredentialIds = listOf("cred-1", "cred-2"))
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -124,7 +125,7 @@ class WalletDemoAppTestScenarios {
 
     fun receiveTabCanStartNewFlowAfterSuccess() = runComposeUiTest {
         val wallet = FakeDemoWallet(credentialsAfterReceive = listOf(sampleCredential))
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -144,7 +145,7 @@ class WalletDemoAppTestScenarios {
 
     fun receiveDetailsStayScopedToReceiveTabNavigationStack() = runComposeUiTest {
         val wallet = FakeDemoWallet(credentialsAfterReceive = listOf(sampleCredential))
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -173,7 +174,7 @@ class WalletDemoAppTestScenarios {
             credentialsAfterReceive = listOf(sampleCredential),
             receiveGate = receiveGate,
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -208,7 +209,7 @@ class WalletDemoAppTestScenarios {
 
     fun presentTabExplainsWhyPreviewIsUnavailableWithoutCredentials() = runComposeUiTest {
         val wallet = FakeDemoWallet(credentials = emptyList())
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -227,7 +228,7 @@ class WalletDemoAppTestScenarios {
             presentationResult = WalletDemoOperationResult.Success("Presentation sent"),
             presentationPreview = samplePresentationPreview,
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -279,7 +280,7 @@ class WalletDemoAppTestScenarios {
                 credentialOptions = listOf(pathOnlyPortraitDisclosureCredentialOption),
             ),
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -310,7 +311,7 @@ class WalletDemoAppTestScenarios {
                 clientId = sampleDidClientId,
             ),
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -335,7 +336,7 @@ class WalletDemoAppTestScenarios {
                 clientId = sampleX509SanDnsClientId,
             ),
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -388,7 +389,7 @@ class WalletDemoAppTestScenarios {
                 ),
             ),
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -423,7 +424,7 @@ class WalletDemoAppTestScenarios {
             credentials = listOf(sampleCredential),
             presentationPreview = samplePresentationPreview,
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -453,7 +454,7 @@ class WalletDemoAppTestScenarios {
             presentationPreview = samplePresentationPreview,
             previewGate = previewGate,
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -481,7 +482,7 @@ class WalletDemoAppTestScenarios {
             presentationResult = WalletDemoOperationResult.Success("Presentation sent"),
             presentationPreview = samplePresentationPreview,
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -519,7 +520,7 @@ class WalletDemoAppTestScenarios {
             credentialsAfterReceive = listOf(sampleCredential),
             presentationPreview = samplePresentationPreview,
         )
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -554,7 +555,8 @@ class WalletDemoAppTestScenarios {
 
     fun credentialsPersistAcrossControllerRecreation() = runComposeUiTest {
         val wallet = FakeDemoWallet(credentialsAfterReceive = listOf(sampleCredential))
-        val firstController = WalletDemoController(wallet)
+        val pinStore = InMemoryDemoPinStore()
+        val firstController = WalletDemoController(wallet, pinStore)
         var activeController by mutableStateOf(firstController)
 
         setContent { WalletDemoApp(activeController) }
@@ -566,10 +568,12 @@ class WalletDemoAppTestScenarios {
         waitUntil(timeoutMillis = 5_000) { firstController.state.value.statusText.startsWith("Received") }
         onNodeWithTag("wallet.credentialCard.cred-1").performScrollTo().assertIsDisplayed()
 
-        val recreatedController = WalletDemoController(wallet)
+        val recreatedController = WalletDemoController(wallet, pinStore)
         activeController = recreatedController
         waitForIdle()
-        unlockWithPin()
+        onNodeWithText("Enter your PIN").assertIsDisplayed()
+        onAllNodesWithTag("wallet.pinConfirmationInput").assertCountEquals(0)
+        loginWithPin()
         waitUntil(timeoutMillis = 5_000) { recreatedController.state.value.session is WalletSessionState.Ready }
 
         onNodeWithTag("wallet.credentialCard.cred-1").assertIsDisplayed()
@@ -580,6 +584,12 @@ class WalletDemoAppTestScenarios {
         onNodeWithTag("wallet.pinInput").performClick().performTextInput("1234")
         onNodeWithTag("wallet.pinConfirmationInput").performClick().performTextInput("1234")
         waitForIdle()
+        onNodeWithTag("wallet.pinSubmitButton").performSemanticsAction(SemanticsActions.OnClick)
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.loginWithPin() {
+        onNodeWithTag("wallet.pinInput").performClick().performTextInput("1234")
         onNodeWithTag("wallet.pinSubmitButton").performSemanticsAction(SemanticsActions.OnClick)
         waitForIdle()
     }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
@@ -26,9 +26,10 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.v2.runComposeUiTest
-import id.walt.walletdemo.compose.logic.WalletDemoBootstrapResult
+import id.walt.walletdemo.compose.logic.DemoPinStore
 import id.walt.walletdemo.compose.logic.DemoWallet
 import id.walt.walletdemo.compose.logic.InMemoryDemoPinStore
+import id.walt.walletdemo.compose.logic.WalletDemoBootstrapResult
 import id.walt.walletdemo.compose.logic.WalletDemoController
 import id.walt.walletdemo.compose.logic.WalletDemoCredential
 import id.walt.walletdemo.compose.logic.WalletDemoOperationResult
@@ -47,6 +48,23 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class WalletDemoAppTestScenarios {
+
+    fun pinStorageFailureStaysLockedUntilRetrySucceeds() = runComposeUiTest {
+        val pinStore = RecoverableDemoPinStore()
+        val controller = WalletDemoController(FakeDemoWallet(), pinStore)
+
+        setContent { WalletDemoApp(controller) }
+
+        onNodeWithText("PIN storage unavailable").assertIsDisplayed()
+        onAllNodesWithTag("wallet.pinInput").assertCountEquals(0)
+
+        pinStore.isAvailable = true
+        onNodeWithTag("wallet.pinStorageRetryButton").performClick()
+        waitForIdle()
+
+        onNodeWithText("Enter your PIN").assertIsDisplayed()
+        onAllNodesWithTag("wallet.pinConfirmationInput").assertCountEquals(0)
+    }
 
     fun credentialsTabShowsCompactCardsAndNavigatesToDetails() = runComposeUiTest {
         val wallet = FakeDemoWallet(credentials = listOf(sampleCredential))
@@ -194,7 +212,10 @@ class WalletDemoAppTestScenarios {
     }
 
     fun receiveAndPresentTabsExposeQrScanActions() = runComposeUiTest {
-        val controller = WalletDemoController(FakeDemoWallet(credentials = listOf(sampleCredential)))
+        val controller = WalletDemoController(
+            FakeDemoWallet(credentials = listOf(sampleCredential)),
+            InMemoryDemoPinStore(),
+        )
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()
@@ -743,6 +764,19 @@ class WalletDemoAppTestScenarios {
         private val samplePresentationCredentialOption: WalletDemoPresentationCredentialOption
             get() = samplePresentationPreview.credentialOptions.single()
     }
+}
+
+private class RecoverableDemoPinStore : DemoPinStore {
+    var isAvailable = false
+
+    override fun hasPin(): Boolean {
+        check(isAvailable) { "PIN storage is unavailable" }
+        return true
+    }
+
+    override suspend fun setPin(pin: String) = Unit
+
+    override suspend fun verifyPin(pin: String): Boolean = true
 }
 
 private class FakeDemoWallet(

--- a/waltid-applications/waltid-wallet-demo-compose/webApp/src/wasmJsMain/kotlin/id/walt/walletdemo/compose/web/Main.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/webApp/src/wasmJsMain/kotlin/id/walt/walletdemo/compose/web/Main.kt
@@ -2,6 +2,7 @@ package id.walt.walletdemo.compose.web
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
+import id.walt.walletdemo.compose.logic.InMemoryDemoPinStore
 import id.walt.walletdemo.compose.logic.WalletDemoController
 import id.walt.walletdemo.compose.logic.createMockDemoWallet
 import id.walt.walletdemo.compose.ui.WalletDemoApp
@@ -11,7 +12,7 @@ import kotlinx.browser.document
 fun main() {
     ComposeViewport(document.body!!) {
         WalletDemoApp(
-            WalletDemoController(createMockDemoWallet())
+            WalletDemoController(createMockDemoWallet(), InMemoryDemoPinStore()),
         )
     }
 }


### PR DESCRIPTION
## Summary

Fixes the Compose wallet demo relaunch behavior described in [WAL-1184](https://linear.app/walt-new/issue/WAL-1184/persist-compose-demo-pin-and-show-unlock-screen-after-relaunch).

The Android and iOS demos now ask users to create a PIN only when no PIN has been configured. Later launches show the unlock screen and accept the original PIN.

## What changed

- Added an explicit PIN-store dependency to the shared demo controller.
- Persisted a versioned, salted PBKDF2-SHA256 verifier per wallet ID in app-private Android/iOS preferences; the PIN itself is never persisted.
- Kept the wallet locked behind a retryable error state when PIN storage cannot be read, instead of falling back to PIN setup.
- Kept the web demo intentionally ephemeral and made that choice explicit at construction.
- Moved verifier derivation off the UI thread and disabled duplicate authentication submissions.
- Added controller and shared UI coverage plus deterministic Android and iOS relaunch tests that prove setup occurs once and the original PIN unlocks after restart.
- Documented how demo PIN persistence relates to wallet database persistence.

## Scope

This changes only the Compose demo app unlock flow. It does not change the mobile wallet SDK API, wallet database encryption, or credential persistence behavior.

## Caveats

- Clearing app data or uninstalling the demo resets PIN setup.
- The web preview remains in-memory by design.

## Breaking changes

None.
