### PR TITLE
[WAL-1184] Fix Compose iOS test setup after PIN merge

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileUiTest/kotlin/id/walt/walletdemo/compose/ui/WalletDemoAppTestScenarios.kt
@@ -224,7 +224,7 @@ class WalletDemoAppTestScenarios {
 
     fun transactionCodeOfferCanBeDeclinedWithoutCode() = runComposeUiTest {
         val wallet = FakeDemoWallet(transactionCodeRequired = true)
-        val controller = WalletDemoController(wallet)
+        val controller = WalletDemoController(wallet, InMemoryDemoPinStore())
 
         setContent { WalletDemoApp(controller) }
         unlockWithPin()


### PR DESCRIPTION
## Summary

Fixes the post-merge iOS simulator CI failure from [run 29562309025 / job 87827224109](https://github.com/walt-id/waltid-identity/actions/runs/29562309025/job/87827224109).

The merge of [walt-id/waltid-identity#1912](https://github.com/walt-id/waltid-identity/pull/1912) combined the new required `DemoPinStore` constructor dependency with a newer Compose UI test scenario from `main` that still used the old `WalletDemoController(wallet)` call. This PR updates that scenario to use `InMemoryDemoPinStore()`, matching the rest of the mobile UI tests.

## What Changed

- Pass an in-memory PIN store to the transaction-code decline scenario.
- Keep the fix limited to test setup for the Compose wallet demo.

## Caveats and Follow-Ups

- None for this hotfix; it only restores the iOS simulator test compile path.

## Breaking

- None.