### PR TITLE
fix(ci): restore mobile eligibility label detection

### DIFF
--- a/.github/workflows/mobile-eligibility.yml
+++ b/.github/workflows/mobile-eligibility.yml
@@ -120,14 +120,18 @@ jobs:
                 exit 0
               fi
 
-              if jq -e --arg label "$PLATFORM_LABEL" 'index($label) != null or index("ci:mobile") != null' <<< "$PR_LABELS" >/dev/null; then
-                if jq -e --arg label "$PLATFORM_LABEL" 'index($label) != null' <<< "$PR_LABELS" >/dev/null; then
-                  set_decision true "$PLATFORM_LABEL label"
-                else
-                  set_decision true "ci:mobile label"
-                fi
-                exit 0
-              fi
+              label_match="$(
+                jq -er --arg platform_label "$PLATFORM_LABEL" '
+                  if index($platform_label) != null then "platform"
+                  elif index("ci:mobile") != null then "mobile"
+                  else "none"
+                  end
+                ' <<< "$PR_LABELS"
+              )"
+              case "$label_match" in
+                platform) set_decision true "$PLATFORM_LABEL label"; exit 0 ;;
+                mobile) set_decision true "ci:mobile label"; exit 0 ;;
+              esac
 
               if [[ "$PR_DRAFT" == "true" ]]; then
                 set_decision false "draft PR without $PLATFORM_LABEL or ci:mobile label"


### PR DESCRIPTION
## Summary

Restores explicit mobile CI opt-in labels for draft pull requests.

The shared eligibility workflow currently binds the platform label to jq's reserved `label` identifier. On jq 1.6 this fails to compile, but because the command runs as an `if` condition the error is treated as a missing label. Draft PRs then skip Android and iOS jobs even when `ci:mobile`, `ci:android`, or `ci:macos` is present.

This was observed in the labeled [Android device tests run](https://github.com/walt-id/waltid-identity/actions/runs/29422829105) and [iOS build and test run](https://github.com/walt-id/waltid-identity/actions/runs/29422829123).

## What Changed

- Renamed the jq binding to the non-reserved `platform_label`.
- Classified platform-specific, shared mobile, and absent labels in one jq invocation.
- Moved label evaluation into a normal assignment so malformed jq input fails the eligibility job instead of silently producing a false-negative decision.

## Architecture Notes

- The fix remains centralized in the shared mobile eligibility workflow, so Android and macOS callers use identical label semantics.
- Existing path matching, draft handling, fork protection, push behavior, and manual dispatch behavior are unchanged.

## Breaking Changes

None.