### PR TITLE
fix(openid4vci): keep transaction codes separate from offers

### DIFF
--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/EudiOfferFlow.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/EudiOfferFlow.swift
@@ -20,6 +20,11 @@ enum EudiOfferFlowError: LocalizedError {
     }
 }
 
+public struct EudiGeneratedOffer {
+    public let offerUrl: String
+    public let txCode: String
+}
+
 /// Generates credential offers from EUDI test backend.
 /// Handles multi-step form submission flow for pre-authorized offers.
 public final class EudiOfferFlow {
@@ -29,7 +34,7 @@ public final class EudiOfferFlow {
         self.client = client
     }
 
-    public func generate(credentialID: String = "eu.europa.ec.eudi.pid_vc_sd_jwt") async throws -> String {
+    public func generate(credentialID: String = "eu.europa.ec.eudi.pid_vc_sd_jwt") async throws -> EudiGeneratedOffer {
         let entrypoint = URL(string: "https://issuer.eudiw.dev/credential_offer")!
         let backendGenerate = URL(string: "https://backend.issuer.eudiw.dev/credential_offer")!
         let backendAuthorize = URL(string: "https://backend.issuer.eudiw.dev/form_authorize_generate")!
@@ -78,7 +83,7 @@ public final class EudiOfferFlow {
             "proceed": "Authorize",
         ])
 
-        // Step 7: Extract and inject tx_code into offer
+        // Step 7: Return the standard offer and separately delivered transaction code.
         let payloadRaw = try extractPayload(page: offerRedirect.body)
         guard let payloadData = payloadRaw.data(using: .utf8),
               let payloadJSON = try JSONSerialization.jsonObject(with: payloadData) as? [String: Any] else {
@@ -95,31 +100,19 @@ public final class EudiOfferFlow {
               let components = URLComponents(url: offerURI, resolvingAgainstBaseURL: false),
               let credentialOfferRaw = components.queryItems?.first(where: { $0.name == "credential_offer" })?.value,
               let credentialData = credentialOfferRaw.data(using: .utf8),
-              var offerJSON = try JSONSerialization.jsonObject(with: credentialData) as? [String: Any] else {
+              let offerJSON = try JSONSerialization.jsonObject(with: credentialData) as? [String: Any] else {
             throw NSError(domain: "WalletE2E", code: 211, userInfo: [NSLocalizedDescriptionKey: "Missing credential_offer payload"])
         }
 
-        guard var grants = offerJSON["grants"] as? [String: Any],
-              var preAuth = grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"] as? [String: Any] else {
+        guard let grants = offerJSON["grants"] as? [String: Any],
+              let preAuth = grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"] as? [String: Any] else {
             throw NSError(domain: "WalletE2E", code: 212, userInfo: [NSLocalizedDescriptionKey: "Missing pre-authorized grant"])
         }
-
-        var txCode = (preAuth["tx_code"] as? [String: Any]) ?? [:]
-        txCode["value"] = txCodeValue
-        preAuth["tx_code"] = txCode
-        grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"] = preAuth
-        offerJSON["grants"] = grants
-
-        let updated = try jsonString(offerJSON)
-        var out = URLComponents()
-        out.scheme = offerURI.scheme ?? "openid-credential-offer"
-        out.host = "credential_offer"
-        out.queryItems = [URLQueryItem(name: "credential_offer", value: updated)]
-
-        guard let finalURL = out.url?.absoluteString else {
-            throw NSError(domain: "WalletE2E", code: 213, userInfo: [NSLocalizedDescriptionKey: "Failed to build offer URL"])
+        let txCodeMetadata = preAuth["tx_code"] as? [String: Any]
+        guard txCodeMetadata?["value"] == nil else {
+            throw NSError(domain: "WalletE2E", code: 213, userInfo: [NSLocalizedDescriptionKey: "EUDI credential offer embedded a transaction code value"])
         }
-        return finalURL
+        return EudiGeneratedOffer(offerUrl: urlData, txCode: txCodeValue)
     }
 
     private func extractPayload(page: String) throws -> String {
@@ -145,11 +138,6 @@ public final class EudiOfferFlow {
             return v
         }
         throw EudiOfferFlowError.missingUserID
-    }
-
-    private func jsonString(_ object: Any) throws -> String {
-        let data = try JSONSerialization.data(withJSONObject: object, options: [])
-        return String(data: data, encoding: .utf8) ?? "{}"
     }
 
     private func unescapedHTML(_ value: String) -> String {

--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/EudiOfferFlow.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/EudiOfferFlow.swift
@@ -108,9 +108,8 @@ public final class EudiOfferFlow {
               let preAuth = grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"] as? [String: Any] else {
             throw NSError(domain: "WalletE2E", code: 212, userInfo: [NSLocalizedDescriptionKey: "Missing pre-authorized grant"])
         }
-        let txCodeMetadata = preAuth["tx_code"] as? [String: Any]
-        guard txCodeMetadata?["value"] == nil else {
-            throw NSError(domain: "WalletE2E", code: 213, userInfo: [NSLocalizedDescriptionKey: "EUDI credential offer embedded a transaction code value"])
+        guard preAuth["tx_code"] is [String: Any] else {
+            throw NSError(domain: "WalletE2E", code: 213, userInfo: [NSLocalizedDescriptionKey: "Missing tx_code metadata"])
         }
         return EudiGeneratedOffer(offerUrl: urlData, txCode: txCodeValue)
     }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
@@ -13,19 +13,13 @@ actor EudiTestBackend {
         self.offerFlow = EudiOfferFlow(client: client)
     }
 
-    struct GeneratedOffer {
-        let offerUrl: String
-        let txCode: String
-    }
-
     struct VerifierTransaction {
         let transactionId: String
         let authorizationRequestUri: String
     }
 
-    func generateOffer(credentialId: String = "eu.europa.ec.eudi.pid_vc_sd_jwt") async throws -> GeneratedOffer {
-        let offer = try await offerFlow.generate(credentialID: credentialId)
-        return GeneratedOffer(offerUrl: offer.offerUrl, txCode: offer.txCode)
+    func generateOffer(credentialId: String = "eu.europa.ec.eudi.pid_vc_sd_jwt") async throws -> EudiGeneratedOffer {
+        try await offerFlow.generate(credentialID: credentialId)
     }
 
     func extractCredentialIdFromOfferUrl(offerUrl: String) -> String {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
@@ -15,7 +15,7 @@ actor EudiTestBackend {
 
     struct GeneratedOffer {
         let offerUrl: String
-        let txCode: String?
+        let txCode: String
     }
 
     struct VerifierTransaction {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
@@ -24,21 +24,8 @@ actor EudiTestBackend {
     }
 
     func generateOffer(credentialId: String = "eu.europa.ec.eudi.pid_vc_sd_jwt") async throws -> GeneratedOffer {
-        let offerUrl = try await offerFlow.generate(credentialID: credentialId)
-        // Extract tx_code from the offer URL
-        guard let url = URL(string: offerUrl),
-              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              let offerParam = components.queryItems?.first(where: { $0.name == "credential_offer" })?.value,
-              let offerData = offerParam.data(using: .utf8),
-              let offerJson = try? JSONSerialization.jsonObject(with: offerData) as? [String: Any],
-              let grants = offerJson["grants"] as? [String: Any],
-              let preAuth = grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"] as? [String: Any],
-              let txCodeDict = preAuth["tx_code"] as? [String: Any],
-              let txCodeValue = txCodeDict["value"] as? String else {
-            return GeneratedOffer(offerUrl: offerUrl, txCode: nil)
-        }
-
-        return GeneratedOffer(offerUrl: offerUrl, txCode: txCodeValue)
+        let offer = try await offerFlow.generate(credentialID: credentialId)
+        return GeneratedOffer(offerUrl: offer.offerUrl, txCode: offer.txCode)
     }
 
     func extractCredentialIdFromOfferUrl(offerUrl: String) -> String {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -180,7 +180,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet.receive(offer: offerURL)
+        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
 
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one credential")
     }
@@ -205,7 +205,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet.receive(offer: offerURL)
+        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one credential")
 
         let credentials = try await wallet.credentials()
@@ -239,7 +239,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet.receive(offer: offerURL)
+        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one EUDI credential")
 
         let credentialId = await EudiTestBackend.shared.extractCredentialIdFromOfferUrl(offerUrl: offer.offerUrl)
@@ -296,7 +296,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet1.receive(offer: offerURL)
+        let credentialIDs = try await wallet1.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one credential")
 
         // Recreate wallet facade (simulates app restart)

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -180,7 +180,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
+        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: offer.txCode)
 
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one credential")
     }
@@ -205,7 +205,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
+        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: offer.txCode)
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one credential")
 
         let credentials = try await wallet.credentials()
@@ -239,7 +239,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
+        let credentialIDs = try await wallet.receive(offer: offerURL, txCode: offer.txCode)
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one EUDI credential")
 
         let credentialId = await EudiTestBackend.shared.extractCredentialIdFromOfferUrl(offerUrl: offer.offerUrl)
@@ -296,7 +296,7 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
         let offer = try await EudiTestBackend.shared.generateOffer()
         let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
-        let credentialIDs = try await wallet1.receive(offer: offerURL, txCode: try XCTUnwrap(offer.txCode))
+        let credentialIDs = try await wallet1.receive(offer: offerURL, txCode: offer.txCode)
         XCTAssertFalse(credentialIDs.isEmpty, "Should receive at least one credential")
 
         // Recreate wallet facade (simulates app restart)

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
@@ -14,5 +14,8 @@ kotlin {
             implementation(identityLibs.ktor.client.core)
             implementation(identityLibs.kotlinx.serialization.json)
         }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
@@ -129,15 +129,13 @@ object EudiTestBackend {
         val credentialOffer = Url(offerUrl).parameters["credential_offer"]
             ?.let { Json.parseToJsonElement(it).jsonObject }
             ?: error("credential_offer query parameter missing from url_data")
-        val txCode = credentialOffer["grants"]
+        credentialOffer["grants"]
             ?.jsonObject
             ?.get("urn:ietf:params:oauth:grant-type:pre-authorized_code")
             ?.jsonObject
             ?.get("tx_code")
             ?.jsonObject
-        require(txCode == null || "value" !in txCode) {
-            "EUDI credential offer must not embed a transaction code value"
-        }
+            ?: error("credential offer missing tx_code metadata")
 
         return GeneratedOffer(offerUrl = offerUrl, txCode = txCodeValue)
     }

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
@@ -33,7 +33,7 @@ object EudiTestBackend {
         }
     }
 
-    data class GeneratedOffer(val offerUrl: String, val txCode: String?)
+    data class GeneratedOffer(val offerUrl: String, val txCode: String)
 
     data class VerifierTransaction(val transactionId: String, val authorizationRequestUri: String)
 
@@ -123,6 +123,7 @@ object EudiTestBackend {
 
     internal fun generatedOfferFromFinalPayload(finalPayload: JsonObject): GeneratedOffer {
         val txCodeValue = finalPayload["tx_code"]?.jsonPrimitive?.content
+            ?: error("final payload missing tx_code")
         val offerUrl = finalPayload["url_data"]?.jsonPrimitive?.content
             ?: error("final payload missing url_data")
         val credentialOffer = Url(offerUrl).parameters["credential_offer"]

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
@@ -118,30 +118,27 @@ object EudiTestBackend {
 
         // Step 7: Extract final payload with tx_code and url_data
         val finalPayload = Json.parseToJsonElement(extractPayload(offerBody)).jsonObject
+        return generatedOfferFromFinalPayload(finalPayload)
+    }
+
+    internal fun generatedOfferFromFinalPayload(finalPayload: JsonObject): GeneratedOffer {
         val txCodeValue = finalPayload["tx_code"]?.jsonPrimitive?.content
-        val urlData = finalPayload["url_data"]?.jsonPrimitive?.content
+        val offerUrl = finalPayload["url_data"]?.jsonPrimitive?.content
             ?: error("final payload missing url_data")
-
-        // Step 8: Parse credential_offer, inject tx_code
-        val credentialOfferParam = Url(urlData).parameters["credential_offer"]
+        val credentialOffer = Url(offerUrl).parameters["credential_offer"]
+            ?.let { Json.parseToJsonElement(it).jsonObject }
             ?: error("credential_offer query parameter missing from url_data")
-        val offerJson = Json.parseToJsonElement(credentialOfferParam).jsonObject.toMutableMap()
-
-        if (txCodeValue != null) {
-            val grants = offerJson["grants"]?.jsonObject?.toMutableMap() ?: mutableMapOf()
-            val preAuth = grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
-                ?.jsonObject?.toMutableMap() ?: mutableMapOf()
-            val txCode = preAuth["tx_code"]?.jsonObject?.toMutableMap() ?: mutableMapOf()
-            txCode["value"] = JsonPrimitive(txCodeValue)
-            preAuth["tx_code"] = JsonObject(txCode)
-            grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"] = JsonObject(preAuth)
-            offerJson["grants"] = JsonObject(grants)
+        val txCode = credentialOffer["grants"]
+            ?.jsonObject
+            ?.get("urn:ietf:params:oauth:grant-type:pre-authorized_code")
+            ?.jsonObject
+            ?.get("tx_code")
+            ?.jsonObject
+        require(txCode == null || "value" !in txCode) {
+            "EUDI credential offer must not embed a transaction code value"
         }
 
-        val encodedOffer = JsonObject(offerJson).toString().encodeURLParameter()
-        val injectedOfferUrl = "openid-credential-offer://credential_offer?credential_offer=$encodedOffer"
-
-        return GeneratedOffer(offerUrl = injectedOfferUrl, txCode = txCodeValue)
+        return GeneratedOffer(offerUrl = offerUrl, txCode = txCodeValue)
     }
 
     suspend fun createVerifierTransaction(credentialId: String = "eu.europa.ec.eudi.pid_vc_sd_jwt"): VerifierTransaction {

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
@@ -50,4 +50,28 @@ class EudiTestBackendTest {
             EudiTestBackend.generatedOfferFromFinalPayload(payload)
         }
     }
+
+    @Test
+    fun rejectsOfferWithoutTransactionCodeMetadata() {
+        val offerJson = """
+            {
+              "credential_issuer": "https://issuer.example",
+              "credential_configuration_ids": ["credential-id"],
+              "grants": {
+                "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                  "pre-authorized_code": "pre-authorized-code"
+                }
+              }
+            }
+        """.trimIndent()
+        val offerUrl = "openid-credential-offer://credential_offer?credential_offer=${offerJson.encodeURLParameter()}"
+        val payload = buildJsonObject {
+            put("url_data", JsonPrimitive(offerUrl))
+            put("tx_code", JsonPrimitive("1234"))
+        }
+
+        assertFailsWith<IllegalStateException> {
+            EudiTestBackend.generatedOfferFromFinalPayload(payload)
+        }
+    }
 }

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
@@ -1,0 +1,40 @@
+package id.walt.mobile.test.backend
+
+import io.ktor.http.encodeURLParameter
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EudiTestBackendTest {
+    @Test
+    fun preservesStandardOfferAndReturnsTransactionCodeSeparately() {
+        val offerJson = """
+            {
+              "credential_issuer": "https://issuer.example",
+              "credential_configuration_ids": ["credential-id"],
+              "grants": {
+                "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                  "pre-authorized_code": "pre-authorized-code",
+                  "tx_code": {
+                    "input_mode": "numeric",
+                    "length": 4,
+                    "description": "Enter the separately delivered code"
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+        val offerUrl = "openid-credential-offer://credential_offer?credential_offer=${offerJson.encodeURLParameter()}"
+        val payload = buildJsonObject {
+            put("url_data", JsonPrimitive(offerUrl))
+            put("tx_code", JsonPrimitive("1234"))
+        }
+
+        val generated = EudiTestBackend.generatedOfferFromFinalPayload(payload)
+
+        assertEquals(offerUrl, generated.offerUrl)
+        assertEquals("1234", generated.txCode)
+    }
+}

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class EudiTestBackendTest {
     @Test
@@ -36,5 +37,17 @@ class EudiTestBackendTest {
 
         assertEquals(offerUrl, generated.offerUrl)
         assertEquals("1234", generated.txCode)
+    }
+
+    @Test
+    fun rejectsPayloadWithoutSeparatelyDeliveredTransactionCode() {
+        val offerUrl = "openid-credential-offer://credential_offer?credential_offer={}".encodeURLParameter()
+        val payload = buildJsonObject {
+            put("url_data", JsonPrimitive(offerUrl))
+        }
+
+        assertFailsWith<IllegalStateException> {
+            EudiTestBackend.generatedOfferFromFinalPayload(payload)
+        }
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -369,9 +369,6 @@ object WalletIssuanceHandler {
             onAttestationObtained = { onEvent(WalletSessionEvent.issuance_attestation_obtained) },
         )
 
-        val effectiveTxCode = request.txCode
-            ?: preAuthGrant.txCode?.value?.content
-
         val anonymousPreAuthorizedCode =
             asMetadata.preAuthorizedGrantAnonymousAccessSupported == true &&
                     request.tokenRequestHeaders.isEmpty() &&
@@ -380,7 +377,7 @@ object WalletIssuanceHandler {
         val tokenResponse = tokenBuilder.exchangePreAuthorizedCode(
             tokenEndpoint = tokenEndpoint,
             preAuthorizedCode = preAuthGrant.preAuthorizedCode,
-            txCode = effectiveTxCode,
+            txCode = request.txCode,
             additionalHeaders = request.tokenRequestHeaders,
             attestationHeaders = attestationHeaders,
             anonymous = anonymousPreAuthorizedCode,

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/offers/CredentialOffer.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/offers/CredentialOffer.kt
@@ -4,7 +4,6 @@ import id.walt.openid4vci.GrantType
 import io.ktor.http.Url
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 data class CredentialOffer(
@@ -129,7 +128,6 @@ data class TxCode(
     val inputMode: String? = null,
     val length: Int? = null,
     val description: String? = null,
-    val value: JsonPrimitive? = null,
 )
 
 private const val GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/offers/CredentialOfferTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonTest/kotlin/id/walt/openid4vci/offers/CredentialOfferTest.kt
@@ -1,7 +1,8 @@
 package id.walt.openid4vci.offers
 
-import kotlinx.serialization.json.Json
+import id.walt.openid4vci.GrantType
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -10,7 +11,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import id.walt.openid4vci.GrantType
 
 class CredentialOfferTest {
 
@@ -198,9 +198,11 @@ class CredentialOfferTest {
         assertEquals("numeric", txCode["input_mode"]?.jsonPrimitive?.content)
         assertEquals(6, txCode["length"]?.jsonPrimitive?.content?.toInt())
         assertEquals("Enter the code from your device", txCode["description"]?.jsonPrimitive?.content)
+        assertTrue("value" !in txCode)
     }
+
     @Test
-    fun `credential offer deserializes tx_code with embedded value`() {
+    fun `strict decoding rejects embedded transaction code value`() {
         val payload = """
         {
           "credential_issuer": "https://issuer.example",
@@ -211,7 +213,6 @@ class CredentialOfferTest {
               "tx_code": {
                 "input_mode": "numeric",
                 "length": 4,
-                "description": "Enter the PIN",
                 "value": "1234"
               }
             }
@@ -219,36 +220,8 @@ class CredentialOfferTest {
         }
         """.trimIndent()
 
-        val offer = json.decodeFromString(CredentialOffer.serializer(), payload)
-        val txCode = offer.grants?.preAuthorizedCode?.txCode
-        assertNotNull(txCode)
-        assertEquals("numeric", txCode.inputMode)
-        assertEquals(4, txCode.length)
-        assertEquals("1234", txCode.value?.content)
-    }
-
-    @Test
-    fun `credential offer deserializes tx_code with numeric value`() {
-        val payload = """
-        {
-          "credential_issuer": "https://issuer.example",
-          "credential_configuration_ids": ["cred-id-1"],
-          "grants": {
-            "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
-              "pre-authorized_code": "pre-auth-456",
-              "tx_code": {
-                "input_mode": "numeric",
-                "length": 4,
-                "value": 5678
-              }
-            }
-          }
+        assertFailsWith<SerializationException> {
+            json.decodeFromString(CredentialOffer.serializer(), payload)
         }
-        """.trimIndent()
-
-        val offer = json.decodeFromString(CredentialOffer.serializer(), payload)
-        val txCode = offer.grants?.preAuthorizedCode?.txCode
-        assertNotNull(txCode)
-        assertEquals("5678", txCode.value?.content)
     }
 }


### PR DESCRIPTION
## Summary

This removes the non-standard `tx_code.value` shortcut from OpenID4VCI credential offers. Transaction-code metadata remains in the offer as defined by OpenID4VCI, while the actual code is delivered separately and supplied explicitly during the token request.

The EUDI test backend already returns the untouched offer in `url_data` and the code separately in `tx_code`. The Kotlin and Swift test helpers now preserve that response shape instead of rewriting the offer, so integration tests exercise the same contract as real wallet clients.

## What Changed

### OpenID4VCI and wallet core

- Removes the non-standard `TxCode.value` property from the OpenID4VCI model.
- Removes the wallet fallback that read a transaction-code value from credential-offer metadata.
- Continues to serialize the standard `input_mode`, `length`, and `description` metadata fields.
- Adds focused coverage proving that standard offers omit values and that strict decoding rejects the non-standard field.

### Mobile EUDI fixtures

- Returns the original EUDI `url_data` offer and separately returned transaction code from the Kotlin and Swift helpers.
- Stops reconstructing or mutating credential-offer URLs.
- Passes the separate code explicitly in native iOS integration tests.
- Adds Kotlin fixture coverage asserting that the original offer URL is preserved unchanged.

## Architecture Notes

- The transaction-code value is runtime input for the token request, not credential-offer metadata.
- This is intentionally a narrow prerequisite for [#1913](https://github.com/walt-id/waltid-identity/pull/1913). Mobile prompting, validation, retry behavior, and receive-flow state remain in that PR.
- No core resolve-offer or REST response contract is changed.

## Caveats and Follow-Ups

- EUDI-backed integration coverage still depends on the availability and behavior of the public EUDI test services.

## Breaking Changes

- `TxCode.value` is removed from the Kotlin OpenID4VCI model, which is source- and binary-incompatible for callers using that non-standard property or constructor argument.
- Callers that relied on an embedded transaction-code value must pass the code explicitly when receiving the credential.
