### PR TITLE
[WAL-1158] fix(openid4vci): align wallet nonce handling with 1.0

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
@@ -585,6 +585,17 @@ object Wallet2RouteHandler {
                         )
                     }
 
+                    post("/request-nonce", {
+                        summary = "Isolated: obtain a fresh credential proof nonce"
+                        request { pathParameter<String>("walletId"); body<RequestNonceRequest>() }
+                        response { HttpStatusCode.OK to { body<RequestNonceResult>() } }
+                    }) {
+                        val req = call.receive<RequestNonceRequest>()
+                        call.respond(
+                            WalletIssuanceHandler.requestNonce(request = req)
+                        )
+                    }
+
                     post("/sign-proof", {
                         summary = "Isolated: sign a proof-of-possession JWT"
                         request { pathParameter<String>("walletId"); body<SignProofRequest>() }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
@@ -3,6 +3,7 @@ package id.walt.wallet2.server.handlers
 import id.walt.crypto.keys.KeyManager
 import id.walt.crypto.keys.TypedKeyGenerationRequest
 import id.walt.did.dids.DidService
+import id.walt.openid4vci.errors.CredentialError
 import id.walt.wallet2.data.*
 import id.walt.wallet2.handlers.*
 import id.walt.verifier.openid.transactiondata.TransactionDataTypeRegistry
@@ -609,13 +610,23 @@ object Wallet2RouteHandler {
                     post("/fetch-credential", {
                         summary = "Isolated: fetch a credential from the issuer's credential endpoint"
                         description = "When storeInWallet is true the fetched credential(s) are automatically " +
-                                "stored in the wallet, removing the need to call the import endpoint afterwards."
+                                "stored in the wallet, removing the need to call the import endpoint afterwards. " +
+                                "If the issuer returns invalid_nonce, request a fresh nonce, sign a new proof, " +
+                                "and repeat this isolated fetch step."
                         request { pathParameter<String>("walletId"); body<FetchCredentialRequest>() }
-                        response { HttpStatusCode.OK to { body<FetchCredentialResult>() } }
+                        response {
+                            HttpStatusCode.OK to { body<FetchCredentialResult>() }
+                            HttpStatusCode.BadRequest to { body<CredentialError>() }
+                        }
                     }) {
                         val wallet = call.resolveOrRespond(resolver, getAccountId) ?: return@post
                         val req = call.receive<FetchCredentialRequest>()
-                        call.respond(WalletIssuanceHandler.fetchCredential(wallet, req))
+                        try {
+                            call.respond(WalletIssuanceHandler.fetchCredential(wallet, req))
+                        } catch (error: CredentialEndpointException) {
+                            if (!error.isInvalidNonce) throw error
+                            call.respond(HttpStatusCode.BadRequest, requireNotNull(error.credentialError))
+                        }
                     }
 
                     // Auth-code grant isolated steps

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -23,6 +23,7 @@ import id.waltid.openid4vci.wallet.attestation.ClientAttestationAssembler
 import id.waltid.openid4vci.wallet.attestation.ClientAttestationHeaders
 import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
 import id.waltid.openid4vci.wallet.metadata.OfferedCredentialResolver
+import id.waltid.openid4vci.wallet.nonce.NonceRequestBuilder
 import id.waltid.openid4vci.wallet.oauth.ClientConfiguration
 import id.waltid.openid4vci.wallet.offer.CredentialOfferParser
 import id.waltid.openid4vci.wallet.offer.CredentialOfferResolver
@@ -198,6 +199,7 @@ data class ResolveOfferResult(
     val credentialEndpoint: Url,
     val offeredCredentials: List<String>,
     val tokenEndpoint: Url? = null,
+    val nonceEndpoint: Url? = null,
 )
 
 /** A credential-offer preview and the opaque handle required to act on that review. */
@@ -258,14 +260,28 @@ data class RequestTokenRequest(
 @Serializable
 data class RequestTokenResult(
     val accessToken: String,
-    val cNonce: String? = null,
     val expiresIn: Long? = null
+) {
+    override fun toString(): String =
+        "RequestTokenResult(accessToken=<redacted>, expiresIn=$expiresIn)"
+}
+
+@Serializable
+data class RequestNonceRequest(
+    val credentialIssuer: Url,
 )
+
+@Serializable
+data class RequestNonceResult(
+    val nonce: String?,
+) {
+    override fun toString(): String = "RequestNonceResult(nonce=<redacted>)"
+}
 
 @Serializable
 data class SignProofRequest(
     val issuerUrl: Url,
-    val nonce: String,
+    val nonce: String? = null,
     /** Inline key to sign the proof with; takes precedence over [keyId]. */
     val key: DirectSerializedKey? = null,
     val keyId: String? = null,
@@ -328,6 +344,7 @@ data class GenerateAuthorizationUrlResult(
     val codeVerifier: String? = null,
     val credentialConfigurationId: String,
     val credentialIssuerBaseUrl: String,
+    val nonceEndpoint: Url? = null,
 )
 
 @Serializable
@@ -356,7 +373,7 @@ object WalletIssuanceHandler {
     private val lenientJson = Json { ignoreUnknownKeys = true; encodeDefaults = false }
     private val previewedOffers = PreviewSessionStore<ResolvedIssuanceOffer>(sessionName = "Issuance")
 
-    /** HTTP redirect status codes that the wallet should follow for credential/nonce endpoints. */
+    /** Existing redirect handling for credential endpoint POSTs; nonce requests never use this path. */
     private val REDIRECT_STATUS_CODES = setOf(301, 302, 303, 307, 308)
 
     /**
@@ -397,7 +414,7 @@ object WalletIssuanceHandler {
      * Builds a proof JWT, choosing DID-based binding when [did] is non-null, or JWK-inclusion
      * otherwise. Extracted to eliminate three identical `if (did != null)` proof-building blocks.
      */
-    private suspend fun JwtProofBuilder.buildProof(key: Key, issuer: String, nonce: String, did: String?) =
+    private suspend fun JwtProofBuilder.buildProof(key: Key, issuer: String, nonce: String?, did: String?) =
         if (did != null) buildJwtProof(key, issuer, nonce, keyId = did)
         else buildJwtProof(key, issuer, nonce, includeJwk = true)
 
@@ -521,25 +538,18 @@ object WalletIssuanceHandler {
             attestationHeaders = attestationHeaders,
             anonymous = anonymousPreAuthorizedCode,
         )
-        log.trace { "Token obtained, c_nonce=${tokenResponse.c_nonce}" }
+        log.trace { "Token obtained" }
         onEvent(WalletSessionEvent.issuance_token_obtained)
-
-        // 5. Fetch c_nonce
-        val cNonce = issuerMetadata.nonceEndpoint
-            ?.let { fetchCNonce(httpClient, it) }
-            ?: tokenResponse.c_nonce
-        log.trace { "Using nonce: $cNonce (from ${if (issuerMetadata.nonceEndpoint != null) "nonce endpoint" else "token response"})" }
 
         val credentialEndpoint = issuerMetadata.credentialEndpoint
         log.trace { "Credential endpoint: $credentialEndpoint" }
 
-        // 6. Issue each offered credential
+        // 5. Issue each offered credential with a fresh nonce when proof is required.
         for (offeredCredential in offeredCredentials) {
             log.trace { "Issuing credential configId=${offeredCredential.credentialConfigurationId}, format=${offeredCredential.configuration.format}" }
             val proofs = if (offeredCredential.configuration.proofTypesSupported?.isNotEmpty() == true) {
-                val nonce = cNonce
-                    ?: error("Issuer requires proof but did not provide a c_nonce")
-                log.trace { "Building proof JWT, did=$did, nonce=$nonce" }
+                val nonce = requestProofNonce(httpClient, issuerMetadata)
+                log.trace { "Building credential proof JWT" }
                 val preferJwkBinding =
                     shouldPreferJwkBinding(offeredCredential.configuration.cryptographicBindingMethodsSupported)
                 if (did != null && !preferJwkBinding) {
@@ -548,7 +558,7 @@ object WalletIssuanceHandler {
                     proofBuilder.buildJwtProof(key, offer.credentialIssuer, nonce, includeJwk = true)
                 }
             } else null
-            log.trace { "Proof JWT present: ${proofs?.jwt?.firstOrNull()?.take(40)}..." }
+            log.trace { "Proof JWT present: ${proofs?.jwt?.isNotEmpty() == true}" }
             onEvent(WalletSessionEvent.issuance_proof_signed)
 
             // Build the credential request JSON manually to ensure proofs serializes correctly.
@@ -562,7 +572,7 @@ object WalletIssuanceHandler {
                     }
                 }
             }
-            log.trace { "Posting to credential endpoint: ${credentialRequestJson.toString().take(200)}" }
+            log.trace { "Posting credential request" }
 
             val credentialResponse = postFollowingRedirects(httpClient, credentialEndpoint) {
                 header(HttpHeaders.Authorization, "Bearer ${tokenResponse.access_token}")
@@ -582,7 +592,7 @@ object WalletIssuanceHandler {
                 // Deferred issuance: the issuer accepted the request but will issue the credential later.
                 // The transactionId can be used to poll the deferred credential endpoint.
                 val transactionId = credentialResponse.transactionId
-                log.info { "Deferred issuance: credential for '${offeredCredential.credentialConfigurationId}' will be available later. transactionId=$transactionId" }
+                log.info { "Deferred issuance: credential for '${offeredCredential.credentialConfigurationId}' will be available later" }
                 if (transactionId != null) {
                     onDeferredTransactionId(offeredCredential.credentialConfigurationId, transactionId)
                 }
@@ -619,7 +629,7 @@ object WalletIssuanceHandler {
             attestationAssembler,
             onEvent,
             httpClient,
-            onDeferredTransactionId = { configId, txId -> deferredIds[configId] = txId }
+            onDeferredTransactionId = { configId, txId -> deferredIds[configId] = txId },
         ).collect { ids += it.id }
         return ReceiveCredentialResult(credentialIds = ids, deferredTransactionIds = deferredIds)
     }
@@ -704,6 +714,7 @@ object WalletIssuanceHandler {
                 tokenEndpoint = asMetadata.tokenEndpoint?.let { Url(it) },
                 credentialEndpoint = Url(issuerMetadata.credentialEndpoint),
                 offeredCredentials = offeredCredentials.map { it.credentialConfigurationId },
+                nonceEndpoint = issuerMetadata.nonceEndpoint?.let { Url(it) },
             ),
             offer = offer,
             issuerMetadata = issuerMetadata,
@@ -807,8 +818,21 @@ object WalletIssuanceHandler {
         )
         return RequestTokenResult(
             accessToken = tokenResponse.access_token,
-            cNonce = tokenResponse.c_nonce,
             expiresIn = tokenResponse.expires_in
+        )
+    }
+
+    suspend fun requestNonce(
+        request: RequestNonceRequest,
+        httpClient: HttpClient = defaultHttpClient(),
+    ): RequestNonceResult {
+        val issuerMetadata = IssuerMetadataResolver(httpClient)
+            .resolveCredentialIssuerMetadata(request.credentialIssuer.toString())
+        return RequestNonceResult(
+            nonce = requestProofNonce(
+                httpClient = httpClient,
+                issuerMetadata = issuerMetadata,
+            )
         )
     }
 
@@ -949,16 +973,13 @@ object WalletIssuanceHandler {
         return response
     }
 
-    private suspend fun fetchCNonce(httpClient: HttpClient, nonceEndpoint: String): String? =
-        runCatching {
-            val response = postFollowingRedirects(httpClient, nonceEndpoint) {
-                contentType(ContentType.Application.Json)
-            }
-            if (response.status.isSuccess()) {
-                response.body<JsonObject>()["c_nonce"]
-                    ?.let { (it as? JsonPrimitive)?.content }
-            } else null
-        }.getOrNull()
+    private suspend fun requestProofNonce(
+        httpClient: HttpClient,
+        issuerMetadata: CredentialIssuerMetadata,
+    ): String? = issuerMetadata.nonceEndpoint
+        ?.let {
+            NonceRequestBuilder(httpClient).requestNonce(it).cNonce
+        }
 
     private fun shouldPreferJwkBinding(
         methods: Set<CryptographicBindingMethod>?
@@ -1012,6 +1033,7 @@ object WalletIssuanceHandler {
             codeVerifier = authRequest.pkceData?.codeVerifier,
             credentialConfigurationId = credentialConfigurationId,
             credentialIssuerBaseUrl = offer.credentialIssuer,
+            nonceEndpoint = issuerMetadata.nonceEndpoint?.let { Url(it) },
         )
     }
 
@@ -1079,7 +1101,6 @@ object WalletIssuanceHandler {
         )
         return RequestTokenResult(
             accessToken = tokenResponse.access_token,
-            cNonce = tokenResponse.c_nonce,
             expiresIn = tokenResponse.expires_in
         )
     }
@@ -1119,7 +1140,7 @@ object WalletIssuanceHandler {
                 Json.parseToJsonElement(body).jsonObject["error"]?.jsonPrimitive?.content
             }.getOrNull()
             if (errorCode == "issuance_pending") {
-                log.info { "Deferred credential not yet ready for transactionId=${request.transactionId}" }
+                log.info { "Deferred credential not yet ready" }
                 return@channelFlow
             }
             error("Deferred credential endpoint returned ${response.status}: $body")
@@ -1191,10 +1212,15 @@ object WalletIssuanceHandler {
         )
         onEvent(WalletSessionEvent.issuance_token_obtained)
 
-        // Sign proof — nonce from nonce endpoint or token response (never fall back to access_token)
-        val cNonce = nonceEndpoint?.let { fetchCNonce(httpClient, it) }
-            ?: tokenResult.cNonce
-            ?: error("Issuer did not provide a c_nonce (neither via nonce endpoint nor token response)")
+        // Resolve issuer metadata again at continuation time and use only its advertised nonce endpoint.
+        val issuerMetadata = IssuerMetadataResolver(httpClient)
+            .resolveCredentialIssuerMetadata(credentialIssuerBaseUrl)
+        nonceEndpoint?.let { expected ->
+            require(expected == issuerMetadata.nonceEndpoint) {
+                "Provided nonce endpoint does not match credential issuer metadata"
+            }
+        }
+        val cNonce = requestProofNonce(httpClient, issuerMetadata)
         val proofBuilder = JwtProofBuilder()
         val proofs = proofBuilder.buildProof(key, credentialIssuerBaseUrl, cNonce, did)
         onEvent(WalletSessionEvent.issuance_proof_signed)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -5,6 +5,8 @@ import id.walt.crypto.keys.DirectSerializedKey
 import id.walt.crypto.keys.Key
 import id.walt.openid4vci.CryptographicBindingMethod
 import id.walt.openid4vci.clientauth.ClientAuthenticationMethods
+import id.walt.openid4vci.errors.CredentialError
+import id.walt.openid4vci.errors.CredentialErrorCodes
 import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
 import id.walt.openid4vci.metadata.oauth.AuthorizationServerMetadata
 import id.walt.openid4vci.offers.CredentialOffer
@@ -312,6 +314,25 @@ data class FetchCredentialResult(
     val rawCredentials: List<String>
 )
 
+/**
+ * A sanitized failure returned by an OpenID4VCI Credential Endpoint.
+ *
+ * The response body is parsed into [credentialError] when it follows the OID4VCI error shape;
+ * raw response content, access tokens, and proof material are deliberately not retained.
+ */
+class CredentialEndpointException(
+    val statusCode: Int,
+    val credentialError: CredentialError? = null,
+) : Exception(
+    buildString {
+        append("Credential endpoint returned HTTP ").append(statusCode)
+        credentialError?.error?.let { append(" (").append(it).append(')') }
+    }
+) {
+    val isInvalidNonce: Boolean
+        get() = credentialError?.error == CredentialErrorCodes.INVALID_NONCE
+}
+
 // Deferred issuance types
 
 @Serializable
@@ -547,43 +568,32 @@ object WalletIssuanceHandler {
         // 5. Issue each offered credential with a fresh nonce when proof is required.
         for (offeredCredential in offeredCredentials) {
             log.trace { "Issuing credential configId=${offeredCredential.credentialConfigurationId}, format=${offeredCredential.configuration.format}" }
-            val proofs = if (offeredCredential.configuration.proofTypesSupported?.isNotEmpty() == true) {
-                val nonce = requestProofNonce(httpClient, issuerMetadata)
-                log.trace { "Building credential proof JWT" }
-                val preferJwkBinding =
-                    shouldPreferJwkBinding(offeredCredential.configuration.cryptographicBindingMethodsSupported)
-                if (did != null && !preferJwkBinding) {
-                    proofBuilder.buildJwtProof(key, offer.credentialIssuer, nonce, keyId = did)
-                } else {
-                    proofBuilder.buildJwtProof(key, offer.credentialIssuer, nonce, includeJwk = true)
-                }
-            } else null
-            log.trace { "Proof JWT present: ${proofs?.jwt?.isNotEmpty() == true}" }
-            onEvent(WalletSessionEvent.issuance_proof_signed)
-
-            // Build the credential request JSON manually to ensure proofs serializes correctly.
-            // Using DefaultCredentialRequest + setBody risks proofs being serialized as null
-            // due to Proofs.additional: Map<String,JsonElement> interacting with encodeDefaults=false.
-            val credentialRequestJson = buildJsonObject {
-                put("credential_configuration_id", offeredCredential.credentialConfigurationId)
-                proofs?.jwt?.firstOrNull()?.let { jwt ->
-                    putJsonObject("proofs") {
-                        put("jwt", buildJsonArray { add(JsonPrimitive(jwt)) })
+            val buildProof: (suspend (String?) -> String?)? =
+                if (offeredCredential.configuration.proofTypesSupported?.isNotEmpty() == true) {
+                    { nonce ->
+                        log.trace { "Building credential proof JWT" }
+                        val preferJwkBinding = shouldPreferJwkBinding(
+                            offeredCredential.configuration.cryptographicBindingMethodsSupported
+                        )
+                        if (did != null && !preferJwkBinding) {
+                            proofBuilder.buildJwtProof(key, offer.credentialIssuer, nonce, keyId = did).jwt?.firstOrNull()
+                        } else {
+                            proofBuilder.buildJwtProof(key, offer.credentialIssuer, nonce, includeJwk = true).jwt?.firstOrNull()
+                        }
                     }
-                }
-            }
-            log.trace { "Posting credential request" }
+                } else null
 
-            val credentialResponse = postFollowingRedirects(httpClient, credentialEndpoint) {
-                header(HttpHeaders.Authorization, "Bearer ${tokenResponse.access_token}")
-                contentType(ContentType.Application.Json)
-                setBody(credentialRequestJson.toString())
-            }.let { response ->
-                if (!response.status.isSuccess()) {
-                    error("Credential endpoint returned ${response.status}: ${response.bodyAsText()}")
-                }
-                response.body<CredentialResponse>()
-            }
+            val credentialResponse = requestCredentialWithNonceRetry(
+                request = FetchCredentialRequest(
+                    credentialEndpoint = Url(credentialEndpoint),
+                    accessToken = tokenResponse.access_token,
+                    credentialConfigurationId = offeredCredential.credentialConfigurationId,
+                ),
+                nonceEndpoint = issuerMetadata.nonceEndpoint,
+                httpClient = httpClient,
+                buildProof = buildProof,
+                onProofGenerated = { onEvent(WalletSessionEvent.issuance_proof_signed) },
+            )
             onEvent(WalletSessionEvent.issuance_credential_received)
 
             val rawCredentials = credentialResponse.credentials
@@ -844,8 +854,24 @@ object WalletIssuanceHandler {
         return SignProofResult(proofJwt = proofs.jwt?.firstOrNull() ?: error("Proof signing produced no JWT"))
     }
 
-    suspend fun fetchCredential(request: FetchCredentialRequest): FetchCredentialResult {
+    suspend fun fetchCredential(request: FetchCredentialRequest): FetchCredentialResult =
+        fetchCredential(request, defaultHttpClient())
 
+    internal suspend fun fetchCredential(
+        request: FetchCredentialRequest,
+        httpClient: HttpClient,
+    ): FetchCredentialResult {
+        val credentialResponse = requestCredential(request, httpClient)
+        val rawCredentials = credentialResponse.credentials
+            ?.map { it.credential.let { c -> if (c is JsonPrimitive) c.content else c.toString() } }
+            ?: error("Credential response contained no credentials")
+        return FetchCredentialResult(rawCredentials = rawCredentials)
+    }
+
+    private suspend fun requestCredential(
+        request: FetchCredentialRequest,
+        httpClient: HttpClient,
+    ): CredentialResponse {
         // Build JSON manually to avoid Proofs serialization issue
         val credentialRequestJson = buildJsonObject {
             put("credential_configuration_id", request.credentialConfigurationId)
@@ -861,13 +887,47 @@ object WalletIssuanceHandler {
             setBody(credentialRequestJson.toString())
         }
         if (!response.status.isSuccess()) {
-            error("Credential endpoint returned ${response.status}: ${response.bodyAsText()}")
+            val credentialError = runCatching {
+                lenientJson.decodeFromString<CredentialError>(response.bodyAsText())
+            }.getOrNull()
+            throw CredentialEndpointException(
+                statusCode = response.status.value,
+                credentialError = credentialError,
+            )
         }
-        val credentialResponse = response.body<CredentialResponse>()
-        val rawCredentials = credentialResponse.credentials
-            ?.map { it.credential.let { c -> if (c is JsonPrimitive) c.content else c.toString() } }
-            ?: error("Credential response contained no credentials")
-        return FetchCredentialResult(rawCredentials = rawCredentials)
+        return response.body()
+    }
+
+    /**
+     * Fetches a credential with a freshly generated proof, retrying once only when the issuer
+     * explicitly rejects that proof with the OID4VCI `invalid_nonce` error.
+     *
+     * Isolated fetch callers deliberately do not use this helper: they own the separate
+     * request-nonce and sign-proof steps and therefore must handle [CredentialEndpointException]
+     * themselves.
+     */
+    internal suspend fun requestCredentialWithNonceRetry(
+        request: FetchCredentialRequest,
+        nonceEndpoint: String?,
+        httpClient: HttpClient,
+        buildProof: (suspend (String?) -> String?)?,
+        onProofGenerated: suspend () -> Unit = {},
+    ): CredentialResponse {
+        suspend fun fetchWithFreshProof(): CredentialResponse {
+            val proofJwt = buildProof?.invoke(requestProofNonce(httpClient, nonceEndpoint))
+            onProofGenerated()
+            return requestCredential(request.copy(proofJwt = proofJwt), httpClient)
+        }
+
+        return try {
+            fetchWithFreshProof()
+        } catch (error: CredentialEndpointException) {
+            if (!error.isInvalidNonce || buildProof == null || nonceEndpoint == null) {
+                throw error
+            }
+            log.info { "Credential issuer rejected the proof nonce; obtaining a fresh nonce and retrying once" }
+            fetchWithFreshProof()
+        }
     }
 
     /**
@@ -976,10 +1036,14 @@ object WalletIssuanceHandler {
     private suspend fun requestProofNonce(
         httpClient: HttpClient,
         issuerMetadata: CredentialIssuerMetadata,
-    ): String? = issuerMetadata.nonceEndpoint
-        ?.let {
-            NonceRequestBuilder(httpClient).requestNonce(it).cNonce
-        }
+    ): String? = requestProofNonce(httpClient, issuerMetadata.nonceEndpoint)
+
+    private suspend fun requestProofNonce(
+        httpClient: HttpClient,
+        nonceEndpoint: String?,
+    ): String? = nonceEndpoint?.let {
+        NonceRequestBuilder(httpClient).requestNonce(it).cNonce
+    }
 
     private fun shouldPreferJwkBinding(
         methods: Set<CryptographicBindingMethod>?
@@ -1220,24 +1284,28 @@ object WalletIssuanceHandler {
                 "Provided nonce endpoint does not match credential issuer metadata"
             }
         }
-        val cNonce = requestProofNonce(httpClient, issuerMetadata)
         val proofBuilder = JwtProofBuilder()
-        val proofs = proofBuilder.buildProof(key, credentialIssuerBaseUrl, cNonce, did)
-        onEvent(WalletSessionEvent.issuance_proof_signed)
-
-        // Fetch credential
-        val fetchResult = fetchCredential(
-            FetchCredentialRequest(
+        val credentialResponse = requestCredentialWithNonceRetry(
+            request = FetchCredentialRequest(
                 credentialEndpoint = credentialEndpoint,
                 accessToken = tokenResult.accessToken,
                 credentialConfigurationId = credentialConfigurationId,
-                proofJwt = proofs.jwt?.firstOrNull(),
-                clientId = clientId
-            )
+                clientId = clientId,
+            ),
+            nonceEndpoint = issuerMetadata.nonceEndpoint,
+            httpClient = httpClient,
+            buildProof = { nonce ->
+                proofBuilder.buildProof(key, credentialIssuerBaseUrl, nonce, did).jwt?.firstOrNull()
+            },
+            onProofGenerated = { onEvent(WalletSessionEvent.issuance_proof_signed) },
         )
         onEvent(WalletSessionEvent.issuance_credential_received)
 
-        for (rawString in fetchResult.rawCredentials) {
+        val rawCredentials = credentialResponse.credentials
+            ?.map { it.credential.let { credential -> if (credential is JsonPrimitive) credential.content else credential.toString() } }
+            ?: error("Credential response contained no credentials")
+
+        for (rawString in rawCredentials) {
             val (_, parsed) = CredentialParser.detectAndParse(rawString)
             val entry = StoredCredential(
                 id = Uuid.random().toString(),

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerInvalidNonceTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerInvalidNonceTest.kt
@@ -1,0 +1,166 @@
+package id.walt.wallet2.handlers
+
+import id.walt.openid4vci.errors.CredentialErrorCodes
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class WalletIssuanceHandlerInvalidNonceTest {
+
+    @Test
+    fun retriesOnceWithFreshNonceAndNewProof() = runTest {
+        var nonceRequests = 0
+        var credentialRequests = 0
+        val proofNonces = mutableListOf<String?>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        NONCE_ENDPOINT -> respondJson(
+                            """{"c_nonce":"${if (++nonceRequests == 1) "stale-nonce" else "fresh-nonce"}"}"""
+                        )
+
+                        CREDENTIAL_ENDPOINT -> {
+                            credentialRequests++
+                            if (credentialRequests == 1) {
+                                respondJson(
+                                    """{"error":"invalid_nonce","error_description":"Proof nonce has expired"}""",
+                                    HttpStatusCode.BadRequest,
+                                )
+                            } else {
+                                respondJson("""{"credentials":[{"credential":"issued-credential"}]}""")
+                            }
+                        }
+
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val response = WalletIssuanceHandler.requestCredentialWithNonceRetry(
+            request = fetchRequest(),
+            nonceEndpoint = NONCE_ENDPOINT,
+            httpClient = client,
+            buildProof = { nonce ->
+                proofNonces += nonce
+                "proof-for-$nonce"
+            },
+        )
+
+        assertEquals(listOf<String?>("stale-nonce", "fresh-nonce"), proofNonces)
+        assertEquals(2, nonceRequests)
+        assertEquals(2, credentialRequests)
+        assertEquals("issued-credential", response.credentials?.single()?.credential.toString().removeSurrounding("\""))
+    }
+
+    @Test
+    fun stopsAfterOneInvalidNonceRetry() = runTest {
+        var nonceRequests = 0
+        var credentialRequests = 0
+        val proofNonces = mutableListOf<String?>()
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        NONCE_ENDPOINT -> respondJson("""{"c_nonce":"nonce-${++nonceRequests}"}""")
+                        CREDENTIAL_ENDPOINT -> {
+                            credentialRequests++
+                            respondJson("""{"error":"invalid_nonce"}""", HttpStatusCode.BadRequest)
+                        }
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val failure = try {
+            WalletIssuanceHandler.requestCredentialWithNonceRetry(
+                request = fetchRequest(),
+                nonceEndpoint = NONCE_ENDPOINT,
+                httpClient = client,
+                buildProof = { nonce ->
+                    proofNonces += nonce
+                    "proof-for-$nonce"
+                },
+            )
+            fail("Expected invalid_nonce to be propagated after the retry")
+        } catch (error: CredentialEndpointException) {
+            error
+        }
+
+        assertEquals(true, failure.isInvalidNonce)
+        assertEquals(listOf<String?>("nonce-1", "nonce-2"), proofNonces)
+        assertEquals(2, nonceRequests)
+        assertEquals(2, credentialRequests)
+    }
+
+    @Test
+    fun isolatedFetchPropagatesTypedInvalidNonceWithoutRetry() = runTest {
+        var credentialRequests = 0
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    assertEquals(CREDENTIAL_ENDPOINT, request.url.toString())
+                    credentialRequests++
+                    respondJson(
+                        """{"error":"invalid_nonce","error_description":"Proof nonce has expired"}""",
+                        HttpStatusCode.BadRequest,
+                    )
+                }
+            }
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val failure = try {
+            WalletIssuanceHandler.fetchCredential(fetchRequest(), client)
+            fail("Expected invalid_nonce to be propagated")
+        } catch (error: CredentialEndpointException) {
+            error
+        }
+
+        assertEquals(HttpStatusCode.BadRequest.value, failure.statusCode)
+        assertEquals(CredentialErrorCodes.INVALID_NONCE, failure.credentialError?.error)
+        assertEquals("Proof nonce has expired", failure.credentialError?.description)
+        assertEquals(1, credentialRequests)
+    }
+
+    private fun fetchRequest() = FetchCredentialRequest(
+        credentialEndpoint = Url(CREDENTIAL_ENDPOINT),
+        accessToken = "access-token",
+        credentialConfigurationId = "pid",
+    )
+
+    private companion object {
+        const val NONCE_ENDPOINT = "https://issuer.example/nonce"
+        const val CREDENTIAL_ENDPOINT = "https://issuer.example/credential"
+    }
+}
+
+private fun io.ktor.client.engine.mock.MockRequestHandleScope.respondJson(
+    content: String,
+    status: HttpStatusCode = HttpStatusCode.OK,
+) = respond(
+    content = content,
+    status = status,
+    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerNonceTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerNonceTest.kt
@@ -1,0 +1,111 @@
+package id.walt.wallet2.handlers
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class WalletIssuanceHandlerNonceTest {
+
+    @Test
+    fun tokenResultDescriptionRedactsAccessToken() {
+        val result = RequestTokenResult(accessToken = "private-token", expiresIn = 300)
+
+        assertFalse(result.toString().contains("private-token"))
+    }
+
+    @Test
+    fun requestsNonceOnlyFromIssuerMetadata() = runTest {
+        var nonceRequests = 0
+        val client = issuerClient(nonceEndpoint = NONCE_ENDPOINT) { request ->
+            nonceRequests += 1
+            assertEquals(HttpMethod.Post, request.method)
+            assertEquals(NONCE_ENDPOINT, request.url.toString())
+            """{"c_nonce":"fresh-proof-nonce"}"""
+        }
+
+        val result = WalletIssuanceHandler.requestNonce(
+            RequestNonceRequest(Url(ISSUER)),
+            client,
+        )
+
+        assertEquals("fresh-proof-nonce", result.nonce)
+        assertEquals(1, nonceRequests)
+        assertFalse(result.toString().contains("fresh-proof-nonce"))
+    }
+
+    @Test
+    fun proofRequiredWithoutNonceEndpointReturnsNoNonce() = runTest {
+        val client = issuerClient(nonceEndpoint = null) {
+            error("Nonce endpoint must not be called")
+        }
+
+        val result = WalletIssuanceHandler.requestNonce(
+            RequestNonceRequest(Url(ISSUER)),
+            client,
+        )
+
+        assertEquals(null, result.nonce)
+    }
+
+    private fun issuerClient(
+        nonceEndpoint: String?,
+        nonceResponse: (io.ktor.client.request.HttpRequestData) -> String,
+    ): HttpClient = HttpClient(MockEngine) {
+        engine {
+            addHandler { request ->
+                when (request.url.toString()) {
+                    METADATA_ENDPOINT -> respond(
+                        content = issuerMetadata(nonceEndpoint),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+
+                    NONCE_ENDPOINT -> respond(
+                        content = nonceResponse(request),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+
+                    else -> error("Unexpected request: ${request.url}")
+                }
+            }
+        }
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+    }
+
+    private fun issuerMetadata(nonceEndpoint: String?): String = """
+        {
+          "credential_issuer": "$ISSUER",
+          "credential_endpoint": "$ISSUER/credential",
+          ${nonceEndpoint?.let { "\"nonce_endpoint\": \"$it\"," } ?: ""}
+          "credential_configurations_supported": {
+            "test": {
+              "format": "jwt_vc_json",
+              "credential_definition": {
+                "type": ["VerifiableCredential", "TestCredential"]
+              }
+            }
+          }
+        }
+    """.trimIndent()
+
+    private companion object {
+        const val ISSUER = "https://issuer.example"
+        const val METADATA_ENDPOINT = "$ISSUER/.well-known/openid-credential-issuer"
+        const val NONCE_ENDPOINT = "$ISSUER/nonce"
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/README.md
@@ -126,16 +126,22 @@ if (preAuthGrant != null) {
         txCode = null // or user-provided PIN
     )
 
-    // 7. Generate proof of possession
+    // 7. Obtain a fresh proof nonce from the issuer-advertised Nonce Endpoint
+    val nonceEndpoint = requireNotNull(issuerMetadata.nonceEndpoint) {
+        "A nonce_endpoint is required when the credential configuration requires proof"
+    }
+    val nonce = NonceRequestBuilder(httpClient).requestNonce(nonceEndpoint)
+
+    // 8. Generate proof of possession
     val key = KeyManager.loadKey("my-key-id")
     val proofBuilder = JwtProofBuilder()
     val proof = proofBuilder.buildProof(
         key = key,
         audience = offer.credentialIssuer,
-        nonce = tokenResponse.c_nonce!!
+        nonce = nonce.cNonce
     )
 
-    // 8. Request credential (Implementation coming soon)
+    // 9. Request credential (Implementation coming soon)
     // ...
 }
 ```
@@ -145,6 +151,7 @@ if (preAuthGrant != null) {
 - `oauth/` - OAuth 2.0 client components (PKCE, State management)
 - `offer/` - Credential offer parsing and resolution
 - `metadata/` - Issuer and authorization server metadata discovery
+- `nonce/` - OpenID4VCI 1.0 Nonce Endpoint requests
 - `authorization/` - Authorization request building and response parsing
 - `token/` - Token exchange logic for both grant types
 - `proof/` - Proof of possession building (JWT-based)

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/README.md
@@ -85,6 +85,7 @@ import id.waltid.openid4vci.wallet.*
 import id.waltid.openid4vci.wallet.oauth.ClientConfiguration
 import id.waltid.openid4vci.wallet.offer.*
 import id.waltid.openid4vci.wallet.metadata.*
+import id.waltid.openid4vci.wallet.nonce.NonceRequestBuilder
 import id.waltid.openid4vci.wallet.token.*
 import id.waltid.openid4vci.wallet.proof.*
 import io.ktor.client.*
@@ -126,19 +127,18 @@ if (preAuthGrant != null) {
         txCode = null // or user-provided PIN
     )
 
-    // 7. Obtain a fresh proof nonce from the issuer-advertised Nonce Endpoint
-    val nonceEndpoint = requireNotNull(issuerMetadata.nonceEndpoint) {
-        "A nonce_endpoint is required when the credential configuration requires proof"
+    // 7. Obtain a fresh proof nonce when the issuer advertises a Nonce Endpoint
+    val nonce = issuerMetadata.nonceEndpoint?.let { nonceEndpoint ->
+        NonceRequestBuilder(httpClient).requestNonce(nonceEndpoint).cNonce
     }
-    val nonce = NonceRequestBuilder(httpClient).requestNonce(nonceEndpoint)
 
-    // 8. Generate proof of possession
+    // 8. Generate proof of possession, omitting the nonce claim when none was obtained
     val key = KeyManager.loadKey("my-key-id")
     val proofBuilder = JwtProofBuilder()
     val proof = proofBuilder.buildProof(
         key = key,
         audience = offer.credentialIssuer,
-        nonce = nonce.cNonce
+        nonce = nonce
     )
 
     // 9. Request credential (Implementation coming soon)

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/nonce/NonceRequestBuilder.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/nonce/NonceRequestBuilder.kt
@@ -1,0 +1,97 @@
+package id.waltid.openid4vci.wallet.nonce
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Url
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Stable failure categories for an OpenID4VCI Nonce Endpoint request. */
+enum class NonceRequestError {
+    INVALID_ENDPOINT,
+    NETWORK,
+    ISSUER_RESPONSE,
+    INVALID_RESPONSE,
+}
+
+/** Sanitized nonce-endpoint failure that never retains response or nonce material. */
+class NonceRequestException internal constructor(
+    val error: NonceRequestError,
+    val statusCode: Int? = null,
+) : Exception(
+    buildString {
+        append("Nonce request failed: ")
+        append(error.name.lowercase())
+        statusCode?.let { append(" (HTTP ").append(it).append(')') }
+    },
+)
+
+/** OpenID4VCI 1.0 Nonce Endpoint response. */
+@Serializable
+data class NonceResponse(
+    @SerialName("c_nonce") val cNonce: String,
+) {
+    override fun toString(): String = "NonceResponse(cNonce=<redacted>)"
+}
+
+/**
+ * Obtains fresh credential-proof nonces from the issuer's advertised Nonce Endpoint.
+ */
+class NonceRequestBuilder(
+    private val httpClient: HttpClient,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    suspend fun requestNonce(nonceEndpoint: String): NonceResponse {
+        validateEndpoint(nonceEndpoint)
+        val response = send(nonceEndpoint)
+
+        if (!response.status.isSuccess()) {
+            throw NonceRequestException(NonceRequestError.ISSUER_RESPONSE, response.status.value)
+        }
+
+        val responseBody = try {
+            response.bodyAsText()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            throw NonceRequestException(NonceRequestError.NETWORK)
+        }
+        val parsed = try {
+            json.decodeFromString<NonceResponse>(responseBody)
+        } catch (_: Exception) {
+            throw NonceRequestException(NonceRequestError.INVALID_RESPONSE)
+        }
+        if (parsed.cNonce.isBlank()) {
+            throw NonceRequestException(NonceRequestError.INVALID_RESPONSE)
+        }
+        return parsed
+    }
+
+    private suspend fun send(endpoint: String): HttpResponse = try {
+        httpClient.post(endpoint) {
+            accept(ContentType.Application.Json)
+            contentType(ContentType.Application.Json)
+        }
+    } catch (error: CancellationException) {
+        throw error
+    } catch (_: Exception) {
+        throw NonceRequestException(NonceRequestError.NETWORK)
+    }
+
+    private fun validateEndpoint(endpoint: String) {
+        val url = try {
+            Url(endpoint)
+        } catch (_: Exception) {
+            throw NonceRequestException(NonceRequestError.INVALID_ENDPOINT)
+        }
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/proof/JwtProofBuilder.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/proof/JwtProofBuilder.kt
@@ -35,11 +35,11 @@ class JwtProofBuilder : ProofOfPossessionBuilder {
      * - iss: client_id or key identifier
      * - aud: credential issuer URL
      * - iat: current timestamp
-     * - nonce: c_nonce from issuer
+     * - nonce: c_nonce from issuer, when one was obtained
      * 
      * @param key The cryptographic key to use for signing
      * @param audience The credential issuer URL
-     * @param nonce The c_nonce from the issuer
+     * @param nonce The optional c_nonce obtained from the issuer's Nonce Endpoint
      * @param keyId Optional key identifier (DID) for kid header
      * @param includeJwk Whether to include the public key as JWK in the header
      * @return Proofs object containing the JWT proof
@@ -47,7 +47,7 @@ class JwtProofBuilder : ProofOfPossessionBuilder {
     suspend fun buildJwtProof(
         key: Key,
         audience: String,
-        nonce: String,
+        nonce: String?,
         keyId: String? = null,
         includeJwk: Boolean = false,
     ): Proofs {
@@ -59,7 +59,7 @@ class JwtProofBuilder : ProofOfPossessionBuilder {
         val payload = buildJsonObject {
             put("aud", audience)
             put("iat", ProofBuilderUtils.currentTimestampSeconds())
-            put("nonce", nonce)
+            nonce?.let { put("nonce", it) }
         }
 
         // Build JWT header with typ
@@ -115,7 +115,7 @@ class JwtProofBuilder : ProofOfPossessionBuilder {
     override suspend fun buildProof(
         key: Key,
         audience: String,
-        nonce: String,
+        nonce: String?,
     ): Proofs {
         // Default: try to use DID if available, otherwise use JWK
         val keyId = key.getKeyId()

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/proof/ProofOfPossessionBuilder.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/proof/ProofOfPossessionBuilder.kt
@@ -14,13 +14,13 @@ interface ProofOfPossessionBuilder {
      * 
      * @param key The cryptographic key to use for signing
      * @param audience The credential issuer URL (aud claim)
-     * @param nonce The c_nonce from the issuer
+     * @param nonce The optional c_nonce obtained from the issuer's Nonce Endpoint
      * @return Proofs object containing the proof
      */
     suspend fun buildProof(
         key: Key,
         audience: String,
-        nonce: String,
+        nonce: String?,
     ): Proofs
 
     /**
@@ -45,9 +45,9 @@ object ProofBuilderUtils {
      */
     fun validateProofParameters(
         audience: String,
-        nonce: String,
+        nonce: String?,
     ) {
         require(audience.isNotBlank()) { "Audience (issuer URL) cannot be blank" }
-        require(nonce.isNotBlank()) { "Nonce (c_nonce) cannot be blank" }
+        require(nonce == null || nonce.isNotBlank()) { "Nonce (c_nonce) cannot be blank" }
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/token/TokenRequestBuilder.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/token/TokenRequestBuilder.kt
@@ -6,13 +6,14 @@ import id.waltid.openid4vci.wallet.attestation.ClientAttestationHeaders
 import id.waltid.openid4vci.wallet.oauth.ClientConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
-import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 private val log = KotlinLogging.logger {}
+private val tokenResponseJson = Json { ignoreUnknownKeys = true }
 
 /**
  * Builds OAuth 2.0 token requests for OpenID4VCI.
@@ -36,8 +37,6 @@ class TokenRequestBuilder(
         val expires_in: Long? = null,
         val refresh_token: String? = null,
         val scope: String? = null,
-        val c_nonce: String? = null,
-        val c_nonce_expires_in: Long? = null,
         val authorization_details: List<AuthorizationDetail>? = null
     )
 
@@ -49,7 +48,7 @@ class TokenRequestBuilder(
      * @param codeVerifier The PKCE code verifier (if PKCE was used)
      * @param additionalHeaders Extra HTTP headers for token endpoint client authentication
      * @param attestationHeaders Attestation-based client authentication headers
-     * @return TokenResponse containing access token and optional c_nonce
+     * @return TokenResponse containing the OAuth access token response fields
      * @throws Exception if token request fails
      */
     suspend fun exchangeAuthorizationCode(
@@ -92,7 +91,7 @@ class TokenRequestBuilder(
      * @param additionalHeaders Extra HTTP headers for token endpoint client authentication
      * @param attestationHeaders Attestation-based client authentication headers
      * @param anonymous Whether to omit client_id for anonymous pre-authorized code token requests
-     * @return TokenResponse containing access token and optional c_nonce
+     * @return TokenResponse containing the OAuth access token response fields
      * @throws Exception if token request fails
      */
     suspend fun exchangePreAuthorizedCode(
@@ -224,18 +223,17 @@ class TokenRequestBuilder(
         }
 
         if (!response.status.isSuccess()) {
-            val errorBody = response.bodyAsText()
             log.error {
-                "Token request failed - Status: ${response.status.value} ${response.status.description}, " +
-                "Response body: ${errorBody.take(200)}${if (errorBody.length > 200) "..." else ""}"
+                "Token request failed - Status: ${response.status.value} ${response.status.description}"
             }
-            throw Exception("Token request failed. Status: ${response.status}, Body: $errorBody")
+            throw Exception("Token request failed. Status: ${response.status}")
         }
 
         log.trace { "Received successful token response (${response.status.value}), parsing" }
         
+        val responseBody = response.bodyAsText()
         return try {
-            val tokenResponse = response.body<TokenResponse>()
+            val tokenResponse = tokenResponseJson.decodeFromString<TokenResponse>(responseBody)
             log.info {
                 "Successfully obtained access token - " +
                 "Type: ${tokenResponse.token_type}, " +
@@ -244,13 +242,9 @@ class TokenRequestBuilder(
             }
             log.trace { "Token scope: ${tokenResponse.scope ?: "not specified"}" }
             tokenResponse
-        } catch (e: Exception) {
-            val responseBody = response.bodyAsText()
-            log.error(e) {
-                "Failed to parse token response - " +
-                "Body preview: ${responseBody.take(200)}${if (responseBody.length > 200) "..." else ""}"
-            }
-            throw Exception("Failed to parse token response", e)
+        } catch (_: Exception) {
+            log.error { "Failed to parse token response" }
+            throw Exception("Failed to parse token response")
         }
     }
 

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/nonce/NonceRequestBuilderTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/nonce/NonceRequestBuilderTest.kt
@@ -1,0 +1,127 @@
+package id.waltid.openid4vci.wallet.nonce
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class NonceRequestBuilderTest {
+    private fun client(
+        handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
+    ): HttpClient = HttpClient(MockEngine) {
+        engine { addHandler(handler) }
+    }
+
+    @Test
+    fun obtainsNonceAndIgnoresExtensionParameters() = runTest {
+        val builder = NonceRequestBuilder(client { request ->
+            assertEquals(NONCE_ENDPOINT, request.url.toString())
+            respond(
+                content = """{"c_nonce":"proof-nonce","c_nonce_expires_in":300}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        })
+
+        val response = builder.requestNonce(NONCE_ENDPOINT)
+
+        assertEquals("proof-nonce", response.cNonce)
+        assertFalse(response.toString().contains("proof-nonce"))
+    }
+
+    @Test
+    fun rejectsMissingOrBlankNonce() = runTest {
+        for (body in listOf("{}", """{"c_nonce":""}""")) {
+            val error = assertFailsWith<NonceRequestException> {
+                NonceRequestBuilder(client { respond(body, HttpStatusCode.OK) })
+                    .requestNonce(NONCE_ENDPOINT)
+            }
+            assertEquals(NonceRequestError.INVALID_RESPONSE, error.error)
+        }
+    }
+
+    @Test
+    fun malformedResponseDoesNotEscapeThroughException() = runTest {
+        val error = assertFailsWith<NonceRequestException> {
+            NonceRequestBuilder(client {
+                respond("""{"private":"issuer-secret"}""", HttpStatusCode.OK)
+            }).requestNonce(NONCE_ENDPOINT)
+        }
+
+        assertEquals(NonceRequestError.INVALID_RESPONSE, error.error)
+        assertFalse(error.message.orEmpty().contains("issuer-secret"))
+        assertEquals(null, error.cause)
+    }
+
+    @Test
+    fun reportsIssuerRejectionWithoutRetainingResponseBody() = runTest {
+        val error = assertFailsWith<NonceRequestException> {
+            NonceRequestBuilder(client {
+                respond("""{"error":"secret-detail"}""", HttpStatusCode.BadRequest)
+            }).requestNonce(NONCE_ENDPOINT)
+        }
+
+        assertEquals(NonceRequestError.ISSUER_RESPONSE, error.error)
+        assertEquals(400, error.statusCode)
+        assertFalse(error.message.orEmpty().contains("secret-detail"))
+    }
+
+    @Test
+    fun networkFailureDoesNotRetainSensitiveCause() = runTest {
+        val error = assertFailsWith<NonceRequestException> {
+            NonceRequestBuilder(client { error("private-network-detail") })
+                .requestNonce(NONCE_ENDPOINT)
+        }
+
+        assertEquals(NonceRequestError.NETWORK, error.error)
+        assertFalse(error.message.orEmpty().contains("private-network-detail"))
+        assertEquals(null, error.cause)
+    }
+
+    @Test
+    fun doesNotFollowRedirects() = runTest {
+        for (status in listOf(
+            HttpStatusCode.SeeOther,
+            HttpStatusCode.TemporaryRedirect,
+            HttpStatusCode.PermanentRedirect,
+        )) {
+            var calls = 0
+            val error = assertFailsWith<NonceRequestException> {
+                NonceRequestBuilder(client {
+                    calls += 1
+                    respond(
+                        content = "",
+                        status = status,
+                        headers = headersOf(HttpHeaders.Location, "$ISSUER/nonce-v2"),
+                    )
+                }).requestNonce(NONCE_ENDPOINT)
+            }
+
+            assertEquals(NonceRequestError.ISSUER_RESPONSE, error.error)
+            assertEquals(status.value, error.statusCode)
+            assertEquals(1, calls)
+        }
+    }
+
+    @Test
+    fun acceptsHttpEndpoints() = runTest {
+        val response = NonceRequestBuilder(client { request ->
+            assertEquals("http://127.0.0.1/nonce", request.url.toString())
+            respond("""{"c_nonce":"test-nonce"}""", HttpStatusCode.OK)
+        }).requestNonce("http://127.0.0.1/nonce")
+
+        assertEquals("test-nonce", response.cNonce)
+    }
+
+    private companion object {
+        const val ISSUER = "https://issuer.example"
+        const val NONCE_ENDPOINT = "$ISSUER/nonce"
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/proof/JwtProofBuilderTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/proof/JwtProofBuilderTest.kt
@@ -4,22 +4,30 @@ import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyMeta
 import id.walt.crypto.keys.KeyType
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 
 class MockKey(
     val kid: String? = null,
     override val keyType: KeyType = KeyType.Ed25519,
 ) : Key() {
+    var signedPayload: JsonObject? = null
+
     override suspend fun getKeyId(): String = kid ?: "mock-kid"
     override suspend fun getThumbprint(): String = "mock-thumbprint"
     override suspend fun exportJWK(): String = """{"kty":"OKP","crv":"Ed25519","x":"..."}"""
     override suspend fun exportJWKObject(): JsonObject = JsonObject(emptyMap())
     override val hasPrivateKey: Boolean = true
-    override suspend fun signJws(plaintext: ByteArray, headers: Map<String, JsonElement>): String = "mock.jwt.proof"
+    override suspend fun signJws(plaintext: ByteArray, headers: Map<String, JsonElement>): String {
+        signedPayload = Json.parseToJsonElement(plaintext.decodeToString()).jsonObject
+        return "mock.jwt.proof"
+    }
     override suspend fun getPublicKey(): Key = this
     override suspend fun getMeta(): KeyMeta = throw NotImplementedError()
     override suspend fun deleteKey(): Boolean = true
@@ -70,5 +78,20 @@ class JwtProofBuilderTest {
 
         assertNotNull(proof.jwt)
         assertEquals("mock.jwt.proof", proof.jwt!!.first())
+    }
+
+    @Test
+    fun proofWithoutNonceOmitsNonceClaim() = runTest {
+        val mockKey = MockKey()
+
+        val proof = builder.buildJwtProof(
+            key = mockKey,
+            audience = audience,
+            nonce = null,
+            includeJwk = true,
+        )
+
+        assertEquals("mock.jwt.proof", proof.jwt!!.first())
+        assertFalse("nonce" in requireNotNull(mockKey.signedPayload))
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/token/TokenRequestBuilderTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/token/TokenRequestBuilderTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class TokenRequestBuilderTest {
@@ -40,7 +41,7 @@ class TokenRequestBuilderTest {
         (body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
 
     @Test
-    fun testExchangeAuthorizationCodeSuccess() = runTest {
+    fun testExchangeAuthorizationCodeIgnoresTokenResponseNonceExtension() = runTest {
         val mockResponse = """
             {
                 "access_token": "test-access-token",
@@ -65,7 +66,6 @@ class TokenRequestBuilderTest {
         val response = builder.exchangeAuthorizationCode(tokenEndpoint, "test-code", "test-verifier")
 
         assertEquals("test-access-token", response.access_token)
-        assertEquals("test-nonce", response.c_nonce)
     }
 
     @Test
@@ -123,15 +123,36 @@ class TokenRequestBuilderTest {
     fun testTokenRequestFailure() = runTest {
         val client = createMockClient { _ ->
             respond(
-                content = "Invalid code",
+                content = "private-error-detail",
                 status = HttpStatusCode.BadRequest
             )
         }
 
         val builder = TokenRequestBuilder(clientConfig, client)
-        assertFailsWith<Exception> {
+        val error = assertFailsWith<Exception> {
             builder.exchangeAuthorizationCode(tokenEndpoint, "invalid-code")
         }
+        assertFalse(error.message.orEmpty().contains("private-error-detail"))
+        assertNull(error.cause)
+    }
+
+    @Test
+    fun testMalformedSuccessResponseDoesNotEscapeTokenMaterial() = runTest {
+        val client = createMockClient {
+            respond(
+                content = """{"access_token":"private-token"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+
+        val error = assertFailsWith<Exception> {
+            TokenRequestBuilder(clientConfig, client)
+                .exchangeAuthorizationCode(tokenEndpoint, "test-code")
+        }
+
+        assertFalse(error.message.orEmpty().contains("private-token"))
+        assertNull(error.cause)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/errors/CredentialError.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci/src/commonMain/kotlin/id/walt/openid4vci/errors/CredentialError.kt
@@ -1,10 +1,12 @@
 package id.walt.openid4vci.errors
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class CredentialError(
     val error: String,
+    @SerialName("error_description")
     val description: String? = null,
 )
 

--- a/waltid-services/waltid-wallet-api2/README.md
+++ b/waltid-services/waltid-wallet-api2/README.md
@@ -283,16 +283,22 @@ curl -s -X POST http://localhost:7005/wallet/$WALLET_ID/credentials/receive/requ
   }'
 
 ACCESS_TOKEN="..."
+
+# Step 3 (only when nonceEndpoint is advertised): obtain a fresh proof nonce
+curl -s -X POST http://localhost:7005/wallet/$WALLET_ID/credentials/receive/request-nonce \
+  -H "Content-Type: application/json" \
+  -d '{"credentialIssuer":"https://issuer.example.com"}'
+
 C_NONCE="..."
 
-# Step 3: Sign a proof of possession
+# Step 4: Sign a proof of possession; omit nonce when request-nonce returned null
 curl -s -X POST http://localhost:7005/wallet/$WALLET_ID/credentials/receive/sign-proof \
   -H "Content-Type: application/json" \
   -d "{\"issuerUrl\":\"https://issuer.example.com\",\"nonce\":\"$C_NONCE\",\"keyId\":\"$KEY_ID\"}"
 
 PROOF_JWT="..."
 
-# Step 4: Fetch the credential
+# Step 5: Fetch the credential
 curl -s -X POST http://localhost:7005/wallet/$WALLET_ID/credentials/receive/fetch-credential \
   -H "Content-Type: application/json" \
   -d "{
@@ -323,7 +329,13 @@ curl -s -X POST http://localhost:7005/wallet/$WALLET_ID/credentials/receive/exch
     "codeVerifier": "<pkce-verifier>",
     "redirectUri": "openid://"
   }'
-# → {"accessToken":"...","cNonce":"..."}
+# → {"accessToken":"..."}
+
+# Step 3 (only when nonceEndpoint is advertised): obtain a fresh proof nonce
+curl -s -X POST http://localhost:7005/wallet/$WALLET_ID/credentials/receive/request-nonce \
+  -H "Content-Type: application/json" \
+  -d '{"credentialIssuer":"https://issuer.example.com"}'
+# → {"nonce":"..."}; when no endpoint is advertised, proof JWTs omit the nonce claim
 ```
 
 ### Present credentials (OID4VP 1.0 / DCQL)

--- a/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2AdditionalUseCasesTest.kt
+++ b/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2AdditionalUseCasesTest.kt
@@ -422,8 +422,11 @@ class Wallet2AdditionalUseCasesTest {
                         put("access_token", resp.response.accessToken); put(
                         "token_type",
                         "Bearer"
-                    ); put("c_nonce", "pres-nonce"); put("c_nonce_expires_in", 300)
+                    )
                     })
+                }
+                post("/nonce") {
+                    call.respond(buildJsonObject { put("c_nonce", "pres-nonce") })
                 }
                 post("/credential") {
                     val body = json.parseToJsonElement(call.receiveText()).jsonObject
@@ -755,8 +758,11 @@ class Wallet2AdditionalUseCasesTest {
                         put("access_token", resp.response.accessToken); put(
                         "token_type",
                         "Bearer"
-                    ); put("c_nonce", "auth-nonce"); put("c_nonce_expires_in", 300)
+                    )
                     })
+                }
+                post("/nonce") {
+                    call.respond(buildJsonObject { put("c_nonce", "auth-nonce") })
                 }
                 post("/credential") {
                     val body = json.parseToJsonElement(call.receiveText()).jsonObject

--- a/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2ExtendedIntegrationTest.kt
+++ b/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2ExtendedIntegrationTest.kt
@@ -409,9 +409,10 @@ class Wallet2ExtendedIntegrationTest {
                     call.respond(buildJsonObject {
                         put("access_token", tokenResponse.response.accessToken)
                         put("token_type", "Bearer")
-                        put("c_nonce", "isolated-nonce")
-                        put("c_nonce_expires_in", 300)
                     })
+                }
+                post("/nonce") {
+                    call.respond(buildJsonObject { put("c_nonce", "isolated-nonce") })
                 }
                 post("/credential") {
                     val body = json.parseToJsonElement(call.receiveText()).jsonObject
@@ -506,14 +507,23 @@ class Wallet2ExtendedIntegrationTest {
                 }
                 assertNotNull(tokenResult.accessToken)
 
-                // -- Isolated step 3: Sign proof of possession --
+                // -- Isolated step 3: Obtain a fresh proof nonce --
+                val nonceResult = testAndReturn("Isolated: request-nonce") {
+                    http.post("/wallet/$walletId/credentials/receive/request-nonce") {
+                        contentType(ContentType.Application.Json)
+                        setBody(RequestNonceRequest(Url(resolveResult.credentialIssuer)))
+                    }.also { assertEquals(HttpStatusCode.OK, it.status, it.bodyAsText()) }
+                        .body<RequestNonceResult>()
+                }
+
+                // -- Isolated step 4: Sign proof of possession --
                 val signResult = testAndReturn("Isolated: sign-proof") {
                     http.post("/wallet/$walletId/credentials/receive/sign-proof") {
                         contentType(ContentType.Application.Json)
                         setBody(
                             SignProofRequest(
                                 issuerUrl = Url(issuerBase),
-                                nonce = tokenResult.cNonce ?: "isolated-nonce",
+                                nonce = nonceResult.nonce,
                                 keyId = keyInfo.keyId
                             )
                         )
@@ -522,7 +532,7 @@ class Wallet2ExtendedIntegrationTest {
                 }
                 assertNotNull(signResult.proofJwt)
 
-                // -- Isolated step 4: Fetch credential --
+                // -- Isolated step 5: Fetch credential --
                 val fetchResult = testAndReturn("Isolated: fetch-credential") {
                     http.post("/wallet/$walletId/credentials/receive/fetch-credential") {
                         contentType(ContentType.Application.Json)

--- a/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2IssuerVerifier2IntegrationTest.kt
+++ b/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2IssuerVerifier2IntegrationTest.kt
@@ -381,9 +381,10 @@ class Wallet2IssuerVerifier2IntegrationTest {
                     call.respond(buildJsonObject {
                         put("access_token", tokenResponse.response.accessToken)
                         put("token_type", "Bearer")
-                        put("c_nonce", "test-nonce")
-                        put("c_nonce_expires_in", 300)
                     })
+                }
+                post("/nonce") {
+                    call.respond(buildJsonObject { put("c_nonce", "test-nonce") })
                 }
                 post("/credential") {
                     val rawBody = call.receiveText()

--- a/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2MoreUseCasesTest.kt
+++ b/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/Wallet2MoreUseCasesTest.kt
@@ -200,7 +200,10 @@ class Wallet2MoreUseCasesTest {
                     if (tr !is AccessTokenRequestResult.Success) return@post call.respond(HttpStatusCode.BadRequest, buildJsonObject { put("error","invalid_grant") })
                     val resp = provider.createAccessTokenResponse(tr.request.withIssuer(issuerBase))
                     if (resp !is AccessTokenResponseResult.Success) return@post call.respond(HttpStatusCode.InternalServerError, buildJsonObject { put("error","server_error") })
-                    call.respond(buildJsonObject { put("access_token", resp.response.accessToken); put("token_type", "Bearer"); put("c_nonce", "nonce-$preAuthCode"); put("c_nonce_expires_in", 300) })
+                    call.respond(buildJsonObject { put("access_token", resp.response.accessToken); put("token_type", "Bearer") })
+                }
+                post("/nonce") {
+                    call.respond(buildJsonObject { put("c_nonce", "nonce-$preAuthCode") })
                 }
                 post("/credential") {
                     val body = json.parseToJsonElement(call.receiveText()).jsonObject


### PR DESCRIPTION
## Summary

Implements [WAL-1158](https://linear.app/walt-new/issue/WAL-1158/wallet-align-openid4vci-nonce-handling-with-10) as the wallet-side OpenID4VCI 1.0 correction for proof nonce handling and `invalid_nonce` recovery.

When an issuer advertises `nonce_endpoint`, the wallet obtains a fresh `c_nonce` for each proof-bound credential request. When it does not, the wallet still creates the required proof without a `nonce` claim; token-response `c_nonce` values and access tokens are never used as proof nonces.

Enterprise PR: [walt-id/waltid-identity-enterprise#547](https://github.com/walt-id/waltid-identity-enterprise/pull/547)

## What Changed

- adds a reusable typed KMP `NonceRequestBuilder` for nonce-endpoint responses with sanitized failures
- makes proof nonce input nullable and omits the JWT `nonce` claim when no nonce was obtained
- obtains a fresh metadata-advertised nonce for each proof-bound credential request
- removes token-response `c_nonce` and access-token fallback from proof construction and isolated token results
- retries a full credential request exactly once after an issuer returns the standard `invalid_nonce` error, using a newly fetched nonce and freshly signed proof
- keeps isolated `fetch-credential` calls single-shot and propagates the typed credential error so API clients explicitly control any retry
- maps the exact `invalid_nonce` credential error to the Wallet2 HTTP API response
- updates focused wallet, route, and nonce-client coverage plus protocol documentation

## Architecture Notes

`NonceRequestBuilder` is deliberately a small protocol client: it requests and parses the nonce response, preserves cancellation, and redacts malformed response material. The higher-level issuance flow owns the bounded retry because it alone can fetch a nonce and regenerate a proof safely.


This PR is the prerequisite for [walt-id/waltid-identity#1935](https://github.com/walt-id/waltid-identity/pull/1935), which is restacked to consume the shared implementation instead of carrying WAL-1158 inside the broader WAL-995 change.

## Caveats and Follow-Ups

- The wallet intentionally applies no HTTPS-enforcement or redirect-rejection policy to `nonce_endpoint`; transport reachability remains the HTTP client's concern. This is the agreed non-standard-compliance trade-off for these PRs.
- Automatic recovery is limited to one retry and only to the standard `invalid_nonce` error. Other credential errors propagate unchanged.
- Isolated API consumers receive the typed error rather than an implicit replay, because they own the surrounding issuance state.

## Breaking Changes

- `TokenRequestBuilder.TokenResponse.c_nonce` and `c_nonce_expires_in` are removed.
- `RequestTokenResult.cNonce` is removed.
- `RequestNonceResult.nonce` and proof-builder nonce inputs are nullable so issuers can require proofs without advertising a Nonce Endpoint.
