### PR TITLE
[WAL-1211] feat(wallet): support signed issuer metadata and request authentication

### DIFF
--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 public struct DemoCredentialScenario {
     public let id: String
@@ -17,6 +18,11 @@ public struct DemoOffer {
 public struct DemoVerifierSession {
     public let sessionID: String
     public let authorizationRequestUri: String
+}
+
+public struct DemoMetadataSigner {
+    public let keyID: String?
+    public let algorithm: String
 }
 
 public final class DemoBackend {
@@ -73,7 +79,16 @@ public final class DemoBackend {
     public static let persistenceScenario = scenarios.first { $0.id == "eudi-pid-mdoc" }!
 
     private static let issuerBaseURL = URL(string: "https://issuer2.demo.walt.id")!
+    public static let issuerIdentifier = "https://issuer2.demo.walt.id/openid4vci"
+    // RFC 7638 thumbprint of the public issuer2 signing key from /openid4vci/jwks.
+    // This independent pin must not be learned from the signed metadata JWT.
+    private static let issuerMetadataSigningKeyThumbprint = "gzGuLAZEJ5AsVMZ3mRQ1jsRQbbaS78mpHzQmTFytwF0"
     private static let verifierBaseURL = URL(string: "https://verifier2.demo.walt.id")!
+    /// The public verifier requires this explicit client ID for signed request objects.
+    public static let verifierClientID = "verifier2"
+    /// Pre-registered metadata for the ES256 request-object signing key currently served by verifier2.
+    /// This key is an independent trust anchor and must not be learned from the request object.
+    public static let verifierRequestObjectClientMetadataJSON = #"{"jwks":{"keys":[{"kty":"EC","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}]}}"#
 
     private let client: WalletE2EClient
 
@@ -134,6 +149,62 @@ public final class DemoBackend {
         )
     }
 
+    public func createVerifierSession(
+        scenario: DemoCredentialScenario,
+        signedRequest: Bool
+    ) async throws -> DemoVerifierSession {
+        try await createVerifierSession(
+            scenario: scenario,
+            transactionData: [],
+            signedRequest: signedRequest
+        )
+    }
+
+    /** Verifies an ES256 signed-metadata JWS served by the public issuer2 demo. */
+    public static func verifySignedIssuerMetadata(
+        compactJWT: String,
+        expectedCredentialIssuer: String
+    ) throws -> DemoMetadataSigner {
+        guard expectedCredentialIssuer == issuerIdentifier else {
+            throw NSError(
+                domain: "WalletE2E",
+                code: 309,
+                userInfo: [NSLocalizedDescriptionKey: "Unexpected public demo Credential Issuer: \(expectedCredentialIssuer)"]
+            )
+        }
+        let parts = compactJWT.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let headerData = base64URLData(String(parts[0])),
+              let header = try JSONSerialization.jsonObject(with: headerData) as? [String: Any],
+              let algorithm = header["alg"] as? String,
+              algorithm == "ES256",
+              let jwk = header["jwk"] as? [String: Any],
+              jwk["kty"] as? String == "EC",
+              jwk["crv"] as? String == "P-256",
+              let x = jwk["x"] as? String,
+              let y = jwk["y"] as? String,
+              let xData = base64URLData(x),
+              let yData = base64URLData(y),
+              let signatureData = base64URLData(String(parts[2])) else {
+            throw NSError(domain: "WalletE2E", code: 310, userInfo: [NSLocalizedDescriptionKey: "Malformed public demo signed metadata"])
+        }
+        let thumbprintJwk = "{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"\(x)\",\"y\":\"\(y)\"}"
+        let thumbprint = base64URLString(Data(SHA256.hash(data: Data(thumbprintJwk.utf8))))
+        guard thumbprint == Self.issuerMetadataSigningKeyThumbprint else {
+            throw NSError(
+                domain: "WalletE2E",
+                code: 312,
+                userInfo: [NSLocalizedDescriptionKey: "Public demo signed metadata key is not the pinned issuer2 signing key"]
+            )
+        }
+        let publicKey = try P256.Signing.PublicKey(x963Representation: Data([0x04]) + xData + yData)
+        let signature = try P256.Signing.ECDSASignature(rawRepresentation: signatureData)
+        guard publicKey.isValidSignature(signature, for: Data("\(parts[0]).\(parts[1])".utf8)) else {
+            throw NSError(domain: "WalletE2E", code: 311, userInfo: [NSLocalizedDescriptionKey: "Invalid public demo signed metadata signature"])
+        }
+        return DemoMetadataSigner(keyID: header["kid"] as? String, algorithm: algorithm)
+    }
+
     public func createResponseBoundVerifierSession(scenario: DemoCredentialScenario) async throws -> DemoVerifierSession {
         try await createVerifierSession(
             scenario: scenario,
@@ -181,8 +252,13 @@ public final class DemoBackend {
     private func createVerifierSession(
         scenario: DemoCredentialScenario,
         transactionData: [[String: Any]],
-        bindClientIDToResponseURI: Bool = false
+        bindClientIDToResponseURI: Bool = false,
+        signedRequest: Bool = false
     ) async throws -> DemoVerifierSession {
+        precondition(
+            !(bindClientIDToResponseURI && signedRequest),
+            "A signed verifier request cannot use a response-bound redirect_uri client ID"
+        )
         let endpoint = Self.verifierBaseURL
             .appendingPathComponent("verification-session")
             .appendingPathComponent("create")
@@ -192,6 +268,10 @@ public final class DemoBackend {
                 "credentials": [scenario.verifierCredentialQuery],
             ],
         ]
+        if signedRequest {
+            coreFlow["signed_request"] = true
+            coreFlow["clientId"] = Self.verifierClientID
+        }
         if let requestedSessionID {
             let responseURI = Self.verifierBaseURL
                 .appendingPathComponent("verification-session")
@@ -363,6 +443,21 @@ public final class DemoBackend {
         payload.putProfileField(fields: fields, key: "currency", value: "EUR")
         return payload
     }
+}
+
+private func base64URLData(_ value: String) -> Data? {
+    let padded = value
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+        .padding(toLength: ((value.count + 3) / 4) * 4, withPad: "=", startingAt: 0)
+    return Data(base64Encoded: padded)
+}
+
+private func base64URLString(_ value: Data) -> String {
+    value.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
 }
 
 private extension Dictionary where Key == String, Value == Any {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/MockWalletClient.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/MockWalletClient.swift
@@ -58,7 +58,14 @@ actor MockWalletClient: WalletClient {
             id: "mock-session",
             offer: .init(
                 grant: issuanceGrant,
-                issuer: .init(identifier: "https://issuer.example", name: "Example Issuer", locale: nil, logoURI: nil, logoAltText: nil),
+                issuer: .init(
+                    identifier: "https://issuer.example",
+                    name: "Example Issuer",
+                    locale: nil,
+                    logoURI: nil,
+                    logoAltText: nil,
+                    metadataProvenance: .unsigned
+                ),
                 credentials: [.init(configurationID: "ExampleCredential", format: "dc+sd-jwt", name: "Example", descriptionText: nil, logoURI: nil)],
                 transactionCode: transactionCodeRequired
                     ? .init(inputMode: "numeric", length: 6, descriptionText: "Enter the six-digit code")
@@ -163,6 +170,7 @@ actor MockWalletClient: WalletClient {
                     termsOfServiceURI: "https://verifier.example/terms"
                 )
             },
+            requestAuthentication: .unauthenticated,
             responseURI: URL(string: "https://verifier.example/response"),
             state: "state-123",
             nonce: "nonce-456",

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
@@ -805,6 +805,7 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
     func testTransactionDataGroupsRenderProfileAndDetailsReadably() throws {
         let request = PresentationRequestInfo(
             clientID: "https://verifier.example",
+            requestAuthentication: .unauthenticated,
             nonce: "nonce-1",
             responseEncryption: .notRequired,
             transactionData: [

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -104,7 +104,8 @@ final class MobileWalletIntegrationTests: XCTestCase {
                     ]
                 ),
                 issuerMetadataTrustResolver: PublicDemoIssuerMetadataTrustResolver(),
-                transactionDataProfiles: Self.demoTransactionDataProfiles
+                transactionDataProfiles: Self.demoTransactionDataProfiles,
+                defaultKeyUseAuthorizationPolicy: .none
             )
         )
     }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -94,6 +94,21 @@ final class MobileWalletIntegrationTests: XCTestCase {
         )
     }
 
+    private func makeSignedMetadataWallet(walletId: String) async throws -> Wallet {
+        try await Wallet(
+            configuration: WalletConfiguration(
+                walletID: walletId,
+                clientIDTrustConfiguration: WalletClientIDTrustConfiguration(
+                    preRegisteredClientMetadataJSON: [
+                        DemoBackend.verifierClientID: DemoBackend.verifierRequestObjectClientMetadataJSON,
+                    ]
+                ),
+                issuerMetadataTrustResolver: PublicDemoIssuerMetadataTrustResolver(),
+                transactionDataProfiles: Self.demoTransactionDataProfiles
+            )
+        )
+    }
+
     private func makeWallet(persistence: WalletPersistence) async throws -> Wallet {
         try await Wallet(
             configuration: WalletConfiguration(
@@ -311,6 +326,56 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
     func testReceiveIsoMdlCredentialFromDemoIssuer2() async throws {
         try await receiveCredentialFromDemoIssuer2(scenarioID: "iso-mdl")
+    }
+
+    func testReceiveAndPresentUsingSignedMetadataAgainstDemoIssuer2AndVerifier2() async throws {
+        let scenario = try demoPresentationScenario("eudi-pid-mdoc")
+        let walletID = "ios-demo-signed-\(UUID().uuidString)"
+        await clearTestData(walletId: walletID)
+        let wallet = try await makeSignedMetadataWallet(walletId: walletID)
+        let bootstrap = try await wallet.bootstrap()
+        let offer = try await DemoBackend.shared.createOffer(scenario: scenario)
+        let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
+
+        let issuanceSession = try await startIssuance(wallet: wallet, offerURL: offerURL)
+        guard case let .signed(issuerProvenance) = issuanceSession.offer.issuer.metadataProvenance else {
+            return XCTFail("Expected signed issuer metadata provenance")
+        }
+        XCTAssertFalse(issuerProvenance.compactJWT.isEmpty)
+        XCTAssertEqual("ES256", issuerProvenance.algorithm)
+        XCTAssertNotNil(issuerProvenance.keyID)
+        XCTAssertEqual(.trustedIssuer, issuerProvenance.trustType)
+
+        let outcome = try await wallet.continuePreAuthorizedIssuance(
+            sessionID: issuanceSession.id,
+            transactionCode: offer.txCode
+        )
+        guard case let .stored(_, credentialIDs) = outcome else {
+            throw MobileWalletIntegrationError.unexpectedIssuanceOutcome
+        }
+        XCTAssertFalse(credentialIDs.isEmpty, "Should receive a credential from reviewed signed metadata")
+
+        let signedSession = try await DemoBackend.shared.createVerifierSession(scenario: scenario, signedRequest: true)
+        let presentationURL = try XCTUnwrap(URL(string: signedSession.authorizationRequestUri))
+        let preview = try requireReadyPreview(try await wallet.previewPresentation(request: presentationURL))
+        guard case let .authenticated(compactRequestObject, algorithm, keyID, clientIDScheme) = preview.request.requestAuthentication else {
+            return XCTFail("Expected authenticated signed verifier request")
+        }
+        XCTAssertFalse(compactRequestObject.isEmpty)
+        XCTAssertEqual("ES256", algorithm)
+        XCTAssertNotNil(keyID)
+        XCTAssertEqual(.preRegistered, clientIDScheme)
+
+        let result = try await wallet.submitPresentation(
+            previewHandle: preview.previewHandle,
+            selectedCredentialOptions: preview.credentialOptions.map(\.selection),
+            did: bootstrap.did
+        )
+        assertTransmittedSuccess(result, "Signed public demo presentation should succeed")
+        try await DemoBackend.shared.waitForVerifierSuccess(
+            sessionID: signedSession.sessionID,
+            timeoutSeconds: verifierPollingTimeout
+        )
     }
 
     func testReceiveAndPresentEudiEhicSdJwtAgainstEudi() async throws {
@@ -768,6 +833,20 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
 private enum MobileWalletIntegrationError: Error {
     case unexpectedIssuanceOutcome
+}
+
+private struct PublicDemoIssuerMetadataTrustResolver: IssuerMetadataTrustResolver {
+    func verify(compactJWT: String, expectedCredentialIssuer: String) async throws -> IssuerMetadataSigner {
+        let signer = try DemoBackend.verifySignedIssuerMetadata(
+            compactJWT: compactJWT,
+            expectedCredentialIssuer: expectedCredentialIssuer
+        )
+        return IssuerMetadataSigner(
+            keyID: signer.keyID,
+            algorithm: signer.algorithm,
+            trustType: .trustedIssuer
+        )
+    }
 }
 
 private actor RecordingWalletCredentialStore: WalletCredentialStore {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/SharingReviewModelTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/SharingReviewModelTests.swift
@@ -301,6 +301,7 @@ final class SharingReviewModelTests: XCTestCase {
                 policyURI: nil,
                 termsOfServiceURI: nil
             ),
+            requestAuthentication: .unauthenticated,
             responseEncryption: .notRequired
         ).sharingRequest()
 
@@ -423,6 +424,7 @@ final class SharingReviewModelTests: XCTestCase {
             request: PresentationRequestInfo(
                 clientID: "https://verifier.example",
                 verifierMetadata: verifierMetadata,
+                requestAuthentication: .unauthenticated,
                 responseURI: URL(string: "https://verifier.example/response"),
                 state: "state-123",
                 nonce: "nonce-456",

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelPresentationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelPresentationTests.swift
@@ -24,6 +24,7 @@ final class WalletViewModelPresentationTests: XCTestCase {
                     policyURI: nil,
                     termsOfServiceURI: nil
                 ),
+                requestAuthentication: .unauthenticated,
                 responseEncryption: .notRequired
             ),
             code: .invalidTransactionData,

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelReceiveTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelReceiveTests.swift
@@ -289,7 +289,14 @@ private actor TransactionCodeWalletClient: WalletClient {
             id: "transaction-code-session",
             offer: IssuanceOfferPreview(
                 grant: issuanceGrant,
-                issuer: IssuanceIssuerPreview(identifier: "https://issuer.example", name: "Example Issuer", locale: nil, logoURI: nil, logoAltText: nil),
+                issuer: IssuanceIssuerPreview(
+                    identifier: "https://issuer.example",
+                    name: "Example Issuer",
+                    locale: nil,
+                    logoURI: nil,
+                    logoAltText: nil,
+                    metadataProvenance: .unsigned
+                ),
                 credentials: [IssuanceCredentialPreview(configurationID: "ExampleCredential", format: "vc+sd-jwt", name: "Example credential", descriptionText: nil, logoURI: nil)],
                 transactionCode: transactionCode
             )
@@ -344,6 +351,7 @@ private actor TransactionCodeWalletClient: WalletClient {
                 previewHandle: PresentationPreviewHandle(value: "transaction-code-presentation-preview"),
                 request: PresentationRequestInfo(
                     clientID: "https://verifier.example",
+                    requestAuthentication: .unauthenticated,
                     nonce: "nonce-1",
                     responseEncryption: .notRequired,
                 ),

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
@@ -11,6 +11,10 @@ waltidMobile {
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(project(":waltid-libraries:crypto:waltid-crypto2"))
+            implementation(project(":waltid-libraries:crypto:waltid-jose"))
+            implementation(project(":waltid-libraries:protocols:waltid-openid4vci"))
+            implementation(project(":waltid-libraries:protocols:waltid-openid4vci-wallet"))
             implementation(identityLibs.ktor.client.core)
             implementation(identityLibs.kotlinx.serialization.json)
         }

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -1,5 +1,19 @@
 package id.walt.mobile.test.backend
 
+import id.walt.crypto2.CryptoRuntime
+import id.walt.crypto2.jose.CompactJws
+import id.walt.crypto2.jose.Jwk
+import id.walt.crypto2.jose.JwsAlgorithm
+import id.walt.crypto2.keys.EncodedKey
+import id.walt.crypto2.keys.KeyId
+import id.walt.crypto2.keys.KeyUsage
+import id.walt.crypto2.keys.toStoredSoftwareKey
+import id.walt.crypto2.providers.cryptography.CryptographySoftwareKeyProvider
+import id.walt.crypto2.serialization.BinaryData
+import id.walt.openid4vci.tokens.jwt.JwtHeaderParams
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.*
@@ -29,7 +43,20 @@ import kotlin.uuid.Uuid
 object DemoTestBackend {
 
     private const val ISSUER_BASE_URL = "https://issuer2.demo.walt.id"
+    private const val ISSUER_IDENTIFIER = "$ISSUER_BASE_URL/openid4vci"
+    // RFC 7638 thumbprint of the issuer2 metadata signing key published at
+    // https://issuer2.demo.walt.id/openid4vci/jwks. This is an independent trust anchor;
+    // it must not be learned from the signed metadata JWT itself.
+    private const val ISSUER_METADATA_SIGNING_KEY_THUMBPRINT =
+        "gzGuLAZEJ5AsVMZ3mRQ1jsRQbbaS78mpHzQmTFytwF0"
     private const val VERIFIER_BASE_URL = "https://verifier2.demo.walt.id"
+    // The demo verifier only accepts signed requests for an explicitly configured client ID.
+    const val PUBLIC_DEMO_VERIFIER_CLIENT_ID = "verifier2"
+    // `kid`, `x`, and `y` of the ES256 request-object signing key served by verifier2's x5c header.
+    // This is a pre-registered trust anchor: it must not be learned from the request object itself.
+    private const val VERIFIER_REQUEST_OBJECT_SIGNING_KEY_ID = "_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug"
+    private const val VERIFIER_REQUEST_OBJECT_SIGNING_KEY_X = "G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0"
+    private const val VERIFIER_REQUEST_OBJECT_SIGNING_KEY_Y = "VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"
 
     const val TRANSACTION_DATA_PROFILES_URL = "https://wallet.demo.walt.id/wallet-api/transaction-data-profiles"
     private const val EUDI_PID_SD_JWT_VCT = "$ISSUER_BASE_URL/openid4vci/urn:eudi:pid:1"
@@ -42,6 +69,7 @@ object DemoTestBackend {
     const val SCA_PAYMENT_AMOUNT = 11.56
     const val SCA_PAYMENT_TRANSACTION_ID = "8D8AC610-566D-4EF0-9C22-186B2A5ED793"
     private val requiredPaymentAuthorizationFields = setOf("merchant_name", "amount", "currency")
+    private val metadataCryptoRuntime = CryptoRuntime(listOf(CryptographySoftwareKeyProvider()))
 
     val scenarios = listOf(
         CredentialScenario(
@@ -248,6 +276,61 @@ object DemoTestBackend {
         return createVerifierSession(scenario.verifierCredentialQuery)
     }
 
+    suspend fun createVerifierSession(
+        scenario: CredentialScenario,
+        signedRequest: Boolean,
+    ): VerifierSession = createVerifierSession(
+        credentialQuery = scenario.verifierCredentialQuery,
+        transactionData = emptyList(),
+        signedRequest = signedRequest,
+    )
+
+    /** Public key that authenticates signed request objects served by the public verifier2 demo. */
+    val publicDemoVerifierRequestObjectSigningJwk = buildJsonObject {
+        put("kty", "EC")
+        put("crv", "P-256")
+        put("kid", VERIFIER_REQUEST_OBJECT_SIGNING_KEY_ID)
+        put("x", VERIFIER_REQUEST_OBJECT_SIGNING_KEY_X)
+        put("y", VERIFIER_REQUEST_OBJECT_SIGNING_KEY_Y)
+    }
+
+    /** Trust resolver for signed metadata served by the public issuer2 demo. */
+    val publicDemoIssuerMetadataTrustResolver = CredentialIssuerMetadataTrustResolver { compactJwt, expectedCredentialIssuer ->
+        require(expectedCredentialIssuer == ISSUER_IDENTIFIER) {
+            "Unexpected public demo Credential Issuer: $expectedCredentialIssuer"
+        }
+        val decoded = CompactJws.decodeUnverified(compactJwt)
+        val algorithm = decoded.protectedHeader[JwtHeaderParams.ALGORITHM]?.jsonPrimitive?.contentOrNull
+            ?: error("Public demo signed metadata is missing alg")
+        require(algorithm == "ES256") {
+            "Unsupported public demo signed metadata algorithm: $algorithm"
+        }
+        val jwk = decoded.protectedHeader[JwtHeaderParams.JSON_WEB_KEY]?.jsonObject
+            ?: error("Public demo signed metadata is missing jwk")
+        require(jwk["kty"]?.jsonPrimitive?.contentOrNull == "EC") {
+            "Public demo signed metadata jwk must use EC"
+        }
+        require(jwk["crv"]?.jsonPrimitive?.contentOrNull == "P-256") {
+            "Public demo signed metadata jwk must use P-256"
+        }
+        val encodedVerificationKey = EncodedKey.Jwk(
+            data = BinaryData(jwk.toString().encodeToByteArray()),
+            privateMaterial = false,
+        )
+        require(Jwk.sha256Thumbprint(encodedVerificationKey) == ISSUER_METADATA_SIGNING_KEY_THUMBPRINT) {
+            "Public demo signed metadata key is not the pinned issuer2 signing key"
+        }
+        val verificationKey = metadataCryptoRuntime.restore(
+            encodedVerificationKey.toStoredSoftwareKey(KeyId("issuer2-metadata"), setOf(KeyUsage.VERIFY))
+        )
+        CompactJws.verify(compactJwt, verificationKey, JwsAlgorithm.ES256)
+        MetadataSigner(
+            keyId = decoded.protectedHeader[JwtHeaderParams.KEY_ID]?.jsonPrimitive?.contentOrNull,
+            algorithm = algorithm,
+            trustType = MetadataSignerTrustType.TRUSTED_ISSUER,
+        )
+    }
+
     suspend fun createResponseBoundVerifierSession(scenario: CredentialScenario): VerifierSession {
         return createVerifierSession(
             credentialQuery = scenario.verifierCredentialQuery,
@@ -355,11 +438,19 @@ object DemoTestBackend {
         credentialQuery: JsonObject,
         transactionData: List<JsonObject>,
         bindClientIdToResponseUri: Boolean = false,
+        signedRequest: Boolean = false,
     ): VerifierSession {
+        require(!(bindClientIdToResponseUri && signedRequest)) {
+            "A signed verifier request cannot use a response-bound redirect_uri client ID"
+        }
         val requestedSessionId = Uuid.random().toString().takeIf { bindClientIdToResponseUri }
         val payload = buildJsonObject {
             put("flow_type", "cross_device")
             putJsonObject("core_flow") {
+                if (signedRequest) {
+                    put("signed_request", true)
+                    put("clientId", PUBLIC_DEMO_VERIFIER_CLIENT_ID)
+                }
                 requestedSessionId?.let { sessionId ->
                     val responseUri = "$VERIFIER_BASE_URL/verification-session/$sessionId/response"
                     put("sessionId", sessionId)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -41,6 +41,17 @@ final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeErrorCategory :
     }
 }
 
+final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType|null[0]
+    enum entry TrustedDelegate // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.TrustedDelegate|null[0]
+    enum entry TrustedIssuer // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.TrustedIssuer|null[0]
+
+    final val entries // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.values|values#static(){}[0]
+}
+
 final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType|null[0]
     enum entry BiometricCurrentSet // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.BiometricCurrentSet|null[0]
     enum entry BiometricTimedReuse // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse|null[0]
@@ -103,6 +114,22 @@ final enum class id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus : 
 
     final fun valueOf(kotlin/String): id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus> // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.values|values#static(){}[0]
+}
+
+final enum class id.walt.wallet2.mobile/MobileWalletClientIdScheme : kotlin/Enum<id.walt.wallet2.mobile/MobileWalletClientIdScheme> { // id.walt.wallet2.mobile/MobileWalletClientIdScheme|null[0]
+    enum entry DECENTRALIZED_IDENTIFIER // id.walt.wallet2.mobile/MobileWalletClientIdScheme.DECENTRALIZED_IDENTIFIER|null[0]
+    enum entry OPENID_FEDERATION // id.walt.wallet2.mobile/MobileWalletClientIdScheme.OPENID_FEDERATION|null[0]
+    enum entry PRE_REGISTERED // id.walt.wallet2.mobile/MobileWalletClientIdScheme.PRE_REGISTERED|null[0]
+    enum entry REDIRECT_URI // id.walt.wallet2.mobile/MobileWalletClientIdScheme.REDIRECT_URI|null[0]
+    enum entry VERIFIER_ATTESTATION // id.walt.wallet2.mobile/MobileWalletClientIdScheme.VERIFIER_ATTESTATION|null[0]
+    enum entry X509_HASH // id.walt.wallet2.mobile/MobileWalletClientIdScheme.X509_HASH|null[0]
+    enum entry X509_SAN_DNS // id.walt.wallet2.mobile/MobileWalletClientIdScheme.X509_SAN_DNS|null[0]
+
+    final val entries // id.walt.wallet2.mobile/MobileWalletClientIdScheme.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile/MobileWalletClientIdScheme> // id.walt.wallet2.mobile/MobileWalletClientIdScheme.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile/MobileWalletClientIdScheme // id.walt.wallet2.mobile/MobileWalletClientIdScheme.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile/MobileWalletClientIdScheme> // id.walt.wallet2.mobile/MobileWalletClientIdScheme.values|values#static(){}[0]
 }
 
 final enum class id.walt.wallet2.mobile/MobileWalletDigitalCredentialFormat : kotlin/Enum<id.walt.wallet2.mobile/MobileWalletDigitalCredentialFormat> { // id.walt.wallet2.mobile/MobileWalletDigitalCredentialFormat|null[0]
@@ -260,6 +287,10 @@ abstract interface id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore { //
     abstract suspend fun getDid(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeStoredDid? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore.getDid|getDid(kotlin.String){}[0]
     abstract suspend fun listDids(): kotlin.collections/List<id.walt.wallet2.mobile.swiftinterop/WalletBridgeStoredDid> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore.listDids|listDids(){}[0]
     abstract suspend fun removeDid(kotlin/String): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore.removeDid|removeDid(kotlin.String){}[0]
+}
+
+abstract interface id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver|null[0]
+    abstract suspend fun verify(kotlin/String, kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver.verify|verify(kotlin.String;kotlin.String){}[0]
 }
 
 abstract interface id.walt.wallet2.mobile/MobileWalletCredentialRegistry { // id.walt.wallet2.mobile/MobileWalletCredentialRegistry|null[0]
@@ -530,6 +561,36 @@ sealed interface id.walt.wallet2.mobile/MobileWalletReaderTrust { // id.walt.wal
 
 sealed interface id.walt.wallet2.mobile/MobileWalletReaderTrustDecision : id.walt.wallet2.mobile/MobileWalletReaderTrust // id.walt.wallet2.mobile/MobileWalletReaderTrustDecision|null[0]
 
+sealed interface id.walt.wallet2.mobile/MobileWalletRequestAuthentication { // id.walt.wallet2.mobile/MobileWalletRequestAuthentication|null[0]
+    final class Authenticated : id.walt.wallet2.mobile/MobileWalletRequestAuthentication { // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated|null[0]
+        constructor <init>(kotlin/String, kotlin/String, kotlin/String?, id.walt.wallet2.mobile/MobileWalletClientIdScheme) // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.<init>|<init>(kotlin.String;kotlin.String;kotlin.String?;id.walt.wallet2.mobile.MobileWalletClientIdScheme){}[0]
+
+        final val algorithm // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.algorithm|{}algorithm[0]
+            final fun <get-algorithm>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.algorithm.<get-algorithm>|<get-algorithm>(){}[0]
+        final val clientIdScheme // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.clientIdScheme|{}clientIdScheme[0]
+            final fun <get-clientIdScheme>(): id.walt.wallet2.mobile/MobileWalletClientIdScheme // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.clientIdScheme.<get-clientIdScheme>|<get-clientIdScheme>(){}[0]
+        final val compactRequestObject // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.compactRequestObject|{}compactRequestObject[0]
+            final fun <get-compactRequestObject>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.compactRequestObject.<get-compactRequestObject>|<get-compactRequestObject>(){}[0]
+        final val keyId // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.keyId|{}keyId[0]
+            final fun <get-keyId>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.keyId.<get-keyId>|<get-keyId>(){}[0]
+
+        final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component1|component1(){}[0]
+        final fun component2(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component2|component2(){}[0]
+        final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component3|component3(){}[0]
+        final fun component4(): id.walt.wallet2.mobile/MobileWalletClientIdScheme // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component4|component4(){}[0]
+        final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletClientIdScheme = ...): id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.copy|copy(kotlin.String;kotlin.String;kotlin.String?;id.walt.wallet2.mobile.MobileWalletClientIdScheme){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.toString|toString(){}[0]
+    }
+
+    final object Unauthenticated : id.walt.wallet2.mobile/MobileWalletRequestAuthentication { // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated.toString|toString(){}[0]
+    }
+}
+
 sealed interface id.walt.wallet2.mobile/MobileWalletResponseEncryption { // id.walt.wallet2.mobile/MobileWalletResponseEncryption|null[0]
     abstract val contentEncryptionAlgorithm // id.walt.wallet2.mobile/MobileWalletResponseEncryption.contentEncryptionAlgorithm|{}contentEncryptionAlgorithm[0]
         abstract fun <get-contentEncryptionAlgorithm>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletResponseEncryption.contentEncryptionAlgorithm.<get-contentEncryptionAlgorithm>|<get-contentEncryptionAlgorithm>(){}[0]
@@ -585,20 +646,23 @@ sealed interface id.walt.wallet2.mobile/MobileWalletResponseEncryption { // id.w
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration|null[0]
-    constructor <init>(kotlin.collections/List<kotlin/String> = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.<init>|<init>(kotlin.collections.List<kotlin.String>){}[0]
+    constructor <init>(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.<init>|<init>(kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
 
+    final val preRegisteredClientMetadataJson // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.preRegisteredClientMetadataJson|{}preRegisteredClientMetadataJson[0]
+        final fun <get-preRegisteredClientMetadataJson>(): kotlin.collections/Map<kotlin/String, kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.preRegisteredClientMetadataJson.<get-preRegisteredClientMetadataJson>|<get-preRegisteredClientMetadataJson>(){}[0]
     final val x509TrustAnchorsPem // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.x509TrustAnchorsPem|{}x509TrustAnchorsPem[0]
         final fun <get-x509TrustAnchorsPem>(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.x509TrustAnchorsPem.<get-x509TrustAnchorsPem>|<get-x509TrustAnchorsPem>(){}[0]
 
     final fun component1(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.component1|component1(){}[0]
-    final fun copy(kotlin.collections/List<kotlin/String> = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.copy|copy(kotlin.collections.List<kotlin.String>){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/String, kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.copy|copy(kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.toString|toString(){}[0]
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration|null[0]
-    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
+    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataTrustResolver?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
 
     final val appGroupIdentifier // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.appGroupIdentifier|{}appGroupIdentifier[0]
         final fun <get-appGroupIdentifier>(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.appGroupIdentifier.<get-appGroupIdentifier>|<get-appGroupIdentifier>(){}[0]
@@ -612,6 +676,8 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // i
         final fun <get-defaultKeyType>(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyType.<get-defaultKeyType>|<get-defaultKeyType>(){}[0]
     final val defaultKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyUseAuthorizationPolicy|{}defaultKeyUseAuthorizationPolicy[0]
         final fun <get-defaultKeyUseAuthorizationPolicy>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyUseAuthorizationPolicy.<get-defaultKeyUseAuthorizationPolicy>|<get-defaultKeyUseAuthorizationPolicy>(){}[0]
+    final val issuerMetadataTrustResolver // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.issuerMetadataTrustResolver|{}issuerMetadataTrustResolver[0]
+        final fun <get-issuerMetadataTrustResolver>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.issuerMetadataTrustResolver.<get-issuerMetadataTrustResolver>|<get-issuerMetadataTrustResolver>(){}[0]
     final val keyUseAuthorizationPrompt // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keyUseAuthorizationPrompt|{}keyUseAuthorizationPrompt[0]
         final fun <get-keyUseAuthorizationPrompt>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keyUseAuthorizationPrompt.<get-keyUseAuthorizationPrompt>|<get-keyUseAuthorizationPrompt>(){}[0]
     final val keychainAccessGroup // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keychainAccessGroup|{}keychainAccessGroup[0]
@@ -627,17 +693,18 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // i
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component1|component1(){}[0]
     final fun component10(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component10|component10(){}[0]
-    final fun component11(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component11|component11(){}[0]
-    final fun component12(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component12|component12(){}[0]
+    final fun component11(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component11|component11(){}[0]
+    final fun component12(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component12|component12(){}[0]
+    final fun component13(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component13|component13(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component2|component2(){}[0]
     final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component3|component3(){}[0]
     final fun component4(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component4|component4(){}[0]
     final fun component5(): id.walt.wallet2.mobile/WalletAttestationConfig? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component5|component5(){}[0]
-    final fun component6(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component7|component7(){}[0]
-    final fun component8(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component8|component8(){}[0]
-    final fun component9(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component9|component9(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
+    final fun component6(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component6|component6(){}[0]
+    final fun component7(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component8|component8(){}[0]
+    final fun component9(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component9|component9(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataTrustResolver?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.toString|toString(){}[0]
@@ -677,6 +744,25 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeError { // id.walt.w
         final fun deserialize(kotlinx.serialization.encoding/Decoder): id.walt.wallet2.mobile.swiftinterop/WalletBridgeError // id.walt.wallet2.mobile.swiftinterop/WalletBridgeError.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
         final fun serialize(kotlinx.serialization.encoding/Encoder, id.walt.wallet2.mobile.swiftinterop/WalletBridgeError) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeError.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;id.walt.wallet2.mobile.swiftinterop.WalletBridgeError){}[0]
     }
+}
+
+final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner|null[0]
+    constructor <init>(kotlin/String?, kotlin/String, id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.<init>|<init>(kotlin.String?;kotlin.String;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataSignerTrustType){}[0]
+
+    final val algorithm // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.algorithm|{}algorithm[0]
+        final fun <get-algorithm>(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.algorithm.<get-algorithm>|<get-algorithm>(){}[0]
+    final val keyId // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.keyId|{}keyId[0]
+        final fun <get-keyId>(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.keyId.<get-keyId>|<get-keyId>(){}[0]
+    final val trustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.trustType|{}trustType[0]
+        final fun <get-trustType>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.trustType.<get-trustType>|<get-trustType>(){}[0]
+
+    final fun component1(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.component1|component1(){}[0]
+    final fun component2(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.component2|component2(){}[0]
+    final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.component3|component3(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.copy|copy(kotlin.String?;kotlin.String;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataSignerTrustType){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.toString|toString(){}[0]
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight|null[0]
@@ -1077,10 +1163,12 @@ final class id.walt.wallet2.mobile/MobileWalletBootstrapResult { // id.walt.wall
 }
 
 final class id.walt.wallet2.mobile/MobileWalletConfig { // id.walt.wallet2.mobile/MobileWalletConfig|null[0]
-    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...) // id.walt.wallet2.mobile/MobileWalletConfig.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
+    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...) // id.walt.wallet2.mobile/MobileWalletConfig.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver?;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
 
     final val attestationConfig // id.walt.wallet2.mobile/MobileWalletConfig.attestationConfig|{}attestationConfig[0]
         final fun <get-attestationConfig>(): id.walt.wallet2.mobile/WalletAttestationConfig? // id.walt.wallet2.mobile/MobileWalletConfig.attestationConfig.<get-attestationConfig>|<get-attestationConfig>(){}[0]
+    final val credentialIssuerMetadataTrustResolver // id.walt.wallet2.mobile/MobileWalletConfig.credentialIssuerMetadataTrustResolver|{}credentialIssuerMetadataTrustResolver[0]
+        final fun <get-credentialIssuerMetadataTrustResolver>(): id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? // id.walt.wallet2.mobile/MobileWalletConfig.credentialIssuerMetadataTrustResolver.<get-credentialIssuerMetadataTrustResolver>|<get-credentialIssuerMetadataTrustResolver>(){}[0]
     final val credentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.credentialRegistry|{}credentialRegistry[0]
         final fun <get-credentialRegistry>(): id.walt.wallet2.mobile/MobileWalletCredentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.credentialRegistry.<get-credentialRegistry>|<get-credentialRegistry>(){}[0]
     final val crossProcessAccess // id.walt.wallet2.mobile/MobileWalletConfig.crossProcessAccess|{}crossProcessAccess[0]
@@ -1107,19 +1195,20 @@ final class id.walt.wallet2.mobile/MobileWalletConfig { // id.walt.wallet2.mobil
         final fun <get-walletId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletConfig.walletId.<get-walletId>|<get-walletId>(){}[0]
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletConfig.component1|component1(){}[0]
-    final fun component10(): id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? // id.walt.wallet2.mobile/MobileWalletConfig.component10|component10(){}[0]
-    final fun component11(): kotlin.coroutines/SuspendFunction0<kotlin/Unit> // id.walt.wallet2.mobile/MobileWalletConfig.component11|component11(){}[0]
-    final fun component12(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.mobile/MobileWalletConfig.component12|component12(){}[0]
-    final fun component13(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt // id.walt.wallet2.mobile/MobileWalletConfig.component13|component13(){}[0]
+    final fun component10(): id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator // id.walt.wallet2.mobile/MobileWalletConfig.component10|component10(){}[0]
+    final fun component11(): id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? // id.walt.wallet2.mobile/MobileWalletConfig.component11|component11(){}[0]
+    final fun component12(): kotlin.coroutines/SuspendFunction0<kotlin/Unit> // id.walt.wallet2.mobile/MobileWalletConfig.component12|component12(){}[0]
+    final fun component13(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.mobile/MobileWalletConfig.component13|component13(){}[0]
+    final fun component14(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt // id.walt.wallet2.mobile/MobileWalletConfig.component14|component14(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile/MobileWalletConfig.component2|component2(){}[0]
     final fun component3(): id.walt.wallet2.mobile/WalletAttestationConfig? // id.walt.wallet2.mobile/MobileWalletConfig.component3|component3(){}[0]
     final fun component4(): id.walt.wallet2.mobile/MobileWalletPersistence // id.walt.wallet2.mobile/MobileWalletConfig.component4|component4(){}[0]
     final fun component5(): kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> // id.walt.wallet2.mobile/MobileWalletConfig.component5|component5(){}[0]
     final fun component6(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile/MobileWalletConfig.component6|component6(){}[0]
     final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> // id.walt.wallet2.mobile/MobileWalletConfig.component7|component7(){}[0]
-    final fun component8(): id.walt.wallet2.mobile/MobileWalletCredentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.component8|component8(){}[0]
-    final fun component9(): id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator // id.walt.wallet2.mobile/MobileWalletConfig.component9|component9(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...): id.walt.wallet2.mobile/MobileWalletConfig // id.walt.wallet2.mobile/MobileWalletConfig.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
+    final fun component8(): id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? // id.walt.wallet2.mobile/MobileWalletConfig.component8|component8(){}[0]
+    final fun component9(): id.walt.wallet2.mobile/MobileWalletCredentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.component9|component9(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...): id.walt.wallet2.mobile/MobileWalletConfig // id.walt.wallet2.mobile/MobileWalletConfig.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver?;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletConfig.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletConfig.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletConfig.toString|toString(){}[0]
@@ -1625,12 +1714,14 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle { // id
 }
 
 final class id.walt.wallet2.mobile/MobileWalletPresentationRequestContext { // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext|null[0]
-    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, kotlin/String?, kotlin/String?, kotlin/String?, id.walt.wallet2.mobile/MobileWalletResponseEncryption) // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
+    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, id.walt.wallet2.mobile/MobileWalletRequestAuthentication, kotlin/String?, kotlin/String?, kotlin/String?, id.walt.wallet2.mobile/MobileWalletResponseEncryption) // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
 
     final val clientId // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.clientId|{}clientId[0]
         final fun <get-clientId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.clientId.<get-clientId>|<get-clientId>(){}[0]
     final val nonce // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.nonce|{}nonce[0]
         final fun <get-nonce>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.nonce.<get-nonce>|<get-nonce>(){}[0]
+    final val requestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.requestAuthentication|{}requestAuthentication[0]
+        final fun <get-requestAuthentication>(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.requestAuthentication.<get-requestAuthentication>|<get-requestAuthentication>(){}[0]
     final val responseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseEncryption|{}responseEncryption[0]
         final fun <get-responseEncryption>(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseEncryption.<get-responseEncryption>|<get-responseEncryption>(){}[0]
     final val responseUri // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseUri|{}responseUri[0]
@@ -1642,23 +1733,26 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationRequestContext { // i
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component1|component1(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component2|component2(){}[0]
-    final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component3|component3(){}[0]
+    final fun component3(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component3|component3(){}[0]
     final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component4|component4(){}[0]
     final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component5|component5(){}[0]
-    final fun component6(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component6|component6(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestContext // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
+    final fun component6(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component6|component6(){}[0]
+    final fun component7(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., id.walt.wallet2.mobile/MobileWalletRequestAuthentication = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestContext // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.toString|toString(){}[0]
 }
 
 final class id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo { // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo|null[0]
-    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, kotlin/String?, kotlin/String?, kotlin/String, id.walt.wallet2.mobile/MobileWalletResponseEncryption, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...) // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
+    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, id.walt.wallet2.mobile/MobileWalletRequestAuthentication, kotlin/String?, kotlin/String?, kotlin/String, id.walt.wallet2.mobile/MobileWalletResponseEncryption, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...) // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
 
     final val clientId // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId|{}clientId[0]
         final fun <get-clientId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId.<get-clientId>|<get-clientId>(){}[0]
     final val nonce // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce|{}nonce[0]
         final fun <get-nonce>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce.<get-nonce>|<get-nonce>(){}[0]
+    final val requestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.requestAuthentication|{}requestAuthentication[0]
+        final fun <get-requestAuthentication>(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.requestAuthentication.<get-requestAuthentication>|<get-requestAuthentication>(){}[0]
     final val responseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseEncryption|{}responseEncryption[0]
         final fun <get-responseEncryption>(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseEncryption.<get-responseEncryption>|<get-responseEncryption>(){}[0]
     final val responseUri // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseUri|{}responseUri[0]
@@ -1672,12 +1766,13 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo { // id.w
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component1|component1(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component2|component2(){}[0]
-    final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component3|component3(){}[0]
+    final fun component3(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component3|component3(){}[0]
     final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component4|component4(){}[0]
-    final fun component5(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component5|component5(){}[0]
-    final fun component6(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component7|component7(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
+    final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component5|component5(){}[0]
+    final fun component6(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component6|component6(){}[0]
+    final fun component7(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component8|component8(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., id.walt.wallet2.mobile/MobileWalletRequestAuthentication = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.toString|toString(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -11,8 +11,11 @@ import id.walt.dcql.models.meta.NoMeta
 import id.walt.mobile.test.backend.DemoTestBackend
 import id.walt.mobile.test.backend.EudiTestBackend
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.authorization.ClientMetadata
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import id.walt.wallet2.handlers.WalletIssuanceMetadataProvenance
 import id.walt.wallet2.handlers.WalletIssuanceOutcome
 import id.walt.wallet2.mobile.MobileWallet
 import id.walt.wallet2.mobile.MobileWalletConfig
@@ -28,6 +31,8 @@ import id.walt.wallet2.mobile.MobileWalletPresentationPreviewResult
 import id.walt.wallet2.mobile.MobileWalletPresentationResult
 import id.walt.wallet2.mobile.MobileWalletResponseEncryption
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
+import id.walt.wallet2.mobile.MobileWalletRequestAuthentication
+import id.walt.wallet2.mobile.MobileWalletClientIdScheme
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
 import id.walt.x509.CertificateDer
 import kotlinx.coroutines.runBlocking
@@ -73,6 +78,15 @@ class MobileWalletIntegrationTest {
 
         private val DEMO_TRANSACTION_DATA_PROFILES = demoTransactionDataProfiles(
             paymentAuthorizationFields = listOf("merchant_name", "amount", "currency"),
+        )
+
+        @OptIn(ExperimentalSerializationApi::class)
+        private val DEMO_VERIFIER_TRUST = ClientIdTrustConfiguration(
+            preRegisteredClients = mapOf(
+                DemoTestBackend.PUBLIC_DEMO_VERIFIER_CLIENT_ID to ClientMetadata(
+                    jwks = ClientMetadata.Jwks(listOf(DemoTestBackend.publicDemoVerifierRequestObjectSigningJwk)),
+                ),
+            ),
         )
 
         private fun demoTransactionDataProfiles(
@@ -139,6 +153,51 @@ class MobileWalletIntegrationTest {
     @Test
     fun receiveIsoMdlFromDemoIssuer2() = runBlocking {
         receiveCredentialFromDemoIssuer2("iso-mdl")
+    }
+
+    @Test
+    fun receiveAndPresentUsingSignedMetadataAgainstDemoIssuer2AndVerifier2() = runBlocking {
+        val scenario = demoPresentationScenario("eudi-pid-mdoc")
+        val client = MobileWalletFactory(context).create(
+            walletConfig("signed-${scenario.id}").copy(
+                credentialIssuerMetadataTrustResolver = DemoTestBackend.publicDemoIssuerMetadataTrustResolver,
+            ),
+            DEMO_VERIFIER_TRUST,
+        )
+        val bootstrap = client.bootstrap()
+        val offer = DemoTestBackend.createOffer(scenario)
+
+        val issuanceSession = client.startIssuance(
+            MobileWalletIssuanceRequest(offer = MobileWalletCredentialOffer.Uri(offer.offerUrl)),
+        )
+        val issuerProvenance = assertIs<WalletIssuanceMetadataProvenance.Signed>(
+            issuanceSession.offer.issuer.metadataProvenance,
+        )
+        assertTrue(issuerProvenance.compactJwt.isNotBlank())
+        assertEquals("ES256", issuerProvenance.algorithm)
+        assertEquals(MetadataSignerTrustType.TRUSTED_ISSUER, issuerProvenance.trustType)
+        assertNotNull(issuerProvenance.keyId)
+
+        val credentialIds = client.continuePreAuthorizedIssuance(issuanceSession.id, offer.txCode).storedCredentialIds()
+        assertTrue(credentialIds.isNotEmpty(), "Should receive a credential from reviewed signed metadata")
+
+        val signedSession = DemoTestBackend.createVerifierSession(scenario, signedRequest = true)
+        val preview = client.previewPresentation(signedSession.authorizationRequestUri).requireReadyPreview()
+        val verifierAuthentication = assertIs<MobileWalletRequestAuthentication.Authenticated>(
+            preview.request.requestAuthentication,
+        )
+        assertTrue(verifierAuthentication.compactRequestObject.isNotBlank())
+        assertEquals("ES256", verifierAuthentication.algorithm)
+        assertNotNull(verifierAuthentication.keyId)
+        assertEquals(MobileWalletClientIdScheme.PRE_REGISTERED, verifierAuthentication.clientIdScheme)
+
+        val result = client.submitPresentation(
+            previewHandle = preview.previewHandle,
+            selectedCredentialOptions = preview.credentialOptions.map { it.selection },
+            did = bootstrap.did,
+        )
+        assertIs<MobileWalletPresentationResult.Transmitted.Succeeded>(result)
+        DemoTestBackend.waitForVerifierSuccess(signedSession.sessionId)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -50,6 +50,7 @@ import id.walt.openid4vp.clientidprefix.prefixes.DecentralizedIdentifier
 import id.walt.openid4vp.clientidprefix.prefixes.OpenIdFederation
 import id.walt.openid4vp.clientidprefix.prefixes.PreRegistered
 import id.walt.openid4vp.clientidprefix.prefixes.RedirectUri
+import id.walt.openid4vp.clientidprefix.prefixes.Unsupported
 import id.walt.openid4vp.clientidprefix.prefixes.VerifierAttestation
 import id.walt.openid4vp.clientidprefix.prefixes.X509Hash
 import id.walt.openid4vp.clientidprefix.prefixes.X509SanDns
@@ -1113,7 +1114,7 @@ private fun ClientId.toMobileClientIdScheme(): MobileWalletClientIdScheme = when
     is DecentralizedIdentifier -> MobileWalletClientIdScheme.DECENTRALIZED_IDENTIFIER
     is VerifierAttestation -> MobileWalletClientIdScheme.VERIFIER_ATTESTATION
     is OpenIdFederation -> MobileWalletClientIdScheme.OPENID_FEDERATION
-    else -> error("Unsupported authenticated client identifier type: ${this::class.simpleName}")
+    is Unsupported -> error("Unsupported client identifier cannot be authenticated: $prefix")
 }
 
 private fun WalletPresentFunctionality2.OID4VPErrorCode.toMobileErrorCode(): MobileWalletPresentationErrorCode = when (this) {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -45,6 +45,16 @@ import id.waltid.openid4vci.wallet.attestation.HttpWalletAttestationProvider
 import id.waltid.openid4vp.wallet.WalletPresentFunctionality2
 import id.waltid.openid4vp.wallet.WalletPresentFunctionality2.WalletPresentResult
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.walt.openid4vp.clientidprefix.prefixes.ClientId
+import id.walt.openid4vp.clientidprefix.prefixes.DecentralizedIdentifier
+import id.walt.openid4vp.clientidprefix.prefixes.OpenIdFederation
+import id.walt.openid4vp.clientidprefix.prefixes.PreRegistered
+import id.walt.openid4vp.clientidprefix.prefixes.RedirectUri
+import id.walt.openid4vp.clientidprefix.prefixes.VerifierAttestation
+import id.walt.openid4vp.clientidprefix.prefixes.X509Hash
+import id.walt.openid4vp.clientidprefix.prefixes.X509SanDns
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vp.wallet.request.ResolvedAuthorizationRequest
 import id.waltid.openid4vp.wallet.response.ResponseEncryption
 import id.waltid.openid4vp.wallet.DcApiCredentialResponse
 import id.waltid.openid4vp.wallet.DcApiWallet
@@ -200,6 +210,7 @@ public class MobileWallet internal constructor(
     private val preferredLocales: List<String> = emptyList(),
     private val transactionDataProfiles: List<MobileWalletTransactionDataProfile> = emptyList(),
     private val clientIdTrustConfiguration: ClientIdTrustConfiguration = ClientIdTrustConfiguration(),
+    private val credentialIssuerMetadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     private val credentialRegistry: MobileWalletCredentialRegistry = UnavailableMobileWalletCredentialRegistry,
     private val readerTrustEvaluator: MobileWalletReaderTrustEvaluator = UnconfiguredMobileWalletReaderTrustEvaluator,
     private val onEvent: suspend (MobileWalletEvent) -> Unit = {},
@@ -242,6 +253,7 @@ public class MobileWallet internal constructor(
     private val issuanceSessions = WalletIssuanceSessionService(
         wallet = wallet,
         attestationAssembler = attestationAssembler,
+        metadataTrustResolver = credentialIssuerMetadataTrustResolver,
         onEvent = ::emitSessionEvent,
         sessionStore = issuanceSessionStore,
         httpClient = issuanceHttpClient,
@@ -722,7 +734,10 @@ public class MobileWallet internal constructor(
             is PreviewPresentationResult.Invalid ->
                 MobileWalletPresentationPreviewResult.Invalid(
                     previewHandle = MobileWalletPresentationPreviewHandle(result.handle.value),
-                    request = result.authorizationRequest.toMobileRequestContext(preferredLocales),
+                    request = result.authorizationRequest.toMobileRequestContext(
+                        preferredLocales = preferredLocales,
+                        resolvedAuthorizationRequest = result.resolvedAuthorizationRequest,
+                    ),
                     errorCode = result.error.code.toMobileErrorCode(),
                     message = result.error.message,
                 )
@@ -745,6 +760,7 @@ public class MobileWallet internal constructor(
                         previewHandle = MobileWalletPresentationPreviewHandle(result.handle.value),
                         request = result.authorizationRequest.toMobileRequestInfo(
                             preferredLocales = preferredLocales,
+                            resolvedAuthorizationRequest = result.resolvedAuthorizationRequest,
                             responseEncryption = result.responseEncryption,
                             transactionData = transactionData,
                         ),
@@ -1020,16 +1036,19 @@ internal fun WalletPresentResult.toMobilePresentationResult(): MobileWalletPrese
         }
     }
 
-private fun AuthorizationRequest.toMobileRequestInfo(
+internal fun AuthorizationRequest.toMobileRequestInfo(
     preferredLocales: List<String>,
+    resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
     responseEncryption: ResponseEncryption.Metadata? = null,
     transactionData: List<MobileWalletTransactionDataItem> = emptyList(),
 ): MobileWalletPresentationRequestInfo {
-    return MobileWalletPresentationRequestInfo(
-        clientId = requireNotNull(clientId) {
+    val verifiedClientId = requireNotNull(clientId) {
             "A validated presentation request must contain client_id."
-        },
+        }
+    return MobileWalletPresentationRequestInfo(
+        clientId = verifiedClientId,
         verifierMetadata = clientMetadata?.toMobileVerifierMetadata(preferredLocales),
+        requestAuthentication = resolvedAuthorizationRequest.toMobileRequestAuthentication(),
         responseUri = responseUri,
         state = state,
         nonce = requireNotNull(nonce) {
@@ -1056,19 +1075,46 @@ private fun AuthorizationRequest.toMobileDigitalCredentialRequestInfo(
         transactionData = transactionData,
     )
 
-private fun AuthorizationRequest.toMobileRequestContext(
+internal fun AuthorizationRequest.toMobileRequestContext(
     preferredLocales: List<String>,
-): MobileWalletPresentationRequestContext =
-    MobileWalletPresentationRequestContext(
-        clientId = requireNotNull(clientId) {
+    resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
+): MobileWalletPresentationRequestContext {
+    val verifiedClientId = requireNotNull(clientId) {
             "A reportable invalid presentation request must contain client_id."
-        },
+        }
+    return MobileWalletPresentationRequestContext(
+        clientId = verifiedClientId,
         verifierMetadata = clientMetadata?.toMobileVerifierMetadata(preferredLocales),
+        requestAuthentication = resolvedAuthorizationRequest.toMobileRequestAuthentication(),
         responseUri = responseUri,
         state = state,
         nonce = nonce,
         responseEncryption = null.toMobileResponseEncryption(),
     )
+}
+
+internal fun ResolvedAuthorizationRequest.toMobileRequestAuthentication(): MobileWalletRequestAuthentication =
+    when (this) {
+        is ResolvedAuthorizationRequest.Plain -> MobileWalletRequestAuthentication.Unauthenticated
+        is ResolvedAuthorizationRequest.UnsignedRequestObject -> MobileWalletRequestAuthentication.Unauthenticated
+        is ResolvedAuthorizationRequest.AuthenticatedRequestObject -> MobileWalletRequestAuthentication.Authenticated(
+            compactRequestObject = requestObject,
+            algorithm = authentication.algorithm,
+            keyId = authentication.keyId,
+            clientIdScheme = authentication.clientId.toMobileClientIdScheme(),
+        )
+    }
+
+private fun ClientId.toMobileClientIdScheme(): MobileWalletClientIdScheme = when (this) {
+    is PreRegistered -> MobileWalletClientIdScheme.PRE_REGISTERED
+    is RedirectUri -> MobileWalletClientIdScheme.REDIRECT_URI
+    is X509SanDns -> MobileWalletClientIdScheme.X509_SAN_DNS
+    is X509Hash -> MobileWalletClientIdScheme.X509_HASH
+    is DecentralizedIdentifier -> MobileWalletClientIdScheme.DECENTRALIZED_IDENTIFIER
+    is VerifierAttestation -> MobileWalletClientIdScheme.VERIFIER_ATTESTATION
+    is OpenIdFederation -> MobileWalletClientIdScheme.OPENID_FEDERATION
+    else -> error("Unsupported authenticated client identifier type: ${this::class.simpleName}")
+}
 
 private fun WalletPresentFunctionality2.OID4VPErrorCode.toMobileErrorCode(): MobileWalletPresentationErrorCode = when (this) {
     WalletPresentFunctionality2.OID4VPErrorCode.ACCESS_DENIED -> MobileWalletPresentationErrorCode.accessDenied

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -41,6 +41,7 @@ import kotlin.uuid.Uuid
  * When no preference matches, selection falls back to an unlocalized entry and then the first entry.
  * @property transactionDataProfiles Transaction data profiles this mobile wallet accepts in OpenID4VP requests.
  * @property credentialIssuerMetadataTrustResolver Optional trust boundary for signed Credential Issuer Metadata.
+ * When absent, signed metadata is neither requested nor accepted.
  * @property credentialRegistry Platform metadata registry. Platform factories install their native default when omitted.
  * @property readerTrustEvaluator Application trust policy for verified ISO 18013-7 reader chains.
  * @property crossProcessAccess Optional shared-container/keychain configuration for provider extensions.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -22,6 +22,7 @@ import id.walt.wallet2.persistence.stores.SqlDelightDidStore
 import id.walt.wallet2.persistence.stores.SqlDelightIssuanceSessionStore
 import id.walt.verifier.openid.transactiondata.TransactionDataTypeRegistry
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.uuid.Uuid
 
@@ -39,6 +40,7 @@ import kotlin.uuid.Uuid
  * @property preferredLocales Ordered BCP 47 locale preferences used for progressive language-tag lookup.
  * When no preference matches, selection falls back to an unlocalized entry and then the first entry.
  * @property transactionDataProfiles Transaction data profiles this mobile wallet accepts in OpenID4VP requests.
+ * @property credentialIssuerMetadataTrustResolver Optional trust boundary for signed Credential Issuer Metadata.
  * @property credentialRegistry Platform metadata registry. Platform factories install their native default when omitted.
  * @property readerTrustEvaluator Application trust policy for verified ISO 18013-7 reader chains.
  * @property crossProcessAccess Optional shared-container/keychain configuration for provider extensions.
@@ -53,6 +55,7 @@ public data class MobileWalletConfig(
     public val onEvent: suspend (MobileWalletEvent) -> Unit = {},
     public val preferredLocales: List<String> = emptyList(),
     public val transactionDataProfiles: List<MobileWalletTransactionDataProfile> = emptyList(),
+    public val credentialIssuerMetadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     public val credentialRegistry: MobileWalletCredentialRegistry = UnavailableMobileWalletCredentialRegistry,
     public val readerTrustEvaluator: MobileWalletReaderTrustEvaluator = UnconfiguredMobileWalletReaderTrustEvaluator,
     public val crossProcessAccess: MobileWalletCrossProcessAccess? = null,
@@ -232,6 +235,7 @@ internal fun createSqlDelightMobileWallet(
         preferredLocales = config.preferredLocales,
         transactionDataProfiles = config.transactionDataProfiles,
         clientIdTrustConfiguration = clientIdTrustConfiguration,
+        credentialIssuerMetadataTrustResolver = config.credentialIssuerMetadataTrustResolver,
         onEvent = config.onEvent,
         credentialRegistry = config.credentialRegistry,
         onDigitalCredentialRegistryChanged = config.onDigitalCredentialRegistryChanged,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
@@ -59,6 +59,7 @@ public data class MobileWalletPresentationPreviewHandle(val value: String) {
  *
  * @property clientId Required OpenID4VP `client_id` value identifying the verifier.
  * @property verifierMetadata Typed verifier metadata supplied by the OpenID4VP client, when available.
+ * @property requestAuthentication Authentication established for the Authorization Request or its Request Object.
  * @property responseUri Verifier response URI to which the wallet would submit the presentation or error, when provided.
  * @property state OpenID4VP state value supplied by the verifier, when provided.
  * @property nonce OpenID4VP nonce value supplied by the verifier, when provided. May be null if the missing nonce is the validation error.
@@ -67,6 +68,7 @@ public data class MobileWalletPresentationPreviewHandle(val value: String) {
 public data class MobileWalletPresentationRequestContext(
     val clientId: String,
     val verifierMetadata: MobileWalletVerifierMetadata?,
+    val requestAuthentication: MobileWalletRequestAuthentication,
     val responseUri: String?,
     val state: String?,
     val nonce: String?,
@@ -110,6 +112,7 @@ public data class MobileWalletPresentationCredentialRequirement(
  * Credentials API previews use [MobileWalletDigitalCredentialRequestInfo] instead because
  * unsigned requests intentionally have no trusted request-supplied `client_id`.
  * @property verifierMetadata Typed verifier metadata supplied by the OpenID4VP client, when available.
+ * @property requestAuthentication Authentication established for the Authorization Request or its Request Object.
  * @property responseUri Verifier response URI to which the wallet will submit the presentation, when provided.
  * @property state OpenID4VP state value supplied by the verifier, when provided.
  * @property nonce Required OpenID4VP nonce value supplied by the verifier.
@@ -119,6 +122,7 @@ public data class MobileWalletPresentationCredentialRequirement(
 public data class MobileWalletPresentationRequestInfo(
     val clientId: String,
     val verifierMetadata: MobileWalletVerifierMetadata?,
+    val requestAuthentication: MobileWalletRequestAuthentication,
     val responseUri: String?,
     val state: String?,
     val nonce: String,
@@ -129,6 +133,42 @@ public data class MobileWalletPresentationRequestInfo(
         require(clientId.isNotBlank()) { "A presentation request client ID must not be blank." }
         require(nonce.isNotBlank()) { "A presentation request nonce must not be blank." }
     }
+}
+
+/** Authentication established for an OpenID4VP Authorization Request or Request Object. */
+public sealed interface MobileWalletRequestAuthentication {
+    /** The request was not authenticated by a signed Request Object. */
+    public data object Unauthenticated : MobileWalletRequestAuthentication
+
+    /** The Request Object was authenticated by the OpenID4VP client-ID layer. */
+    public data class Authenticated(
+        /** Exact compact Request Object received from the verifier. */
+        public val compactRequestObject: String,
+        /** JWS algorithm established by request authentication. */
+        public val algorithm: String,
+        /** Request-object signing key identifier, when supplied. */
+        public val keyId: String?,
+        /** Client identifier scheme established by the authentication layer. */
+        public val clientIdScheme: MobileWalletClientIdScheme,
+    ) : MobileWalletRequestAuthentication
+}
+
+/** Client identifier scheme established while authenticating an OpenID4VP request. */
+public enum class MobileWalletClientIdScheme {
+    /** The verifier is identified through pre-registered metadata. */
+    PRE_REGISTERED,
+    /** The verifier is identified by a redirect URI. */
+    REDIRECT_URI,
+    /** The verifier is identified by an X.509 SAN DNS name. */
+    X509_SAN_DNS,
+    /** The verifier is identified by an X.509 certificate hash. */
+    X509_HASH,
+    /** The verifier is identified by a decentralized identifier. */
+    DECENTRALIZED_IDENTIFIER,
+    /** The verifier is identified by a verifier attestation. */
+    VERIFIER_ATTESTATION,
+    /** The verifier is identified through OpenID Federation. */
+    OPENID_FEDERATION,
 }
 
 /**

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
@@ -78,6 +78,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLBuilder
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.http.Url
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -135,7 +136,16 @@ class MobileWalletTest {
     @Test
     fun mobileWalletConfigUsesStableDefaults() {
         val config = MobileWalletConfig()
-        val (walletId, defaultKeyType, attestationConfig, persistence, onEvent, preferredLocales, transactionDataProfiles) = config
+        val (
+            walletId,
+            defaultKeyType,
+            attestationConfig,
+            persistence,
+            onEvent,
+            preferredLocales,
+            transactionDataProfiles,
+            credentialIssuerMetadataTrustResolver,
+        ) = config
 
         assertEquals("default", walletId)
         assertEquals(MobileWalletKeyType.secp256r1, defaultKeyType)
@@ -143,6 +153,7 @@ class MobileWalletTest {
         assertEquals(MobileWalletPersistence(), persistence)
         assertEquals(emptyList(), preferredLocales)
         assertEquals(emptyList(), transactionDataProfiles)
+        assertEquals(null, credentialIssuerMetadataTrustResolver)
         assertSame(config.onEvent, onEvent)
         assertIs<MobileWalletDatabaseKey.Managed>(config.persistence.databaseKey)
         assertEquals(null, config.persistence.credentialStore)
@@ -176,7 +187,14 @@ class MobileWalletTest {
             ClientIdTrustConfiguration(
                 preRegisteredClients = mapOf(
                     "verifier2" to ClientMetadata(
-                        jwks = ClientMetadata.Jwks(listOf(verifierKey.getPublicKey().exportJWKObject())),
+                        jwks = ClientMetadata.Jwks(
+                            listOf(
+                                JsonObject(
+                                    verifierKey.getPublicKey().exportJWKObject() +
+                                        ("kid" to JsonPrimitive(verifierKey.getKeyId())),
+                                ),
+                            ),
+                        ),
                     )
                 ),
             )
@@ -188,6 +206,13 @@ class MobileWalletTest {
 
         assertEquals("verifier2", preview.request.clientId)
         assertEquals(MobileWalletPresentationErrorCode.invalidRequest, preview.errorCode)
+        val authentication = assertIs<MobileWalletRequestAuthentication.Authenticated>(
+            preview.request.requestAuthentication,
+        )
+        assertEquals(Url(requestUrl).parameters["request"], authentication.compactRequestObject)
+        assertEquals("EdDSA", authentication.algorithm)
+        assertEquals(verifierKey.getKeyId(), authentication.keyId)
+        assertEquals(MobileWalletClientIdScheme.PRE_REGISTERED, authentication.clientIdScheme)
     }
 
     @Test
@@ -381,6 +406,7 @@ class MobileWalletTest {
             MobileWalletPresentationRequestContext(
                 clientId = " ",
                 verifierMetadata = null,
+                requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
                 responseUri = null,
                 state = null,
                 nonce = null,
@@ -391,6 +417,7 @@ class MobileWalletTest {
         val context = MobileWalletPresentationRequestContext(
             clientId = "https://verifier.example",
             verifierMetadata = null,
+            requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
             responseUri = null,
             state = null,
             nonce = null,
@@ -541,6 +568,7 @@ class MobileWalletTest {
                     policyUri = null,
                     termsOfServiceUri = null,
                 ),
+                requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
                 responseUri = "https://verifier.example/direct-post",
                 state = "state-1",
                 nonce = "nonce-1",
@@ -1663,6 +1691,7 @@ class MobileWalletTest {
             policyUri = null,
             termsOfServiceUri = null,
         ),
+        requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
         responseUri = "https://verifier.example/direct-post",
         state = null,
         nonce = nonce,
@@ -1713,7 +1742,10 @@ class MobileWalletTest {
                 put("response_uri", "https://verifier.example/direct-post")
                 put("dcql_query", buildJsonObject { put("credentials", buildJsonArray {}) })
             }.toString().encodeToByteArray(),
-            mapOf("typ" to JsonPrimitive("oauth-authz-req+jwt")),
+            mapOf(
+                "typ" to JsonPrimitive("oauth-authz-req+jwt"),
+                "kid" to JsonPrimitive(verifierKey.getKeyId()),
+            ),
         )
         return URLBuilder("openid4vp://authorize").apply {
             parameters.append("client_id", "verifier2")

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
@@ -41,6 +41,8 @@ import id.walt.mdoc.objects.deviceretrieval.UseCase
 import id.walt.openid4vci.offers.CROSS_DEVICE_CREDENTIAL_OFFER_URL
 import id.walt.openid4vp.clientidprefix.ClientIdError
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.walt.openid4vp.clientidprefix.prefixes.Unsupported
+import id.walt.verifier.openid.models.authorization.AuthorizationRequest
 import id.walt.verifier.openid.models.authorization.ClientMetadata
 import id.walt.x509.GenericX509CertificateBuilder
 import id.walt.x509.GenericX509CertificateProfileData
@@ -66,6 +68,8 @@ import id.walt.wallet2.stores.inmemory.InMemoryDidStore
 import id.walt.wallet2.stores.inmemory.InMemoryKeyStore
 import id.waltid.openid4vp.wallet.WalletPresentFunctionality2.WalletPresentResult
 import id.waltid.openid4vp.wallet.request.AuthorizationRequestResolver
+import id.waltid.openid4vp.wallet.request.RequestObjectAuthentication
+import id.waltid.openid4vp.wallet.request.ResolvedAuthorizationRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
@@ -213,6 +217,25 @@ class MobileWalletTest {
         assertEquals("EdDSA", authentication.algorithm)
         assertEquals(verifierKey.getKeyId(), authentication.keyId)
         assertEquals(MobileWalletClientIdScheme.PRE_REGISTERED, authentication.clientIdScheme)
+    }
+
+    @Test
+    fun unsupportedAuthenticatedClientIdFailsClosed() {
+        val resolved = ResolvedAuthorizationRequest.AuthenticatedRequestObject(
+            authorizationRequest = AuthorizationRequest(clientId = "unsupported:verifier"),
+            requestObject = "header.payload.signature",
+            authentication = RequestObjectAuthentication(
+                clientId = Unsupported(prefix = "unsupported", rawValue = "unsupported:verifier"),
+                algorithm = "ES256",
+                keyId = null,
+            ),
+        )
+
+        val failure = assertFailsWith<IllegalStateException> {
+            resolved.toMobileRequestAuthentication()
+        }
+
+        assertEquals("Unsupported client identifier cannot be authenticated: unsupported", failure.message)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -8,6 +8,7 @@ import id.walt.credentials.CredentialParser
 import id.walt.credentials.formats.DigitalCredential
 import id.walt.credentials.signatures.sdjwt.SelectivelyDisclosableVerifiableCredential
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.walt.verifier.openid.models.authorization.ClientMetadata
 import id.walt.wallet2.data.StoredCredential
 import id.walt.wallet2.data.WalletCredentialStore
 import id.walt.wallet2.data.WalletDidEntry
@@ -20,6 +21,9 @@ import id.walt.wallet2.mobile.MobileWalletKeyType
 import id.walt.wallet2.mobile.MobileWalletPersistence
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
 import id.walt.wallet2.mobile.WalletAttestationConfig
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKey
 import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKeyProvider
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationException
@@ -50,6 +54,7 @@ import kotlin.time.Instant
  * @property databaseKeyProvider Swift-owned database key provider used when [persistence] uses
  * [WalletBridgeDatabaseKeyConfiguration.Provided].
  * @property attestation Optional client-attestation configuration for issuers that require it.
+ * @property issuerMetadataTrustResolver Optional Swift-owned verifier for signed Credential Issuer Metadata.
  * @property preferredLocales Ordered BCP 47 locale preferences used to select display metadata.
  * @property transactionDataProfiles Transaction data profiles this wallet accepts.
  * @property clientIdTrustConfiguration Trust anchors used to authenticate verifier Request Objects.
@@ -64,6 +69,7 @@ public data class WalletBridgeConfiguration(
     public val persistence: WalletBridgePersistence = WalletBridgePersistence(),
     public val databaseKeyProvider: WalletBridgeDatabaseEncryptionKeyProvider? = null,
     public val attestation: WalletAttestationConfig? = null,
+    public val issuerMetadataTrustResolver: WalletBridgeIssuerMetadataTrustResolver? = null,
     public val preferredLocales: List<String> = emptyList(),
     public val transactionDataProfiles: List<MobileWalletTransactionDataProfile> = emptyList(),
     public val clientIdTrustConfiguration: WalletBridgeClientIdTrustConfiguration = WalletBridgeClientIdTrustConfiguration(),
@@ -202,14 +208,21 @@ internal fun KeyUseAuthorizationReuseTimeoutValidation.toBridgeModel():
  * Verifier Request Object trust configuration exposed to the Swift wallet bridge.
  *
  * @property x509TrustAnchorsPem PEM-encoded trust anchors pinned by the hosting application.
+ * @property preRegisteredClientMetadataJson Explicit pre-registered client metadata, keyed by client ID.
  */
 public data class WalletBridgeClientIdTrustConfiguration(
     public val x509TrustAnchorsPem: List<String> = emptyList(),
+    public val preRegisteredClientMetadataJson: Map<String, String> = emptyMap(),
 )
 
 internal fun WalletBridgeClientIdTrustConfiguration.toClientIdTrustConfiguration(): ClientIdTrustConfiguration =
     ClientIdTrustConfiguration(
         x509TrustAnchors = InMemoryTrustStore(x509TrustAnchorsPem.map(X509CertificateUtil::parseCertificatePem)),
+        preRegisteredClients = preRegisteredClientMetadataJson.mapValues { (clientId, metadataJson) ->
+            ClientMetadata.fromJson(metadataJson).getOrElse { cause ->
+                throw IllegalArgumentException("Malformed pre-registered client metadata for '$clientId'", cause)
+            }
+        },
     )
 
 internal fun WalletBridgeConfiguration.toMobileWalletConfig(): MobileWalletConfig {
@@ -220,6 +233,11 @@ internal fun WalletBridgeConfiguration.toMobileWalletConfig(): MobileWalletConfi
         walletId = walletId,
         defaultKeyType = defaultKeyType,
         attestationConfig = attestation,
+        credentialIssuerMetadataTrustResolver = issuerMetadataTrustResolver?.let { bridgeResolver ->
+            CredentialIssuerMetadataTrustResolver { compactJwt, expectedCredentialIssuer ->
+                bridgeResolver.verify(compactJwt, expectedCredentialIssuer).toMetadataSigner()
+            }
+        },
         persistence = persistence.toMobileWalletPersistence(databaseKeyProvider),
         preferredLocales = preferredLocales,
         transactionDataProfiles = transactionDataProfiles,
@@ -233,6 +251,51 @@ internal fun WalletBridgeConfiguration.toMobileWalletConfig(): MobileWalletConfi
         },
     )
 }
+
+/** Trusted signer details returned after Swift verifies signed Credential Issuer Metadata. */
+public data class WalletBridgeIssuerMetadataSigner(
+    /** Identifier of the trusted verification key, as reported by the trust resolver. */
+    public val keyId: String?,
+    /** JWS algorithm verified by the trust resolver. */
+    public val algorithm: String,
+    /** Authority category established by the trust resolver. */
+    public val trustType: WalletBridgeIssuerMetadataSignerTrustType,
+)
+
+/** Authority category assigned by Swift after it verifies the signed metadata JWS. */
+public enum class WalletBridgeIssuerMetadataSignerTrustType {
+    /** The signer is the trusted credential issuer. */
+    TrustedIssuer,
+    /** The signer is a trusted delegate of the credential issuer. */
+    TrustedDelegate,
+}
+
+/**
+ * Swift-facing trust boundary for signed Credential Issuer Metadata.
+ *
+ * Implementations must verify the JWS and establish that its signer is authorized for the requested issuer.
+ * Returning normally authorizes the metadata for wallet use.
+ */
+public interface WalletBridgeIssuerMetadataTrustResolver {
+    /**
+     * @param compactJwt Compact JWS returned by the Credential Issuer Metadata endpoint.
+     * @param expectedCredentialIssuer Credential issuer for which signer authority must be established.
+     * @return Trusted signer details used to retain metadata provenance.
+     */
+    public suspend fun verify(
+        compactJwt: String,
+        expectedCredentialIssuer: String,
+    ): WalletBridgeIssuerMetadataSigner
+}
+
+private fun WalletBridgeIssuerMetadataSigner.toMetadataSigner(): MetadataSigner = MetadataSigner(
+    keyId = keyId,
+    algorithm = algorithm,
+    trustType = when (trustType) {
+        WalletBridgeIssuerMetadataSignerTrustType.TrustedIssuer -> MetadataSignerTrustType.TRUSTED_ISSUER
+        WalletBridgeIssuerMetadataSignerTrustType.TrustedDelegate -> MetadataSignerTrustType.TRUSTED_DELEGATE
+    },
+)
 
 /**
  * Persistence configuration exposed to the Swift wallet bridge.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -69,6 +69,7 @@ public data class WalletBridgeConfiguration(
     public val persistence: WalletBridgePersistence = WalletBridgePersistence(),
     public val databaseKeyProvider: WalletBridgeDatabaseEncryptionKeyProvider? = null,
     public val attestation: WalletAttestationConfig? = null,
+    /** Signed metadata is neither requested nor accepted when this trust resolver is absent. */
     public val issuerMetadataTrustResolver: WalletBridgeIssuerMetadataTrustResolver? = null,
     public val preferredLocales: List<String> = emptyList(),
     public val transactionDataProfiles: List<MobileWalletTransactionDataProfile> = emptyList(),

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -13,6 +13,7 @@ import id.walt.wallet2.mobile.MobileWalletKeyType
 import id.walt.wallet2.mobile.MobileWalletIssuanceRequest
 import id.walt.wallet2.mobile.MobileWalletBootstrapResult
 import id.walt.wallet2.mobile.MobileWalletConfig
+import id.walt.wallet2.mobile.MobileWalletClientIdScheme
 import id.walt.wallet2.mobile.MobileWalletCredential
 import id.walt.wallet2.mobile.MobileWalletMetadataDisplay
 import id.walt.wallet2.mobile.MobileWalletDatabaseKey
@@ -31,16 +32,20 @@ import id.walt.wallet2.mobile.MobileWalletResponseEncryption
 import id.walt.wallet2.mobile.MobileWalletPersistence
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
 import id.walt.wallet2.mobile.MobileWalletVerifierMetadata
+import id.walt.wallet2.mobile.MobileWalletRequestAuthentication
 import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKey
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
 import id.walt.wallet2.handlers.WalletIssuanceOutcome
 import id.walt.wallet2.handlers.WalletIssuanceAuthorization
 import id.walt.wallet2.mobile.WalletAttestationConfig
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -190,6 +195,68 @@ class WalletSdkBridgeTest {
     }
 
     @Test
+    fun bridgePresentationPreviewPreservesAuthenticatedRequestFacts() = runTest {
+        val operations = FakeWalletSdkBridgeOperations(
+            requestAuthentication = MobileWalletRequestAuthentication.Authenticated(
+                compactRequestObject = "signed-request-object",
+                algorithm = "ES256",
+                keyId = "verifier-kid",
+                clientIdScheme = MobileWalletClientIdScheme.PRE_REGISTERED,
+            ),
+        )
+        val bridge = WalletSdkBridge.forOperations(operations)
+
+        val result = bridge.previewPresentation("openid4vp://request")
+
+        val preview = assertIs<MobileWalletPresentationPreviewResult.Ready>(
+            assertIs<WalletBridgeResult.Success<MobileWalletPresentationPreviewResult>>(result).value,
+        ).preview
+        assertEquals(
+            MobileWalletRequestAuthentication.Authenticated(
+                compactRequestObject = "signed-request-object",
+                algorithm = "ES256",
+                keyId = "verifier-kid",
+                clientIdScheme = MobileWalletClientIdScheme.PRE_REGISTERED,
+            ),
+            preview.request.requestAuthentication,
+        )
+    }
+
+    @Test
+    fun bridgeIssuerMetadataTrustResolverPreservesSignerFacts() = runTest {
+        listOf(
+            WalletBridgeIssuerMetadataSignerTrustType.TrustedIssuer to MetadataSignerTrustType.TRUSTED_ISSUER,
+            WalletBridgeIssuerMetadataSignerTrustType.TrustedDelegate to MetadataSignerTrustType.TRUSTED_DELEGATE,
+        ).forEach { (bridgeTrustType, expectedTrustType) ->
+            val configured = WalletBridgeConfiguration(
+                issuerMetadataTrustResolver = object : WalletBridgeIssuerMetadataTrustResolver {
+                    override suspend fun verify(
+                        compactJwt: String,
+                        expectedCredentialIssuer: String,
+                    ) = WalletBridgeIssuerMetadataSigner(
+                        keyId = "issuer-key",
+                        algorithm = "ES256",
+                        trustType = bridgeTrustType,
+                    ).also {
+                        assertEquals("signed-metadata-jwt", compactJwt)
+                        assertEquals("https://issuer.example", expectedCredentialIssuer)
+                    }
+                },
+            ).toMobileWalletConfig()
+
+            val signer = requireNotNull(configured.credentialIssuerMetadataTrustResolver).verify(
+                "signed-metadata-jwt",
+                "https://issuer.example",
+            )
+
+            assertEquals(
+                MetadataSigner("issuer-key", "ES256", expectedTrustType),
+                signer,
+            )
+        }
+    }
+
+    @Test
     fun bridgePresentationPreviewPreservesDetectedProtocolError() = runTest {
         val expected = MobileWalletPresentationPreviewResult.Invalid(
             previewHandle = MobileWalletPresentationPreviewHandle("presentation-preview"),
@@ -206,6 +273,7 @@ class WalletSdkBridgeTest {
                     policyUri = null,
                     termsOfServiceUri = null,
                 ),
+                requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
                 responseUri = "https://verifier.example/direct-post",
                 state = "state-1",
                 nonce = null,
@@ -277,6 +345,7 @@ class WalletSdkBridgeTest {
     }
 
     @Test
+    @OptIn(ExperimentalSerializationApi::class)
     fun factoryMapsSwiftFriendlyConfigurationToMobileWalletConfig() = runTest {
         var capturedConfig: MobileWalletConfig? = null
         var capturedTrustConfiguration: ClientIdTrustConfiguration? = null
@@ -302,6 +371,9 @@ class WalletSdkBridgeTest {
                 ),
                 clientIdTrustConfiguration = WalletBridgeClientIdTrustConfiguration(
                     x509TrustAnchorsPem = listOf(validTrustAnchorPem),
+                    preRegisteredClientMetadataJson = mapOf(
+                        "demo-verifier" to """{"jwks":{"keys":[{"kty":"EC","crv":"P-256","x":"x","y":"y"}]}}""",
+                    ),
                 ),
                 preferredLocales = listOf("de-AT", "en"),
                 transactionDataProfiles = listOf(
@@ -330,6 +402,7 @@ class WalletSdkBridgeTest {
             .findCertificateBySubjectDn(expectedTrustAnchor.data.subjectDn)
             .single()
         assertEquals(expectedTrustAnchor.encodedDer, capturedTrustAnchor.encodedDer)
+        assertEquals(setOf("demo-verifier"), capturedTrustConfiguration?.preRegisteredClients?.keys)
         assertEquals(listOf("de-AT", "en"), capturedConfig?.preferredLocales)
         assertEquals(
             listOf(
@@ -571,6 +644,8 @@ class WalletSdkBridgeTest {
 
     private class FakeWalletSdkBridgeOperations(
         private val previewResult: MobileWalletPresentationPreviewResult? = null,
+        private val requestAuthentication: MobileWalletRequestAuthentication =
+            MobileWalletRequestAuthentication.Unauthenticated,
     ) : WalletSdkBridgeOperations {
         var bootstrapKeyType: MobileWalletKeyType? = null
             private set
@@ -694,6 +769,7 @@ class WalletSdkBridgeTest {
                         policyUri = null,
                         termsOfServiceUri = null,
                     ),
+                    requestAuthentication = requestAuthentication,
                     responseUri = "https://verifier.example/direct-post",
                     state = "state-1",
                     nonce = "nonce-1",

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/models/ResolveOfferDetailedResponse.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/models/ResolveOfferDetailedResponse.kt
@@ -97,8 +97,8 @@ fun WalletOfferResolution.toDetailedResponse(
     tokenEndpoint = summary.tokenEndpoint,
     nonceEndpoint = summary.nonceEndpoint,
     issuer = OfferIssuerMetadata(
-        credentialIssuer = issuerMetadata.credentialIssuer,
-        display = issuerMetadata.display.selectPreferredByLocale(preferredLocales) { it.locale }?.toOfferDisplay(),
+        credentialIssuer = resolvedIssuerMetadata.metadata.credentialIssuer,
+        display = resolvedIssuerMetadata.metadata.display.selectPreferredByLocale(preferredLocales) { it.locale }?.toOfferDisplay(),
     ),
     offeredCredentials = offeredCredentials.map { offered ->
         val configuration = offered.configuration

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -34,7 +34,9 @@ import id.waltid.openid4vci.wallet.dpop.DPOP_NONCE_ATTEMPTS
 import id.waltid.openid4vci.wallet.dpop.DPOP_NONCE_HEADER
 import id.waltid.openid4vci.wallet.dpop.USE_DPOP_NONCE
 import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
 import id.waltid.openid4vci.wallet.metadata.OfferedCredentialResolver
+import id.waltid.openid4vci.wallet.metadata.ResolvedCredentialIssuerMetadata
 import id.waltid.openid4vci.wallet.nonce.NonceRequestBuilder
 import id.waltid.openid4vci.wallet.oauth.ClientConfiguration
 import id.waltid.openid4vci.wallet.offer.CredentialOfferParser
@@ -241,13 +243,14 @@ data class IssuancePreview(
  * consumers can project them into platform-safe API models without parsing raw JSON or refetching.
  *
  * @property previewHandle Opaque handle required to act on this retained preview.
- * @property issuerMetadata Credential issuer metadata used by the retained issuance snapshot.
- * @property offeredCredentials Offered credential configurations resolved against [issuerMetadata].
+ * @property resolvedIssuerMetadata Canonical issuer-metadata resolution retained for this preview.
+ * @property offeredCredentials Offered credential configurations resolved against
+ * [resolvedIssuerMetadata].metadata.
  * @property transactionCode Canonical OpenID4VCI transaction-code metadata, when required.
  */
 data class WalletOfferPreviewResult(
     val previewHandle: IssuancePreviewHandle,
-    val issuerMetadata: CredentialIssuerMetadata,
+    val resolvedIssuerMetadata: ResolvedCredentialIssuerMetadata,
     val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
     val transactionCode: TxCode?,
 )
@@ -263,13 +266,14 @@ data class WalletOfferPreviewResult(
  * stateless "resolve for display" endpoints where issuance is completed by re-sending the offer.
  *
  * @property summary App-facing offer summary (identical to [resolveOffer]'s result).
- * @property issuerMetadata Resolved credential issuer metadata.
- * @property offeredCredentials Offered credential configurations resolved against [issuerMetadata].
+ * @property resolvedIssuerMetadata Canonical issuer-metadata resolution returned with this result.
+ * @property offeredCredentials Offered credential configurations resolved against
+ * [resolvedIssuerMetadata].metadata.
  * @property transactionCode Canonical OpenID4VCI transaction-code metadata, when required.
  */
 data class WalletOfferResolution(
     val summary: ResolveOfferResult,
-    val issuerMetadata: CredentialIssuerMetadata,
+    val resolvedIssuerMetadata: ResolvedCredentialIssuerMetadata,
     val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
     val transactionCode: TxCode?,
 )
@@ -279,15 +283,17 @@ data class WalletOfferResolution(
  *
  * @property summary App-facing metadata derived from the resolution.
  * @property offer Exact parsed credential offer, including its grants.
- * @property issuerMetadata Credential issuer metadata used to validate the offered configurations.
+ * @property resolvedIssuerMetadata Canonical issuer-metadata resolution used to validate the
+ * offered configurations.
  * @property authorizationServerMetadata Authorization server metadata used for the token request.
- * @property offeredCredentials Offered configurations resolved against [issuerMetadata].
+ * @property offeredCredentials Offered configurations resolved against
+ * [resolvedIssuerMetadata].metadata.
  */
 internal class ResolvedIssuanceOffer(
     val source: ResolveOfferRequest,
     val summary: ResolveOfferResult,
     val offer: CredentialOffer,
-    val issuerMetadata: CredentialIssuerMetadata,
+    val resolvedIssuerMetadata: ResolvedCredentialIssuerMetadata,
     val authorizationServerMetadata: AuthorizationServerMetadata,
     val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
 )
@@ -602,6 +608,7 @@ object WalletIssuanceHandler {
         /** Called with the exact response batch size before any credential of that batch is persisted. */
         beforeCredentialsStored: suspend (Int) -> Unit = {},
         onCredentialStored: suspend (StoredCredential) -> Unit = {},
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): Flow<StoredCredential> = receiveCredentialFlowInternal(
         wallet = wallet,
         request = request,
@@ -612,6 +619,7 @@ object WalletIssuanceHandler {
         onDeferredTransactionId = onDeferredTransactionId,
         beforeCredentialsStored = beforeCredentialsStored,
         onCredentialStored = onCredentialStored,
+        metadataTrustResolver = metadataTrustResolver,
     )
 
     /**
@@ -644,6 +652,7 @@ object WalletIssuanceHandler {
                 onDeferredTransactionId = onDeferredTransactionId,
                 beforeCredentialsStored = beforeCredentialsStored,
                 onCredentialStored = onCredentialStored,
+                metadataTrustResolver = null,
             ).collect(::send)
         }
     }
@@ -658,6 +667,7 @@ object WalletIssuanceHandler {
         onDeferredTransactionId: suspend (credentialConfigurationId: String, transactionId: String) -> Unit,
         beforeCredentialsStored: suspend (Int) -> Unit,
         onCredentialStored: suspend (StoredCredential) -> Unit,
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver?,
     ): Flow<StoredCredential> = channelFlow {
         val keyMaterial = request.key?.key?.let { WalletKeyStoreEntry(it.getKeyId(), it, null) }
             ?: wallet.resolveKeyMaterial(request.keyId, setOf(KeyUsage.SIGN))
@@ -685,11 +695,12 @@ object WalletIssuanceHandler {
         val effectiveResolvedOffer = resolvedOffer ?: resolveIssuanceOffer(
             request.toResolveOfferRequest(),
             httpClient,
+            metadataTrustResolver,
         )
 
         // 2. Reuse issuer metadata and offered configurations from that resolution.
         val offer = effectiveResolvedOffer.offer
-        val issuerMetadata = effectiveResolvedOffer.issuerMetadata
+        val issuerMetadata = effectiveResolvedOffer.resolvedIssuerMetadata.metadata
         val offeredCredentials = effectiveResolvedOffer.offeredCredentials
         val asMetadata = effectiveResolvedOffer.authorizationServerMetadata
         log.trace { "Resolved offer: issuer=${offer.credentialIssuer}, configIds=${offer.credentialConfigurationIds}" }
@@ -842,6 +853,7 @@ object WalletIssuanceHandler {
         /** Called with the exact response batch size before any credential of that batch is persisted. */
         beforeCredentialsStored: suspend (Int) -> Unit = {},
         onCredentialStored: suspend (StoredCredential) -> Unit = {},
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): ReceiveCredentialResult {
         val ids = mutableListOf<String>()
         val deferredIds = mutableMapOf<String, String>()
@@ -854,6 +866,7 @@ object WalletIssuanceHandler {
             onDeferredTransactionId = { configId, txId -> deferredIds[configId] = txId },
             beforeCredentialsStored = beforeCredentialsStored,
             onCredentialStored = onCredentialStored,
+            metadataTrustResolver = metadataTrustResolver,
         ).collect { ids += it.id }
         return ReceiveCredentialResult(credentialIds = ids, deferredTransactionIds = deferredIds)
     }
@@ -899,14 +912,15 @@ object WalletIssuanceHandler {
         wallet: Wallet,
         request: ResolveOfferRequest,
         httpClient: HttpClient = WalletIssuanceHandler.httpClient,
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): WalletOfferPreviewResult {
-        val resolvedOffer = resolveIssuanceOffer(request, httpClient)
+        val resolvedOffer = resolveIssuanceOffer(request, httpClient, metadataTrustResolver)
         val previewHandle = IssuancePreviewHandle(
             previewedOffers.create(walletId = wallet.id, value = resolvedOffer)
         )
         return WalletOfferPreviewResult(
             previewHandle = previewHandle,
-            issuerMetadata = resolvedOffer.issuerMetadata,
+            resolvedIssuerMetadata = resolvedOffer.resolvedIssuerMetadata,
             offeredCredentials = resolvedOffer.offeredCredentials,
             transactionCode = resolvedOffer.offer.grants?.preAuthorizedCode?.txCode,
         )
@@ -925,10 +939,12 @@ object WalletIssuanceHandler {
     private suspend fun resolveIssuanceOffer(
         request: ResolveOfferRequest,
         httpClient: HttpClient = WalletIssuanceHandler.httpClient,
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): ResolvedIssuanceOffer {
         val offer = resolveOffer(request, httpClient)
-        val metadataResolver = IssuerMetadataResolver(httpClient)
-        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val metadataResolver = IssuerMetadataResolver(httpClient, metadataTrustResolver)
+        val resolvedIssuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val issuerMetadata = resolvedIssuerMetadata.metadata
         val asMetadata = metadataResolver.resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
         val offeredCredentials = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata)
         return ResolvedIssuanceOffer(
@@ -946,7 +962,7 @@ object WalletIssuanceHandler {
                 nonceEndpoint = issuerMetadata.nonceEndpoint?.let { Url(it) },
             ),
             offer = offer,
-            issuerMetadata = issuerMetadata,
+            resolvedIssuerMetadata = resolvedIssuerMetadata,
             authorizationServerMetadata = asMetadata,
             offeredCredentials = offeredCredentials,
         )
@@ -990,15 +1006,22 @@ object WalletIssuanceHandler {
      *
      * Use this for stateless "resolve for display" flows that render an issuer/credential preview and then
      * complete issuance by re-sending the offer (e.g. via the pre-authorized or authorization-code endpoints).
+     *
+     * @param request Credential offer URL or inline offer JSON to resolve.
+     * @param httpClient HTTP client used for offer and metadata resolution.
+     * @param metadataTrustResolver Optional trust boundary for signed Credential Issuer Metadata. When
+     * absent, only unsigned metadata is accepted.
+     * @return Resolved offer summary, issuer metadata resolution, offered credentials, and transaction code.
      */
     suspend fun resolveOfferDetailed(
         request: ResolveOfferRequest,
         httpClient: HttpClient = WalletIssuanceHandler.httpClient,
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): WalletOfferResolution {
-        val resolved = resolveIssuanceOffer(request, httpClient)
+        val resolved = resolveIssuanceOffer(request, httpClient, metadataTrustResolver)
         return WalletOfferResolution(
             summary = resolved.summary,
-            issuerMetadata = resolved.issuerMetadata,
+            resolvedIssuerMetadata = resolved.resolvedIssuerMetadata,
             offeredCredentials = resolved.offeredCredentials,
             transactionCode = resolved.offer.grants?.preAuthorizedCode?.txCode,
         )
@@ -1021,7 +1044,7 @@ object WalletIssuanceHandler {
         val credentialIssuer = request.credentialIssuer?.takeIf { it.isNotBlank() }
         val asMetadata = credentialIssuer?.let {
             val metadataResolver = IssuerMetadataResolver(httpClient)
-            val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(it)
+            val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(it).metadata
             metadataResolver.resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
         }
         val attestationHeaders = asMetadata?.let {
@@ -1079,7 +1102,7 @@ object WalletIssuanceHandler {
         httpClient: HttpClient = WalletIssuanceHandler.httpClient,
     ): RequestNonceResult {
         val issuerMetadata = IssuerMetadataResolver(httpClient)
-            .resolveCredentialIssuerMetadata(request.credentialIssuer.toString())
+            .resolveCredentialIssuerMetadata(request.credentialIssuer.toString()).metadata
         return RequestNonceResult(
             nonce = requestProofNonce(
                 httpClient = httpClient,
@@ -1097,7 +1120,7 @@ object WalletIssuanceHandler {
             ?: wallet.resolveKeyMaterial(request.keyId, setOf(KeyUsage.SIGN))
             ?: error("No key available for signing proof")
         val issuerMetadata = IssuerMetadataResolver(httpClient)
-            .resolveCredentialIssuerMetadata(request.issuerUrl.toString())
+            .resolveCredentialIssuerMetadata(request.issuerUrl.toString()).metadata
         val configuration = issuerMetadata.credentialConfigurationsSupported[request.credentialConfigurationId]
             ?: error(
                 "Unknown credential configuration '${request.credentialConfigurationId}' " +
@@ -1494,7 +1517,7 @@ object WalletIssuanceHandler {
     ): CredentialStorageContext {
         val resolvedIssuerMetadata = issuerMetadata
             ?: credentialIssuerBaseUrl?.let {
-                IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(it)
+                IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(it).metadata
             }
         return CredentialStorageContext(
             label = labelOverride
@@ -1575,7 +1598,7 @@ object WalletIssuanceHandler {
         httpClient: HttpClient,
     ): AuthorizationServerMetadata {
         val metadataResolver = IssuerMetadataResolver(httpClient)
-        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(credentialIssuerBaseUrl)
+        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(credentialIssuerBaseUrl).metadata
         return metadataResolver.resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
     }
 
@@ -1666,7 +1689,7 @@ object WalletIssuanceHandler {
         attestationAssembler: ClientAttestationAssembler? = null,
     ): GenerateAuthorizationUrlResult {
         val offer = resolveOffer(request, httpClient)
-        val issuerMetadata = IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val issuerMetadata = IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(offer.credentialIssuer).metadata
         val asMetadata =
             IssuerMetadataResolver(httpClient).resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
 
@@ -1994,7 +2017,7 @@ object WalletIssuanceHandler {
 
         // Resolve issuer metadata again at continuation time and use only its advertised nonce endpoint.
         val issuerMetadata = IssuerMetadataResolver(httpClient)
-            .resolveCredentialIssuerMetadata(credentialIssuerBaseUrl)
+            .resolveCredentialIssuerMetadata(credentialIssuerBaseUrl).metadata
         nonceEndpoint?.let { expected ->
             require(expected == issuerMetadata.nonceEndpoint) {
                 "Provided nonce endpoint does not match credential issuer metadata"

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
@@ -1328,6 +1328,8 @@ class WalletIssuanceSessionService(
         }
 
         val offer = json.decodeFromString<CredentialOffer>(persisted.offer)
+        // The store is an integrity-protected persistence boundary. Restore the resolution snapshot
+        // established when the session started, then revalidate its protocol bindings below.
         val issuerMetadata = json.decodeFromString<ResolvedCredentialIssuerMetadata>(persisted.issuerMetadata)
         val authorizationServerMetadata =
             json.decodeFromString<AuthorizationServerMetadata>(persisted.authorizationServerMetadata)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
@@ -38,7 +38,10 @@ import id.waltid.openid4vci.wallet.dpop.DPOP_NONCE_ATTEMPTS
 import id.waltid.openid4vci.wallet.dpop.DPOP_NONCE_HEADER
 import id.waltid.openid4vci.wallet.dpop.USE_DPOP_NONCE
 import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.waltid.openid4vci.wallet.metadata.OfferedCredentialResolver
+import id.waltid.openid4vci.wallet.metadata.ResolvedCredentialIssuerMetadata
 import id.waltid.openid4vci.wallet.nonce.NonceRequestBuilder
 import id.waltid.openid4vci.wallet.nonce.NonceRequestError
 import id.waltid.openid4vci.wallet.nonce.NonceRequestException
@@ -96,7 +99,30 @@ data class WalletIssuanceIssuerPreview(
     val locale: String?,
     val logoUri: String?,
     val logoAltText: String?,
+    /** Whether the issuer metadata was unsigned or verified signed metadata. */
+    val metadataProvenance: WalletIssuanceMetadataProvenance,
 )
+
+/** Verification provenance of issuer metadata retained by an issuance session. */
+@Serializable
+sealed interface WalletIssuanceMetadataProvenance {
+    /** Metadata was received as an unsigned JSON document. */
+    @Serializable
+    data object Unsigned : WalletIssuanceMetadataProvenance
+
+    /** Metadata was received in a JWS verified by the configured trust resolver. */
+    @Serializable
+    data class Signed(
+        /** Exact compact JWS returned by the issuer. */
+        val compactJwt: String,
+        /** JWS algorithm verified by the configured trust resolver. */
+        val algorithm: String,
+        /** Identifier of the trusted verification key, as reported by the trust resolver. */
+        val keyId: String?,
+        /** Authority relationship established by the trust resolver. */
+        val trustType: MetadataSignerTrustType,
+    ) : WalletIssuanceMetadataProvenance
+}
 
 /** Offered credential information safe for an app review screen. */
 @Serializable
@@ -240,6 +266,7 @@ sealed interface WalletIssuanceOutcome {
 class WalletIssuanceSessionService(
     private val wallet: Wallet,
     private val attestationAssembler: ClientAttestationAssembler? = null,
+    private val metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     private val onEvent: suspend (WalletSessionEvent) -> Unit = {},
     private val sessionStore: WalletIssuanceSessionStore? = null,
     httpClient: HttpClient? = null,
@@ -604,7 +631,7 @@ class WalletIssuanceSessionService(
             } catch (error: Exception) {
                 throw IssuanceStageException(WalletIssuanceErrorCode.CRYPTO, error)
             }
-            val proofNonce = if (proof.required) fetchNonce(active.resolved.issuerMetadata) else null
+            val proofNonce = if (proof.required) fetchNonce(active.resolved.issuerMetadata.metadata) else null
             val proofJwt = if (proof.required) {
                 try {
                     buildCredentialProof(
@@ -632,7 +659,7 @@ class WalletIssuanceSessionService(
                 }
             }.toString()
             val protected = postProtected(
-                endpoint = active.resolved.issuerMetadata.credentialEndpoint,
+                endpoint = active.resolved.issuerMetadata.metadata.credentialEndpoint,
                 accessToken = token.access_token,
                 tokenType = token.token_type,
                 dpop = dpopAlgorithms,
@@ -683,7 +710,7 @@ class WalletIssuanceSessionService(
                     }
                     val transactionId = response.transactionId
                         ?: throw IssuanceStageException(WalletIssuanceErrorCode.PROTOCOL)
-                    val deferredEndpoint = active.resolved.issuerMetadata.deferredCredentialEndpoint
+                    val deferredEndpoint = active.resolved.issuerMetadata.metadata.deferredCredentialEndpoint
                         ?: throw IssuanceStageException(WalletIssuanceErrorCode.PROTOCOL)
                     val public = WalletDeferredCredential(
                         id = Uuid.random().toString(),
@@ -925,12 +952,12 @@ class WalletIssuanceSessionService(
             val parsed = CredentialOfferParser.parseCredentialOfferUrl(request.getEffectiveOfferString())
             CredentialOfferResolver(httpClient).resolveCredentialOffer(parsed.credentialOffer, parsed.credentialOfferUri)
         }
-        val resolver = IssuerMetadataResolver(httpClient)
+        val resolver = IssuerMetadataResolver(httpClient, metadataTrustResolver)
         // Operational metadata is always resolved from issuer-derived well-known endpoints.
         // Unrecognized offer parameters are caller-controlled and must not select network
         // endpoints for issuance.
         val issuerMetadata = resolver.resolveCredentialIssuerMetadata(offer.credentialIssuer)
-        require(issuerMetadata.credentialIssuer == offer.credentialIssuer) {
+        require(issuerMetadata.metadata.credentialIssuer == offer.credentialIssuer) {
             "Credential issuer metadata identifier does not match the offer"
         }
         val grantAuthorizationServer = when (offer.getGrantType()) {
@@ -938,12 +965,12 @@ class WalletIssuanceSessionService(
             is GrantType.PreAuthorizedCode -> offer.grants?.preAuthorizedCode?.authorizationServer
             else -> null
         }
-        val selectedAuthorizationServer = selectAuthorizationServer(issuerMetadata, grantAuthorizationServer)
+        val selectedAuthorizationServer = selectAuthorizationServer(issuerMetadata.metadata, grantAuthorizationServer)
         val authorizationServerMetadata = resolver.resolveAuthorizationServerMetadata(selectedAuthorizationServer)
         require(authorizationServerMetadata.issuer == selectedAuthorizationServer) {
             "Authorization server metadata issuer does not match the selected server"
         }
-        val offered = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata)
+        val offered = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata.metadata)
         require(offered.isNotEmpty()) { "Credential offer resolved no supported credentials" }
         return ResolvedOffer(offer, issuerMetadata, authorizationServerMetadata, offered)
     }
@@ -964,7 +991,7 @@ class WalletIssuanceSessionService(
     }
 
     private fun ResolvedOffer.toPreview(grant: GrantType): WalletIssuanceOfferPreview {
-        val issuerDisplay = issuerMetadata.display?.firstOrNull()
+        val issuerDisplay = issuerMetadata.metadata.display?.firstOrNull()
         val txCode = offer.grants?.preAuthorizedCode?.txCode
         return WalletIssuanceOfferPreview(
             grant = when (grant) {
@@ -973,11 +1000,12 @@ class WalletIssuanceSessionService(
                 else -> error("Unsupported credential offer grant")
             },
             issuer = WalletIssuanceIssuerPreview(
-                identifier = offer.credentialIssuer,
+                identifier = issuerMetadata.metadata.credentialIssuer,
                 name = issuerDisplay?.name,
                 locale = issuerDisplay?.locale,
                 logoUri = issuerDisplay?.logo?.uri,
                 logoAltText = issuerDisplay?.logo?.altText,
+                metadataProvenance = issuerMetadata.toPreviewProvenance(),
             ),
             credentials = offeredCredentials.map { offered ->
                 val display = offered.configuration.credentialMetadata?.display?.firstOrNull()
@@ -992,6 +1020,16 @@ class WalletIssuanceSessionService(
             transactionCode = txCode?.let {
                 WalletIssuanceTransactionCode(it.inputMode, it.length, it.description)
             },
+        )
+    }
+
+    private fun ResolvedCredentialIssuerMetadata.toPreviewProvenance(): WalletIssuanceMetadataProvenance = when (this) {
+        is ResolvedCredentialIssuerMetadata.Unsigned -> WalletIssuanceMetadataProvenance.Unsigned
+        is ResolvedCredentialIssuerMetadata.Signed -> WalletIssuanceMetadataProvenance.Signed(
+            compactJwt = compactJwt,
+            algorithm = signer.algorithm,
+            keyId = signer.keyId,
+            trustType = signer.trustType,
         )
     }
 
@@ -1290,10 +1328,10 @@ class WalletIssuanceSessionService(
         }
 
         val offer = json.decodeFromString<CredentialOffer>(persisted.offer)
-        val issuerMetadata = json.decodeFromString<CredentialIssuerMetadata>(persisted.issuerMetadata)
+        val issuerMetadata = json.decodeFromString<ResolvedCredentialIssuerMetadata>(persisted.issuerMetadata)
         val authorizationServerMetadata =
             json.decodeFromString<AuthorizationServerMetadata>(persisted.authorizationServerMetadata)
-        val offeredCredentials = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata)
+        val offeredCredentials = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata.metadata)
         val resolved = ResolvedOffer(offer, issuerMetadata, authorizationServerMetadata, offeredCredentials)
         validatePersistedResolution(persisted.public, resolved)
 
@@ -1361,10 +1399,10 @@ class WalletIssuanceSessionService(
         require(resolved.offer.credentialIssuer == public.offer.issuer.identifier) {
             "Stored issuance session issuer binding is invalid"
         }
-        require(resolved.issuerMetadata.credentialIssuer == resolved.offer.credentialIssuer) {
+        require(resolved.issuerMetadata.metadata.credentialIssuer == resolved.offer.credentialIssuer) {
             "Stored credential issuer metadata binding is invalid"
         }
-        require(resolved.authorizationServerMetadata.issuer in resolved.issuerMetadata.authorizationServerIssuers()) {
+        require(resolved.authorizationServerMetadata.issuer in resolved.issuerMetadata.metadata.authorizationServerIssuers()) {
             "Stored authorization server binding is invalid"
         }
         require(
@@ -1648,7 +1686,7 @@ class WalletIssuanceSessionService(
 
     private data class ResolvedOffer(
         val offer: CredentialOffer,
-        val issuerMetadata: CredentialIssuerMetadata,
+        val issuerMetadata: ResolvedCredentialIssuerMetadata,
         val authorizationServerMetadata: AuthorizationServerMetadata,
         val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
     )

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionStore.kt
@@ -10,7 +10,7 @@ enum class WalletIssuanceSessionRecordKind {
  * Opaque issuance continuation stored outside the protocol engine.
  *
  * [payload] can contain authorization codes, PKCE material, access tokens, and deferred
- * transaction identifiers. Implementations must encrypt it at rest.
+ * transaction identifiers. Implementations must protect its confidentiality and integrity at rest.
  */
 data class WalletIssuanceSessionRecord(
     val id: String,
@@ -23,8 +23,10 @@ data class WalletIssuanceSessionRecord(
 /**
  * Durable storage boundary for issuance continuations.
  *
- * Mobile SDK factories provide an encrypted SQLDelight implementation. Callers constructing the
- * protocol engine directly may omit the store and receive process-local continuation semantics.
+ * Implementations are an authoritative security boundary and must reject records whose integrity
+ * cannot be established. Mobile SDK factories provide an integrity-protected, encrypted SQLDelight
+ * implementation. Callers constructing the protocol engine directly may omit the store and receive
+ * process-local continuation semantics.
  */
 interface WalletIssuanceSessionStore {
     suspend fun get(id: String): WalletIssuanceSessionRecord?

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletPresentationHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletPresentationHandler.kt
@@ -185,10 +185,13 @@ value class PresentationPreviewHandle(val value: String) {
 
 sealed interface PreviewPresentationResult {
     val handle: PresentationPreviewHandle
+    val resolvedAuthorizationRequest: ResolvedAuthorizationRequest
+    val authorizationRequest: AuthorizationRequest
+        get() = resolvedAuthorizationRequest.authorizationRequest
 
     data class Ready(
         override val handle: PresentationPreviewHandle,
-        val authorizationRequest: AuthorizationRequest,
+        override val resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
         /** Response-encryption selection derived from this authenticated request, or `null` for a plain response. */
         val responseEncryption: ResponseEncryption.Metadata?,
         val credentialOptions: List<PresentationCredentialOption>,
@@ -198,7 +201,7 @@ sealed interface PreviewPresentationResult {
 
     data class Invalid(
         override val handle: PresentationPreviewHandle,
-        val authorizationRequest: AuthorizationRequest,
+        override val resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
         val error: PresentationRequestError,
     ) : PreviewPresentationResult
 }
@@ -708,7 +711,7 @@ object WalletPresentationHandler {
                     error = validation.error,
                 ),
             )
-            return PreviewPresentationResult.Invalid(handle, authorizationRequest, validation.error)
+            return PreviewPresentationResult.Invalid(handle, resolvedAuthorizationRequest, validation.error)
         }
 
         val valid = validation as PresentationRequestValidationResult.Valid
@@ -742,7 +745,7 @@ object WalletPresentationHandler {
                     error = availabilityError,
                 ),
             )
-            return PreviewPresentationResult.Invalid(handle, authorizationRequest, availabilityError)
+            return PreviewPresentationResult.Invalid(handle, resolvedAuthorizationRequest, availabilityError)
         }
         onEvent(WalletSessionEvent.presentation_credentials_selected)
         val credentialOptions = matched.flatMap { (queryId, results) ->
@@ -773,7 +776,7 @@ object WalletPresentationHandler {
         )
         return PreviewPresentationResult.Ready(
             handle = handle,
-            authorizationRequest = authorizationRequest,
+            resolvedAuthorizationRequest = resolvedAuthorizationRequest,
             responseEncryption = responseEncryption,
             credentialRequirements = query.requiredCredentialRequirements(),
             credentialOptions = credentialOptions,
@@ -1498,6 +1501,7 @@ object WalletPresentationHandler {
                     requestUriPostWalletMetadata = AuthorizationRequestResolver.buildRequestUriPostWalletMetadata(
                         WalletPresentationFormatRegistry.buildVpFormatsSupported(capabilities()),
                         clientIdTrustConfiguration,
+                        AuthorizationRequestResolver.UnsignedRequestObjectPolicy.REQUIRE_SIGNED,
                     ),
                 )
             },

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerPreviewTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerPreviewTest.kt
@@ -2,9 +2,16 @@ package id.walt.wallet2.handlers
 
 import id.walt.crypto.keys.KeyType
 import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.openid4vci.CredentialFormat
+import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.toSignedJwt
 import id.walt.wallet2.data.StoredCredential
 import id.walt.wallet2.data.Wallet
 import id.walt.wallet2.data.WalletCredentialStore
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
+import id.waltid.openid4vci.wallet.metadata.ResolvedCredentialIssuerMetadata
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -23,6 +30,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 
 class WalletIssuanceHandlerPreviewTest {
 
@@ -180,7 +188,8 @@ class WalletIssuanceHandlerPreviewTest {
             httpClient = client,
         )
 
-        assertEquals(ISSUER, preview.issuerMetadata.credentialIssuer)
+        assertEquals(ISSUER, preview.resolvedIssuerMetadata.metadata.credentialIssuer)
+        assertIs<ResolvedCredentialIssuerMetadata.Unsigned>(preview.resolvedIssuerMetadata)
         assertEquals("pid", preview.offeredCredentials.single().credentialConfigurationId)
         assertEquals("text", preview.transactionCode?.inputMode)
 
@@ -215,6 +224,143 @@ class WalletIssuanceHandlerPreviewTest {
         assertEquals(2, offerFetches)
         assertEquals(4, metadataFetches)
         assertEquals(3, tokenRequests)
+    }
+
+    @Test
+    fun signedPreviewRetainsExactMetadataResolutionAndSigner() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val compactJwt = signedIssuerMetadata().toSignedJwt(key)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respond(
+                            content = compactJwt,
+                            headers = headersOf(HttpHeaders.ContentType, "application/jwt"),
+                        )
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val preview = WalletIssuanceHandler.previewOffer(
+            wallet = Wallet(id = "signed-preview", staticKey = JWKKey.generate(KeyType.Ed25519)),
+            request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+            httpClient = client,
+            metadataTrustResolver = { candidate, expectedIssuer ->
+                assertEquals(compactJwt, candidate)
+                assertEquals(ISSUER, expectedIssuer)
+                key.getPublicKey().verifyJws(candidate).getOrThrow()
+                MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+            },
+        )
+
+        val signed = assertIs<ResolvedCredentialIssuerMetadata.Signed>(preview.resolvedIssuerMetadata)
+        assertEquals(compactJwt, signed.compactJwt)
+        assertEquals(
+            MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER),
+            signed.signer,
+        )
+        assertEquals(ISSUER, signed.metadata.credentialIssuer)
+    }
+
+    @Test
+    fun detailedOfferResolutionRetainsUnsignedMetadataWithoutTrustResolver() = runTest {
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respondJson(ISSUER_METADATA)
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val resolution = WalletIssuanceHandler.resolveOfferDetailed(
+            request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+            httpClient = client,
+        )
+
+        assertIs<ResolvedCredentialIssuerMetadata.Unsigned>(resolution.resolvedIssuerMetadata)
+        assertEquals(ISSUER, resolution.resolvedIssuerMetadata.metadata.credentialIssuer)
+        assertEquals("pid", resolution.offeredCredentials.single().credentialConfigurationId)
+    }
+
+    @Test
+    fun detailedOfferResolutionRetainsExactSignedMetadataAndSigner() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val compactJwt = signedIssuerMetadata().toSignedJwt(key)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respond(
+                            content = compactJwt,
+                            headers = headersOf(HttpHeaders.ContentType, "application/jwt"),
+                        )
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val signer = MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+        val resolution = WalletIssuanceHandler.resolveOfferDetailed(
+            request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+            httpClient = client,
+            metadataTrustResolver = { candidate, expectedIssuer ->
+                assertEquals(compactJwt, candidate)
+                assertEquals(ISSUER, expectedIssuer)
+                key.getPublicKey().verifyJws(candidate).getOrThrow()
+                signer
+            },
+        )
+
+        val signed = assertIs<ResolvedCredentialIssuerMetadata.Signed>(resolution.resolvedIssuerMetadata)
+        assertEquals(compactJwt, signed.compactJwt)
+        assertEquals(signer, signed.signer)
+        assertEquals(ISSUER, signed.metadata.credentialIssuer)
+    }
+
+    @Test
+    fun detailedOfferResolutionRejectsUntrustedSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val compactJwt = signedIssuerMetadata().toSignedJwt(key)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respond(
+                            content = compactJwt,
+                            headers = headersOf(HttpHeaders.ContentType, "application/jwt"),
+                        )
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        assertFails {
+            WalletIssuanceHandler.resolveOfferDetailed(
+                request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+                httpClient = client,
+                metadataTrustResolver = { _, _ -> error("untrusted signer") },
+            )
+        }
     }
 
     @Test
@@ -290,6 +436,14 @@ class WalletIssuanceHandlerPreviewTest {
           "response_types_supported": ["code"]
         }
     """
+
+    private fun signedIssuerMetadata() = CredentialIssuerMetadata(
+        credentialIssuer = ISSUER,
+        credentialEndpoint = "$ISSUER/credential",
+        credentialConfigurationsSupported = mapOf(
+            "pid" to CredentialConfiguration(CredentialFormat.SD_JWT_VC),
+        ),
+    )
 
     private companion object {
         const val ISSUER = "https://issuer.example"

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
@@ -1,25 +1,43 @@
 package id.waltid.openid4vci.wallet.metadata
 
 import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadataJwt
 import id.walt.openid4vci.metadata.oauth.AuthorizationServerMetadata
 import id.walt.openid4vci.metadata.oidc.OpenIDProviderMetadata
+import id.walt.openid4vci.tokens.jwt.JwtPayloadClaims
+import id.walt.crypto2.jose.CompactJws
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlin.time.Clock
 
 private val log = KotlinLogging.logger {}
 
 /**
- * Resolves issuer metadata from well-known endpoints.
- * Implements §11.2 of OpenID4VCI 1.0 specification (Credential Issuer Metadata).
- * 
- * @property httpClient The HTTP client to use for fetching metadata
+ * Resolves unsigned or signed Credential Issuer Metadata from its well-known endpoint.
+ *
+ * Implements OpenID4VCI 1.0 section 12.2 and signed metadata in section 12.2.3.
+ * A signed response is accepted only after [metadataTrustResolver] independently establishes
+ * both the JWS signature and the signer's authority for the credential issuer.
+ *
+ * @property httpClient HTTP client used to fetch metadata.
+ * @property metadataTrustResolver Optional trust boundary for signed metadata. Without it,
+ * only unsigned metadata is accepted.
  */
 class IssuerMetadataResolver(
     private val httpClient: HttpClient,
+    private val metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
 ) {
 
     companion object {
@@ -29,13 +47,14 @@ class IssuerMetadataResolver(
     }
 
     /**
-     * Resolves credential issuer metadata from the issuer's well-known endpoint
-     * 
-     * @param credentialIssuerUrl The credential issuer identifier URL
-     * @return CredentialIssuerMetadata
-     * @throws Exception if metadata cannot be fetched or parsed
+     * Resolves credential issuer metadata and retains its signed/unsigned provenance.
+     *
+     * @param credentialIssuerUrl Credential issuer identifier URL.
+     * @return Parsed metadata with explicit unsigned or verified signed provenance.
      */
-    suspend fun resolveCredentialIssuerMetadata(credentialIssuerUrl: String): CredentialIssuerMetadata {
+    suspend fun resolveCredentialIssuerMetadata(
+        credentialIssuerUrl: String,
+    ): ResolvedCredentialIssuerMetadata {
         require(credentialIssuerUrl.isNotBlank()) { "Credential issuer URL cannot be blank" }
 
         log.info { "Resolving credential issuer metadata" }
@@ -55,8 +74,16 @@ class IssuerMetadataResolver(
             log.debug { "Attempt ${index + 1}/${urlsToTry.size}: Fetching from $metadataUrl" }
 
             val response: HttpResponse = try {
-                httpClient.get(metadataUrl)
+                httpClient.get(metadataUrl) {
+                    header(
+                        HttpHeaders.Accept,
+                        metadataTrustResolver?.let {
+                            "${CredentialIssuerMetadataJwt.MEDIA_TYPE}, ${ContentType.Application.Json}"
+                        } ?: ContentType.Application.Json.toString(),
+                    )
+                }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 log.warn(e) { "Network error fetching credential issuer metadata from: $metadataUrl" }
                 failures += ResolveFailure.Network(metadataUrl, e)
                 continue
@@ -65,15 +92,30 @@ class IssuerMetadataResolver(
             if (response.status.isSuccess()) {
                 log.trace { "Received successful response (${response.status.value}), parsing metadata" }
                 try {
-                    val metadata = response.body<CredentialIssuerMetadata>()
+                    val body = response.bodyAsText()
+                    val metadata = when (response.contentType()?.withoutParameters()) {
+                        ContentType.Application.Json -> ResolvedCredentialIssuerMetadata.Unsigned(
+                            parseAndValidateMetadata(body, credentialIssuerUrl),
+                        )
+                        ContentType.parse(CredentialIssuerMetadataJwt.MEDIA_TYPE),
+                        ContentType.parse(CredentialIssuerMetadataJwt.TYPED_MEDIA_TYPE) ->
+                            parseSignedMetadata(body, credentialIssuerUrl)
+                        else -> throw IllegalArgumentException(
+                            "Unsupported Credential Issuer Metadata content type: ${response.contentType()}",
+                        )
+                    }
                     log.info {
                         "Successfully resolved credential issuer metadata - " +
-                                "Issuer: ${metadata.credentialIssuer}, " +
-                                "Configurations: ${metadata.credentialConfigurationsSupported.size}"
+                                "Issuer: ${metadata.metadata.credentialIssuer}, " +
+                                "Configurations: ${metadata.metadata.credentialConfigurationsSupported.size}"
                     }
-                    log.trace { "Supported credential configurations: ${metadata.credentialConfigurationsSupported.keys.joinToString()}" }
+                    log.trace {
+                        "Supported credential configurations: " +
+                            metadata.metadata.credentialConfigurationsSupported.keys.joinToString()
+                    }
                     return metadata
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     val responseBody = runCatching { response.bodyAsText() }.getOrDefault("")
                     log.error(e) {
                         "Failed to parse credential issuer metadata from $metadataUrl - " +
@@ -103,6 +145,72 @@ class IssuerMetadataResolver(
             urlsToTry,
             failures,
         )
+    }
+
+    private suspend fun parseSignedMetadata(
+        compactJwt: String,
+        expectedCredentialIssuer: String,
+    ): ResolvedCredentialIssuerMetadata.Signed {
+        val decoded = runCatching { CompactJws.decodeUnverified(compactJwt) }
+            .getOrElse { throw IllegalArgumentException("Invalid signed Credential Issuer Metadata", it) }
+        val algorithm = decoded.algorithm.identifier
+        require(!algorithm.equals("none", ignoreCase = true) && !algorithm.startsWith("HS", ignoreCase = true)) {
+            "Signed Credential Issuer Metadata must use an asymmetric JWS algorithm"
+        }
+        require(decoded.protectedHeader.requiredString("typ", "typ") == CredentialIssuerMetadataJwt.TYPE) {
+            "Signed Credential Issuer Metadata has an invalid typ"
+        }
+        val signer = requireNotNull(metadataTrustResolver) {
+            "Signed Credential Issuer Metadata requires a configured trust resolver"
+        }.verify(compactJwt, expectedCredentialIssuer)
+        require(signer.algorithm == algorithm) { "Trusted signer algorithm does not match JWS alg" }
+
+        val payload = runCatching {
+            lenientJson.parseToJsonElement(decoded.payload.decodeToString()).jsonObject
+        }.getOrElse { throw IllegalArgumentException("Signed Credential Issuer Metadata payload is not a JSON object", it) }
+        val subject = payload.requiredString(JwtPayloadClaims.SUBJECT, "sub")
+        payload.optionalString(JwtPayloadClaims.ISSUER, "iss")
+        payload.requiredLong(JwtPayloadClaims.ISSUED_AT, "iat")
+        val now = Clock.System.now().epochSeconds
+        payload.optionalLong(JwtPayloadClaims.EXPIRATION, "exp")?.let { expiry ->
+            require(now < expiry) { "Signed Credential Issuer Metadata has expired" }
+        }
+        val metadata = parseAndValidateMetadata(
+            JsonObject(payload.filterKeys { it !in signedMetadataReservedPayloadClaims }).toString(),
+            expectedCredentialIssuer,
+        )
+        require(subject == metadata.credentialIssuer) {
+            "Signed Credential Issuer Metadata sub must match credential_issuer"
+        }
+        return ResolvedCredentialIssuerMetadata.Signed(metadata, compactJwt, signer)
+    }
+
+    private fun JsonObject.requiredString(claim: String, label: String): String =
+        this[claim]?.jsonPrimitive?.takeIf { it.isString }?.content
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata is missing or malformed $label")
+
+    private fun JsonObject.requiredLong(claim: String, label: String): Long =
+        this[claim].strictLongOrNull()
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata is missing or malformed $label")
+
+    private fun JsonObject.optionalLong(claim: String, label: String): Long? = when (val value = this[claim]) {
+        null -> null
+        else -> value.strictLongOrNull()
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata has malformed $label")
+    }
+
+    private fun JsonObject.optionalString(claim: String, label: String): String? = when (val value = this[claim]) {
+        null -> null
+        else -> (value as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata has malformed $label")
+    }
+
+    private fun parseAndValidateMetadata(body: String, expectedCredentialIssuer: String): CredentialIssuerMetadata {
+        val metadata = lenientJson.decodeFromString(CredentialIssuerMetadata.serializer(), body)
+        require(metadata.credentialIssuer == expectedCredentialIssuer) {
+            "Credential Issuer Metadata credential_issuer does not match requested issuer"
+        }
+        return metadata
     }
 
     /**
@@ -136,6 +244,7 @@ class IssuerMetadataResolver(
             val response: HttpResponse = try {
                 httpClient.get(metadataUrl)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 log.warn(e) { "Network error fetching authorization server metadata from: $metadataUrl" }
                 failures += ResolveFailure.Network(metadataUrl, e)
                 continue
@@ -145,6 +254,7 @@ class IssuerMetadataResolver(
                 try {
                     return response.body<AuthorizationServerMetadata>()
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     val responseBody = runCatching { response.bodyAsText() }.getOrDefault("")
                     log.error(e) { "Failed to parse authorization server metadata from $metadataUrl. Body: $responseBody" }
                     failures += ResolveFailure.Parse(metadataUrl, e, bodyPreview(responseBody))
@@ -189,6 +299,7 @@ class IssuerMetadataResolver(
             val response: HttpResponse = try {
                 httpClient.get(metadataUrl)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 log.warn(e) { "Network error fetching OpenID provider metadata from: $metadataUrl" }
                 failures += ResolveFailure.Network(metadataUrl, e)
                 continue
@@ -198,6 +309,7 @@ class IssuerMetadataResolver(
                 try {
                     return response.body<OpenIDProviderMetadata>()
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     val responseBody = runCatching { response.bodyAsText() }.getOrDefault("")
                     log.error(e) { "Failed to parse OpenID provider metadata from $metadataUrl. Body: $responseBody" }
                     failures += ResolveFailure.Parse(metadataUrl, e, bodyPreview(responseBody))
@@ -283,6 +395,18 @@ class IssuerMetadataResolver(
     }
 }
 
+private val signedMetadataReservedPayloadClaims = setOf(
+    JwtPayloadClaims.ISSUER,
+    JwtPayloadClaims.SUBJECT,
+    JwtPayloadClaims.ISSUED_AT,
+    JwtPayloadClaims.EXPIRATION,
+)
+
+private val lenientJson = Json { ignoreUnknownKeys = true }
+
+private fun JsonElement?.strictLongOrNull(): Long? =
+    (this as? JsonPrimitive)?.takeIf { !it.isString }?.longOrNull
+
 /**
  * Per-URL failure captured while iterating candidate well-known endpoints. Used to build the
  * final resolution error so wallet integrators can distinguish HTTP status, network, and
@@ -363,5 +487,9 @@ private fun resolutionException(
         }
     }
     val cause = failures.firstNotNullOfOrNull { it.throwable }
-    return Exception(summary, cause)
+    return if (cause is IllegalArgumentException) {
+        IllegalArgumentException(summary, cause)
+    } else {
+        Exception(summary, cause)
+    }
 }

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
@@ -169,7 +169,11 @@ class IssuerMetadataResolver(
             lenientJson.parseToJsonElement(decoded.payload.decodeToString()).jsonObject
         }.getOrElse { throw IllegalArgumentException("Signed Credential Issuer Metadata payload is not a JSON object", it) }
         val subject = payload.requiredString(JwtPayloadClaims.SUBJECT, "sub")
+        // `iss` identifies the optional attesting party and may be a trusted delegate. `sub` and
+        // `credential_issuer` provide issuer binding; the trust resolver establishes signer authority.
         payload.optionalString(JwtPayloadClaims.ISSUER, "iss")
+        // The signed-metadata profile requires a numeric `iat` but defines no wallet freshness
+        // window. `exp` is enforced strictly below; `nbf` is not a profile claim.
         payload.requiredLong(JwtPayloadClaims.ISSUED_AT, "iat")
         val now = Clock.System.now().epochSeconds
         payload.optionalLong(JwtPayloadClaims.EXPIRATION, "exp")?.let { expiry ->

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/ResolvedCredentialIssuerMetadata.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/ResolvedCredentialIssuerMetadata.kt
@@ -1,0 +1,58 @@
+package id.waltid.openid4vci.wallet.metadata
+
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import kotlinx.serialization.Serializable
+
+/** Metadata resolution whose variant makes its verification state explicit. */
+@Serializable
+sealed interface ResolvedCredentialIssuerMetadata {
+    /** Parsed Credential Issuer Metadata. */
+    val metadata: CredentialIssuerMetadata
+
+    /** Metadata received as an unsigned JSON document. */
+    @Serializable
+    data class Unsigned(override val metadata: CredentialIssuerMetadata) : ResolvedCredentialIssuerMetadata
+
+    /** Metadata received in a compact JWS verified by the configured trust resolver. */
+    @Serializable
+    data class Signed(
+        override val metadata: CredentialIssuerMetadata,
+        /** Exact compact JWS returned by the metadata endpoint. */
+        val compactJwt: String,
+        /** Trusted signer details reported by the trust resolver. */
+        val signer: MetadataSigner,
+    ) : ResolvedCredentialIssuerMetadata
+}
+
+/** Stable provenance of the signer trusted by the embedding wallet. */
+@Serializable
+data class MetadataSigner(
+    /** Identifier of the trusted verification key, as reported by the trust resolver. */
+    val keyId: String?,
+    /** JWS algorithm verified by the trust resolver. */
+    val algorithm: String,
+    /** Authority relationship established by the trust resolver. */
+    val trustType: MetadataSignerTrustType,
+)
+
+/** Authority relationship established for a signed metadata signer. */
+@Serializable
+enum class MetadataSignerTrustType {
+    /** The signer is the trusted credential issuer. */
+    TRUSTED_ISSUER,
+    /** The signer is a trusted delegate of the credential issuer. */
+    TRUSTED_DELEGATE,
+}
+
+/**
+ * Verifies both the JWS signature and the signer's authority for an expected credential issuer.
+ * Returning normally is the trust boundary: callers never receive decoded-but-untrusted metadata.
+ */
+fun interface CredentialIssuerMetadataTrustResolver {
+    /**
+     * @param compactJwt Compact JWS returned by the Credential Issuer Metadata endpoint.
+     * @param expectedCredentialIssuer Credential issuer for which signer authority must be established.
+     * @return Trusted signer details retained with the resolved metadata.
+     */
+    suspend fun verify(compactJwt: String, expectedCredentialIssuer: String): MetadataSigner
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
@@ -60,8 +60,8 @@ class IssuerMetadataResolverTest {
         val resolver = IssuerMetadataResolver(client)
         val metadata = resolver.resolveCredentialIssuerMetadata(issuerUrl)
 
-        assertEquals(issuerUrl, metadata.credentialIssuer)
-        assertEquals(1, metadata.credentialConfigurationsSupported.size)
+        assertEquals(issuerUrl, metadata.metadata.credentialIssuer)
+        assertEquals(1, metadata.metadata.credentialConfigurationsSupported.size)
     }
 
     @Test
@@ -97,8 +97,8 @@ class IssuerMetadataResolverTest {
         val resolver = IssuerMetadataResolver(client)
         val metadata = resolver.resolveCredentialIssuerMetadata(issuerUrl)
 
-        assertEquals(issuerUrl, metadata.credentialIssuer)
-        assertEquals("$issuerUrl/credential", metadata.credentialEndpoint)
+        assertEquals(issuerUrl, metadata.metadata.credentialIssuer)
+        assertEquals("$issuerUrl/credential", metadata.metadata.credentialEndpoint)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/SignedIssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/SignedIssuerMetadataResolverTest.kt
@@ -1,0 +1,220 @@
+package id.waltid.openid4vci.wallet.metadata
+
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
+import id.walt.openid4vci.CredentialFormat
+import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadataJwt
+import id.walt.openid4vci.metadata.issuer.toSignedJwt
+import id.walt.openid4vci.tokens.jwt.JwtHeaderParams
+import id.walt.openid4vci.tokens.jwt.JwtPayloadClaims
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.time.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class SignedIssuerMetadataResolverTest {
+    private val issuer = "https://issuer.example"
+
+    @Test
+    fun trustedSignedMetadataRetainsTheExactJwtAndSignerAndAdvertisesJwt() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = validMetadata().toSignedJwt(key)
+        var accept: String? = null
+
+        val resolved = IssuerMetadataResolver(signedClient(jwt) { accept = it }) { compactJwt, expectedIssuer ->
+            key.getPublicKey().verifyJws(compactJwt).getOrThrow()
+            assertEquals(issuer, expectedIssuer)
+            MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+        }.resolveCredentialIssuerMetadata(issuer)
+
+        val signed = assertIs<ResolvedCredentialIssuerMetadata.Signed>(resolved)
+        assertEquals("application/jwt, application/json", accept)
+        assertEquals(jwt, signed.compactJwt)
+        assertEquals(issuer, signed.metadata.credentialIssuer)
+        assertEquals(
+            MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER),
+            signed.signer,
+        )
+    }
+
+    @Test
+    fun rejectedTrustResolverRejectsSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = validMetadata().toSignedJwt(key)
+
+        assertFailsWith<Exception> {
+            IssuerMetadataResolver(signedClient(jwt)) { _, _ -> error("untrusted signer") }
+                .resolveCredentialIssuerMetadata(issuer)
+        }
+    }
+
+    @Test
+    fun malformedOrExpiredExpirationRejectsSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        listOf(
+            JsonPrimitive("tomorrow"),
+            JsonPrimitive(Clock.System.now().epochSeconds),
+            JsonPrimitive(Clock.System.now().epochSeconds - 1),
+        ).forEach { expiry ->
+            val jwt = key.signJws(
+                payload(subject = issuer, expiry = expiry).toString().encodeToByteArray(),
+                headers = signedMetadataHeaders(),
+            )
+
+            assertFailsWith<Exception> {
+                trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+            }
+        }
+    }
+
+    @Test
+    fun futureIssuedAtDoesNotApplyWalletSpecificClockSkewPolicy() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = key.signJws(
+            payload(issuedAt = JsonPrimitive(Clock.System.now().epochSeconds + 3_600)).toString().encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+
+        val resolved = trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+
+        assertIs<ResolvedCredentialIssuerMetadata.Signed>(resolved)
+    }
+
+    @Test
+    fun quotedNumericClaimsAndMalformedOptionalIssuerAreRejected() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        listOf(
+            payload(issuedAt = JsonPrimitive(Clock.System.now().epochSeconds.toString())),
+            payload(expiry = JsonPrimitive((Clock.System.now().epochSeconds + 60).toString())),
+            payload(signedIssuer = JsonPrimitive(7)),
+        ).forEach { claims ->
+            val jwt = key.signJws(claims.toString().encodeToByteArray(), signedMetadataHeaders())
+
+            assertFailsWith<Exception> {
+                trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+            }
+        }
+    }
+
+    @Test
+    fun invalidTypeOrDisallowedAlgorithmRejectsBeforeTrust() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        listOf(
+            key.signJws(payload().toString().encodeToByteArray(), mapOf(JwtHeaderParams.TYPE to JsonPrimitive("wrong"))),
+            key.signJws(payload().toString().encodeToByteArray(), signedMetadataHeaders()),
+        ).forEachIndexed { index, jwt ->
+            var trustCalled = false
+            val candidate = if (index == 0) jwt else jwt.withAlgorithm("none")
+            assertFailsWith<Exception> {
+                IssuerMetadataResolver(signedClient(candidate)) { _, _ ->
+                    trustCalled = true
+                    MetadataSigner(null, "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+                }.resolveCredentialIssuerMetadata(issuer)
+            }
+            assertTrue(!trustCalled)
+        }
+    }
+
+    @Test
+    fun issuerAndSubjectMismatchRejectsSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val subjectMismatch = key.signJws(
+            payload(subject = "https://other.example").toString().encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+        val issuerMismatch = key.signJws(
+            payload(metadataIssuer = "https://other.example").toString().encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+
+        listOf(subjectMismatch, issuerMismatch).forEach { jwt ->
+            assertFailsWith<Exception> {
+                trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+            }
+        }
+    }
+
+    @Test
+    fun trustResolverRunsBeforeMalformedPayloadClaimsAreRead() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = key.signJws(
+            """{"sub":7,"iat":"not-a-number"}""".encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+        var trustResolverCalled = false
+
+        assertFailsWith<Exception> {
+            IssuerMetadataResolver(signedClient(jwt)) { _, _ ->
+                trustResolverCalled = true
+                error("untrusted signer")
+            }.resolveCredentialIssuerMetadata(issuer)
+        }
+
+        assertTrue(trustResolverCalled)
+    }
+
+    private fun validMetadata() = CredentialIssuerMetadata(
+        credentialIssuer = issuer,
+        credentialEndpoint = "$issuer/credential",
+        credentialConfigurationsSupported = mapOf("pid" to CredentialConfiguration(CredentialFormat.SD_JWT_VC)),
+    )
+
+    private fun payload(
+        metadataIssuer: String = issuer,
+        subject: String = issuer,
+        issuedAt: JsonPrimitive = JsonPrimitive(Clock.System.now().epochSeconds),
+        expiry: JsonPrimitive? = null,
+        signedIssuer: JsonPrimitive? = null,
+    ) = buildJsonObject {
+        put("credential_issuer", metadataIssuer)
+        put("credential_endpoint", "$metadataIssuer/credential")
+        put("credential_configurations_supported", buildJsonObject { })
+        put(JwtPayloadClaims.SUBJECT, subject)
+        put(JwtPayloadClaims.ISSUED_AT, issuedAt)
+        expiry?.let { put(JwtPayloadClaims.EXPIRATION, it) }
+        signedIssuer?.let { put(JwtPayloadClaims.ISSUER, it) }
+    }
+
+    private fun signedMetadataHeaders() = mapOf(
+        JwtHeaderParams.TYPE to JsonPrimitive(CredentialIssuerMetadataJwt.TYPE),
+    )
+
+    private fun signedClient(jwt: String, onRequest: (String?) -> Unit = {}): HttpClient = HttpClient(MockEngine) {
+        engine {
+            addHandler { request ->
+                onRequest(request.headers[HttpHeaders.Accept])
+                respond(jwt, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/jwt"))
+            }
+        }
+    }
+
+    private fun trustedResolver(key: JWKKey, jwt: String) = IssuerMetadataResolver(signedClient(jwt)) { compactJwt, _ ->
+        key.getPublicKey().verifyJws(compactJwt).getOrThrow()
+        MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+    }
+
+    private fun String.withAlgorithm(algorithm: String): String {
+        val parts = split('.')
+        val header = parts[0].decodeFromBase64Url().decodeToString()
+            .replace("\"alg\":\"EdDSA\"", "\"alg\":\"$algorithm\"")
+            .encodeToByteArray()
+            .encodeToBase64Url()
+        return "$header.${parts[1]}.${parts[2]}"
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestAuthentication.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestAuthentication.kt
@@ -1,0 +1,13 @@
+package id.waltid.openid4vp.wallet.request
+
+import id.walt.openid4vp.clientidprefix.prefixes.ClientId
+
+/** Authentication result established while resolving an OpenID4VP Request Object. */
+data class RequestObjectAuthentication(
+    /** Parsed client identifier, including the pre-registered representation when applicable. */
+    val clientId: ClientId,
+    /** JOSE algorithm from the authenticated Request Object. */
+    val algorithm: String,
+    /** JOSE key identifier from the authenticated Request Object, when supplied. */
+    val keyId: String?,
+)

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolver.kt
@@ -3,6 +3,7 @@ package id.waltid.openid4vp.wallet.request
 import id.walt.credentials.utils.JwtUtils.isJwt
 import id.walt.crypto.utils.UuidUtils
 import id.walt.crypto.utils.JwsUtils.decodeJws
+import id.walt.crypto2.jose.JwsAlgorithm
 import id.walt.openid4vp.clientidprefix.ClientIdError
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
 import id.walt.openid4vp.clientidprefix.ClientIdPrefix
@@ -83,21 +84,31 @@ object AuthorizationRequestResolver {
             .map { json.encodeToJsonElement(OpenID4VPResponseMode.serializer(), it).jsonPrimitive.content }
 
         private val unsupportedClientIdPrefixes = setOf(
-            // Pre-registered clients require a verifier metadata provider; this resolver uses the authenticator default.
-            ClientIdPrefix.PRE_REGISTERED,
             // OpenID Federation parsing exists, but trust chain resolution is not implemented yet.
             ClientIdPrefix.OPENID_FEDERATION,
         )
 
+        // Ed448 is modelled by the JOSE layer but is not supported by the wallet's platform crypto providers.
+        private val requestObjectSigningAlgorithmsSupported = JwsAlgorithm.entries
+            .filterNot { it == JwsAlgorithm.ED448 }
+            .map { it.identifier }
+
         fun build(
             vpFormatsSupported: JsonObject,
             trustConfiguration: ClientIdTrustConfiguration = ClientIdTrustConfiguration(),
+            unsignedRequestObjectPolicy: UnsignedRequestObjectPolicy = UnsignedRequestObjectPolicy.ALLOW_UNSIGNED,
         ): String = json.encodeToString(
             serializer = JsonObject.serializer(),
             value = buildJsonObject {
                 put("response_types_supported", responseTypesSupported.toJsonArray())
                 put("response_modes_supported", responseModesSupported.toJsonArray())
                 val unsupported = unsupportedClientIdPrefixes + buildSet {
+                    if (trustConfiguration.preRegisteredClients.isEmpty()) {
+                        add(ClientIdPrefix.PRE_REGISTERED)
+                    }
+                    if (unsignedRequestObjectPolicy == UnsignedRequestObjectPolicy.REQUIRE_SIGNED) {
+                        add(ClientIdPrefix.REDIRECT_URI)
+                    }
                     if (trustConfiguration.x509TrustAnchors == null) {
                         add(ClientIdPrefix.X509_SAN_DNS)
                         add(ClientIdPrefix.X509_HASH)
@@ -106,7 +117,11 @@ object AuthorizationRequestResolver {
                         add(ClientIdPrefix.VERIFIER_ATTESTATION)
                     }
                 }
-                put("client_id_prefixes_supported", (ClientIdPrefix.entries - unsupported).map { it.value }.toJsonArray())
+                val supportedClientIdPrefixes = ClientIdPrefix.entries - unsupported
+                put("client_id_prefixes_supported", supportedClientIdPrefixes.map { it.value }.toJsonArray())
+                if (supportedClientIdPrefixes.any { it != ClientIdPrefix.REDIRECT_URI }) {
+                    put("request_object_signing_alg_values_supported", requestObjectSigningAlgorithmsSupported.toJsonArray())
+                }
                 put("vp_formats_supported", vpFormatsSupported)
             },
         )
@@ -115,16 +130,18 @@ object AuthorizationRequestResolver {
             JsonArray(map(::JsonPrimitive))
     }
 
-    fun buildRequestUriPostWalletMetadata(vpFormatsSupported: JsonObject): String =
-        RequestUriPostWalletMetadata.build(vpFormatsSupported)
-
     val defaultRequestUriPostWalletMetadata: String
         get() = RequestUriPostWalletMetadata.default
 
     fun buildRequestUriPostWalletMetadata(
         vpFormatsSupported: JsonObject,
-        trustConfiguration: ClientIdTrustConfiguration,
-    ): String = RequestUriPostWalletMetadata.build(vpFormatsSupported, trustConfiguration)
+        trustConfiguration: ClientIdTrustConfiguration = ClientIdTrustConfiguration(),
+        unsignedRequestObjectPolicy: UnsignedRequestObjectPolicy = UnsignedRequestObjectPolicy.ALLOW_UNSIGNED,
+    ): String = RequestUriPostWalletMetadata.build(
+        vpFormatsSupported,
+        trustConfiguration,
+        unsignedRequestObjectPolicy,
+    )
 
     /**
      * Shared transport mapping for retrieving Authorization Requests via `request_uri`.
@@ -336,17 +353,31 @@ object AuthorizationRequestResolver {
                 clientId = authReqJws.payload["client_id"]?.jsonPrimitive?.contentOrNull,
                 policy = unsignedRequestObjectPolicy,
             )
-        } else {
-            log.trace { "Authenticating signed AuthorizationRequest object" }
-            authenticateSignedRequestObject(requestObject, authReqJws.payload, trustConfiguration)
+            return ResolvedAuthorizationRequest.UnsignedRequestObject(
+                authorizationRequest = json.decodeFromJsonElement(
+                    deserializer = AuthorizationRequest.serializer(),
+                    element = applyRedirectUriPrefixBinding(authReqJws.payload),
+                ),
+                requestObject = requestObject,
+            )
         }
 
-        return ResolvedAuthorizationRequest.WithRequestObject(
+        log.trace { "Authenticating signed AuthorizationRequest object" }
+        val authentication = authenticateSignedRequestObject(
+            requestObject = requestObject,
+            payload = authReqJws.payload,
+            algorithm = requireNotNull(jwtAlg) { "Signed AuthorizationRequest is missing alg" },
+            keyId = authReqJws.header["kid"]?.jsonPrimitive?.contentOrNull,
+            trustConfiguration = trustConfiguration,
+        )
+
+        return ResolvedAuthorizationRequest.AuthenticatedRequestObject(
             authorizationRequest = json.decodeFromJsonElement(
                 deserializer = AuthorizationRequest.serializer(),
                 element = applyRedirectUriPrefixBinding(authReqJws.payload),
             ),
             requestObject = requestObject,
+            authentication = authentication,
         )
     }
 
@@ -354,12 +385,14 @@ object AuthorizationRequestResolver {
     private suspend fun authenticateSignedRequestObject(
         requestObject: String,
         payload: JsonObject,
+        algorithm: String,
+        keyId: String?,
         trustConfiguration: ClientIdTrustConfiguration,
-    ) {
+    ): RequestObjectAuthentication {
         val clientId = requireNotNull(payload["client_id"]?.jsonPrimitive?.contentOrNull) {
             "Missing client_id for signed AuthorizationRequest"
         }
-        val clientIdPrefix = ClientIdPrefixParser.parse(clientId)
+        val parsedClientId = ClientIdPrefixParser.parse(clientId)
             .getOrElse { error -> throw IllegalArgumentException("Could not parse client_id prefix: $clientId", error) }
         val clientMetadata = payload["client_metadata"]?.let {
             ClientMetadata.fromJson(it)
@@ -375,7 +408,7 @@ object AuthorizationRequestResolver {
         )
 
         when (val validationResult = ClientIdPrefixAuthenticator.authenticate(
-            clientIdPrefix,
+            parsedClientId,
             context,
             preRegisteredMetadataProvider = { clientId ->
                 trustConfiguration.preRegisteredClients[clientId]?.let {
@@ -385,11 +418,16 @@ object AuthorizationRequestResolver {
             trustConfiguration = trustConfiguration,
         )) {
             is ClientValidationResult.Success -> {
-                log.trace { "Signed AuthorizationRequest authentication succeeded for client_id prefix ${clientIdPrefix::class.simpleName}" }
+                log.trace { "Signed AuthorizationRequest authentication succeeded for client_id scheme ${parsedClientId::class.simpleName}" }
             }
 
             is ClientValidationResult.Failure -> throw SignedAuthorizationRequestValidationException(validationResult.error)
         }
+        return RequestObjectAuthentication(
+            clientId = parsedClientId,
+            algorithm = algorithm,
+            keyId = keyId,
+        )
     }
 
     private fun parseRequestUriMethod(value: String): RequestUriHttpMethod = when (value) {

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/ResolvedAuthorizationRequest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/ResolvedAuthorizationRequest.kt
@@ -9,8 +9,15 @@ sealed class ResolvedAuthorizationRequest {
         override val authorizationRequest: AuthorizationRequest,
     ) : ResolvedAuthorizationRequest()
 
-    data class WithRequestObject(
+    data class UnsignedRequestObject(
         override val authorizationRequest: AuthorizationRequest,
         val requestObject: String,
+    ) : ResolvedAuthorizationRequest()
+
+    data class AuthenticatedRequestObject(
+        override val authorizationRequest: AuthorizationRequest,
+        val requestObject: String,
+        /** Authentication facts established by [AuthorizationRequestResolver]. */
+        val authentication: RequestObjectAuthentication,
     ) : ResolvedAuthorizationRequest()
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/PresentationRequestValidatorTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/PresentationRequestValidatorTest.kt
@@ -153,7 +153,7 @@ class PresentationRequestValidatorTest {
         )
 
         val result = PresentationRequestValidator.validate(
-            resolvedRequest = ResolvedAuthorizationRequest.WithRequestObject(
+            resolvedRequest = ResolvedAuthorizationRequest.UnsignedRequestObject(
                 authorizationRequest = request,
                 requestObject = "authenticated.request.object",
             ),
@@ -410,7 +410,7 @@ class PresentationRequestValidatorTest {
     private fun validate(
         request: AuthorizationRequest,
         transactionDataTypes: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
-        resolvedRequest: ResolvedAuthorizationRequest = ResolvedAuthorizationRequest.WithRequestObject(
+        resolvedRequest: ResolvedAuthorizationRequest = ResolvedAuthorizationRequest.UnsignedRequestObject(
             authorizationRequest = request,
             requestObject = "authenticated.request.object",
         ),

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolverJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolverJvmTest.kt
@@ -6,6 +6,7 @@ import id.walt.certificate.x509.truststore.InMemoryTrustStore
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
 import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.crypto2.jose.JwsAlgorithm
 import id.walt.openid4vp.clientidprefix.ClientIdError
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
 import id.walt.verifier.openid.models.authorization.ClientMetadata
@@ -62,6 +63,10 @@ class AuthorizationRequestResolverJvmTest {
             metadata.getValue("client_id_prefixes_supported").jsonArray.map { it.jsonPrimitive.content },
         )
         assertEquals(
+            JwsAlgorithm.entries.filterNot { it == JwsAlgorithm.ED448 }.map { it.identifier },
+            metadata.getValue("request_object_signing_alg_values_supported").jsonArray.map { it.jsonPrimitive.content },
+        )
+        assertEquals(
             jsonObjectOf("dc+sd-jwt" to jsonObjectOf()),
             metadata.getValue("vp_formats_supported").jsonObject,
         )
@@ -82,6 +87,28 @@ class AuthorizationRequestResolverJvmTest {
         assertEquals(
             listOf("redirect_uri", "x509_san_dns", "x509_hash", "decentralized_identifier", "verifier_attestation"),
             metadata.getValue("client_id_prefixes_supported").jsonArray.map { it.jsonPrimitive.content },
+        )
+    }
+
+    @Test
+    fun `signed-only wallet metadata advertises configured pre-registered clients but not redirect uri`() {
+        val metadata = Json.parseToJsonElement(
+            AuthorizationRequestResolver.buildRequestUriPostWalletMetadata(
+                vpFormatsSupported = jsonObjectOf(),
+                trustConfiguration = ClientIdTrustConfiguration(
+                    preRegisteredClients = mapOf("verifier2" to ClientMetadata()),
+                ),
+                unsignedRequestObjectPolicy = AuthorizationRequestResolver.UnsignedRequestObjectPolicy.REQUIRE_SIGNED,
+            )
+        ).jsonObject
+
+        assertEquals(
+            listOf("pre-registered", "decentralized_identifier"),
+            metadata.getValue("client_id_prefixes_supported").jsonArray.map { it.jsonPrimitive.content },
+        )
+        assertEquals(
+            JwsAlgorithm.entries.filterNot { it == JwsAlgorithm.ED448 }.map { it.identifier },
+            metadata.getValue("request_object_signing_alg_values_supported").jsonArray.map { it.jsonPrimitive.content },
         )
     }
 
@@ -172,7 +199,7 @@ class AuthorizationRequestResolverJvmTest {
             }
         }
 
-        assertIs<ResolvedAuthorizationRequest.WithRequestObject>(resolved)
+        assertIs<ResolvedAuthorizationRequest.UnsignedRequestObject>(resolved)
         assertEquals("verifier2", resolved.authorizationRequest.clientId)
         assertEquals(requestObject, resolved.requestObject)
     }
@@ -238,7 +265,11 @@ class AuthorizationRequestResolverJvmTest {
             ),
         )
 
-        assertIs<ResolvedAuthorizationRequest.WithRequestObject>(resolved)
+        val authenticated = assertIs<ResolvedAuthorizationRequest.AuthenticatedRequestObject>(resolved)
+        assertEquals(requestObject, authenticated.requestObject)
+        assertEquals("EdDSA", authenticated.authentication.algorithm)
+        assertEquals(trustedKey.getKeyId(), authenticated.authentication.keyId)
+        assertIs<id.walt.openid4vp.clientidprefix.prefixes.PreRegistered>(authenticated.authentication.clientId)
     }
 
     @Test
@@ -295,7 +326,10 @@ class AuthorizationRequestResolverJvmTest {
             put("client_id", "verifier2")
             put("nonce", "nonce-123")
         }.toString().encodeToByteArray(),
-        mapOf("typ" to JsonPrimitive("oauth-authz-req+jwt")),
+        mapOf(
+            "typ" to JsonPrimitive("oauth-authz-req+jwt"),
+            "kid" to JsonPrimitive(key.getKeyId()),
+        ),
     )
 
     private fun jsonObjectOf(vararg pairs: Pair<String, kotlinx.serialization.json.JsonElement>) =

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -390,8 +390,29 @@ private extension Waltid_openid4vc_walletWalletIssuanceIssuerPreview {
             name: name,
             locale: locale,
             logoURI: logoUri.flatMap(URL.init(string:)),
-            logoAltText: logoAltText
+            logoAltText: logoAltText,
+            metadataProvenance: metadataProvenance.toSwiftMetadataProvenance()
         )
+    }
+}
+
+private extension Waltid_openid4vc_walletWalletIssuanceMetadataProvenance {
+    func toSwiftMetadataProvenance() -> MetadataProvenance {
+        switch self {
+        case is Waltid_openid4vc_walletWalletIssuanceMetadataProvenanceUnsigned:
+            return .unsigned
+        case let signed as Waltid_openid4vc_walletWalletIssuanceMetadataProvenanceSigned:
+            return .signed(
+                SignedMetadataProvenance(
+                    compactJWT: signed.compactJwt,
+                    algorithm: signed.algorithm,
+                    keyID: signed.keyId,
+                    trustType: signed.trustType == .trustedIssuer ? .trustedIssuer : .trustedDelegate
+                )
+            )
+        default:
+            preconditionFailure("Unsupported issuer metadata provenance: \(type(of: self))")
+        }
     }
 }
 
@@ -501,6 +522,9 @@ private extension WalletConfiguration {
             persistence: persistence.toKMPPersistence(),
             databaseKeyProvider: persistence.toKMPDatabaseKeyProvider(),
             attestation: attestation?.toKMPAttestationConfiguration(),
+            issuerMetadataTrustResolver: issuerMetadataTrustResolver.map {
+                KMPIssuerMetadataTrustResolverAdapter(resolver: $0)
+            },
             preferredLocales: preferredLocales,
             transactionDataProfiles: transactionDataProfiles.map { $0.toKMPTransactionDataProfile() },
             clientIdTrustConfiguration: clientIDTrustConfiguration.toKMPClientIDTrustConfiguration(),
@@ -515,9 +539,43 @@ private extension WalletConfiguration {
     }
 }
 
+private final class KMPIssuerMetadataTrustResolverAdapter: WalletBridgeIssuerMetadataTrustResolver, @unchecked Sendable {
+    private let resolver: any IssuerMetadataTrustResolver
+
+    init(resolver: any IssuerMetadataTrustResolver) {
+        self.resolver = resolver
+    }
+
+    func __verify(compactJwt: String, expectedCredentialIssuer: String) async throws -> WalletBridgeIssuerMetadataSigner {
+        let signer = try await resolver.verify(
+            compactJWT: compactJwt,
+            expectedCredentialIssuer: expectedCredentialIssuer
+        )
+        return WalletBridgeIssuerMetadataSigner(
+            keyId: signer.keyID,
+            algorithm: signer.algorithm,
+            trustType: signer.trustType.toKMPTrustType()
+        )
+    }
+}
+
+private extension MetadataTrustType {
+    func toKMPTrustType() -> WalletBridgeIssuerMetadataSignerTrustType {
+        switch self {
+        case .trustedIssuer:
+            return .trustedIssuer
+        case .trustedDelegate:
+            return .trustedDelegate
+        }
+    }
+}
+
 private extension WalletClientIDTrustConfiguration {
     func toKMPClientIDTrustConfiguration() -> WalletBridgeClientIdTrustConfiguration {
-        WalletBridgeClientIdTrustConfiguration(x509TrustAnchorsPem: x509TrustAnchorsPEM)
+        WalletBridgeClientIdTrustConfiguration(
+            x509TrustAnchorsPem: x509TrustAnchorsPEM,
+            preRegisteredClientMetadataJson: preRegisteredClientMetadataJSON
+        )
     }
 }
 
@@ -921,6 +979,7 @@ private extension MobileWalletPresentationRequestContext {
         PresentationRequestContext(
             clientID: clientId,
             verifierMetadata: verifierMetadata?.toSwiftVerifierMetadata(),
+            requestAuthentication: requestAuthentication.toSwiftRequestAuthentication(),
             responseURI: responseUri.flatMap(URL.init(string:)),
             state: state,
             nonce: nonce,
@@ -934,6 +993,7 @@ private extension MobileWalletPresentationRequestInfo {
         PresentationRequestInfo(
             clientID: clientId,
             verifierMetadata: verifierMetadata?.toSwiftVerifierMetadata(),
+            requestAuthentication: requestAuthentication.toSwiftRequestAuthentication(),
             responseURI: responseUri.flatMap(URL.init(string:)),
             state: state,
             nonce: nonce,
@@ -941,6 +1001,45 @@ private extension MobileWalletPresentationRequestInfo {
             transactionData: swiftArray(transactionData, of: MobileWalletTransactionDataItem.self)
                 .map { $0.toSwiftTransactionData() }
         )
+    }
+}
+
+private extension MobileWalletRequestAuthentication {
+    func toSwiftRequestAuthentication() -> PresentationRequestAuthentication {
+        switch self {
+        case is MobileWalletRequestAuthenticationUnauthenticated:
+            return .unauthenticated
+        case let authenticated as MobileWalletRequestAuthenticationAuthenticated:
+            return .authenticated(
+                compactRequestObject: authenticated.compactRequestObject,
+                algorithm: authenticated.algorithm,
+                keyID: authenticated.keyId,
+                clientIDScheme: authenticated.clientIdScheme.toSwiftClientIDScheme()
+            )
+        default:
+            preconditionFailure("Unsupported request authentication: \(type(of: self))")
+        }
+    }
+}
+
+private extension MobileWalletClientIdScheme {
+    func toSwiftClientIDScheme() -> PresentationClientIDScheme {
+        switch self {
+        case .preRegistered:
+            return .preRegistered
+        case .redirectUri:
+            return .redirectURI
+        case .x509SanDns:
+            return .x509SanDNS
+        case .x509Hash:
+            return .x509Hash
+        case .decentralizedIdentifier:
+            return .decentralizedIdentifier
+        case .verifierAttestation:
+            return .verifierAttestation
+        case .openidFederation:
+            return .openIDFederation
+        }
     }
 }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -20,6 +20,9 @@ public struct WalletConfiguration: Sendable {
     /// Trust anchors used to authenticate verifier Request Objects.
     public var clientIDTrustConfiguration: WalletClientIDTrustConfiguration
 
+    /// Optional verifier for signed Credential Issuer Metadata.
+    public var issuerMetadataTrustResolver: (any IssuerMetadataTrustResolver)?
+
     /// Wallet-local persistence configuration.
     public var persistence: WalletPersistence
 
@@ -42,6 +45,8 @@ public struct WalletConfiguration: Sendable {
     ///     that require client attestation.
     ///   - clientIDTrustConfiguration: Trust anchors used to authenticate verifier
     ///     Request Objects. The default trusts no X.509 verifier by configuration.
+    ///   - issuerMetadataTrustResolver: Verifies signed Credential Issuer Metadata
+    ///     and establishes the signer's authority.
     ///   - persistence: Local persistence configuration for wallet-owned state.
     ///   - transactionDataProfiles: OpenID4VP transaction data profiles this
     ///     wallet accepts before previewing or submitting a presentation.
@@ -57,6 +62,7 @@ public struct WalletConfiguration: Sendable {
         defaultKeyType: WalletKeyType = .secp256r1,
         attestation: WalletAttestationConfiguration? = nil,
         clientIDTrustConfiguration: WalletClientIDTrustConfiguration = .init(),
+        issuerMetadataTrustResolver: (any IssuerMetadataTrustResolver)? = nil,
         persistence: WalletPersistence = WalletPersistence(),
         transactionDataProfiles: [WalletTransactionDataProfile] = [],
         preferredLocales: [String] = Locale.preferredLanguages,
@@ -70,6 +76,7 @@ public struct WalletConfiguration: Sendable {
         self.keyUseAuthorizationPrompt = keyUseAuthorizationPrompt
         self.attestation = attestation
         self.clientIDTrustConfiguration = clientIDTrustConfiguration
+        self.issuerMetadataTrustResolver = issuerMetadataTrustResolver
         self.persistence = persistence
         self.transactionDataProfiles = transactionDataProfiles
         self.preferredLocales = preferredLocales
@@ -192,17 +199,66 @@ public enum WalletKeyUseAuthorizationReuseTimeoutValidation: Equatable, Sendable
     case providerConfigurationOnly
 }
 
+/// Trusted signer details returned after verifying signed Credential Issuer Metadata.
+public struct IssuerMetadataSigner: Equatable, Sendable {
+    /// Identifier of the trusted verification key, as reported by the trust resolver.
+    public let keyID: String?
+    /// JWS algorithm verified by the trust resolver.
+    public let algorithm: String
+    /// Authority category established by the trust resolver.
+    public let trustType: MetadataTrustType
+
+    /// Creates trusted signer details.
+    ///
+    /// - Parameters:
+    ///   - keyID: Identifier of the trusted verification key, as reported by the trust resolver.
+    ///   - algorithm: JWS algorithm verified by the trust resolver.
+    ///   - trustType: Authority category established by the trust resolver.
+    public init(keyID: String?, algorithm: String, trustType: MetadataTrustType) {
+        self.keyID = keyID
+        self.algorithm = algorithm
+        self.trustType = trustType
+    }
+}
+
+/// Authority category established for a signer of Credential Issuer Metadata.
+public enum MetadataTrustType: Equatable, Sendable {
+    /// The signer is the trusted credential issuer.
+    case trustedIssuer
+    /// The signer is a trusted delegate of the credential issuer.
+    case trustedDelegate
+}
+
+/// Verifies signed Credential Issuer Metadata before the wallet reads its claims.
+public protocol IssuerMetadataTrustResolver: Sendable {
+    /// Verifies a compact JWS and establishes that its signer is authorized for the expected issuer.
+    ///
+    /// - Parameters:
+    ///   - compactJWT: Compact JWS returned by the Credential Issuer Metadata endpoint.
+    ///   - expectedCredentialIssuer: Credential issuer for which signer authority must be established.
+    /// - Returns: Trusted signer details used to retain metadata provenance.
+    func verify(compactJWT: String, expectedCredentialIssuer: String) async throws -> IssuerMetadataSigner
+}
+
 /// Trust configuration used to authenticate verifier Request Objects.
 public struct WalletClientIDTrustConfiguration: Sendable, Equatable {
     /// PEM-encoded X.509 trust anchors pinned by the hosting application.
     public var x509TrustAnchorsPEM: [String]
 
+    /// Explicit pre-registered client metadata JSON, keyed by client ID.
+    public var preRegisteredClientMetadataJSON: [String: String]
+
     /// Creates client-ID trust configuration.
     ///
-    /// - Parameter x509TrustAnchorsPEM: PEM-encoded X.509 trust anchors pinned
-    ///   by the hosting application.
-    public init(x509TrustAnchorsPEM: [String] = []) {
+    /// - Parameters:
+    ///   - x509TrustAnchorsPEM: PEM-encoded X.509 trust anchors pinned by the hosting application.
+    ///   - preRegisteredClientMetadataJSON: Client metadata JSON for explicit pre-registered verifiers.
+    public init(
+        x509TrustAnchorsPEM: [String] = [],
+        preRegisteredClientMetadataJSON: [String: String] = [:]
+    ) {
         self.x509TrustAnchorsPEM = x509TrustAnchorsPEM
+        self.preRegisteredClientMetadataJSON = preRegisteredClientMetadataJSON
     }
 }
 
@@ -756,6 +812,9 @@ public struct IssuanceIssuerPreview: Equatable, Sendable {
     /// Alternative text for the issuer logo.
     public let logoAltText: String?
 
+    /// Source and verification provenance for this metadata.
+    public let metadataProvenance: MetadataProvenance
+
     /// Creates an issuer preview.
     ///
     /// - Parameters:
@@ -764,12 +823,55 @@ public struct IssuanceIssuerPreview: Equatable, Sendable {
     ///   - locale: Locale associated with the display entry.
     ///   - logoURI: Issuer logo URL.
     ///   - logoAltText: Alternative text for the issuer logo.
-    public init(identifier: String, name: String?, locale: String?, logoURI: URL?, logoAltText: String?) {
+    ///   - metadataProvenance: Source and verification provenance for this metadata.
+    public init(
+        identifier: String,
+        name: String?,
+        locale: String?,
+        logoURI: URL?,
+        logoAltText: String?,
+        metadataProvenance: MetadataProvenance
+    ) {
         self.identifier = identifier
         self.name = name
         self.locale = locale
         self.logoURI = logoURI
         self.logoAltText = logoAltText
+        self.metadataProvenance = metadataProvenance
+    }
+}
+
+/// Provenance for Credential Issuer Metadata used by the wallet.
+public enum MetadataProvenance: Equatable, Sendable {
+    /// Metadata was received as an unsigned JSON document.
+    case unsigned
+    /// Metadata was received in a JWS verified by the configured trust resolver.
+    case signed(SignedMetadataProvenance)
+}
+
+/// Verified signed Credential Issuer Metadata provenance.
+public struct SignedMetadataProvenance: Equatable, Sendable {
+    /// Exact compact JWS returned by the issuer.
+    public let compactJWT: String
+    /// JWS algorithm verified by the configured trust resolver.
+    public let algorithm: String
+    /// Identifier of the trusted verification key, as reported by the trust resolver.
+    public let keyID: String?
+    /// Authority category established by the trust resolver.
+    public let trustType: MetadataTrustType
+
+    /// Creates signed metadata provenance.
+    ///
+    /// - Parameters:
+    ///   - compactJWT: Exact compact JWS returned by the issuer.
+    ///   - algorithm: JWS algorithm verified by the trust resolver.
+    ///   - keyID: Identifier of the trusted verification key, as reported by the trust resolver.
+    ///   - trustType: Authority category established by the trust resolver.
+    public init(compactJWT: String, algorithm: String, keyID: String?, trustType: MetadataTrustType) {
+        self.compactJWT = compactJWT
+        self.algorithm = algorithm
+        self.keyID = keyID
+        self.trustType = trustType
     }
 }
 
@@ -1185,6 +1287,9 @@ public struct PresentationRequestContext: Equatable, Sendable {
     /// Typed metadata supplied by the OpenID4VP verifier when available.
     public let verifierMetadata: VerifierMetadata?
 
+    /// Authentication established for the authorization request or its Request Object.
+    public let requestAuthentication: PresentationRequestAuthentication
+
     /// Response URI used for direct-post responses when available.
     public let responseURI: URL?
 
@@ -1202,6 +1307,7 @@ public struct PresentationRequestContext: Equatable, Sendable {
     /// - Parameters:
     ///   - clientID: Validated OpenID4VP client identifier from the request.
     ///   - verifierMetadata: Typed metadata supplied by the verifier when available.
+    ///   - requestAuthentication: Authentication facts established while resolving the request.
     ///   - responseURI: Response URI to which the wallet would submit the presentation or error, when provided.
     ///   - state: OpenID state value from the request, when provided.
     ///   - nonce: OpenID nonce value from the request, when provided. May be nil if the missing nonce is the validation error.
@@ -1209,6 +1315,7 @@ public struct PresentationRequestContext: Equatable, Sendable {
     public init(
         clientID: String,
         verifierMetadata: VerifierMetadata? = nil,
+        requestAuthentication: PresentationRequestAuthentication,
         responseURI: URL? = nil,
         state: String? = nil,
         nonce: String? = nil,
@@ -1220,6 +1327,7 @@ public struct PresentationRequestContext: Equatable, Sendable {
         )
         self.clientID = clientID
         self.verifierMetadata = verifierMetadata
+        self.requestAuthentication = requestAuthentication
         self.responseURI = responseURI
         self.state = state
         self.nonce = nonce
@@ -1276,6 +1384,37 @@ public struct ResponseEncryptionDetails: Equatable, Sendable {
     }
 }
 
+/// Authentication established for an OpenID4VP authorization request.
+public enum PresentationRequestAuthentication: Equatable, Sendable {
+    /// No signed Request Object authenticated this request.
+    case unauthenticated
+    /// The Request Object was authenticated by the OpenID4VP client-ID layer.
+    case authenticated(
+        compactRequestObject: String,
+        algorithm: String,
+        keyID: String?,
+        clientIDScheme: PresentationClientIDScheme
+    )
+}
+
+/// Client identifier scheme established while authenticating a Request Object.
+public enum PresentationClientIDScheme: Equatable, Sendable {
+    /// The verifier is identified through pre-registered metadata.
+    case preRegistered
+    /// The verifier is identified by a redirect URI.
+    case redirectURI
+    /// The verifier is identified by an X.509 SAN DNS name.
+    case x509SanDNS
+    /// The verifier is identified by an X.509 certificate hash.
+    case x509Hash
+    /// The verifier is identified by a decentralized identifier.
+    case decentralizedIdentifier
+    /// The verifier is identified by a verifier attestation.
+    case verifierAttestation
+    /// The verifier is identified through OpenID Federation.
+    case openIDFederation
+}
+
 /// Verifier, transaction, and response-protection metadata extracted from a presentation request.
 public struct PresentationRequestInfo: Equatable, Sendable {
     /// OpenID4VP client identifier.
@@ -1283,6 +1422,9 @@ public struct PresentationRequestInfo: Equatable, Sendable {
 
     /// Typed metadata supplied by the OpenID4VP verifier when available.
     public let verifierMetadata: VerifierMetadata?
+
+    /// Authentication established for the authorization request or its Request Object.
+    public let requestAuthentication: PresentationRequestAuthentication
 
     /// Response URI used for direct-post responses when available.
     public let responseURI: URL?
@@ -1304,6 +1446,7 @@ public struct PresentationRequestInfo: Equatable, Sendable {
     /// - Parameters:
     ///   - clientID: OpenID4VP client identifier from the request.
     ///   - verifierMetadata: Typed metadata supplied by the verifier.
+    ///   - requestAuthentication: Authentication facts established while resolving the request.
     ///   - responseURI: Direct-post response URI when available.
     ///   - state: OpenID state value from the request.
     ///   - nonce: OpenID nonce value from the request.
@@ -1312,6 +1455,7 @@ public struct PresentationRequestInfo: Equatable, Sendable {
     public init(
         clientID: String,
         verifierMetadata: VerifierMetadata? = nil,
+        requestAuthentication: PresentationRequestAuthentication,
         responseURI: URL? = nil,
         state: String? = nil,
         nonce: String,
@@ -1324,6 +1468,7 @@ public struct PresentationRequestInfo: Equatable, Sendable {
         )
         self.clientID = clientID
         self.verifierMetadata = verifierMetadata
+        self.requestAuthentication = requestAuthentication
         self.responseURI = responseURI
         self.state = state
         self.nonce = nonce

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -20,7 +20,8 @@ public struct WalletConfiguration: Sendable {
     /// Trust anchors used to authenticate verifier Request Objects.
     public var clientIDTrustConfiguration: WalletClientIDTrustConfiguration
 
-    /// Optional verifier for signed Credential Issuer Metadata.
+    /// Optional verifier for signed Credential Issuer Metadata. When `nil`, signed metadata is
+    /// neither requested nor accepted.
     public var issuerMetadataTrustResolver: (any IssuerMetadataTrustResolver)?
 
     /// Wallet-local persistence configuration.
@@ -46,7 +47,8 @@ public struct WalletConfiguration: Sendable {
     ///   - clientIDTrustConfiguration: Trust anchors used to authenticate verifier
     ///     Request Objects. The default trusts no X.509 verifier by configuration.
     ///   - issuerMetadataTrustResolver: Verifies signed Credential Issuer Metadata
-    ///     and establishes the signer's authority.
+    ///     and establishes the signer's authority. When `nil`, signed metadata is neither
+    ///     requested nor accepted.
     ///   - persistence: Local persistence configuration for wallet-owned state.
     ///   - transactionDataProfiles: OpenID4VP transaction data profiles this
     ///     wallet accepts before previewing or submitting a presentation.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -159,6 +159,7 @@ final class WalletAPITests: XCTestCase {
             request: .init(
                 clientID: "https://verifier.example",
                 verifierMetadata: testVerifierMetadata,
+                requestAuthentication: .unauthenticated,
                 responseURI: URL(string: "https://verifier.example/direct-post"),
                 state: "state-1",
                 nonce: "nonce-1",
@@ -197,6 +198,44 @@ final class WalletAPITests: XCTestCase {
         XCTAssertEqual(preview.credentialOptions.single?.selection, PresentationCredentialSelection(queryID: "pid", credentialID: "credential-1"))
         XCTAssertEqual(preview.credentialOptions.single?.id, preview.credentialOptions.single?.selection.id)
         XCTAssertEqual(preview.credentialRequirements.single?.options, [["pid"]])
+    }
+
+    func testAuthenticatedRequestAuthenticationRetainsExactSecurityFacts() {
+        let authentication = PresentationRequestAuthentication.authenticated(
+            compactRequestObject: "signed-request-object",
+            algorithm: "ES256",
+            keyID: "verifier-kid",
+            clientIDScheme: .preRegistered
+        )
+
+        guard case let .authenticated(compactRequestObject, algorithm, keyID, clientIDScheme) = authentication else {
+            return XCTFail("Expected authenticated request object")
+        }
+
+        XCTAssertEqual(compactRequestObject, "signed-request-object")
+        XCTAssertEqual(algorithm, "ES256")
+        XCTAssertEqual(keyID, "verifier-kid")
+        XCTAssertEqual(clientIDScheme, .preRegistered)
+    }
+
+    func testSignedIssuerMetadataProvenanceRetainsTrustResolverFacts() {
+        let provenance = MetadataProvenance.signed(
+            SignedMetadataProvenance(
+                compactJWT: "signed-metadata-jwt",
+                algorithm: "EdDSA",
+                keyID: "issuer-key",
+                trustType: .trustedIssuer
+            )
+        )
+
+        guard case let .signed(signed) = provenance else {
+            return XCTFail("Expected signed issuer metadata provenance")
+        }
+
+        XCTAssertEqual(signed.compactJWT, "signed-metadata-jwt")
+        XCTAssertEqual(signed.algorithm, "EdDSA")
+        XCTAssertEqual(signed.keyID, "issuer-key")
+        XCTAssertEqual(signed.trustType, .trustedIssuer)
     }
 
     func testWalletHasAsyncFacadeShape() async {
@@ -361,6 +400,7 @@ final class WalletAPITests: XCTestCase {
                 request: .init(
                     clientID: "https://verifier.example",
                     verifierMetadata: testVerifierMetadata,
+                    requestAuthentication: .unauthenticated,
                     responseURI: nil,
                     state: nil,
                     nonce: "nonce-1",
@@ -417,6 +457,7 @@ final class WalletAPITests: XCTestCase {
         let requestInfo = PresentationRequestContext(
             clientID: "https://verifier.example",
             verifierMetadata: testVerifierMetadata,
+            requestAuthentication: .unauthenticated,
             responseEncryption: .notRequired
         )
         let bridge = FakeWalletCoreBridge()
@@ -802,7 +843,14 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
         id: "issuance-session-1",
         offer: IssuanceOfferPreview(
             grant: .preAuthorizedCode,
-            issuer: .init(identifier: "https://issuer.example", name: nil, locale: nil, logoURI: nil, logoAltText: nil),
+            issuer: .init(
+                identifier: "https://issuer.example",
+                name: nil,
+                locale: nil,
+                logoURI: nil,
+                logoAltText: nil,
+                metadataProvenance: .unsigned
+            ),
             credentials: [],
             transactionCode: nil
         )
@@ -815,6 +863,7 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
             previewHandle: PresentationPreviewHandle(value: "fake-presentation-preview"),
             request: .init(
                 clientID: "https://verifier.example",
+                requestAuthentication: .unauthenticated,
                 nonce: "nonce-1",
                 responseEncryption: .notRequired,
             ),

--- a/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/testsupport/Issuer2WalletFlowDriver.kt
+++ b/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/testsupport/Issuer2WalletFlowDriver.kt
@@ -61,7 +61,9 @@ class Issuer2WalletFlowDriver(
             credentialOffer = offerRequest.credentialOffer,
             credentialOfferUri = offerRequest.credentialOfferUri,
         )
-        val issuerMetadata = IssuerMetadataResolver(client).resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val issuerMetadata = IssuerMetadataResolver(client)
+            .resolveCredentialIssuerMetadata(offer.credentialIssuer)
+            .metadata
         val authorizationServerMetadata = IssuerMetadataResolver(client)
             .resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
 
@@ -174,7 +176,9 @@ class Issuer2WalletFlowDriver(
         requestMode: Issuer2AuthorizationRequestMode,
         credentialIssuer: String = DEFAULT_CREDENTIAL_ISSUER,
     ): String {
-        val issuerMetadata = IssuerMetadataResolver(client).resolveCredentialIssuerMetadata(credentialIssuer)
+        val issuerMetadata = IssuerMetadataResolver(client)
+            .resolveCredentialIssuerMetadata(credentialIssuer)
+            .metadata
         val authorizationServerMetadata = IssuerMetadataResolver(client)
             .resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
         val authorizationUrl = buildAuthorizationRequestUrl(

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/OpenId4VpPresentationService.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/OpenId4VpPresentationService.kt
@@ -52,7 +52,13 @@ class OpenId4VpPresentationService(
         request: String,
         walletId: Uuid? = null,
     ): Result<ResolvedAuthorizationRequest> = runCatching {
-        val runtimeRequestUriPostWalletMetadata = walletId?.let { buildRuntimeRequestUriPostWalletMetadata(it) }
+        val runtimeRequestUriPostWalletMetadata = walletId
+            ?.let { buildRuntimeRequestUriPostWalletMetadata(it) }
+            ?: AuthorizationRequestResolver.buildRequestUriPostWalletMetadata(
+                WalletPresentationFormatRegistry.buildVpFormatsSupported(),
+                clientIdTrustConfiguration,
+                unsignedRequestObjectPolicy,
+            )
 
         AuthorizationRequestResolver.resolve(
             requestUrl = Url(request),
@@ -86,7 +92,8 @@ class OpenId4VpPresentationService(
         resolvedRequest: ResolvedAuthorizationRequest,
     ): Url = when (resolvedRequest) {
         is ResolvedAuthorizationRequest.Plain -> buildWalletPresentationRequest(request, resolvedRequest.authorizationRequest)
-        is ResolvedAuthorizationRequest.WithRequestObject -> buildWalletPresentationRequest(request, resolvedRequest.requestObject)
+        is ResolvedAuthorizationRequest.UnsignedRequestObject -> buildWalletPresentationRequest(request, resolvedRequest.requestObject)
+        is ResolvedAuthorizationRequest.AuthenticatedRequestObject -> buildWalletPresentationRequest(request, resolvedRequest.requestObject)
     }
 
     suspend fun matchCredentialsForPresentationRequest(
@@ -195,7 +202,11 @@ class OpenId4VpPresentationService(
 
         val runtimeCapabilities = WalletPresentationFormatRegistry.capabilitiesFromKeyTypes(runtimeKeyTypes)
         val runtimeVpFormatsSupported = WalletPresentationFormatRegistry.buildVpFormatsSupported(runtimeCapabilities)
-        return AuthorizationRequestResolver.buildRequestUriPostWalletMetadata(runtimeVpFormatsSupported)
+        return AuthorizationRequestResolver.buildRequestUriPostWalletMetadata(
+            runtimeVpFormatsSupported,
+            clientIdTrustConfiguration,
+            unsignedRequestObjectPolicy,
+        )
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Implements [WAL-1211](https://linear.app/walt-new/issue/WAL-1211/add-support-for-signed-metadata) across the wallet core and pre-1.0 mobile SDK: trusted signed Credential Issuer Metadata, authenticated OpenID4VP Request Objects, and truthful security provenance for KMP and Swift consumers.

Coordinated service-boundary adaptations are in [walt-id/waltid-identity-enterprise#596](https://github.com/walt-id/waltid-identity-enterprise/pull/596) and [walt-id/waltid-identity-enterprise-license#3](https://github.com/walt-id/waltid-identity-enterprise-license/pull/3). The public Android/iOS journey formerly staged in [#2016](https://github.com/walt-id/waltid-identity/pull/2016) is folded into this PR.

## What Changed

### Signed Credential Issuer Metadata

- Negotiates and resolves OpenID4VCI signed metadata only when the caller supplies an independent trust resolver.
- Validates the compact JWS before semantic use, including `typ`, asymmetric algorithm policy, issuer binding, time claims, and typed optional claims.
- Makes `ResolvedCredentialIssuerMetadata` the canonical result and retains the exact signed metadata plus trusted signer details throughout offer preview, direct issuance, and session issuance.

### Authenticated OpenID4VP Requests

- Distinguishes plain requests, accepted unsigned Request Objects, and authenticated signed Request Objects in the authoritative resolver result.
- Carries verified algorithm, key identifier, and client-ID scheme facts from the lower-layer authenticator instead of reparsing them in mobile or service adapters.
- Derives wallet metadata capabilities from the configured trust schemes and unsigned-request policy, including supported signing algorithms, so signed-only wallets do not advertise `redirect_uri` support.

### Mobile SDK and Public Journey

- Exposes issuer-metadata provenance and request authentication consistently through KMP, Kotlin/Native, and Swift preview models.
- Allows native iOS hosts to configure explicit pre-registered verifier metadata alongside X.509 trust anchors.
- Covers the complete public issuer2/verifier2 signed-metadata journey on Android and native iOS without requiring a WAL-1211 deployment.
- Updates the Kotlin ABI and Swift bridge surface for the final pre-1.0 API shape.

## Architecture Notes

Trust establishment remains in the protocol layer. Service and mobile layers only configure trust and project already-verified facts into their public models. Request-signing material is never accepted as its own authority, and signed issuer metadata is not used unless an independent trust resolver authenticates it.

Lower-layer Kotlin models intentionally break where the richer security state is the semantic result. The pre-1.0 mobile/KMP/Swift surface is likewise optimized for the final shape rather than retaining aliases or compatibility constructors.

## Scope and Contracts

Existing service HTTP paths, JSON contracts, defaults, and unsigned flows remain unchanged. Legacy wallet1 issuance is outside WAL-1211 and is not changed here.

## Breaking

- `IssuerMetadataResolver.resolveCredentialIssuerMetadata()` now returns `ResolvedCredentialIssuerMetadata`; metadata-only callers project `.metadata`.
- `ResolvedAuthorizationRequest` uses explicit plain, unsigned Request Object, and authenticated Request Object variants.
- `WalletIssuanceSessionService` persists resolved metadata; active sessions created by older mobile builds must be restarted after upgrade.
- Pre-1.0 mobile/KMP/Swift constructors, property names, bridge shapes, and serialized models are intentionally updated without compatibility aliases.

