### PR TITLE
refactor(mobile): enforce result model invariants

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileDemoWallet.kt
@@ -90,7 +90,7 @@ internal class MobileDemoWallet(
                         state = result.request.state,
                         nonce = result.request.nonce,
                         responseEncryption = result.request.responseEncryption.toDemoResponseEncryption(),
-                        transactionData = result.request.transactionData.toDemoTransactionDataGroups(),
+                        transactionData = emptyList(),
                         errorCode = result.errorCode.errorCode,
                         message = result.message,
                     )

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/VerifierReviewSections.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/VerifierReviewSections.swift
@@ -2,16 +2,30 @@ import SwiftUI
 import WalletSDK
 
 struct VerifierReviewSections: View {
-    let request: PresentationRequestInfo
+    private enum Request {
+        case ready(PresentationRequestInfo)
+        case invalid(PresentationRequestContext)
+    }
+
+    private let request: Request
     @State private var technicalDetailsExpanded = false
 
+    init(request: PresentationRequestInfo) {
+        self.request = .ready(request)
+    }
+
+    init(request: PresentationRequestContext) {
+        self.request = .invalid(request)
+    }
+
     private var transactionDataGroups: [ClaimGroup] {
-        CredentialDisplayNormalizer.transactionDataGroups(for: request)
+        guard case let .ready(request) = request else { return [] }
+        return CredentialDisplayNormalizer.transactionDataGroups(for: request)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            if let verifierMetadata = request.verifierMetadata,
+            if let verifierMetadata,
                verifierDisplayName != nil || !verifierDetails.isEmpty {
                 ReviewMetadataSection(
                     title: "Verifier",
@@ -73,14 +87,14 @@ struct VerifierReviewSections: View {
     }
 
     private var responseEncryptionStatus: String {
-        switch request.responseEncryption {
+        switch responseEncryption {
         case .notRequired: "Not requested"
         case .required: "Required"
         }
     }
 
     private var verifierDisplayName: String? {
-        guard let name = request.verifierMetadata?.display?.name?.trimmingCharacters(in: .whitespacesAndNewlines),
+        guard let name = verifierMetadata?.display?.name?.trimmingCharacters(in: .whitespacesAndNewlines),
               !name.isEmpty else {
             return nil
         }
@@ -88,7 +102,7 @@ struct VerifierReviewSections: View {
     }
 
     private var verifierDetails: [MetadataDetailItem] {
-        guard let metadata = request.verifierMetadata else { return [] }
+        guard let metadata = verifierMetadata else { return [] }
         return [
             MetadataDetailItem(label: "Client URI", value: metadata.clientURI, linkURI: metadata.clientURI),
             MetadataDetailItem(label: "Privacy policy", value: metadata.policyURI, linkURI: metadata.policyURI),
@@ -98,7 +112,7 @@ struct VerifierReviewSections: View {
 
     private var responseProtectionDetails: [MetadataDetailItem] {
         var items = [MetadataDetailItem(label: "Message-level encryption", value: responseEncryptionStatus)]
-        if case let .required(details) = request.responseEncryption {
+        if case let .required(details) = responseEncryption {
             items += [
                 MetadataDetailItem(label: "Key management algorithm", value: details.keyManagementAlgorithm),
                 MetadataDetailItem(label: "Content encryption algorithm", value: details.contentEncryptionAlgorithm),
@@ -111,10 +125,52 @@ struct VerifierReviewSections: View {
 
     private var technicalDetails: [MetadataDetailItem] {
         [
-            MetadataDetailItem(label: "Client ID", value: request.clientID),
-            MetadataDetailItem(label: "Response URI", value: request.responseURI?.absoluteString),
-            MetadataDetailItem(label: "State", value: request.state),
-            MetadataDetailItem(label: "Nonce", value: request.nonce),
+            MetadataDetailItem(label: "Client ID", value: clientID),
+            MetadataDetailItem(label: "Response URI", value: responseURI?.absoluteString),
+            MetadataDetailItem(label: "State", value: state),
+            MetadataDetailItem(label: "Nonce", value: nonce),
         ]
+    }
+
+    private var clientID: String {
+        switch request {
+        case let .ready(request): request.clientID
+        case let .invalid(request): request.clientID
+        }
+    }
+
+    private var verifierMetadata: VerifierMetadata? {
+        switch request {
+        case let .ready(request): request.verifierMetadata
+        case let .invalid(request): request.verifierMetadata
+        }
+    }
+
+    private var responseURI: URL? {
+        switch request {
+        case let .ready(request): request.responseURI
+        case let .invalid(request): request.responseURI
+        }
+    }
+
+    private var state: String? {
+        switch request {
+        case let .ready(request): request.state
+        case let .invalid(request): request.state
+        }
+    }
+
+    private var nonce: String? {
+        switch request {
+        case let .ready(request): request.nonce
+        case let .invalid(request): request.nonce
+        }
+    }
+
+    private var responseEncryption: PresentationResponseEncryption {
+        switch request {
+        case let .ready(request): request.responseEncryption
+        case let .invalid(request): request.responseEncryption
+        }
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayNormalizer.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Display/CredentialDisplayNormalizer.swift
@@ -55,7 +55,11 @@ enum CredentialDisplayNormalizer {
     }
 
     static func transactionDataGroups(for request: PresentationRequestInfo) -> [ClaimGroup] {
-        let baseTitles = request.transactionData.map { item in
+        transactionDataGroups(for: request.transactionData)
+    }
+
+    static func transactionDataGroups(for transactionData: [PresentationTransactionData]) -> [ClaimGroup] {
+        let baseTitles = transactionData.map { item in
             item.displayName.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
                 ?? CredentialDisplayVocabulary.transactionDataTitle
         }
@@ -64,7 +68,7 @@ enum CredentialDisplayNormalizer {
         }
         var seenTitles: [String: Int] = [:]
 
-        return request.transactionData.enumerated().map { index, item in
+        return transactionData.enumerated().map { index, item in
             let baseTitle = baseTitles[index]
             seenTitles[baseTitle, default: 0] += 1
             let title = titleCounts[baseTitle, default: 0] > 1

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
@@ -878,6 +878,8 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
 
     func testTransactionDataGroupsRenderProfileAndDetailsReadably() throws {
         let request = PresentationRequestInfo(
+            clientID: "https://verifier.example",
+            nonce: "nonce-1",
             responseEncryption: .notRequired,
             transactionData: [
                 PresentationTransactionData(

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelPresentationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelPresentationTests.swift
@@ -11,7 +11,7 @@ final class WalletViewModelPresentationTests: XCTestCase {
         let previewHandle = PresentationPreviewHandle(value: "invalid-presentation-preview")
         let previewError = PresentationPreviewError(
             previewHandle: previewHandle,
-            request: PresentationRequestInfo(
+            request: PresentationRequestContext(
                 clientID: "https://verifier.example",
                 verifierMetadata: VerifierMetadata(
                     display: MetadataDisplay(

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelReceiveTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelReceiveTests.swift
@@ -315,8 +315,9 @@ private actor TransactionCodeWalletClient: WalletClient {
             PresentationPreview(
                 previewHandle: PresentationPreviewHandle(value: "transaction-code-presentation-preview"),
                 request: PresentationRequestInfo(
-                    clientID: nil,
-                    responseEncryption: .notRequired
+                    clientID: "https://verifier.example",
+                    nonce: "nonce-1",
+                    responseEncryption: .notRequired,
                 ),
                 credentialOptions: [
                     PresentationCredentialOption(

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -40,6 +40,35 @@ final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeErrorCategory :
     }
 }
 
+final enum class id.walt.wallet2.mobile/MobileWalletEvent : kotlin/Enum<id.walt.wallet2.mobile/MobileWalletEvent> { // id.walt.wallet2.mobile/MobileWalletEvent|null[0]
+    enum entry issuance_attestation_obtained // id.walt.wallet2.mobile/MobileWalletEvent.issuance_attestation_obtained|null[0]
+    enum entry issuance_completed // id.walt.wallet2.mobile/MobileWalletEvent.issuance_completed|null[0]
+    enum entry issuance_credential_received // id.walt.wallet2.mobile/MobileWalletEvent.issuance_credential_received|null[0]
+    enum entry issuance_credential_stored // id.walt.wallet2.mobile/MobileWalletEvent.issuance_credential_stored|null[0]
+    enum entry issuance_deferred // id.walt.wallet2.mobile/MobileWalletEvent.issuance_deferred|null[0]
+    enum entry issuance_failed // id.walt.wallet2.mobile/MobileWalletEvent.issuance_failed|null[0]
+    enum entry issuance_offer_resolved // id.walt.wallet2.mobile/MobileWalletEvent.issuance_offer_resolved|null[0]
+    enum entry issuance_proof_signed // id.walt.wallet2.mobile/MobileWalletEvent.issuance_proof_signed|null[0]
+    enum entry issuance_token_obtained // id.walt.wallet2.mobile/MobileWalletEvent.issuance_token_obtained|null[0]
+    enum entry presentation_completed // id.walt.wallet2.mobile/MobileWalletEvent.presentation_completed|null[0]
+    enum entry presentation_credentials_selected // id.walt.wallet2.mobile/MobileWalletEvent.presentation_credentials_selected|null[0]
+    enum entry presentation_failed // id.walt.wallet2.mobile/MobileWalletEvent.presentation_failed|null[0]
+    enum entry presentation_request_parsed // id.walt.wallet2.mobile/MobileWalletEvent.presentation_request_parsed|null[0]
+    enum entry presentation_response_prepared // id.walt.wallet2.mobile/MobileWalletEvent.presentation_response_prepared|null[0]
+    enum entry presentation_signed // id.walt.wallet2.mobile/MobileWalletEvent.presentation_signed|null[0]
+    enum entry presentation_submitted // id.walt.wallet2.mobile/MobileWalletEvent.presentation_submitted|null[0]
+
+    final val entries // id.walt.wallet2.mobile/MobileWalletEvent.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile/MobileWalletEvent> // id.walt.wallet2.mobile/MobileWalletEvent.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val phase // id.walt.wallet2.mobile/MobileWalletEvent.phase|{}phase[0]
+        final fun <get-phase>(): id.walt.wallet2.mobile/MobileWalletEventPhase // id.walt.wallet2.mobile/MobileWalletEvent.phase.<get-phase>|<get-phase>(){}[0]
+    final val status // id.walt.wallet2.mobile/MobileWalletEvent.status|{}status[0]
+        final fun <get-status>(): id.walt.wallet2.mobile/MobileWalletEventStatus // id.walt.wallet2.mobile/MobileWalletEvent.status.<get-status>|<get-status>(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile/MobileWalletEvent // id.walt.wallet2.mobile/MobileWalletEvent.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile/MobileWalletEvent> // id.walt.wallet2.mobile/MobileWalletEvent.values|values#static(){}[0]
+}
+
 final enum class id.walt.wallet2.mobile/MobileWalletEventPhase : kotlin/Enum<id.walt.wallet2.mobile/MobileWalletEventPhase> { // id.walt.wallet2.mobile/MobileWalletEventPhase|null[0]
     enum entry issuance // id.walt.wallet2.mobile/MobileWalletEventPhase.issuance|null[0]
     enum entry presentation // id.walt.wallet2.mobile/MobileWalletEventPhase.presentation|null[0]
@@ -195,7 +224,7 @@ sealed interface id.walt.wallet2.mobile/MobileWalletDatabaseKey { // id.walt.wal
 
 sealed interface id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult { // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult|null[0]
     final class Invalid : id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult { // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid|null[0]
-        constructor <init>(id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle, id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo, id.walt.wallet2.mobile/MobileWalletPresentationErrorCode, kotlin/String) // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.<init>|<init>(id.walt.wallet2.mobile.MobileWalletPresentationPreviewHandle;id.walt.wallet2.mobile.MobileWalletPresentationRequestInfo;id.walt.wallet2.mobile.MobileWalletPresentationErrorCode;kotlin.String){}[0]
+        constructor <init>(id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle, id.walt.wallet2.mobile/MobileWalletPresentationRequestContext, id.walt.wallet2.mobile/MobileWalletPresentationErrorCode, kotlin/String) // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.<init>|<init>(id.walt.wallet2.mobile.MobileWalletPresentationPreviewHandle;id.walt.wallet2.mobile.MobileWalletPresentationRequestContext;id.walt.wallet2.mobile.MobileWalletPresentationErrorCode;kotlin.String){}[0]
 
         final val errorCode // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.errorCode|{}errorCode[0]
             final fun <get-errorCode>(): id.walt.wallet2.mobile/MobileWalletPresentationErrorCode // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.errorCode.<get-errorCode>|<get-errorCode>(){}[0]
@@ -204,13 +233,13 @@ sealed interface id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult { 
         final val previewHandle // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.previewHandle|{}previewHandle[0]
             final fun <get-previewHandle>(): id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.previewHandle.<get-previewHandle>|<get-previewHandle>(){}[0]
         final val request // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.request|{}request[0]
-            final fun <get-request>(): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.request.<get-request>|<get-request>(){}[0]
+            final fun <get-request>(): id.walt.wallet2.mobile/MobileWalletPresentationRequestContext // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.request.<get-request>|<get-request>(){}[0]
 
         final fun component1(): id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.component1|component1(){}[0]
-        final fun component2(): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.component2|component2(){}[0]
+        final fun component2(): id.walt.wallet2.mobile/MobileWalletPresentationRequestContext // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.component2|component2(){}[0]
         final fun component3(): id.walt.wallet2.mobile/MobileWalletPresentationErrorCode // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.component3|component3(){}[0]
         final fun component4(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.component4|component4(){}[0]
-        final fun copy(id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle = ..., id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo = ..., id.walt.wallet2.mobile/MobileWalletPresentationErrorCode = ..., kotlin/String = ...): id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.copy|copy(id.walt.wallet2.mobile.MobileWalletPresentationPreviewHandle;id.walt.wallet2.mobile.MobileWalletPresentationRequestInfo;id.walt.wallet2.mobile.MobileWalletPresentationErrorCode;kotlin.String){}[0]
+        final fun copy(id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle = ..., id.walt.wallet2.mobile/MobileWalletPresentationRequestContext = ..., id.walt.wallet2.mobile/MobileWalletPresentationErrorCode = ..., kotlin/String = ...): id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.copy|copy(id.walt.wallet2.mobile.MobileWalletPresentationPreviewHandle;id.walt.wallet2.mobile.MobileWalletPresentationRequestContext;id.walt.wallet2.mobile.MobileWalletPresentationErrorCode;kotlin.String){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult.Invalid.toString|toString(){}[0]
@@ -697,25 +726,6 @@ final class id.walt.wallet2.mobile/MobileWalletCredentialClaimMetadata { // id.w
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletCredentialClaimMetadata.toString|toString(){}[0]
 }
 
-final class id.walt.wallet2.mobile/MobileWalletEvent { // id.walt.wallet2.mobile/MobileWalletEvent|null[0]
-    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletEventPhase, id.walt.wallet2.mobile/MobileWalletEventStatus) // id.walt.wallet2.mobile/MobileWalletEvent.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletEventPhase;id.walt.wallet2.mobile.MobileWalletEventStatus){}[0]
-
-    final val name // id.walt.wallet2.mobile/MobileWalletEvent.name|{}name[0]
-        final fun <get-name>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletEvent.name.<get-name>|<get-name>(){}[0]
-    final val phase // id.walt.wallet2.mobile/MobileWalletEvent.phase|{}phase[0]
-        final fun <get-phase>(): id.walt.wallet2.mobile/MobileWalletEventPhase // id.walt.wallet2.mobile/MobileWalletEvent.phase.<get-phase>|<get-phase>(){}[0]
-    final val status // id.walt.wallet2.mobile/MobileWalletEvent.status|{}status[0]
-        final fun <get-status>(): id.walt.wallet2.mobile/MobileWalletEventStatus // id.walt.wallet2.mobile/MobileWalletEvent.status.<get-status>|<get-status>(){}[0]
-
-    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletEvent.component1|component1(){}[0]
-    final fun component2(): id.walt.wallet2.mobile/MobileWalletEventPhase // id.walt.wallet2.mobile/MobileWalletEvent.component2|component2(){}[0]
-    final fun component3(): id.walt.wallet2.mobile/MobileWalletEventStatus // id.walt.wallet2.mobile/MobileWalletEvent.component3|component3(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletEventPhase = ..., id.walt.wallet2.mobile/MobileWalletEventStatus = ...): id.walt.wallet2.mobile/MobileWalletEvent // id.walt.wallet2.mobile/MobileWalletEvent.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletEventPhase;id.walt.wallet2.mobile.MobileWalletEventStatus){}[0]
-    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletEvent.equals|equals(kotlin.Any?){}[0]
-    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletEvent.hashCode|hashCode(){}[0]
-    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletEvent.toString|toString(){}[0]
-}
-
 final class id.walt.wallet2.mobile/MobileWalletFactory { // id.walt.wallet2.mobile/MobileWalletFactory|null[0]
     constructor <init>() // id.walt.wallet2.mobile/MobileWalletFactory.<init>|<init>(){}[0]
 
@@ -1021,13 +1031,41 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle { // id
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle.toString|toString(){}[0]
 }
 
+final class id.walt.wallet2.mobile/MobileWalletPresentationRequestContext { // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext|null[0]
+    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, kotlin/String?, kotlin/String?, kotlin/String?, id.walt.wallet2.mobile/MobileWalletResponseEncryption) // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
+
+    final val clientId // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.clientId|{}clientId[0]
+        final fun <get-clientId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.clientId.<get-clientId>|<get-clientId>(){}[0]
+    final val nonce // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.nonce|{}nonce[0]
+        final fun <get-nonce>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.nonce.<get-nonce>|<get-nonce>(){}[0]
+    final val responseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseEncryption|{}responseEncryption[0]
+        final fun <get-responseEncryption>(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseEncryption.<get-responseEncryption>|<get-responseEncryption>(){}[0]
+    final val responseUri // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseUri|{}responseUri[0]
+        final fun <get-responseUri>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseUri.<get-responseUri>|<get-responseUri>(){}[0]
+    final val state // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.state|{}state[0]
+        final fun <get-state>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.state.<get-state>|<get-state>(){}[0]
+    final val verifierMetadata // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.verifierMetadata|{}verifierMetadata[0]
+        final fun <get-verifierMetadata>(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.verifierMetadata.<get-verifierMetadata>|<get-verifierMetadata>(){}[0]
+
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component1|component1(){}[0]
+    final fun component2(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component2|component2(){}[0]
+    final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component3|component3(){}[0]
+    final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component5|component5(){}[0]
+    final fun component6(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component6|component6(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestContext // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.toString|toString(){}[0]
+}
+
 final class id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo { // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo|null[0]
-    constructor <init>(kotlin/String?, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, kotlin/String?, kotlin/String?, kotlin/String?, id.walt.wallet2.mobile/MobileWalletResponseEncryption, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...) // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.<init>|<init>(kotlin.String?;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
+    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, kotlin/String?, kotlin/String?, kotlin/String, id.walt.wallet2.mobile/MobileWalletResponseEncryption, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...) // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
 
     final val clientId // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId|{}clientId[0]
-        final fun <get-clientId>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId.<get-clientId>|<get-clientId>(){}[0]
+        final fun <get-clientId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId.<get-clientId>|<get-clientId>(){}[0]
     final val nonce // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce|{}nonce[0]
-        final fun <get-nonce>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce.<get-nonce>|<get-nonce>(){}[0]
+        final fun <get-nonce>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce.<get-nonce>|<get-nonce>(){}[0]
     final val responseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseEncryption|{}responseEncryption[0]
         final fun <get-responseEncryption>(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseEncryption.<get-responseEncryption>|<get-responseEncryption>(){}[0]
     final val responseUri // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseUri|{}responseUri[0]
@@ -1039,14 +1077,14 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo { // id.w
     final val verifierMetadata // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.verifierMetadata|{}verifierMetadata[0]
         final fun <get-verifierMetadata>(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.verifierMetadata.<get-verifierMetadata>|<get-verifierMetadata>(){}[0]
 
-    final fun component1(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component1|component1(){}[0]
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component1|component1(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component2|component2(){}[0]
     final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component3|component3(){}[0]
     final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component4|component4(){}[0]
-    final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component5|component5(){}[0]
+    final fun component5(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component5|component5(){}[0]
     final fun component6(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component6|component6(){}[0]
     final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component7|component7(){}[0]
-    final fun copy(kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.copy|copy(kotlin.String?;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.toString|toString(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -387,7 +387,7 @@ public class MobileWallet internal constructor(
             is PreviewPresentationResult.Invalid ->
                 MobileWalletPresentationPreviewResult.Invalid(
                     previewHandle = MobileWalletPresentationPreviewHandle(result.handle.value),
-                    request = result.authorizationRequest.toMobileRequestInfo(preferredLocales),
+                    request = result.authorizationRequest.toMobileRequestContext(preferredLocales),
                     errorCode = result.error.code.toMobileErrorCode(),
                     message = result.error.message,
                 )
@@ -588,15 +588,33 @@ private fun AuthorizationRequest.toMobileRequestInfo(
     transactionData: List<MobileWalletTransactionDataItem> = emptyList(),
 ): MobileWalletPresentationRequestInfo {
     return MobileWalletPresentationRequestInfo(
-        clientId = clientId,
+        clientId = requireNotNull(clientId) {
+            "A validated presentation request must contain client_id."
+        },
         verifierMetadata = clientMetadata?.toMobileVerifierMetadata(preferredLocales),
         responseUri = responseUri,
         state = state,
-        nonce = nonce,
+        nonce = requireNotNull(nonce) {
+            "A validated presentation request must contain nonce."
+        },
         responseEncryption = responseEncryption.toMobileResponseEncryption(),
         transactionData = transactionData,
     )
 }
+
+private fun AuthorizationRequest.toMobileRequestContext(
+    preferredLocales: List<String>,
+): MobileWalletPresentationRequestContext =
+    MobileWalletPresentationRequestContext(
+        clientId = requireNotNull(clientId) {
+            "A reportable invalid presentation request must contain client_id."
+        },
+        verifierMetadata = clientMetadata?.toMobileVerifierMetadata(preferredLocales),
+        responseUri = responseUri,
+        state = state,
+        nonce = nonce,
+        responseEncryption = null.toMobileResponseEncryption(),
+    )
 
 private fun WalletPresentFunctionality2.OID4VPErrorCode.toMobileErrorCode(): MobileWalletPresentationErrorCode = when (this) {
     WalletPresentFunctionality2.OID4VPErrorCode.ACCESS_DENIED -> MobileWalletPresentationErrorCode.accessDenied

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletEvent.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletEvent.kt
@@ -34,15 +34,32 @@ public enum class MobileWalletEventStatus {
 /**
  * Observable mobile wallet session event.
  *
- * @property name Stable event name emitted by the underlying wallet flow.
+ * The enum name is the stable event name emitted by the underlying wallet flow.
+ *
  * @property phase Issuance or presentation flow that emitted the event.
  * @property status Current progress state for the event.
  */
-public data class MobileWalletEvent(
-    public val name: String,
+public enum class MobileWalletEvent(
     public val phase: MobileWalletEventPhase,
     public val status: MobileWalletEventStatus,
-)
+) {
+    issuance_offer_resolved(MobileWalletEventPhase.issuance, MobileWalletEventStatus.progress),
+    issuance_attestation_obtained(MobileWalletEventPhase.issuance, MobileWalletEventStatus.progress),
+    issuance_token_obtained(MobileWalletEventPhase.issuance, MobileWalletEventStatus.progress),
+    issuance_proof_signed(MobileWalletEventPhase.issuance, MobileWalletEventStatus.progress),
+    issuance_credential_received(MobileWalletEventPhase.issuance, MobileWalletEventStatus.progress),
+    issuance_deferred(MobileWalletEventPhase.issuance, MobileWalletEventStatus.progress),
+    issuance_credential_stored(MobileWalletEventPhase.issuance, MobileWalletEventStatus.progress),
+    issuance_completed(MobileWalletEventPhase.issuance, MobileWalletEventStatus.completed),
+    issuance_failed(MobileWalletEventPhase.issuance, MobileWalletEventStatus.failed),
+    presentation_request_parsed(MobileWalletEventPhase.presentation, MobileWalletEventStatus.progress),
+    presentation_credentials_selected(MobileWalletEventPhase.presentation, MobileWalletEventStatus.progress),
+    presentation_signed(MobileWalletEventPhase.presentation, MobileWalletEventStatus.progress),
+    presentation_response_prepared(MobileWalletEventPhase.presentation, MobileWalletEventStatus.progress),
+    presentation_submitted(MobileWalletEventPhase.presentation, MobileWalletEventStatus.progress),
+    presentation_completed(MobileWalletEventPhase.presentation, MobileWalletEventStatus.completed),
+    presentation_failed(MobileWalletEventPhase.presentation, MobileWalletEventStatus.failed),
+}
 
 internal class MobileWalletEventStream(
     replay: Int = 10,
@@ -59,19 +76,22 @@ internal class MobileWalletEventStream(
     fun tryEmit(event: MobileWalletEvent): Boolean = mutableEvents.tryEmit(event)
 }
 
-internal fun WalletSessionEvent.toMobileWalletEvent() = MobileWalletEvent(
-    name = name,
-    phase = when {
-        name.startsWith("issuance_") -> MobileWalletEventPhase.issuance
-        else -> MobileWalletEventPhase.presentation
-    },
-    status = when (this) {
-        WalletSessionEvent.issuance_completed,
-        WalletSessionEvent.presentation_completed -> MobileWalletEventStatus.completed
-
-        WalletSessionEvent.issuance_failed,
-        WalletSessionEvent.presentation_failed -> MobileWalletEventStatus.failed
-
-        else -> MobileWalletEventStatus.progress
-    },
-)
+internal fun WalletSessionEvent.toMobileWalletEvent(): MobileWalletEvent =
+    when (this) {
+        WalletSessionEvent.issuance_offer_resolved -> MobileWalletEvent.issuance_offer_resolved
+        WalletSessionEvent.issuance_attestation_obtained -> MobileWalletEvent.issuance_attestation_obtained
+        WalletSessionEvent.issuance_token_obtained -> MobileWalletEvent.issuance_token_obtained
+        WalletSessionEvent.issuance_proof_signed -> MobileWalletEvent.issuance_proof_signed
+        WalletSessionEvent.issuance_credential_received -> MobileWalletEvent.issuance_credential_received
+        WalletSessionEvent.issuance_deferred -> MobileWalletEvent.issuance_deferred
+        WalletSessionEvent.issuance_credential_stored -> MobileWalletEvent.issuance_credential_stored
+        WalletSessionEvent.issuance_completed -> MobileWalletEvent.issuance_completed
+        WalletSessionEvent.issuance_failed -> MobileWalletEvent.issuance_failed
+        WalletSessionEvent.presentation_request_parsed -> MobileWalletEvent.presentation_request_parsed
+        WalletSessionEvent.presentation_credentials_selected -> MobileWalletEvent.presentation_credentials_selected
+        WalletSessionEvent.presentation_signed -> MobileWalletEvent.presentation_signed
+        WalletSessionEvent.presentation_response_prepared -> MobileWalletEvent.presentation_response_prepared
+        WalletSessionEvent.presentation_submitted -> MobileWalletEvent.presentation_submitted
+        WalletSessionEvent.presentation_completed -> MobileWalletEvent.presentation_completed
+        WalletSessionEvent.presentation_failed -> MobileWalletEvent.presentation_failed
+    }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
@@ -28,7 +28,7 @@ public sealed interface MobileWalletPresentationPreviewResult {
         /** Opaque handle required to reject or discard this reviewed request. */
         public val previewHandle: MobileWalletPresentationPreviewHandle,
         /** Validated response destination and request context to show before returning the error. */
-        public val request: MobileWalletPresentationRequestInfo,
+        public val request: MobileWalletPresentationRequestContext,
         /** Standard OpenID4VP error detected by the wallet. */
         public val errorCode: MobileWalletPresentationErrorCode,
         /** Local diagnostic intended for wallet UI; it is not sent to the verifier automatically. */
@@ -51,6 +51,35 @@ public data class MobileWalletPresentationPreviewHandle(val value: String) {
 }
 
 /**
+ * Partial request context retained when an OpenID4VP request is invalid.
+ *
+ * A reportable invalid request has a validated, non-blank [clientId]. Its [nonce] remains nullable
+ * because a missing nonce can itself be the validation error. A ready preview instead exposes a
+ * validated, non-null nonce through [MobileWalletPresentationRequestInfo].
+ *
+ * @property clientId Required OpenID4VP `client_id` value identifying the verifier.
+ * @property verifierMetadata Typed verifier metadata supplied by the OpenID4VP client, when available.
+ * @property responseUri Verifier response URI to which the wallet would submit the presentation or error, when provided.
+ * @property state OpenID4VP state value supplied by the verifier, when provided.
+ * @property nonce OpenID4VP nonce value supplied by the verifier, when provided. May be null if the missing nonce is the validation error.
+ * @property responseEncryption Response-encryption state selected for this request.
+ */
+public data class MobileWalletPresentationRequestContext(
+    val clientId: String,
+    val verifierMetadata: MobileWalletVerifierMetadata?,
+    val responseUri: String?,
+    val state: String?,
+    val nonce: String?,
+    val responseEncryption: MobileWalletResponseEncryption,
+) {
+    init {
+        require(clientId.isNotBlank()) {
+            "A reportable presentation request client ID must not be blank."
+        }
+    }
+}
+
+/**
  * A required presentation credential-query combination.
  *
  * Each inner option contains DCQL credential query IDs that must all be selected together.
@@ -60,28 +89,45 @@ public data class MobileWalletPresentationPreviewHandle(val value: String) {
  */
 public data class MobileWalletPresentationCredentialRequirement(
     val options: List<List<String>>,
-)
+) {
+    init {
+        require(options.isNotEmpty()) {
+            "A presentation credential requirement must contain at least one option."
+        }
+        require(options.all { it.isNotEmpty() }) {
+            "Each presentation credential requirement option must contain at least one query ID."
+        }
+        require(options.flatten().all(String::isNotBlank)) {
+            "Presentation credential requirement query IDs must not be blank."
+        }
+    }
+}
 
 /**
  * Verifier and transaction metadata extracted from a presentation request.
  *
- * @property clientId Raw OpenID4VP `client_id` value, when available.
+ * @property clientId Required OpenID4VP `client_id` value.
  * @property verifierMetadata Typed verifier metadata supplied by the OpenID4VP client, when available.
  * @property responseUri Verifier response URI to which the wallet will submit the presentation, when provided.
  * @property state OpenID4VP state value supplied by the verifier, when provided.
- * @property nonce OpenID4VP nonce value supplied by the verifier, when provided.
+ * @property nonce Required OpenID4VP nonce value supplied by the verifier.
  * @property responseEncryption Response-encryption state selected for this request.
  * @property transactionData Decoded transaction data items requested by the verifier.
  */
 public data class MobileWalletPresentationRequestInfo(
-    val clientId: String?,
+    val clientId: String,
     val verifierMetadata: MobileWalletVerifierMetadata?,
     val responseUri: String?,
     val state: String?,
-    val nonce: String?,
+    val nonce: String,
     val responseEncryption: MobileWalletResponseEncryption,
     val transactionData: List<MobileWalletTransactionDataItem> = emptyList(),
-)
+) {
+    init {
+        require(clientId.isNotBlank()) { "A presentation request client ID must not be blank." }
+        require(nonce.isNotBlank()) { "A presentation request nonce must not be blank." }
+    }
+}
 
 /**
  * A wallet credential that satisfies one DCQL credential query in the presentation request.
@@ -106,7 +152,13 @@ public data class MobileWalletPresentationCredentialOption(
     val label: String?,
     val credentialDataJson: String,
     val disclosures: List<MobileWalletPresentationDisclosure> = emptyList(),
-)
+) {
+    init {
+        require(queryId.isNotBlank()) {
+            "A presentation credential option query ID must not be blank."
+        }
+    }
+}
 
 /**
  * User-selected presentation credential option.
@@ -155,7 +207,13 @@ public data class MobileWalletPresentationDisclosure(
     val selectivelyDisclosable: Boolean,
     val required: Boolean = !selectivelyDisclosable,
     val selectable: Boolean = selectivelyDisclosable && !required,
-)
+) {
+    init {
+        require(!selectable || (selectivelyDisclosable && !required)) {
+            "A selectable disclosure must be selectively disclosable and optional."
+        }
+    }
+}
 
 /**
  * Decoded transaction_data item attached to a presentation request.
@@ -174,8 +232,16 @@ public data class MobileWalletTransactionDataItem(
     val supportedFields: List<String>,
     val rawJson: String,
     val detailsJson: String,
-)
-
+) {
+    init {
+        require(credentialQueryIds.isNotEmpty()) {
+            "Transaction data must reference at least one credential query ID."
+        }
+        require(credentialQueryIds.all(String::isNotBlank)) {
+            "Transaction data credential query IDs must not be blank."
+        }
+    }
+}
 /**
  * OAuth 2.0 and OpenID4VP 1.0 authorization error codes supported by the wallet.
  *

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
@@ -176,27 +176,96 @@ class MobileWalletTest {
     }
 
     @Test
-    fun walletSessionEventsMapToMobileWalletEventsInCommonCode() {
-        val progress = WalletSessionEvent.issuance_offer_resolved.toMobileWalletEvent()
-        val prepared = WalletSessionEvent.presentation_response_prepared.toMobileWalletEvent()
-        val completed = WalletSessionEvent.presentation_completed.toMobileWalletEvent()
-        val failed = WalletSessionEvent.issuance_failed.toMobileWalletEvent()
+    fun walletSessionEventsMapExhaustivelyToMobileWalletEvents() {
+        assertEquals(WalletSessionEvent.entries.size, MobileWalletEvent.entries.size)
+        WalletSessionEvent.entries.forEach { event ->
+            assertEquals(event.name, event.toMobileWalletEvent().name)
+        }
 
-        assertEquals(MobileWalletEventPhase.issuance, progress.phase)
-        assertEquals(MobileWalletEventStatus.progress, progress.status)
-        assertEquals("issuance_offer_resolved", progress.name)
+        assertEquals(MobileWalletEventPhase.issuance, MobileWalletEvent.issuance_offer_resolved.phase)
+        assertEquals(MobileWalletEventStatus.progress, MobileWalletEvent.issuance_offer_resolved.status)
+        assertEquals(MobileWalletEventPhase.presentation, MobileWalletEvent.presentation_completed.phase)
+        assertEquals(MobileWalletEventStatus.completed, MobileWalletEvent.presentation_completed.status)
+        assertEquals(MobileWalletEventStatus.failed, MobileWalletEvent.issuance_failed.status)
+    }
 
-        assertEquals(MobileWalletEventPhase.presentation, prepared.phase)
-        assertEquals(MobileWalletEventStatus.progress, prepared.status)
-        assertEquals("presentation_response_prepared", prepared.name)
+    @Test
+    fun presentationCredentialRequirementsRejectEmptyCombinations() {
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletPresentationCredentialRequirement(emptyList())
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletPresentationCredentialRequirement(listOf(emptyList()))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletPresentationCredentialRequirement(listOf(listOf(" ")))
+        }
+    }
 
-        assertEquals(MobileWalletEventPhase.presentation, completed.phase)
-        assertEquals(MobileWalletEventStatus.completed, completed.status)
-        assertEquals("presentation_completed", completed.name)
+    @Test
+    fun presentationOutputModelsRejectMissingCredentialQueryIds() {
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletPresentationCredentialOption(
+                queryId = " ",
+                credentialId = "credential-1",
+                format = "vc+sd-jwt",
+                issuer = null,
+                subject = null,
+                label = null,
+                credentialDataJson = "{}",
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            presentationTransactionData(credentialQueryIds = emptyList())
+        }
+        assertFailsWith<IllegalArgumentException> {
+            presentationTransactionData(credentialQueryIds = listOf(" "))
+        }
+    }
 
-        assertEquals(MobileWalletEventPhase.issuance, failed.phase)
-        assertEquals(MobileWalletEventStatus.failed, failed.status)
-        assertEquals("issuance_failed", failed.name)
+    @Test
+    fun presentationRequestInfoRequiresClientIdAndNonce() {
+        assertFailsWith<IllegalArgumentException> {
+            presentationRequestInfo(clientId = " ")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            presentationRequestInfo(nonce = " ")
+        }
+    }
+
+    @Test
+    fun presentationRequestContextRequiresClientIdButAllowsMissingNonce() {
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletPresentationRequestContext(
+                clientId = " ",
+                verifierMetadata = null,
+                responseUri = null,
+                state = null,
+                nonce = null,
+                responseEncryption = MobileWalletResponseEncryption.NotRequired,
+            )
+        }
+
+        val context = MobileWalletPresentationRequestContext(
+            clientId = "https://verifier.example",
+            verifierMetadata = null,
+            responseUri = null,
+            state = null,
+            nonce = null,
+            responseEncryption = MobileWalletResponseEncryption.NotRequired,
+        )
+        assertEquals("https://verifier.example", context.clientId)
+        assertEquals(null, context.nonce)
+    }
+
+    @Test
+    fun presentationDisclosuresRejectImpossibleSelectableStates() {
+        assertFailsWith<IllegalArgumentException> {
+            presentationDisclosure(selectivelyDisclosable = false, required = false, selectable = true)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            presentationDisclosure(selectivelyDisclosable = true, required = true, selectable = true)
+        }
     }
 
     @Test
@@ -381,7 +450,7 @@ class MobileWalletTest {
         runCurrent()
 
         repeat(100) { index ->
-            val emitted = stream.tryEmit(progressEvent("issuance_progress_$index"))
+            val emitted = stream.tryEmit(MobileWalletEvent.issuance_offer_resolved)
 
             assertTrue(emitted, "Progress event $index should not suspend or fail when the buffer is full")
         }
@@ -389,10 +458,51 @@ class MobileWalletTest {
         collector.cancel()
     }
 
-    private fun progressEvent(name: String) = MobileWalletEvent(
-        name = name,
-        phase = MobileWalletEventPhase.issuance,
-        status = MobileWalletEventStatus.progress,
+    private fun presentationRequestInfo(
+        clientId: String = "https://verifier.example",
+        nonce: String = "nonce-1",
+    ) = MobileWalletPresentationRequestInfo(
+        clientId = clientId,
+        verifierMetadata = MobileWalletVerifierMetadata(
+            display = MobileWalletMetadataDisplay(
+                name = "Example Verifier",
+                locale = "en",
+                logoUri = null,
+                logoAltText = null,
+            ),
+            clientUri = null,
+            policyUri = null,
+            termsOfServiceUri = null,
+        ),
+        responseUri = "https://verifier.example/direct-post",
+        state = null,
+        nonce = nonce,
+        responseEncryption = MobileWalletResponseEncryption.NotRequired,
+    )
+
+    private fun presentationTransactionData(
+        credentialQueryIds: List<String>,
+    ) = MobileWalletTransactionDataItem(
+        type = "example",
+        displayName = "Example",
+        credentialQueryIds = credentialQueryIds,
+        supportedFields = emptyList(),
+        rawJson = "{}",
+        detailsJson = "{}",
+    )
+
+    private fun presentationDisclosure(
+        selectivelyDisclosable: Boolean,
+        required: Boolean,
+        selectable: Boolean,
+    ) = MobileWalletPresentationDisclosure(
+        path = "$.claim",
+        name = "claim",
+        valueJson = "true",
+        displayValue = "true",
+        selectivelyDisclosable = selectivelyDisclosable,
+        required = required,
+        selectable = selectable,
     )
 
     private val displayJson = kotlinx.serialization.json.Json {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -28,6 +28,7 @@ import id.walt.wallet2.mobile.MobileWalletPresentationErrorCode
 import id.walt.wallet2.mobile.MobileWalletPresentationPreview
 import id.walt.wallet2.mobile.MobileWalletPresentationPreviewResult
 import id.walt.wallet2.mobile.MobileWalletPresentationPreviewHandle
+import id.walt.wallet2.mobile.MobileWalletPresentationRequestContext
 import id.walt.wallet2.mobile.MobileWalletPresentationRequestInfo
 import id.walt.wallet2.mobile.MobileWalletPresentationResult
 import id.walt.wallet2.mobile.MobileWalletResponseEncryption
@@ -211,7 +212,7 @@ class WalletSdkBridgeTest {
     fun bridgePresentationPreviewPreservesDetectedProtocolError() = runTest {
         val expected = MobileWalletPresentationPreviewResult.Invalid(
             previewHandle = MobileWalletPresentationPreviewHandle("presentation-preview"),
-            request = MobileWalletPresentationRequestInfo(
+            request = MobileWalletPresentationRequestContext(
                 clientId = "https://verifier.example",
                 verifierMetadata = MobileWalletVerifierMetadata(
                     display = MobileWalletMetadataDisplay(
@@ -226,7 +227,7 @@ class WalletSdkBridgeTest {
                 ),
                 responseUri = "https://verifier.example/direct-post",
                 state = "state-1",
-                nonce = "nonce-1",
+                nonce = null,
                 responseEncryption = MobileWalletResponseEncryption.NotRequired,
             ),
             errorCode = MobileWalletPresentationErrorCode.invalidTransactionData,
@@ -616,11 +617,7 @@ class WalletSdkBridgeTest {
         )
 
         events.emit(
-            MobileWalletEvent(
-                name = "presentation_completed",
-                phase = MobileWalletEventPhase.presentation,
-                status = MobileWalletEventStatus.completed,
-            )
+            MobileWalletEvent.presentation_completed
         )
         val event = bridge.events.first()
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -641,7 +641,7 @@ private extension MobileWalletPresentationPreviewResult {
             return .invalid(
                 PresentationPreviewError(
                     previewHandle: PresentationPreviewHandle(value: result.previewHandle.value),
-                    request: result.request.toSwiftRequestInfo(),
+                    request: result.request.toSwiftRequestContext(),
                     code: result.errorCode.toSwiftErrorCode(),
                     message: result.message
                 )
@@ -661,6 +661,19 @@ private extension MobileWalletPresentationPreview {
                 .map { $0.toSwiftCredentialOption() },
             credentialRequirements: swiftArray(credentialRequirements, of: MobileWalletPresentationCredentialRequirement.self)
                 .map { $0.toSwiftCredentialRequirement() }
+        )
+    }
+}
+
+private extension MobileWalletPresentationRequestContext {
+    func toSwiftRequestContext() -> PresentationRequestContext {
+        PresentationRequestContext(
+            clientID: clientId,
+            verifierMetadata: verifierMetadata?.toSwiftVerifierMetadata(),
+            responseURI: responseUri.flatMap(URL.init(string:)),
+            state: state,
+            nonce: nonce,
+            responseEncryption: responseEncryption.toSwiftResponseEncryption()
         )
     }
 }
@@ -941,34 +954,23 @@ private func swiftArray<T>(_ value: Any, of type: T.Type) -> [T] {
 
 private extension MobileWalletEvent {
     func toSwiftEvent() -> WalletEvent {
-        WalletEvent(
-            name: name,
-            phase: phase.toSwiftPhase(),
-            status: status.toSwiftStatus()
-        )
-    }
-}
-
-private extension MobileWalletEventPhase {
-    func toSwiftPhase() -> WalletEventPhase {
         switch self {
-        case .presentation:
-            return .presentation
-        case .issuance:
-            return .issuance
-        }
-    }
-}
-
-private extension MobileWalletEventStatus {
-    func toSwiftStatus() -> WalletEventStatus {
-        switch self {
-        case .completed:
-            return .completed
-        case .failed:
-            return .failed
-        case .progress:
-            return .progress
+        case .issuanceOfferResolved: return .issuanceOfferResolved
+        case .issuanceAttestationObtained: return .issuanceAttestationObtained
+        case .issuanceTokenObtained: return .issuanceTokenObtained
+        case .issuanceProofSigned: return .issuanceProofSigned
+        case .issuanceCredentialReceived: return .issuanceCredentialReceived
+        case .issuanceDeferred: return .issuanceDeferred
+        case .issuanceCredentialStored: return .issuanceCredentialStored
+        case .issuanceCompleted: return .issuanceCompleted
+        case .issuanceFailed: return .issuanceFailed
+        case .presentationRequestParsed: return .presentationRequestParsed
+        case .presentationCredentialsSelected: return .presentationCredentialsSelected
+        case .presentationSigned: return .presentationSigned
+        case .presentationResponsePrepared: return .presentationResponsePrepared
+        case .presentationSubmitted: return .presentationSubmitted
+        case .presentationCompleted: return .presentationCompleted
+        case .presentationFailed: return .presentationFailed
         }
     }
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -853,8 +853,8 @@ public struct PresentationPreviewError: Equatable, Sendable {
     /// Opaque handle required to reject or discard this reviewed request.
     public let previewHandle: PresentationPreviewHandle
 
-    /// Validated response destination and request context to show before returning the error.
-    public let request: PresentationRequestInfo
+    /// Validated response destination and partial request context to show before returning the error.
+    public let request: PresentationRequestContext
 
     /// OpenID4VP or OAuth authorization error code selected by the wallet.
     public let code: PresentationErrorCode
@@ -871,7 +871,7 @@ public struct PresentationPreviewError: Equatable, Sendable {
     ///   - message: Local diagnostic that is not sent to the verifier automatically.
     public init(
         previewHandle: PresentationPreviewHandle,
-        request: PresentationRequestInfo,
+        request: PresentationRequestContext,
         code: PresentationErrorCode,
         message: String
     ) {
@@ -948,7 +948,76 @@ public struct PresentationCredentialRequirement: Equatable, Sendable {
     /// - Parameter options: Alternative query-id combinations that can satisfy
     ///   this requirement.
     public init(options: [[String]]) {
+        precondition(
+            Self.hasValidOptions(options),
+            "A presentation credential requirement must contain non-empty options with non-blank query IDs."
+        )
         self.options = options
+    }
+
+    static func hasValidOptions(_ options: [[String]]) -> Bool {
+        !options.isEmpty && options.allSatisfy { option in
+            !option.isEmpty && option.allSatisfy(isNonBlank)
+        }
+    }
+}
+
+/// Partial request context retained when an OpenID4VP request is invalid.
+///
+/// A reportable invalid request has a validated, non-blank client identifier.
+/// Its nonce remains optional because a missing nonce can itself be the
+/// validation error. A ready preview exposes a validated, non-optional nonce
+/// through ``PresentationRequestInfo``.
+public struct PresentationRequestContext: Equatable, Sendable {
+    /// Validated OpenID4VP client identifier.
+    public let clientID: String
+
+    /// Typed metadata supplied by the OpenID4VP verifier when available.
+    public let verifierMetadata: VerifierMetadata?
+
+    /// Response URI used for direct-post responses when available.
+    public let responseURI: URL?
+
+    /// OpenID state value when available.
+    public let state: String?
+
+    /// OpenID nonce value when available.
+    public let nonce: String?
+
+    /// Response-encryption state selected for the request when available.
+    public let responseEncryption: PresentationResponseEncryption
+
+    /// Creates partial presentation request context.
+    ///
+    /// - Parameters:
+    ///   - clientID: Validated OpenID4VP client identifier from the request.
+    ///   - verifierMetadata: Typed metadata supplied by the verifier when available.
+    ///   - responseURI: Response URI to which the wallet would submit the presentation or error, when provided.
+    ///   - state: OpenID state value from the request, when provided.
+    ///   - nonce: OpenID nonce value from the request, when provided. May be nil if the missing nonce is the validation error.
+    ///   - responseEncryption: Response-encryption state selected for the request.
+    public init(
+        clientID: String,
+        verifierMetadata: VerifierMetadata? = nil,
+        responseURI: URL? = nil,
+        state: String? = nil,
+        nonce: String? = nil,
+        responseEncryption: PresentationResponseEncryption = .notRequired
+    ) {
+        precondition(
+            Self.hasValidClientID(clientID),
+            "A reportable presentation request must contain a non-blank client ID."
+        )
+        self.clientID = clientID
+        self.verifierMetadata = verifierMetadata
+        self.responseURI = responseURI
+        self.state = state
+        self.nonce = nonce
+        self.responseEncryption = responseEncryption
+    }
+
+    static func hasValidClientID(_ clientID: String) -> Bool {
+        isNonBlank(clientID)
     }
 }
 
@@ -1000,7 +1069,7 @@ public struct ResponseEncryptionDetails: Equatable, Sendable {
 /// Verifier, transaction, and response-protection metadata extracted from a presentation request.
 public struct PresentationRequestInfo: Equatable, Sendable {
     /// OpenID4VP client identifier.
-    public let clientID: String?
+    public let clientID: String
 
     /// Typed metadata supplied by the OpenID4VP verifier when available.
     public let verifierMetadata: VerifierMetadata?
@@ -1012,7 +1081,7 @@ public struct PresentationRequestInfo: Equatable, Sendable {
     public let state: String?
 
     /// OpenID nonce value.
-    public let nonce: String?
+    public let nonce: String
 
     /// Response-encryption state selected for this request.
     public let responseEncryption: PresentationResponseEncryption
@@ -1031,14 +1100,18 @@ public struct PresentationRequestInfo: Equatable, Sendable {
     ///   - responseEncryption: Response-encryption state selected for the request.
     ///   - transactionData: Decoded transaction data attached to the request.
     public init(
-        clientID: String? = nil,
+        clientID: String,
         verifierMetadata: VerifierMetadata? = nil,
         responseURI: URL? = nil,
         state: String? = nil,
-        nonce: String? = nil,
+        nonce: String,
         responseEncryption: PresentationResponseEncryption,
         transactionData: [PresentationTransactionData] = []
     ) {
+        precondition(
+            Self.hasRequiredFields(clientID: clientID, nonce: nonce),
+            "A presentation request must contain non-blank client ID and nonce values."
+        )
         self.clientID = clientID
         self.verifierMetadata = verifierMetadata
         self.responseURI = responseURI
@@ -1046,6 +1119,11 @@ public struct PresentationRequestInfo: Equatable, Sendable {
         self.nonce = nonce
         self.responseEncryption = responseEncryption
         self.transactionData = transactionData
+    }
+
+    static func hasRequiredFields(clientID: String, nonce: String) -> Bool {
+        !clientID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !nonce.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 
@@ -1109,6 +1187,10 @@ public struct PresentationCredentialOption: Equatable, Identifiable, Sendable {
         credentialDataJSON: String,
         disclosures: [PresentationDisclosure] = []
     ) {
+        precondition(
+            isNonBlank(queryID),
+            "A presentation credential option must contain a non-blank query ID."
+        )
         self.queryID = queryID
         self.credentialID = credentialID
         self.multiple = multiple
@@ -1222,8 +1304,25 @@ public struct PresentationDisclosure: Equatable, Identifiable, Sendable {
         self.displayValue = displayValue
         self.selectivelyDisclosable = selectivelyDisclosable
         let resolvedRequired = required ?? !selectivelyDisclosable
+        let resolvedSelectable = selectable ?? (selectivelyDisclosable && !resolvedRequired)
+        precondition(
+            Self.hasValidSelectionState(
+                selectivelyDisclosable: selectivelyDisclosable,
+                required: resolvedRequired,
+                selectable: resolvedSelectable
+            ),
+            "A selectable disclosure must be selectively disclosable and optional."
+        )
         self.required = resolvedRequired
-        self.selectable = selectable ?? (selectivelyDisclosable && !resolvedRequired)
+        self.selectable = resolvedSelectable
+    }
+
+    static func hasValidSelectionState(
+        selectivelyDisclosable: Bool,
+        required: Bool,
+        selectable: Bool
+    ) -> Bool {
+        !selectable || (selectivelyDisclosable && !required)
     }
 }
 
@@ -1264,6 +1363,14 @@ public struct PresentationTransactionData: Equatable, Sendable {
         rawJSON: String,
         detailsJSON: String
     ) {
+        precondition(
+            !credentialQueryIDs.isEmpty,
+            "Transaction data must reference at least one credential query ID."
+        )
+        precondition(
+            credentialQueryIDs.allSatisfy(isNonBlank),
+            "Transaction data must contain non-blank credential query IDs."
+        )
         self.type = type
         self.displayName = displayName
         self.credentialQueryIDs = credentialQueryIDs
@@ -1319,31 +1426,107 @@ public enum PresentationErrorCode: String, Equatable, Sendable {
     public var errorCode: String { rawValue }
 }
 
-/// Progress event emitted while issuance or presentation work is running.
-public struct WalletEvent: Equatable, Sendable {
-    /// Event name emitted by the wallet core.
-    public let name: String
+/// Lifecycle event emitted while issuance or presentation work is running.
+public enum WalletEvent: CaseIterable, Equatable, Sendable {
+    /// Credential offer resolution completed.
+    case issuanceOfferResolved
+    /// Wallet attestation was obtained.
+    case issuanceAttestationObtained
+    /// Issuance token was obtained.
+    case issuanceTokenObtained
+    /// Credential proof was signed.
+    case issuanceProofSigned
+    /// Credential was received from the issuer.
+    case issuanceCredentialReceived
+    /// Issuance was deferred by the issuer.
+    case issuanceDeferred
+    /// Credential was stored locally.
+    case issuanceCredentialStored
+    /// Issuance completed successfully.
+    case issuanceCompleted
+    /// Issuance failed.
+    case issuanceFailed
+    /// Presentation request was parsed.
+    case presentationRequestParsed
+    /// Presentation credentials were selected.
+    case presentationCredentialsSelected
+    /// Presentation was signed.
+    case presentationSigned
+    /// Presentation protocol response was prepared for delivery.
+    case presentationResponsePrepared
+    /// Presentation was submitted.
+    case presentationSubmitted
+    /// Presentation completed successfully.
+    case presentationCompleted
+    /// Presentation failed.
+    case presentationFailed
+
+    /// Creates an event from its stable wallet-core name.
+    ///
+    /// - Parameter name: Stable event name emitted by the wallet core.
+    public init?(name: String) {
+        guard let event = Self.allCases.first(where: { $0.name == name }) else {
+            return nil
+        }
+        self = event
+    }
+
+    /// Stable event name emitted by the wallet core.
+    public var name: String {
+        switch self {
+        case .issuanceOfferResolved: return "issuance_offer_resolved"
+        case .issuanceAttestationObtained: return "issuance_attestation_obtained"
+        case .issuanceTokenObtained: return "issuance_token_obtained"
+        case .issuanceProofSigned: return "issuance_proof_signed"
+        case .issuanceCredentialReceived: return "issuance_credential_received"
+        case .issuanceDeferred: return "issuance_deferred"
+        case .issuanceCredentialStored: return "issuance_credential_stored"
+        case .issuanceCompleted: return "issuance_completed"
+        case .issuanceFailed: return "issuance_failed"
+        case .presentationRequestParsed: return "presentation_request_parsed"
+        case .presentationCredentialsSelected: return "presentation_credentials_selected"
+        case .presentationSigned: return "presentation_signed"
+        case .presentationResponsePrepared: return "presentation_response_prepared"
+        case .presentationSubmitted: return "presentation_submitted"
+        case .presentationCompleted: return "presentation_completed"
+        case .presentationFailed: return "presentation_failed"
+        }
+    }
 
     /// High-level workflow phase for the event.
-    public let phase: WalletEventPhase
+    public var phase: WalletEventPhase {
+        switch self {
+        case .issuanceOfferResolved,
+             .issuanceAttestationObtained,
+             .issuanceTokenObtained,
+             .issuanceProofSigned,
+             .issuanceCredentialReceived,
+             .issuanceDeferred,
+             .issuanceCredentialStored,
+             .issuanceCompleted,
+             .issuanceFailed:
+            return .issuance
+        case .presentationRequestParsed,
+             .presentationCredentialsSelected,
+             .presentationSigned,
+             .presentationResponsePrepared,
+             .presentationSubmitted,
+             .presentationCompleted,
+             .presentationFailed:
+            return .presentation
+        }
+    }
 
     /// High-level status for the event.
-    public let status: WalletEventStatus
-
-    /// Creates a wallet progress event.
-    ///
-    /// - Parameters:
-    ///   - name: Event name emitted by the wallet core.
-    ///   - phase: High-level issuance or presentation phase.
-    ///   - status: High-level progress status.
-    public init(
-        name: String,
-        phase: WalletEventPhase,
-        status: WalletEventStatus
-    ) {
-        self.name = name
-        self.phase = phase
-        self.status = status
+    public var status: WalletEventStatus {
+        switch self {
+        case .issuanceCompleted, .presentationCompleted:
+            return .completed
+        case .issuanceFailed, .presentationFailed:
+            return .failed
+        default:
+            return .progress
+        }
     }
 }
 
@@ -1366,4 +1549,8 @@ public enum WalletEventStatus: Equatable, Sendable {
 
     /// The operation failed.
     case failed
+}
+
+private func isNonBlank(_ value: String) -> Bool {
+    !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -420,7 +420,7 @@ final class WalletAPITests: XCTestCase {
 
     func testPreviewPresentationReturnsTypedProtocolError() async throws {
         let request = URL(string: "openid4vp://verifier.example?request_uri=abc")!
-        let requestInfo = PresentationRequestInfo(
+        let requestInfo = PresentationRequestContext(
             clientID: "https://verifier.example",
             verifierMetadata: testVerifierMetadata,
             responseEncryption: .notRequired
@@ -552,7 +552,7 @@ final class WalletAPITests: XCTestCase {
     }
 
     func testEventsReturnsBridgeEventStream() async {
-        let event = WalletEvent(name: "receive", phase: .issuance, status: .progress)
+        let event = WalletEvent.issuanceOfferResolved
         let bridge = FakeWalletCoreBridge(events: [event])
         let wallet = Wallet(bridge: bridge)
 
@@ -563,7 +563,61 @@ final class WalletAPITests: XCTestCase {
         let second = await iterator.next()
 
         XCTAssertEqual(first, event)
+        XCTAssertEqual(first?.phase, .issuance)
+        XCTAssertEqual(first?.status, .progress)
         XCTAssertNil(second)
+    }
+
+    func testWalletEventsHaveAClosedNamePhaseAndStatusMapping() {
+        let completed = WalletEvent.issuanceCompleted
+        let failed = WalletEvent.presentationFailed
+
+        XCTAssertEqual(WalletEvent.allCases.count, 16)
+        XCTAssertEqual(completed.name, "issuance_completed")
+        XCTAssertEqual(completed.phase, .issuance)
+        XCTAssertEqual(completed.status, .completed)
+        XCTAssertEqual(failed.name, "presentation_failed")
+        XCTAssertEqual(failed.phase, .presentation)
+        XCTAssertEqual(failed.status, .failed)
+        XCTAssertEqual(WalletEvent.presentationResponsePrepared.name, "presentation_response_prepared")
+        XCTAssertEqual(WalletEvent.presentationResponsePrepared.status, .progress)
+        XCTAssertNil(WalletEvent(name: "presentation_request_resolved"))
+    }
+
+    func testPresentationModelValidationRejectsInvalidStates() {
+        XCTAssertFalse(PresentationRequestContext.hasValidClientID(" "))
+        XCTAssertTrue(PresentationRequestContext.hasValidClientID("https://verifier.example"))
+
+        XCTAssertFalse(PresentationCredentialRequirement.hasValidOptions([]))
+        XCTAssertFalse(PresentationCredentialRequirement.hasValidOptions([[]]))
+        XCTAssertFalse(PresentationCredentialRequirement.hasValidOptions([[" "]]))
+        XCTAssertTrue(PresentationCredentialRequirement.hasValidOptions([["pid 1", "age.credential"]]))
+
+        XCTAssertFalse(PresentationRequestInfo.hasRequiredFields(clientID: "", nonce: "nonce"))
+        XCTAssertFalse(PresentationRequestInfo.hasRequiredFields(clientID: "client", nonce: " "))
+        XCTAssertTrue(PresentationRequestInfo.hasRequiredFields(clientID: "client", nonce: "nonce"))
+
+        XCTAssertFalse(
+            PresentationDisclosure.hasValidSelectionState(
+                selectivelyDisclosable: false,
+                required: false,
+                selectable: true
+            )
+        )
+        XCTAssertFalse(
+            PresentationDisclosure.hasValidSelectionState(
+                selectivelyDisclosable: true,
+                required: true,
+                selectable: true
+            )
+        )
+        XCTAssertTrue(
+            PresentationDisclosure.hasValidSelectionState(
+                selectivelyDisclosable: true,
+                required: false,
+                selectable: true
+            )
+        )
     }
 
     private func acceptsSendable<T: Sendable>(_ value: T) {
@@ -721,8 +775,9 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
         PresentationPreview(
             previewHandle: PresentationPreviewHandle(value: "fake-presentation-preview"),
             request: .init(
-                clientID: nil,
-                responseEncryption: .notRequired
+                clientID: "https://verifier.example",
+                nonce: "nonce-1",
+                responseEncryption: .notRequired,
             ),
             credentialOptions: []
         )


### PR DESCRIPTION
## Summary

Tightens the Kotlin and Swift mobile-wallet result models so callers cannot construct contradictory or incomplete presentation and event states.

This is the successor to the accidentally merged [walt-id/waltid-identity#1932](https://github.com/walt-id/waltid-identity/pull/1932).

This PR targets `main` and only tightens the existing mobile-wallet presentation and event result models. It preserves the existing reviewed-preview handle contract on `main`; OpenID4VCI authorization-code issuance and issuance-session changes are out of scope.

## What Changed

### Closed Event Domain

- Replaces open event value objects with closed Kotlin and Swift enums covering all wallet-core issuance and presentation events.
- Maps the core Kotlin enum exhaustively through the mobile and Swift facades, so a new event requires an explicit consumer mapping.
- Derives each event’s phase and status from its case rather than accepting independently supplied values.

### Presentation Preview Results

- Makes a ready presentation preview’s `client_id` and `nonce` required and non-blank.
- Gives reportable invalid previews a separate partial request context with a required, non-blank `client_id` and optional `nonce`; a missing nonce can itself be the detected validation error.
- Preserves the existing reviewed-preview handle on ready and invalid results so dismissal or rejection remains tied to the reviewed request.
- Rejects empty credential requirements or alternatives, blank query references, invalid returned credential-option references, and invalid selectable-disclosure combinations.

### Platform Parity

- Keeps Kotlin, SKIE-generated Swift, the Compose demo, and the native iOS demo aligned with the tightened model contracts.
- Updates the published Kotlin ABI baseline for the new public result types.

## Architecture Notes

- Events are enums because their domain is finite and carries no case-specific payload.
- Ready previews expose validated `MobileWalletPresentationRequestInfo` / `PresentationRequestInfo`. Invalid previews expose `MobileWalletPresentationRequestContext` / `PresentationRequestContext` so the API accurately represents a reportable error state without pretending a nonce was validated.
- Public constructors remain available for SDK fixture and preview construction; their checks enforce internally consistent values.

## Caveats and Follow-Ups

- OpenID4VCI authorization-code issuance, issuance-session persistence, callback handling, and demo issuance flows are intentionally outside this PR.
- Mobile wallet configuration and protocol-level DCQL grammar or aggregate request validation remain outside this result-model cleanup.

## Breaking Changes

`MobileWalletEvent` and Swift `WalletEvent` are closed enums. Callers constructing event fixtures must select a declared event case; Swift callers that parse a stable name can use `WalletEvent(name:)`.

Ready preview request `clientId` / `clientID` and `nonce` are now required and non-blank. Invalid preview results use the separate partial request-context type, whose client identifier is required while its nonce remains optional.