### PR TITLE
[WAL-1211] test(wallet): cover public signed metadata journey

### DIFF
--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
@@ -258,8 +258,10 @@ public final class DemoBackend {
             "dcql_query": [
                 "credentials": [scenario.verifierCredentialQuery],
             ],
-            "signed_request": signedRequest,
         ]
+        if signedRequest {
+            coreFlow["signed_request"] = true
+        }
         if let requestedSessionID {
             let responseURI = Self.verifierBaseURL
                 .appendingPathComponent("verification-session")

--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 public struct DemoCredentialScenario {
     public let id: String
@@ -17,6 +18,11 @@ public struct DemoOffer {
 public struct DemoVerifierSession {
     public let sessionID: String
     public let authorizationRequestUri: String
+}
+
+public struct DemoMetadataSigner {
+    public let keyID: String?
+    public let algorithm: String
 }
 
 public final class DemoBackend {
@@ -73,6 +79,10 @@ public final class DemoBackend {
     public static let persistenceScenario = scenarios.first { $0.id == "eudi-pid-mdoc" }!
 
     private static let issuerBaseURL = URL(string: "https://issuer2.demo.walt.id")!
+    public static let issuerIdentifier = "https://issuer2.demo.walt.id/openid4vci"
+    // RFC 7638 thumbprint of the public issuer2 signing key from /openid4vci/jwks.
+    // This independent pin must not be learned from the signed metadata JWT.
+    private static let issuerMetadataSigningKeyThumbprint = "XVz5i-iLcVBvjz5X4LGc6dA-VFNSyzWMW32LAHF8fss"
     private static let verifierBaseURL = URL(string: "https://verifier2.demo.walt.id")!
 
     private let client: WalletE2EClient
@@ -134,6 +144,62 @@ public final class DemoBackend {
         )
     }
 
+    public func createVerifierSession(
+        scenario: DemoCredentialScenario,
+        signedRequest: Bool
+    ) async throws -> DemoVerifierSession {
+        try await createVerifierSession(
+            scenario: scenario,
+            transactionData: [],
+            signedRequest: signedRequest
+        )
+    }
+
+    /** Verifies an ES256 signed-metadata JWS served by the public issuer2 demo. */
+    public static func verifySignedIssuerMetadata(
+        compactJWT: String,
+        expectedCredentialIssuer: String
+    ) throws -> DemoMetadataSigner {
+        guard expectedCredentialIssuer == issuerIdentifier else {
+            throw NSError(
+                domain: "WalletE2E",
+                code: 309,
+                userInfo: [NSLocalizedDescriptionKey: "Unexpected public demo Credential Issuer: \(expectedCredentialIssuer)"]
+            )
+        }
+        let parts = compactJWT.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let headerData = base64URLData(String(parts[0])),
+              let header = try JSONSerialization.jsonObject(with: headerData) as? [String: Any],
+              let algorithm = header["alg"] as? String,
+              algorithm == "ES256",
+              let jwk = header["jwk"] as? [String: Any],
+              jwk["kty"] as? String == "EC",
+              jwk["crv"] as? String == "P-256",
+              let x = jwk["x"] as? String,
+              let y = jwk["y"] as? String,
+              let xData = base64URLData(x),
+              let yData = base64URLData(y),
+              let signatureData = base64URLData(String(parts[2])) else {
+            throw NSError(domain: "WalletE2E", code: 310, userInfo: [NSLocalizedDescriptionKey: "Malformed public demo signed metadata"])
+        }
+        let thumbprintJwk = "{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"\(x)\",\"y\":\"\(y)\"}"
+        let thumbprint = base64URLString(Data(SHA256.hash(data: Data(thumbprintJwk.utf8))))
+        guard thumbprint == Self.issuerMetadataSigningKeyThumbprint else {
+            throw NSError(
+                domain: "WalletE2E",
+                code: 312,
+                userInfo: [NSLocalizedDescriptionKey: "Public demo signed metadata key is not the pinned issuer2 signing key"]
+            )
+        }
+        let publicKey = try P256.Signing.PublicKey(x963Representation: Data([0x04]) + xData + yData)
+        let signature = try P256.Signing.ECDSASignature(rawRepresentation: signatureData)
+        guard publicKey.isValidSignature(signature, for: Data("\(parts[0]).\(parts[1])".utf8)) else {
+            throw NSError(domain: "WalletE2E", code: 311, userInfo: [NSLocalizedDescriptionKey: "Invalid public demo signed metadata signature"])
+        }
+        return DemoMetadataSigner(keyID: header["kid"] as? String, algorithm: algorithm)
+    }
+
     public func createResponseBoundVerifierSession(scenario: DemoCredentialScenario) async throws -> DemoVerifierSession {
         try await createVerifierSession(
             scenario: scenario,
@@ -181,7 +247,8 @@ public final class DemoBackend {
     private func createVerifierSession(
         scenario: DemoCredentialScenario,
         transactionData: [[String: Any]],
-        bindClientIDToResponseURI: Bool = false
+        bindClientIDToResponseURI: Bool = false,
+        signedRequest: Bool = false
     ) async throws -> DemoVerifierSession {
         let endpoint = Self.verifierBaseURL
             .appendingPathComponent("verification-session")
@@ -191,6 +258,7 @@ public final class DemoBackend {
             "dcql_query": [
                 "credentials": [scenario.verifierCredentialQuery],
             ],
+            "signed_request": signedRequest,
         ]
         if let requestedSessionID {
             let responseURI = Self.verifierBaseURL
@@ -363,6 +431,21 @@ public final class DemoBackend {
         payload.putProfileField(fields: fields, key: "currency", value: "EUR")
         return payload
     }
+}
+
+private func base64URLData(_ value: String) -> Data? {
+    let padded = value
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+        .padding(toLength: ((value.count + 3) / 4) * 4, withPad: "=", startingAt: 0)
+    return Data(base64Encoded: padded)
+}
+
+private func base64URLString(_ value: Data) -> String {
+    value.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
 }
 
 private extension Dictionary where Key == String, Value == Any {

--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
@@ -82,8 +82,13 @@ public final class DemoBackend {
     public static let issuerIdentifier = "https://issuer2.demo.walt.id/openid4vci"
     // RFC 7638 thumbprint of the public issuer2 signing key from /openid4vci/jwks.
     // This independent pin must not be learned from the signed metadata JWT.
-    private static let issuerMetadataSigningKeyThumbprint = "XVz5i-iLcVBvjz5X4LGc6dA-VFNSyzWMW32LAHF8fss"
+    private static let issuerMetadataSigningKeyThumbprint = "gzGuLAZEJ5AsVMZ3mRQ1jsRQbbaS78mpHzQmTFytwF0"
     private static let verifierBaseURL = URL(string: "https://verifier2.demo.walt.id")!
+    /// The public verifier requires this explicit client ID for signed request objects.
+    public static let verifierClientID = "verifier2"
+    /// Pre-registered metadata for the ES256 request-object signing key currently served by verifier2.
+    /// This key is an independent trust anchor and must not be learned from the request object.
+    public static let verifierRequestObjectClientMetadataJSON = #"{"jwks":{"keys":[{"kty":"EC","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}]}}"#
 
     private let client: WalletE2EClient
 
@@ -250,6 +255,10 @@ public final class DemoBackend {
         bindClientIDToResponseURI: Bool = false,
         signedRequest: Bool = false
     ) async throws -> DemoVerifierSession {
+        precondition(
+            !(bindClientIDToResponseURI && signedRequest),
+            "A signed verifier request cannot use a response-bound redirect_uri client ID"
+        )
         let endpoint = Self.verifierBaseURL
             .appendingPathComponent("verification-session")
             .appendingPathComponent("create")
@@ -261,6 +270,7 @@ public final class DemoBackend {
         ]
         if signedRequest {
             coreFlow["signed_request"] = true
+            coreFlow["clientId"] = Self.verifierClientID
         }
         if let requestedSessionID {
             let responseURI = Self.verifierBaseURL

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/MockWalletClient.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/MockWalletClient.swift
@@ -58,7 +58,14 @@ actor MockWalletClient: WalletClient {
             id: "mock-session",
             offer: .init(
                 grant: issuanceGrant,
-                issuer: .init(identifier: "https://issuer.example", name: "Example Issuer", locale: nil, logoURI: nil, logoAltText: nil),
+                issuer: .init(
+                    identifier: "https://issuer.example",
+                    name: "Example Issuer",
+                    locale: nil,
+                    logoURI: nil,
+                    logoAltText: nil,
+                    metadataProvenance: .unsigned
+                ),
                 credentials: [.init(configurationID: "ExampleCredential", format: "dc+sd-jwt", name: "Example", descriptionText: nil, logoURI: nil)],
                 transactionCode: transactionCodeRequired
                     ? .init(inputMode: "numeric", length: 6, descriptionText: "Enter the six-digit code")
@@ -163,6 +170,7 @@ actor MockWalletClient: WalletClient {
                     termsOfServiceURI: "https://verifier.example/terms"
                 )
             },
+            requestAuthentication: .unauthenticated,
             responseURI: URL(string: "https://verifier.example/response"),
             state: "state-123",
             nonce: "nonce-456",

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
@@ -805,6 +805,7 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
     func testTransactionDataGroupsRenderProfileAndDetailsReadably() throws {
         let request = PresentationRequestInfo(
             clientID: "https://verifier.example",
+            requestAuthentication: .unauthenticated,
             nonce: "nonce-1",
             responseEncryption: .notRequired,
             transactionData: [

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -334,8 +334,9 @@ final class MobileWalletIntegrationTests: XCTestCase {
             return XCTFail("Expected signed issuer metadata provenance")
         }
         XCTAssertFalse(issuerProvenance.compactJWT.isEmpty)
-        XCTAssertFalse(issuerProvenance.algorithm.isEmpty)
+        XCTAssertEqual("ES256", issuerProvenance.algorithm)
         XCTAssertNotNil(issuerProvenance.keyID)
+        XCTAssertEqual(.trustedIssuer, issuerProvenance.trustType)
 
         let outcome = try await wallet.continuePreAuthorizedIssuance(
             sessionID: issuanceSession.id,
@@ -349,12 +350,13 @@ final class MobileWalletIntegrationTests: XCTestCase {
         let signedSession = try await DemoBackend.shared.createVerifierSession(scenario: scenario, signedRequest: true)
         let presentationURL = try XCTUnwrap(URL(string: signedSession.authorizationRequestUri))
         let preview = try requireReadyPreview(try await wallet.previewPresentation(request: presentationURL))
-        guard case let .signedRequest(verifierProvenance) = preview.request.verifierMetadataProvenance else {
-            return XCTFail("Expected signed verifier request provenance")
+        guard case let .authenticated(compactRequestObject, algorithm, keyID, clientIDScheme) = preview.request.requestAuthentication else {
+            return XCTFail("Expected authenticated signed verifier request")
         }
-        XCTAssertFalse(verifierProvenance.compactRequestObject.isEmpty)
-        XCTAssertFalse(verifierProvenance.algorithm.isEmpty)
-        XCTAssertNotNil(verifierProvenance.keyID)
+        XCTAssertFalse(compactRequestObject.isEmpty)
+        XCTAssertEqual("ES256", algorithm)
+        XCTAssertNotNil(keyID)
+        XCTAssertEqual(.preRegistered, clientIDScheme)
 
         let result = try await wallet.submitPresentation(
             previewHandle: preview.previewHandle,

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -96,6 +96,11 @@ final class MobileWalletIntegrationTests: XCTestCase {
         try await Wallet(
             configuration: WalletConfiguration(
                 walletID: walletId,
+                clientIDTrustConfiguration: WalletClientIDTrustConfiguration(
+                    preRegisteredClientMetadataJSON: [
+                        DemoBackend.verifierClientID: DemoBackend.verifierRequestObjectClientMetadataJSON,
+                    ]
+                ),
                 issuerMetadataTrustResolver: PublicDemoIssuerMetadataTrustResolver(),
                 transactionDataProfiles: Self.demoTransactionDataProfiles
             )

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -92,6 +92,16 @@ final class MobileWalletIntegrationTests: XCTestCase {
         )
     }
 
+    private func makeSignedMetadataWallet(walletId: String) async throws -> Wallet {
+        try await Wallet(
+            configuration: WalletConfiguration(
+                walletID: walletId,
+                issuerMetadataTrustResolver: PublicDemoIssuerMetadataTrustResolver(),
+                transactionDataProfiles: Self.demoTransactionDataProfiles
+            )
+        )
+    }
+
     private func makeWallet(persistence: WalletPersistence) async throws -> Wallet {
         try await Wallet(
             configuration: WalletConfiguration(
@@ -308,6 +318,54 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
     func testReceiveIsoMdlCredentialFromDemoIssuer2() async throws {
         try await receiveCredentialFromDemoIssuer2(scenarioID: "iso-mdl")
+    }
+
+    func testReceiveAndPresentUsingSignedMetadataAgainstDemoIssuer2AndVerifier2() async throws {
+        let scenario = try demoPresentationScenario("eudi-pid-mdoc")
+        let walletID = "ios-demo-signed-\(UUID().uuidString)"
+        await clearTestData(walletId: walletID)
+        let wallet = try await makeSignedMetadataWallet(walletId: walletID)
+        let bootstrap = try await wallet.bootstrap()
+        let offer = try await DemoBackend.shared.createOffer(scenario: scenario)
+        let offerURL = try XCTUnwrap(URL(string: offer.offerUrl))
+
+        let issuanceSession = try await startIssuance(wallet: wallet, offerURL: offerURL)
+        guard case let .signed(issuerProvenance) = issuanceSession.offer.issuer.metadataProvenance else {
+            return XCTFail("Expected signed issuer metadata provenance")
+        }
+        XCTAssertFalse(issuerProvenance.compactJWT.isEmpty)
+        XCTAssertFalse(issuerProvenance.algorithm.isEmpty)
+        XCTAssertNotNil(issuerProvenance.keyID)
+
+        let outcome = try await wallet.continuePreAuthorizedIssuance(
+            sessionID: issuanceSession.id,
+            transactionCode: offer.txCode
+        )
+        guard case let .stored(_, credentialIDs) = outcome else {
+            throw MobileWalletIntegrationError.unexpectedIssuanceOutcome
+        }
+        XCTAssertFalse(credentialIDs.isEmpty, "Should receive a credential from reviewed signed metadata")
+
+        let signedSession = try await DemoBackend.shared.createVerifierSession(scenario: scenario, signedRequest: true)
+        let presentationURL = try XCTUnwrap(URL(string: signedSession.authorizationRequestUri))
+        let preview = try requireReadyPreview(try await wallet.previewPresentation(request: presentationURL))
+        guard case let .signedRequest(verifierProvenance) = preview.request.verifierMetadataProvenance else {
+            return XCTFail("Expected signed verifier request provenance")
+        }
+        XCTAssertFalse(verifierProvenance.compactRequestObject.isEmpty)
+        XCTAssertFalse(verifierProvenance.algorithm.isEmpty)
+        XCTAssertNotNil(verifierProvenance.keyID)
+
+        let result = try await wallet.submitPresentation(
+            previewHandle: preview.previewHandle,
+            selectedCredentialOptions: preview.credentialOptions.map(\.selection),
+            did: bootstrap.did
+        )
+        assertTransmittedSuccess(result, "Signed public demo presentation should succeed")
+        try await DemoBackend.shared.waitForVerifierSuccess(
+            sessionID: signedSession.sessionID,
+            timeoutSeconds: verifierPollingTimeout
+        )
     }
 
     func testReceiveAndPresentEudiEhicSdJwtAgainstEudi() async throws {
@@ -765,6 +823,20 @@ final class MobileWalletIntegrationTests: XCTestCase {
 
 private enum MobileWalletIntegrationError: Error {
     case unexpectedIssuanceOutcome
+}
+
+private struct PublicDemoIssuerMetadataTrustResolver: IssuerMetadataTrustResolver {
+    func verify(compactJWT: String, expectedCredentialIssuer: String) async throws -> IssuerMetadataSigner {
+        let signer = try DemoBackend.verifySignedIssuerMetadata(
+            compactJWT: compactJWT,
+            expectedCredentialIssuer: expectedCredentialIssuer
+        )
+        return IssuerMetadataSigner(
+            keyID: signer.keyID,
+            algorithm: signer.algorithm,
+            trustType: .trustedIssuer
+        )
+    }
 }
 
 private actor RecordingWalletCredentialStore: WalletCredentialStore {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/SharingReviewModelTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/SharingReviewModelTests.swift
@@ -301,6 +301,7 @@ final class SharingReviewModelTests: XCTestCase {
                 policyURI: nil,
                 termsOfServiceURI: nil
             ),
+            requestAuthentication: .unauthenticated,
             responseEncryption: .notRequired
         ).sharingRequest()
 
@@ -423,6 +424,7 @@ final class SharingReviewModelTests: XCTestCase {
             request: PresentationRequestInfo(
                 clientID: "https://verifier.example",
                 verifierMetadata: verifierMetadata,
+                requestAuthentication: .unauthenticated,
                 responseURI: URL(string: "https://verifier.example/response"),
                 state: "state-123",
                 nonce: "nonce-456",

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelPresentationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelPresentationTests.swift
@@ -24,6 +24,7 @@ final class WalletViewModelPresentationTests: XCTestCase {
                     policyURI: nil,
                     termsOfServiceURI: nil
                 ),
+                requestAuthentication: .unauthenticated,
                 responseEncryption: .notRequired
             ),
             code: .invalidTransactionData,

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelReceiveTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/WalletViewModelReceiveTests.swift
@@ -289,7 +289,14 @@ private actor TransactionCodeWalletClient: WalletClient {
             id: "transaction-code-session",
             offer: IssuanceOfferPreview(
                 grant: issuanceGrant,
-                issuer: IssuanceIssuerPreview(identifier: "https://issuer.example", name: "Example Issuer", locale: nil, logoURI: nil, logoAltText: nil),
+                issuer: IssuanceIssuerPreview(
+                    identifier: "https://issuer.example",
+                    name: "Example Issuer",
+                    locale: nil,
+                    logoURI: nil,
+                    logoAltText: nil,
+                    metadataProvenance: .unsigned
+                ),
                 credentials: [IssuanceCredentialPreview(configurationID: "ExampleCredential", format: "vc+sd-jwt", name: "Example credential", descriptionText: nil, logoURI: nil)],
                 transactionCode: transactionCode
             )
@@ -344,6 +351,7 @@ private actor TransactionCodeWalletClient: WalletClient {
                 previewHandle: PresentationPreviewHandle(value: "transaction-code-presentation-preview"),
                 request: PresentationRequestInfo(
                     clientID: "https://verifier.example",
+                    requestAuthentication: .unauthenticated,
                     nonce: "nonce-1",
                     responseEncryption: .notRequired,
                 ),

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
@@ -11,7 +11,8 @@ waltidMobile {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(project(":waltid-libraries:crypto:waltid-crypto"))
+            implementation(project(":waltid-libraries:crypto:waltid-crypto2"))
+            implementation(project(":waltid-libraries:crypto:waltid-jose"))
             implementation(project(":waltid-libraries:protocols:waltid-openid4vci"))
             implementation(project(":waltid-libraries:protocols:waltid-openid4vci-wallet"))
             implementation(identityLibs.ktor.client.core)

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/build.gradle.kts
@@ -11,6 +11,9 @@ waltidMobile {
 kotlin {
     sourceSets {
         commonMain.dependencies {
+            implementation(project(":waltid-libraries:crypto:waltid-crypto"))
+            implementation(project(":waltid-libraries:protocols:waltid-openid4vci"))
+            implementation(project(":waltid-libraries:protocols:waltid-openid4vci-wallet"))
             implementation(identityLibs.ktor.client.core)
             implementation(identityLibs.kotlinx.serialization.json)
         }

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -1,7 +1,15 @@
 package id.walt.mobile.test.backend
 
-import id.walt.crypto.keys.jwk.JWKKey
-import id.walt.crypto.utils.JwsUtils.decodeJws
+import id.walt.crypto2.CryptoRuntime
+import id.walt.crypto2.jose.CompactJws
+import id.walt.crypto2.jose.Jwk
+import id.walt.crypto2.jose.JwsAlgorithm
+import id.walt.crypto2.keys.EncodedKey
+import id.walt.crypto2.keys.KeyId
+import id.walt.crypto2.keys.KeyUsage
+import id.walt.crypto2.keys.toStoredSoftwareKey
+import id.walt.crypto2.providers.cryptography.CryptographySoftwareKeyProvider
+import id.walt.crypto2.serialization.BinaryData
 import id.walt.openid4vci.tokens.jwt.JwtHeaderParams
 import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
 import id.waltid.openid4vci.wallet.metadata.MetadataSigner
@@ -54,6 +62,7 @@ object DemoTestBackend {
     const val SCA_PAYMENT_AMOUNT = 11.56
     const val SCA_PAYMENT_TRANSACTION_ID = "8D8AC610-566D-4EF0-9C22-186B2A5ED793"
     private val requiredPaymentAuthorizationFields = setOf("merchant_name", "amount", "currency")
+    private val metadataCryptoRuntime = CryptoRuntime(listOf(CryptographySoftwareKeyProvider()))
 
     val scenarios = listOf(
         CredentialScenario(
@@ -274,13 +283,13 @@ object DemoTestBackend {
         require(expectedCredentialIssuer == ISSUER_IDENTIFIER) {
             "Unexpected public demo Credential Issuer: $expectedCredentialIssuer"
         }
-        val decoded = compactJwt.decodeJws()
-        val algorithm = decoded.header[JwtHeaderParams.ALGORITHM]?.jsonPrimitive?.contentOrNull
+        val decoded = CompactJws.decodeUnverified(compactJwt)
+        val algorithm = decoded.protectedHeader[JwtHeaderParams.ALGORITHM]?.jsonPrimitive?.contentOrNull
             ?: error("Public demo signed metadata is missing alg")
         require(algorithm == "ES256") {
             "Unsupported public demo signed metadata algorithm: $algorithm"
         }
-        val jwk = decoded.header[JwtHeaderParams.JSON_WEB_KEY]?.jsonObject
+        val jwk = decoded.protectedHeader[JwtHeaderParams.JSON_WEB_KEY]?.jsonObject
             ?: error("Public demo signed metadata is missing jwk")
         require(jwk["kty"]?.jsonPrimitive?.contentOrNull == "EC") {
             "Public demo signed metadata jwk must use EC"
@@ -288,13 +297,19 @@ object DemoTestBackend {
         require(jwk["crv"]?.jsonPrimitive?.contentOrNull == "P-256") {
             "Public demo signed metadata jwk must use P-256"
         }
-        val verificationKey = JWKKey.importJWK(jwk.toString()).getOrThrow()
-        require(verificationKey.getPublicKey().getThumbprint() == ISSUER_METADATA_SIGNING_KEY_THUMBPRINT) {
+        val encodedVerificationKey = EncodedKey.Jwk(
+            data = BinaryData(jwk.toString().encodeToByteArray()),
+            privateMaterial = false,
+        )
+        require(Jwk.sha256Thumbprint(encodedVerificationKey) == ISSUER_METADATA_SIGNING_KEY_THUMBPRINT) {
             "Public demo signed metadata key is not the pinned issuer2 signing key"
         }
-        verificationKey.verifyJws(compactJwt).getOrThrow()
+        val verificationKey = metadataCryptoRuntime.restore(
+            encodedVerificationKey.toStoredSoftwareKey(KeyId("issuer2-metadata"), setOf(KeyUsage.VERIFY))
+        )
+        CompactJws.verify(compactJwt, verificationKey, JwsAlgorithm.ES256)
         MetadataSigner(
-            keyId = decoded.header[JwtHeaderParams.KEY_ID]?.jsonPrimitive?.contentOrNull,
+            keyId = decoded.protectedHeader[JwtHeaderParams.KEY_ID]?.jsonPrimitive?.contentOrNull,
             algorithm = algorithm,
             trustType = MetadataSignerTrustType.TRUSTED_ISSUER,
         )

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -48,7 +48,7 @@ object DemoTestBackend {
     // https://issuer2.demo.walt.id/openid4vci/jwks. This is an independent trust anchor;
     // it must not be learned from the signed metadata JWT itself.
     private const val ISSUER_METADATA_SIGNING_KEY_THUMBPRINT =
-        "XVz5i-iLcVBvjz5X4LGc6dA-VFNSyzWMW32LAHF8fss"
+        "gzGuLAZEJ5AsVMZ3mRQ1jsRQbbaS78mpHzQmTFytwF0"
     private const val VERIFIER_BASE_URL = "https://verifier2.demo.walt.id"
 
     const val TRANSACTION_DATA_PROFILES_URL = "https://wallet.demo.walt.id/wallet-api/transaction-data-profiles"

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -1,5 +1,11 @@
 package id.walt.mobile.test.backend
 
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.crypto.utils.JwsUtils.decodeJws
+import id.walt.openid4vci.tokens.jwt.JwtHeaderParams
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.*
@@ -29,6 +35,12 @@ import kotlin.uuid.Uuid
 object DemoTestBackend {
 
     private const val ISSUER_BASE_URL = "https://issuer2.demo.walt.id"
+    private const val ISSUER_IDENTIFIER = "$ISSUER_BASE_URL/openid4vci"
+    // RFC 7638 thumbprint of the issuer2 metadata signing key published at
+    // https://issuer2.demo.walt.id/openid4vci/jwks. This is an independent trust anchor;
+    // it must not be learned from the signed metadata JWT itself.
+    private const val ISSUER_METADATA_SIGNING_KEY_THUMBPRINT =
+        "XVz5i-iLcVBvjz5X4LGc6dA-VFNSyzWMW32LAHF8fss"
     private const val VERIFIER_BASE_URL = "https://verifier2.demo.walt.id"
 
     const val TRANSACTION_DATA_PROFILES_URL = "https://wallet.demo.walt.id/wallet-api/transaction-data-profiles"
@@ -248,6 +260,46 @@ object DemoTestBackend {
         return createVerifierSession(scenario.verifierCredentialQuery)
     }
 
+    suspend fun createVerifierSession(
+        scenario: CredentialScenario,
+        signedRequest: Boolean,
+    ): VerifierSession = createVerifierSession(
+        credentialQuery = scenario.verifierCredentialQuery,
+        transactionData = emptyList(),
+        signedRequest = signedRequest,
+    )
+
+    /** Trust resolver for signed metadata served by the public issuer2 demo. */
+    val publicDemoIssuerMetadataTrustResolver = CredentialIssuerMetadataTrustResolver { compactJwt, expectedCredentialIssuer ->
+        require(expectedCredentialIssuer == ISSUER_IDENTIFIER) {
+            "Unexpected public demo Credential Issuer: $expectedCredentialIssuer"
+        }
+        val decoded = compactJwt.decodeJws()
+        val algorithm = decoded.header[JwtHeaderParams.ALGORITHM]?.jsonPrimitive?.contentOrNull
+            ?: error("Public demo signed metadata is missing alg")
+        require(algorithm == "ES256") {
+            "Unsupported public demo signed metadata algorithm: $algorithm"
+        }
+        val jwk = decoded.header[JwtHeaderParams.JSON_WEB_KEY]?.jsonObject
+            ?: error("Public demo signed metadata is missing jwk")
+        require(jwk["kty"]?.jsonPrimitive?.contentOrNull == "EC") {
+            "Public demo signed metadata jwk must use EC"
+        }
+        require(jwk["crv"]?.jsonPrimitive?.contentOrNull == "P-256") {
+            "Public demo signed metadata jwk must use P-256"
+        }
+        val verificationKey = JWKKey.importJWK(jwk.toString()).getOrThrow()
+        require(verificationKey.getPublicKey().getThumbprint() == ISSUER_METADATA_SIGNING_KEY_THUMBPRINT) {
+            "Public demo signed metadata key is not the pinned issuer2 signing key"
+        }
+        verificationKey.verifyJws(compactJwt).getOrThrow()
+        MetadataSigner(
+            keyId = decoded.header[JwtHeaderParams.KEY_ID]?.jsonPrimitive?.contentOrNull,
+            algorithm = algorithm,
+            trustType = MetadataSignerTrustType.TRUSTED_ISSUER,
+        )
+    }
+
     suspend fun createResponseBoundVerifierSession(scenario: CredentialScenario): VerifierSession {
         return createVerifierSession(
             credentialQuery = scenario.verifierCredentialQuery,
@@ -355,11 +407,13 @@ object DemoTestBackend {
         credentialQuery: JsonObject,
         transactionData: List<JsonObject>,
         bindClientIdToResponseUri: Boolean = false,
+        signedRequest: Boolean = false,
     ): VerifierSession {
         val requestedSessionId = Uuid.random().toString().takeIf { bindClientIdToResponseUri }
         val payload = buildJsonObject {
             put("flow_type", "cross_device")
             putJsonObject("core_flow") {
+                put("signed_request", signedRequest)
                 requestedSessionId?.let { sessionId ->
                     val responseUri = "$VERIFIER_BASE_URL/verification-session/$sessionId/response"
                     put("sessionId", sessionId)

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -413,7 +413,9 @@ object DemoTestBackend {
         val payload = buildJsonObject {
             put("flow_type", "cross_device")
             putJsonObject("core_flow") {
-                put("signed_request", signedRequest)
+                if (signedRequest) {
+                    put("signed_request", true)
+                }
                 requestedSessionId?.let { sessionId ->
                     val responseUri = "$VERIFIER_BASE_URL/verification-session/$sessionId/response"
                     put("sessionId", sessionId)

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -50,6 +50,13 @@ object DemoTestBackend {
     private const val ISSUER_METADATA_SIGNING_KEY_THUMBPRINT =
         "gzGuLAZEJ5AsVMZ3mRQ1jsRQbbaS78mpHzQmTFytwF0"
     private const val VERIFIER_BASE_URL = "https://verifier2.demo.walt.id"
+    // The demo verifier only accepts signed requests for an explicitly configured client ID.
+    const val PUBLIC_DEMO_VERIFIER_CLIENT_ID = "verifier2"
+    // `kid`, `x`, and `y` of the ES256 request-object signing key served by verifier2's x5c header.
+    // This is a pre-registered trust anchor: it must not be learned from the request object itself.
+    private const val VERIFIER_REQUEST_OBJECT_SIGNING_KEY_ID = "_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug"
+    private const val VERIFIER_REQUEST_OBJECT_SIGNING_KEY_X = "G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0"
+    private const val VERIFIER_REQUEST_OBJECT_SIGNING_KEY_Y = "VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"
 
     const val TRANSACTION_DATA_PROFILES_URL = "https://wallet.demo.walt.id/wallet-api/transaction-data-profiles"
     private const val EUDI_PID_SD_JWT_VCT = "$ISSUER_BASE_URL/openid4vci/urn:eudi:pid:1"
@@ -278,6 +285,15 @@ object DemoTestBackend {
         signedRequest = signedRequest,
     )
 
+    /** Public key that authenticates signed request objects served by the public verifier2 demo. */
+    val publicDemoVerifierRequestObjectSigningJwk = buildJsonObject {
+        put("kty", "EC")
+        put("crv", "P-256")
+        put("kid", VERIFIER_REQUEST_OBJECT_SIGNING_KEY_ID)
+        put("x", VERIFIER_REQUEST_OBJECT_SIGNING_KEY_X)
+        put("y", VERIFIER_REQUEST_OBJECT_SIGNING_KEY_Y)
+    }
+
     /** Trust resolver for signed metadata served by the public issuer2 demo. */
     val publicDemoIssuerMetadataTrustResolver = CredentialIssuerMetadataTrustResolver { compactJwt, expectedCredentialIssuer ->
         require(expectedCredentialIssuer == ISSUER_IDENTIFIER) {
@@ -424,12 +440,16 @@ object DemoTestBackend {
         bindClientIdToResponseUri: Boolean = false,
         signedRequest: Boolean = false,
     ): VerifierSession {
+        require(!(bindClientIdToResponseUri && signedRequest)) {
+            "A signed verifier request cannot use a response-bound redirect_uri client ID"
+        }
         val requestedSessionId = Uuid.random().toString().takeIf { bindClientIdToResponseUri }
         val payload = buildJsonObject {
             put("flow_type", "cross_device")
             putJsonObject("core_flow") {
                 if (signedRequest) {
                     put("signed_request", true)
+                    put("clientId", PUBLIC_DEMO_VERIFIER_CLIENT_ID)
                 }
                 requestedSessionId?.let { sessionId ->
                     val responseUri = "$VERIFIER_BASE_URL/verification-session/$sessionId/response"

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -40,6 +40,17 @@ final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeErrorCategory :
     }
 }
 
+final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType|null[0]
+    enum entry TrustedDelegate // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.TrustedDelegate|null[0]
+    enum entry TrustedIssuer // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.TrustedIssuer|null[0]
+
+    final val entries // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType.values|values#static(){}[0]
+}
+
 final enum class id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus : kotlin/Enum<id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus> { // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus|null[0]
     enum entry AUTHORIZED // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.AUTHORIZED|null[0]
     enum entry NOT_AUTHORIZED // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.NOT_AUTHORIZED|null[0]
@@ -53,6 +64,22 @@ final enum class id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus : 
 
     final fun valueOf(kotlin/String): id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus> // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.values|values#static(){}[0]
+}
+
+final enum class id.walt.wallet2.mobile/MobileWalletClientIdScheme : kotlin/Enum<id.walt.wallet2.mobile/MobileWalletClientIdScheme> { // id.walt.wallet2.mobile/MobileWalletClientIdScheme|null[0]
+    enum entry DECENTRALIZED_IDENTIFIER // id.walt.wallet2.mobile/MobileWalletClientIdScheme.DECENTRALIZED_IDENTIFIER|null[0]
+    enum entry OPENID_FEDERATION // id.walt.wallet2.mobile/MobileWalletClientIdScheme.OPENID_FEDERATION|null[0]
+    enum entry PRE_REGISTERED // id.walt.wallet2.mobile/MobileWalletClientIdScheme.PRE_REGISTERED|null[0]
+    enum entry REDIRECT_URI // id.walt.wallet2.mobile/MobileWalletClientIdScheme.REDIRECT_URI|null[0]
+    enum entry VERIFIER_ATTESTATION // id.walt.wallet2.mobile/MobileWalletClientIdScheme.VERIFIER_ATTESTATION|null[0]
+    enum entry X509_HASH // id.walt.wallet2.mobile/MobileWalletClientIdScheme.X509_HASH|null[0]
+    enum entry X509_SAN_DNS // id.walt.wallet2.mobile/MobileWalletClientIdScheme.X509_SAN_DNS|null[0]
+
+    final val entries // id.walt.wallet2.mobile/MobileWalletClientIdScheme.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile/MobileWalletClientIdScheme> // id.walt.wallet2.mobile/MobileWalletClientIdScheme.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile/MobileWalletClientIdScheme // id.walt.wallet2.mobile/MobileWalletClientIdScheme.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile/MobileWalletClientIdScheme> // id.walt.wallet2.mobile/MobileWalletClientIdScheme.values|values#static(){}[0]
 }
 
 final enum class id.walt.wallet2.mobile/MobileWalletDigitalCredentialFormat : kotlin/Enum<id.walt.wallet2.mobile/MobileWalletDigitalCredentialFormat> { // id.walt.wallet2.mobile/MobileWalletDigitalCredentialFormat|null[0]
@@ -210,6 +237,10 @@ abstract interface id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore { //
     abstract suspend fun getDid(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeStoredDid? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore.getDid|getDid(kotlin.String){}[0]
     abstract suspend fun listDids(): kotlin.collections/List<id.walt.wallet2.mobile.swiftinterop/WalletBridgeStoredDid> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore.listDids|listDids(){}[0]
     abstract suspend fun removeDid(kotlin/String): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeDidStore.removeDid|removeDid(kotlin.String){}[0]
+}
+
+abstract interface id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver|null[0]
+    abstract suspend fun verify(kotlin/String, kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver.verify|verify(kotlin.String;kotlin.String){}[0]
 }
 
 abstract interface id.walt.wallet2.mobile/MobileWalletCredentialRegistry { // id.walt.wallet2.mobile/MobileWalletCredentialRegistry|null[0]
@@ -480,6 +511,36 @@ sealed interface id.walt.wallet2.mobile/MobileWalletReaderTrust { // id.walt.wal
 
 sealed interface id.walt.wallet2.mobile/MobileWalletReaderTrustDecision : id.walt.wallet2.mobile/MobileWalletReaderTrust // id.walt.wallet2.mobile/MobileWalletReaderTrustDecision|null[0]
 
+sealed interface id.walt.wallet2.mobile/MobileWalletRequestAuthentication { // id.walt.wallet2.mobile/MobileWalletRequestAuthentication|null[0]
+    final class Authenticated : id.walt.wallet2.mobile/MobileWalletRequestAuthentication { // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated|null[0]
+        constructor <init>(kotlin/String, kotlin/String, kotlin/String?, id.walt.wallet2.mobile/MobileWalletClientIdScheme) // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.<init>|<init>(kotlin.String;kotlin.String;kotlin.String?;id.walt.wallet2.mobile.MobileWalletClientIdScheme){}[0]
+
+        final val algorithm // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.algorithm|{}algorithm[0]
+            final fun <get-algorithm>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.algorithm.<get-algorithm>|<get-algorithm>(){}[0]
+        final val clientIdScheme // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.clientIdScheme|{}clientIdScheme[0]
+            final fun <get-clientIdScheme>(): id.walt.wallet2.mobile/MobileWalletClientIdScheme // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.clientIdScheme.<get-clientIdScheme>|<get-clientIdScheme>(){}[0]
+        final val compactRequestObject // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.compactRequestObject|{}compactRequestObject[0]
+            final fun <get-compactRequestObject>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.compactRequestObject.<get-compactRequestObject>|<get-compactRequestObject>(){}[0]
+        final val keyId // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.keyId|{}keyId[0]
+            final fun <get-keyId>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.keyId.<get-keyId>|<get-keyId>(){}[0]
+
+        final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component1|component1(){}[0]
+        final fun component2(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component2|component2(){}[0]
+        final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component3|component3(){}[0]
+        final fun component4(): id.walt.wallet2.mobile/MobileWalletClientIdScheme // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.component4|component4(){}[0]
+        final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletClientIdScheme = ...): id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.copy|copy(kotlin.String;kotlin.String;kotlin.String?;id.walt.wallet2.mobile.MobileWalletClientIdScheme){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Authenticated.toString|toString(){}[0]
+    }
+
+    final object Unauthenticated : id.walt.wallet2.mobile/MobileWalletRequestAuthentication { // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletRequestAuthentication.Unauthenticated.toString|toString(){}[0]
+    }
+}
+
 sealed interface id.walt.wallet2.mobile/MobileWalletResponseEncryption { // id.walt.wallet2.mobile/MobileWalletResponseEncryption|null[0]
     abstract val contentEncryptionAlgorithm // id.walt.wallet2.mobile/MobileWalletResponseEncryption.contentEncryptionAlgorithm|{}contentEncryptionAlgorithm[0]
         abstract fun <get-contentEncryptionAlgorithm>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletResponseEncryption.contentEncryptionAlgorithm.<get-contentEncryptionAlgorithm>|<get-contentEncryptionAlgorithm>(){}[0]
@@ -548,7 +609,7 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfigu
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration|null[0]
-    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?){}[0]
+    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataTrustResolver?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?){}[0]
 
     final val appGroupIdentifier // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.appGroupIdentifier|{}appGroupIdentifier[0]
         final fun <get-appGroupIdentifier>(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.appGroupIdentifier.<get-appGroupIdentifier>|<get-appGroupIdentifier>(){}[0]
@@ -560,6 +621,8 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // i
         final fun <get-databaseKeyProvider>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.databaseKeyProvider.<get-databaseKeyProvider>|<get-databaseKeyProvider>(){}[0]
     final val defaultKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyType|{}defaultKeyType[0]
         final fun <get-defaultKeyType>(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyType.<get-defaultKeyType>|<get-defaultKeyType>(){}[0]
+    final val issuerMetadataTrustResolver // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.issuerMetadataTrustResolver|{}issuerMetadataTrustResolver[0]
+        final fun <get-issuerMetadataTrustResolver>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.issuerMetadataTrustResolver.<get-issuerMetadataTrustResolver>|<get-issuerMetadataTrustResolver>(){}[0]
     final val keychainAccessGroup // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keychainAccessGroup|{}keychainAccessGroup[0]
         final fun <get-keychainAccessGroup>(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keychainAccessGroup.<get-keychainAccessGroup>|<get-keychainAccessGroup>(){}[0]
     final val persistence // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.persistence|{}persistence[0]
@@ -573,15 +636,16 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // i
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component1|component1(){}[0]
     final fun component10(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component10|component10(){}[0]
+    final fun component11(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component11|component11(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component2|component2(){}[0]
     final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component3|component3(){}[0]
     final fun component4(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component4|component4(){}[0]
     final fun component5(): id.walt.wallet2.mobile/WalletAttestationConfig? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component5|component5(){}[0]
-    final fun component6(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component7|component7(){}[0]
-    final fun component8(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component8|component8(){}[0]
-    final fun component9(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component9|component9(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?){}[0]
+    final fun component6(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component6|component6(){}[0]
+    final fun component7(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component8|component8(){}[0]
+    final fun component9(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component9|component9(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataTrustResolver? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataTrustResolver?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.toString|toString(){}[0]
@@ -629,6 +693,25 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeError { // id.walt.w
         final fun deserialize(kotlinx.serialization.encoding/Decoder): id.walt.wallet2.mobile.swiftinterop/WalletBridgeError // id.walt.wallet2.mobile.swiftinterop/WalletBridgeError.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
         final fun serialize(kotlinx.serialization.encoding/Encoder, id.walt.wallet2.mobile.swiftinterop/WalletBridgeError) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeError.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;id.walt.wallet2.mobile.swiftinterop.WalletBridgeError){}[0]
     }
+}
+
+final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner|null[0]
+    constructor <init>(kotlin/String?, kotlin/String, id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.<init>|<init>(kotlin.String?;kotlin.String;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataSignerTrustType){}[0]
+
+    final val algorithm // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.algorithm|{}algorithm[0]
+        final fun <get-algorithm>(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.algorithm.<get-algorithm>|<get-algorithm>(){}[0]
+    final val keyId // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.keyId|{}keyId[0]
+        final fun <get-keyId>(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.keyId.<get-keyId>|<get-keyId>(){}[0]
+    final val trustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.trustType|{}trustType[0]
+        final fun <get-trustType>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.trustType.<get-trustType>|<get-trustType>(){}[0]
+
+    final fun component1(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.component1|component1(){}[0]
+    final fun component2(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.component2|component2(){}[0]
+    final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.component3|component3(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSignerTrustType = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.copy|copy(kotlin.String?;kotlin.String;id.walt.wallet2.mobile.swiftinterop.WalletBridgeIssuerMetadataSignerTrustType){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeIssuerMetadataSigner.toString|toString(){}[0]
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence { // id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence|null[0]
@@ -955,10 +1038,12 @@ final class id.walt.wallet2.mobile/MobileWalletBootstrapResult { // id.walt.wall
 }
 
 final class id.walt.wallet2.mobile/MobileWalletConfig { // id.walt.wallet2.mobile/MobileWalletConfig|null[0]
-    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // id.walt.wallet2.mobile/MobileWalletConfig.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
+    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...) // id.walt.wallet2.mobile/MobileWalletConfig.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver?;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
 
     final val attestationConfig // id.walt.wallet2.mobile/MobileWalletConfig.attestationConfig|{}attestationConfig[0]
         final fun <get-attestationConfig>(): id.walt.wallet2.mobile/WalletAttestationConfig? // id.walt.wallet2.mobile/MobileWalletConfig.attestationConfig.<get-attestationConfig>|<get-attestationConfig>(){}[0]
+    final val credentialIssuerMetadataTrustResolver // id.walt.wallet2.mobile/MobileWalletConfig.credentialIssuerMetadataTrustResolver|{}credentialIssuerMetadataTrustResolver[0]
+        final fun <get-credentialIssuerMetadataTrustResolver>(): id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? // id.walt.wallet2.mobile/MobileWalletConfig.credentialIssuerMetadataTrustResolver.<get-credentialIssuerMetadataTrustResolver>|<get-credentialIssuerMetadataTrustResolver>(){}[0]
     final val credentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.credentialRegistry|{}credentialRegistry[0]
         final fun <get-credentialRegistry>(): id.walt.wallet2.mobile/MobileWalletCredentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.credentialRegistry.<get-credentialRegistry>|<get-credentialRegistry>(){}[0]
     final val crossProcessAccess // id.walt.wallet2.mobile/MobileWalletConfig.crossProcessAccess|{}crossProcessAccess[0]
@@ -981,17 +1066,18 @@ final class id.walt.wallet2.mobile/MobileWalletConfig { // id.walt.wallet2.mobil
         final fun <get-walletId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletConfig.walletId.<get-walletId>|<get-walletId>(){}[0]
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletConfig.component1|component1(){}[0]
-    final fun component10(): id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? // id.walt.wallet2.mobile/MobileWalletConfig.component10|component10(){}[0]
-    final fun component11(): kotlin.coroutines/SuspendFunction0<kotlin/Unit> // id.walt.wallet2.mobile/MobileWalletConfig.component11|component11(){}[0]
+    final fun component10(): id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator // id.walt.wallet2.mobile/MobileWalletConfig.component10|component10(){}[0]
+    final fun component11(): id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? // id.walt.wallet2.mobile/MobileWalletConfig.component11|component11(){}[0]
+    final fun component12(): kotlin.coroutines/SuspendFunction0<kotlin/Unit> // id.walt.wallet2.mobile/MobileWalletConfig.component12|component12(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile/MobileWalletConfig.component2|component2(){}[0]
     final fun component3(): id.walt.wallet2.mobile/WalletAttestationConfig? // id.walt.wallet2.mobile/MobileWalletConfig.component3|component3(){}[0]
     final fun component4(): id.walt.wallet2.mobile/MobileWalletPersistence // id.walt.wallet2.mobile/MobileWalletConfig.component4|component4(){}[0]
     final fun component5(): kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> // id.walt.wallet2.mobile/MobileWalletConfig.component5|component5(){}[0]
     final fun component6(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile/MobileWalletConfig.component6|component6(){}[0]
     final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> // id.walt.wallet2.mobile/MobileWalletConfig.component7|component7(){}[0]
-    final fun component8(): id.walt.wallet2.mobile/MobileWalletCredentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.component8|component8(){}[0]
-    final fun component9(): id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator // id.walt.wallet2.mobile/MobileWalletConfig.component9|component9(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...): id.walt.wallet2.mobile/MobileWalletConfig // id.walt.wallet2.mobile/MobileWalletConfig.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
+    final fun component8(): id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? // id.walt.wallet2.mobile/MobileWalletConfig.component8|component8(){}[0]
+    final fun component9(): id.walt.wallet2.mobile/MobileWalletCredentialRegistry // id.walt.wallet2.mobile/MobileWalletConfig.component9|component9(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., id.walt.wallet2.mobile/MobileWalletPersistence = ..., kotlin.coroutines/SuspendFunction1<id.walt.wallet2.mobile/MobileWalletEvent, kotlin/Unit> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.waltid.openid4vci.wallet.metadata/CredentialIssuerMetadataTrustResolver? = ..., id.walt.wallet2.mobile/MobileWalletCredentialRegistry = ..., id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator = ..., id.walt.wallet2.mobile/MobileWalletCrossProcessAccess? = ..., kotlin.coroutines/SuspendFunction0<kotlin/Unit> = ...): id.walt.wallet2.mobile/MobileWalletConfig // id.walt.wallet2.mobile/MobileWalletConfig.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.WalletAttestationConfig?;id.walt.wallet2.mobile.MobileWalletPersistence;kotlin.coroutines.SuspendFunction1<id.walt.wallet2.mobile.MobileWalletEvent,kotlin.Unit>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver?;id.walt.wallet2.mobile.MobileWalletCredentialRegistry;id.walt.wallet2.mobile.MobileWalletReaderTrustEvaluator;id.walt.wallet2.mobile.MobileWalletCrossProcessAccess?;kotlin.coroutines.SuspendFunction0<kotlin.Unit>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletConfig.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletConfig.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletConfig.toString|toString(){}[0]
@@ -1497,12 +1583,14 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle { // id
 }
 
 final class id.walt.wallet2.mobile/MobileWalletPresentationRequestContext { // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext|null[0]
-    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, kotlin/String?, kotlin/String?, kotlin/String?, id.walt.wallet2.mobile/MobileWalletResponseEncryption) // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
+    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, id.walt.wallet2.mobile/MobileWalletRequestAuthentication, kotlin/String?, kotlin/String?, kotlin/String?, id.walt.wallet2.mobile/MobileWalletResponseEncryption) // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
 
     final val clientId // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.clientId|{}clientId[0]
         final fun <get-clientId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.clientId.<get-clientId>|<get-clientId>(){}[0]
     final val nonce // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.nonce|{}nonce[0]
         final fun <get-nonce>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.nonce.<get-nonce>|<get-nonce>(){}[0]
+    final val requestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.requestAuthentication|{}requestAuthentication[0]
+        final fun <get-requestAuthentication>(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.requestAuthentication.<get-requestAuthentication>|<get-requestAuthentication>(){}[0]
     final val responseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseEncryption|{}responseEncryption[0]
         final fun <get-responseEncryption>(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseEncryption.<get-responseEncryption>|<get-responseEncryption>(){}[0]
     final val responseUri // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.responseUri|{}responseUri[0]
@@ -1514,23 +1602,26 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationRequestContext { // i
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component1|component1(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component2|component2(){}[0]
-    final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component3|component3(){}[0]
+    final fun component3(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component3|component3(){}[0]
     final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component4|component4(){}[0]
     final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component5|component5(){}[0]
-    final fun component6(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component6|component6(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestContext // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
+    final fun component6(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component6|component6(){}[0]
+    final fun component7(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., id.walt.wallet2.mobile/MobileWalletRequestAuthentication = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestContext // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.MobileWalletResponseEncryption){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestContext.toString|toString(){}[0]
 }
 
 final class id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo { // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo|null[0]
-    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, kotlin/String?, kotlin/String?, kotlin/String, id.walt.wallet2.mobile/MobileWalletResponseEncryption, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...) // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
+    constructor <init>(kotlin/String, id.walt.wallet2.mobile/MobileWalletVerifierMetadata?, id.walt.wallet2.mobile/MobileWalletRequestAuthentication, kotlin/String?, kotlin/String?, kotlin/String, id.walt.wallet2.mobile/MobileWalletResponseEncryption, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...) // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
 
     final val clientId // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId|{}clientId[0]
         final fun <get-clientId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.clientId.<get-clientId>|<get-clientId>(){}[0]
     final val nonce // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce|{}nonce[0]
         final fun <get-nonce>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.nonce.<get-nonce>|<get-nonce>(){}[0]
+    final val requestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.requestAuthentication|{}requestAuthentication[0]
+        final fun <get-requestAuthentication>(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.requestAuthentication.<get-requestAuthentication>|<get-requestAuthentication>(){}[0]
     final val responseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseEncryption|{}responseEncryption[0]
         final fun <get-responseEncryption>(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseEncryption.<get-responseEncryption>|<get-responseEncryption>(){}[0]
     final val responseUri // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.responseUri|{}responseUri[0]
@@ -1544,12 +1635,13 @@ final class id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo { // id.w
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component1|component1(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletVerifierMetadata? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component2|component2(){}[0]
-    final fun component3(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component3|component3(){}[0]
+    final fun component3(): id.walt.wallet2.mobile/MobileWalletRequestAuthentication // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component3|component3(){}[0]
     final fun component4(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component4|component4(){}[0]
-    final fun component5(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component5|component5(){}[0]
-    final fun component6(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component6|component6(){}[0]
-    final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component7|component7(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
+    final fun component5(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component5|component5(){}[0]
+    final fun component6(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component6|component6(){}[0]
+    final fun component7(): id.walt.wallet2.mobile/MobileWalletResponseEncryption // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.component8|component8(){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletVerifierMetadata? = ..., id.walt.wallet2.mobile/MobileWalletRequestAuthentication = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletResponseEncryption = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataItem> = ...): id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletVerifierMetadata?;id.walt.wallet2.mobile.MobileWalletRequestAuthentication;kotlin.String?;kotlin.String?;kotlin.String;id.walt.wallet2.mobile.MobileWalletResponseEncryption;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataItem>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletPresentationRequestInfo.toString|toString(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -596,13 +596,16 @@ sealed interface id.walt.wallet2.mobile/MobileWalletResponseEncryption { // id.w
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration|null[0]
-    constructor <init>(kotlin.collections/List<kotlin/String> = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.<init>|<init>(kotlin.collections.List<kotlin.String>){}[0]
+    constructor <init>(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.<init>|<init>(kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
 
+    final val preRegisteredClientMetadataJson // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.preRegisteredClientMetadataJson|{}preRegisteredClientMetadataJson[0]
+        final fun <get-preRegisteredClientMetadataJson>(): kotlin.collections/Map<kotlin/String, kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.preRegisteredClientMetadataJson.<get-preRegisteredClientMetadataJson>|<get-preRegisteredClientMetadataJson>(){}[0]
     final val x509TrustAnchorsPem // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.x509TrustAnchorsPem|{}x509TrustAnchorsPem[0]
         final fun <get-x509TrustAnchorsPem>(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.x509TrustAnchorsPem.<get-x509TrustAnchorsPem>|<get-x509TrustAnchorsPem>(){}[0]
 
     final fun component1(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.component1|component1(){}[0]
-    final fun copy(kotlin.collections/List<kotlin/String> = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.copy|copy(kotlin.collections.List<kotlin.String>){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/String, kotlin/String> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.copy|copy(kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration.toString|toString(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -150,7 +150,7 @@ class MobileWalletIntegrationTest {
         val offer = DemoTestBackend.createOffer(scenario)
 
         val issuanceSession = client.startIssuance(
-            MobileWalletIssuanceRequest(offerUrl = offer.offerUrl),
+            MobileWalletIssuanceRequest(offer = MobileWalletCredentialOffer.Uri(offer.offerUrl)),
         )
         val issuerProvenance = assertIs<WalletIssuanceMetadataProvenance.Signed>(
             issuanceSession.offer.issuer.metadataProvenance,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -11,6 +11,7 @@ import id.walt.mobile.test.backend.EudiTestBackend
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
 import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.walt.verifier.openid.models.authorization.AuthorizationRequest
+import id.walt.verifier.openid.models.authorization.ClientMetadata
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
 import id.walt.wallet2.handlers.WalletIssuanceMetadataProvenance
 import id.walt.wallet2.handlers.WalletIssuanceOutcome
@@ -74,6 +75,15 @@ class MobileWalletIntegrationTest {
 
         private val DEMO_TRANSACTION_DATA_PROFILES = demoTransactionDataProfiles(
             paymentAuthorizationFields = listOf("merchant_name", "amount", "currency"),
+        )
+
+        @OptIn(ExperimentalSerializationApi::class)
+        private val DEMO_VERIFIER_TRUST = ClientIdTrustConfiguration(
+            preRegisteredClients = mapOf(
+                DemoTestBackend.PUBLIC_DEMO_VERIFIER_CLIENT_ID to ClientMetadata(
+                    jwks = ClientMetadata.Jwks(listOf(DemoTestBackend.publicDemoVerifierRequestObjectSigningJwk)),
+                ),
+            ),
         )
 
         private fun demoTransactionDataProfiles(
@@ -145,6 +155,7 @@ class MobileWalletIntegrationTest {
             walletConfig("signed-${scenario.id}").copy(
                 credentialIssuerMetadataTrustResolver = DemoTestBackend.publicDemoIssuerMetadataTrustResolver,
             ),
+            DEMO_VERIFIER_TRUST,
         )
         val bootstrap = client.bootstrap()
         val offer = DemoTestBackend.createOffer(scenario)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -9,6 +9,7 @@ import id.walt.dcql.models.meta.NoMeta
 import id.walt.mobile.test.backend.DemoTestBackend
 import id.walt.mobile.test.backend.EudiTestBackend
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.walt.verifier.openid.models.authorization.AuthorizationRequest
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
 import id.walt.wallet2.handlers.WalletIssuanceMetadataProvenance
@@ -27,7 +28,8 @@ import id.walt.wallet2.mobile.MobileWalletPresentationPreviewResult
 import id.walt.wallet2.mobile.MobileWalletPresentationResult
 import id.walt.wallet2.mobile.MobileWalletResponseEncryption
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
-import id.walt.wallet2.mobile.MobileWalletVerifierMetadataProvenance
+import id.walt.wallet2.mobile.MobileWalletRequestAuthentication
+import id.walt.wallet2.mobile.MobileWalletClientIdScheme
 import id.walt.x509.CertificateDer
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -154,7 +156,8 @@ class MobileWalletIntegrationTest {
             issuanceSession.offer.issuer.metadataProvenance,
         )
         assertTrue(issuerProvenance.compactJwt.isNotBlank())
-        assertTrue(issuerProvenance.algorithm.isNotBlank())
+        assertEquals("ES256", issuerProvenance.algorithm)
+        assertEquals(MetadataSignerTrustType.TRUSTED_ISSUER, issuerProvenance.trustType)
         assertNotNull(issuerProvenance.keyId)
 
         val credentialIds = client.continuePreAuthorizedIssuance(issuanceSession.id, offer.txCode).storedCredentialIds()
@@ -162,12 +165,13 @@ class MobileWalletIntegrationTest {
 
         val signedSession = DemoTestBackend.createVerifierSession(scenario, signedRequest = true)
         val preview = client.previewPresentation(signedSession.authorizationRequestUri).requireReadyPreview()
-        val verifierProvenance = assertIs<MobileWalletVerifierMetadataProvenance.SignedRequest>(
-            preview.request.verifierMetadataProvenance,
+        val verifierAuthentication = assertIs<MobileWalletRequestAuthentication.Authenticated>(
+            preview.request.requestAuthentication,
         )
-        assertTrue(verifierProvenance.compactRequestObject.isNotBlank())
-        assertTrue(verifierProvenance.algorithm.isNotBlank())
-        assertNotNull(verifierProvenance.keyId)
+        assertTrue(verifierAuthentication.compactRequestObject.isNotBlank())
+        assertEquals("ES256", verifierAuthentication.algorithm)
+        assertNotNull(verifierAuthentication.keyId)
+        assertEquals(MobileWalletClientIdScheme.PRE_REGISTERED, verifierAuthentication.clientIdScheme)
 
         val result = client.submitPresentation(
             previewHandle = preview.previewHandle,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -11,6 +11,7 @@ import id.walt.mobile.test.backend.EudiTestBackend
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
 import id.walt.verifier.openid.models.authorization.AuthorizationRequest
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
+import id.walt.wallet2.handlers.WalletIssuanceMetadataProvenance
 import id.walt.wallet2.handlers.WalletIssuanceOutcome
 import id.walt.wallet2.mobile.MobileWallet
 import id.walt.wallet2.mobile.MobileWalletConfig
@@ -26,6 +27,7 @@ import id.walt.wallet2.mobile.MobileWalletPresentationPreviewResult
 import id.walt.wallet2.mobile.MobileWalletPresentationResult
 import id.walt.wallet2.mobile.MobileWalletResponseEncryption
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
+import id.walt.wallet2.mobile.MobileWalletVerifierMetadataProvenance
 import id.walt.x509.CertificateDer
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -132,6 +134,48 @@ class MobileWalletIntegrationTest {
     @Test
     fun receiveIsoMdlFromDemoIssuer2() = runBlocking {
         receiveCredentialFromDemoIssuer2("iso-mdl")
+    }
+
+    @Test
+    fun receiveAndPresentUsingSignedMetadataAgainstDemoIssuer2AndVerifier2() = runBlocking {
+        val scenario = demoPresentationScenario("eudi-pid-mdoc")
+        val client = MobileWalletFactory(context).create(
+            walletConfig("signed-${scenario.id}").copy(
+                credentialIssuerMetadataTrustResolver = DemoTestBackend.publicDemoIssuerMetadataTrustResolver,
+            ),
+        )
+        val bootstrap = client.bootstrap()
+        val offer = DemoTestBackend.createOffer(scenario)
+
+        val issuanceSession = client.startIssuance(
+            MobileWalletIssuanceRequest(offerUrl = offer.offerUrl),
+        )
+        val issuerProvenance = assertIs<WalletIssuanceMetadataProvenance.Signed>(
+            issuanceSession.offer.issuer.metadataProvenance,
+        )
+        assertTrue(issuerProvenance.compactJwt.isNotBlank())
+        assertTrue(issuerProvenance.algorithm.isNotBlank())
+        assertNotNull(issuerProvenance.keyId)
+
+        val credentialIds = client.continuePreAuthorizedIssuance(issuanceSession.id, offer.txCode).storedCredentialIds()
+        assertTrue(credentialIds.isNotEmpty(), "Should receive a credential from reviewed signed metadata")
+
+        val signedSession = DemoTestBackend.createVerifierSession(scenario, signedRequest = true)
+        val preview = client.previewPresentation(signedSession.authorizationRequestUri).requireReadyPreview()
+        val verifierProvenance = assertIs<MobileWalletVerifierMetadataProvenance.SignedRequest>(
+            preview.request.verifierMetadataProvenance,
+        )
+        assertTrue(verifierProvenance.compactRequestObject.isNotBlank())
+        assertTrue(verifierProvenance.algorithm.isNotBlank())
+        assertNotNull(verifierProvenance.keyId)
+
+        val result = client.submitPresentation(
+            previewHandle = preview.previewHandle,
+            selectedCredentialOptions = preview.credentialOptions.map { it.selection },
+            did = bootstrap.did,
+        )
+        assertIs<MobileWalletPresentationResult.Transmitted.Succeeded>(result)
+        DemoTestBackend.waitForVerifierSuccess(signedSession.sessionId)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -43,6 +43,16 @@ import id.waltid.openid4vci.wallet.attestation.HttpWalletAttestationProvider
 import id.waltid.openid4vp.wallet.WalletPresentFunctionality2
 import id.waltid.openid4vp.wallet.WalletPresentFunctionality2.WalletPresentResult
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.walt.openid4vp.clientidprefix.prefixes.ClientId
+import id.walt.openid4vp.clientidprefix.prefixes.DecentralizedIdentifier
+import id.walt.openid4vp.clientidprefix.prefixes.OpenIdFederation
+import id.walt.openid4vp.clientidprefix.prefixes.PreRegistered
+import id.walt.openid4vp.clientidprefix.prefixes.RedirectUri
+import id.walt.openid4vp.clientidprefix.prefixes.VerifierAttestation
+import id.walt.openid4vp.clientidprefix.prefixes.X509Hash
+import id.walt.openid4vp.clientidprefix.prefixes.X509SanDns
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vp.wallet.request.ResolvedAuthorizationRequest
 import id.waltid.openid4vp.wallet.response.ResponseEncryption
 import id.waltid.openid4vp.wallet.DcApiCredentialResponse
 import id.waltid.openid4vp.wallet.DcApiWallet
@@ -195,6 +205,7 @@ public class MobileWallet internal constructor(
     private val preferredLocales: List<String> = emptyList(),
     private val transactionDataProfiles: List<MobileWalletTransactionDataProfile> = emptyList(),
     private val clientIdTrustConfiguration: ClientIdTrustConfiguration = ClientIdTrustConfiguration(),
+    private val credentialIssuerMetadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     private val credentialRegistry: MobileWalletCredentialRegistry = UnavailableMobileWalletCredentialRegistry,
     private val readerTrustEvaluator: MobileWalletReaderTrustEvaluator = UnconfiguredMobileWalletReaderTrustEvaluator,
     private val onEvent: suspend (MobileWalletEvent) -> Unit = {},
@@ -237,6 +248,7 @@ public class MobileWallet internal constructor(
     private val issuanceSessions = WalletIssuanceSessionService(
         wallet = wallet,
         attestationAssembler = attestationAssembler,
+        metadataTrustResolver = credentialIssuerMetadataTrustResolver,
         onEvent = ::emitSessionEvent,
         sessionStore = issuanceSessionStore,
         httpClient = issuanceHttpClient,
@@ -708,7 +720,10 @@ public class MobileWallet internal constructor(
             is PreviewPresentationResult.Invalid ->
                 MobileWalletPresentationPreviewResult.Invalid(
                     previewHandle = MobileWalletPresentationPreviewHandle(result.handle.value),
-                    request = result.authorizationRequest.toMobileRequestContext(preferredLocales),
+                    request = result.authorizationRequest.toMobileRequestContext(
+                        preferredLocales = preferredLocales,
+                        resolvedAuthorizationRequest = result.resolvedAuthorizationRequest,
+                    ),
                     errorCode = result.error.code.toMobileErrorCode(),
                     message = result.error.message,
                 )
@@ -731,6 +746,7 @@ public class MobileWallet internal constructor(
                         previewHandle = MobileWalletPresentationPreviewHandle(result.handle.value),
                         request = result.authorizationRequest.toMobileRequestInfo(
                             preferredLocales = preferredLocales,
+                            resolvedAuthorizationRequest = result.resolvedAuthorizationRequest,
                             responseEncryption = result.responseEncryption,
                             transactionData = transactionData,
                         ),
@@ -1006,16 +1022,19 @@ internal fun WalletPresentResult.toMobilePresentationResult(): MobileWalletPrese
         }
     }
 
-private fun AuthorizationRequest.toMobileRequestInfo(
+internal fun AuthorizationRequest.toMobileRequestInfo(
     preferredLocales: List<String>,
+    resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
     responseEncryption: ResponseEncryption.Metadata? = null,
     transactionData: List<MobileWalletTransactionDataItem> = emptyList(),
 ): MobileWalletPresentationRequestInfo {
-    return MobileWalletPresentationRequestInfo(
-        clientId = requireNotNull(clientId) {
+    val verifiedClientId = requireNotNull(clientId) {
             "A validated presentation request must contain client_id."
-        },
+        }
+    return MobileWalletPresentationRequestInfo(
+        clientId = verifiedClientId,
         verifierMetadata = clientMetadata?.toMobileVerifierMetadata(preferredLocales),
+        requestAuthentication = resolvedAuthorizationRequest.toMobileRequestAuthentication(),
         responseUri = responseUri,
         state = state,
         nonce = requireNotNull(nonce) {
@@ -1042,19 +1061,46 @@ private fun AuthorizationRequest.toMobileDigitalCredentialRequestInfo(
         transactionData = transactionData,
     )
 
-private fun AuthorizationRequest.toMobileRequestContext(
+internal fun AuthorizationRequest.toMobileRequestContext(
     preferredLocales: List<String>,
-): MobileWalletPresentationRequestContext =
-    MobileWalletPresentationRequestContext(
-        clientId = requireNotNull(clientId) {
+    resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
+): MobileWalletPresentationRequestContext {
+    val verifiedClientId = requireNotNull(clientId) {
             "A reportable invalid presentation request must contain client_id."
-        },
+        }
+    return MobileWalletPresentationRequestContext(
+        clientId = verifiedClientId,
         verifierMetadata = clientMetadata?.toMobileVerifierMetadata(preferredLocales),
+        requestAuthentication = resolvedAuthorizationRequest.toMobileRequestAuthentication(),
         responseUri = responseUri,
         state = state,
         nonce = nonce,
         responseEncryption = null.toMobileResponseEncryption(),
     )
+}
+
+internal fun ResolvedAuthorizationRequest.toMobileRequestAuthentication(): MobileWalletRequestAuthentication =
+    when (this) {
+        is ResolvedAuthorizationRequest.Plain -> MobileWalletRequestAuthentication.Unauthenticated
+        is ResolvedAuthorizationRequest.UnsignedRequestObject -> MobileWalletRequestAuthentication.Unauthenticated
+        is ResolvedAuthorizationRequest.AuthenticatedRequestObject -> MobileWalletRequestAuthentication.Authenticated(
+            compactRequestObject = requestObject,
+            algorithm = authentication.algorithm,
+            keyId = authentication.keyId,
+            clientIdScheme = authentication.clientId.toMobileClientIdScheme(),
+        )
+    }
+
+private fun ClientId.toMobileClientIdScheme(): MobileWalletClientIdScheme = when (this) {
+    is PreRegistered -> MobileWalletClientIdScheme.PRE_REGISTERED
+    is RedirectUri -> MobileWalletClientIdScheme.REDIRECT_URI
+    is X509SanDns -> MobileWalletClientIdScheme.X509_SAN_DNS
+    is X509Hash -> MobileWalletClientIdScheme.X509_HASH
+    is DecentralizedIdentifier -> MobileWalletClientIdScheme.DECENTRALIZED_IDENTIFIER
+    is VerifierAttestation -> MobileWalletClientIdScheme.VERIFIER_ATTESTATION
+    is OpenIdFederation -> MobileWalletClientIdScheme.OPENID_FEDERATION
+    else -> error("Unsupported authenticated client identifier type: ${this::class.simpleName}")
+}
 
 private fun WalletPresentFunctionality2.OID4VPErrorCode.toMobileErrorCode(): MobileWalletPresentationErrorCode = when (this) {
     WalletPresentFunctionality2.OID4VPErrorCode.ACCESS_DENIED -> MobileWalletPresentationErrorCode.accessDenied

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletFactory.kt
@@ -18,6 +18,7 @@ import id.walt.wallet2.persistence.stores.SqlDelightDidStore
 import id.walt.wallet2.persistence.stores.SqlDelightIssuanceSessionStore
 import id.walt.verifier.openid.transactiondata.TransactionDataTypeRegistry
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.uuid.Uuid
 
@@ -32,6 +33,7 @@ import kotlin.uuid.Uuid
  * @property preferredLocales Ordered BCP 47 locale preferences used for progressive language-tag lookup.
  * When no preference matches, selection falls back to an unlocalized entry and then the first entry.
  * @property transactionDataProfiles Transaction data profiles this mobile wallet accepts in OpenID4VP requests.
+ * @property credentialIssuerMetadataTrustResolver Optional trust boundary for signed Credential Issuer Metadata.
  * @property credentialRegistry Platform metadata registry. Platform factories install their native default when omitted.
  * @property readerTrustEvaluator Application trust policy for verified ISO 18013-7 reader chains.
  * @property crossProcessAccess Optional shared-container/keychain configuration for provider extensions.
@@ -46,6 +48,7 @@ public data class MobileWalletConfig(
     public val onEvent: suspend (MobileWalletEvent) -> Unit = {},
     public val preferredLocales: List<String> = emptyList(),
     public val transactionDataProfiles: List<MobileWalletTransactionDataProfile> = emptyList(),
+    public val credentialIssuerMetadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     public val credentialRegistry: MobileWalletCredentialRegistry = UnavailableMobileWalletCredentialRegistry,
     public val readerTrustEvaluator: MobileWalletReaderTrustEvaluator = UnconfiguredMobileWalletReaderTrustEvaluator,
     public val crossProcessAccess: MobileWalletCrossProcessAccess? = null,
@@ -207,6 +210,7 @@ internal fun createSqlDelightMobileWallet(
         preferredLocales = config.preferredLocales,
         transactionDataProfiles = config.transactionDataProfiles,
         clientIdTrustConfiguration = clientIdTrustConfiguration,
+        credentialIssuerMetadataTrustResolver = config.credentialIssuerMetadataTrustResolver,
         onEvent = config.onEvent,
         credentialRegistry = config.credentialRegistry,
         onDigitalCredentialRegistryChanged = config.onDigitalCredentialRegistryChanged,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletPresentationModels.kt
@@ -59,6 +59,7 @@ public data class MobileWalletPresentationPreviewHandle(val value: String) {
  *
  * @property clientId Required OpenID4VP `client_id` value identifying the verifier.
  * @property verifierMetadata Typed verifier metadata supplied by the OpenID4VP client, when available.
+ * @property requestAuthentication Authentication established for the Authorization Request or its Request Object.
  * @property responseUri Verifier response URI to which the wallet would submit the presentation or error, when provided.
  * @property state OpenID4VP state value supplied by the verifier, when provided.
  * @property nonce OpenID4VP nonce value supplied by the verifier, when provided. May be null if the missing nonce is the validation error.
@@ -67,6 +68,7 @@ public data class MobileWalletPresentationPreviewHandle(val value: String) {
 public data class MobileWalletPresentationRequestContext(
     val clientId: String,
     val verifierMetadata: MobileWalletVerifierMetadata?,
+    val requestAuthentication: MobileWalletRequestAuthentication,
     val responseUri: String?,
     val state: String?,
     val nonce: String?,
@@ -110,6 +112,7 @@ public data class MobileWalletPresentationCredentialRequirement(
  * Credentials API previews use [MobileWalletDigitalCredentialRequestInfo] instead because
  * unsigned requests intentionally have no trusted request-supplied `client_id`.
  * @property verifierMetadata Typed verifier metadata supplied by the OpenID4VP client, when available.
+ * @property requestAuthentication Authentication established for the Authorization Request or its Request Object.
  * @property responseUri Verifier response URI to which the wallet will submit the presentation, when provided.
  * @property state OpenID4VP state value supplied by the verifier, when provided.
  * @property nonce Required OpenID4VP nonce value supplied by the verifier.
@@ -119,6 +122,7 @@ public data class MobileWalletPresentationCredentialRequirement(
 public data class MobileWalletPresentationRequestInfo(
     val clientId: String,
     val verifierMetadata: MobileWalletVerifierMetadata?,
+    val requestAuthentication: MobileWalletRequestAuthentication,
     val responseUri: String?,
     val state: String?,
     val nonce: String,
@@ -129,6 +133,42 @@ public data class MobileWalletPresentationRequestInfo(
         require(clientId.isNotBlank()) { "A presentation request client ID must not be blank." }
         require(nonce.isNotBlank()) { "A presentation request nonce must not be blank." }
     }
+}
+
+/** Authentication established for an OpenID4VP Authorization Request or Request Object. */
+public sealed interface MobileWalletRequestAuthentication {
+    /** The request was not authenticated by a signed Request Object. */
+    public data object Unauthenticated : MobileWalletRequestAuthentication
+
+    /** The Request Object was authenticated by the OpenID4VP client-ID layer. */
+    public data class Authenticated(
+        /** Exact compact Request Object received from the verifier. */
+        public val compactRequestObject: String,
+        /** JWS algorithm established by request authentication. */
+        public val algorithm: String,
+        /** Request-object signing key identifier, when supplied. */
+        public val keyId: String?,
+        /** Client identifier scheme established by the authentication layer. */
+        public val clientIdScheme: MobileWalletClientIdScheme,
+    ) : MobileWalletRequestAuthentication
+}
+
+/** Client identifier scheme established while authenticating an OpenID4VP request. */
+public enum class MobileWalletClientIdScheme {
+    /** The verifier is identified through pre-registered metadata. */
+    PRE_REGISTERED,
+    /** The verifier is identified by a redirect URI. */
+    REDIRECT_URI,
+    /** The verifier is identified by an X.509 SAN DNS name. */
+    X509_SAN_DNS,
+    /** The verifier is identified by an X.509 certificate hash. */
+    X509_HASH,
+    /** The verifier is identified by a decentralized identifier. */
+    DECENTRALIZED_IDENTIFIER,
+    /** The verifier is identified by a verifier attestation. */
+    VERIFIER_ATTESTATION,
+    /** The verifier is identified through OpenID Federation. */
+    OPENID_FEDERATION,
 }
 
 /**

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletTest.kt
@@ -77,6 +77,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLBuilder
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.http.Url
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -134,7 +135,16 @@ class MobileWalletTest {
     @Test
     fun mobileWalletConfigUsesStableDefaults() {
         val config = MobileWalletConfig()
-        val (walletId, defaultKeyType, attestationConfig, persistence, onEvent, preferredLocales, transactionDataProfiles) = config
+        val (
+            walletId,
+            defaultKeyType,
+            attestationConfig,
+            persistence,
+            onEvent,
+            preferredLocales,
+            transactionDataProfiles,
+            credentialIssuerMetadataTrustResolver,
+        ) = config
 
         assertEquals("default", walletId)
         assertEquals(MobileWalletKeyType.secp256r1, defaultKeyType)
@@ -142,6 +152,7 @@ class MobileWalletTest {
         assertEquals(MobileWalletPersistence(), persistence)
         assertEquals(emptyList(), preferredLocales)
         assertEquals(emptyList(), transactionDataProfiles)
+        assertEquals(null, credentialIssuerMetadataTrustResolver)
         assertSame(config.onEvent, onEvent)
         assertIs<MobileWalletDatabaseKey.Managed>(config.persistence.databaseKey)
         assertEquals(null, config.persistence.credentialStore)
@@ -175,7 +186,14 @@ class MobileWalletTest {
             ClientIdTrustConfiguration(
                 preRegisteredClients = mapOf(
                     "verifier2" to ClientMetadata(
-                        jwks = ClientMetadata.Jwks(listOf(verifierKey.getPublicKey().exportJWKObject())),
+                        jwks = ClientMetadata.Jwks(
+                            listOf(
+                                JsonObject(
+                                    verifierKey.getPublicKey().exportJWKObject() +
+                                        ("kid" to JsonPrimitive(verifierKey.getKeyId())),
+                                ),
+                            ),
+                        ),
                     )
                 ),
             )
@@ -187,6 +205,13 @@ class MobileWalletTest {
 
         assertEquals("verifier2", preview.request.clientId)
         assertEquals(MobileWalletPresentationErrorCode.invalidRequest, preview.errorCode)
+        val authentication = assertIs<MobileWalletRequestAuthentication.Authenticated>(
+            preview.request.requestAuthentication,
+        )
+        assertEquals(Url(requestUrl).parameters["request"], authentication.compactRequestObject)
+        assertEquals("EdDSA", authentication.algorithm)
+        assertEquals(verifierKey.getKeyId(), authentication.keyId)
+        assertEquals(MobileWalletClientIdScheme.PRE_REGISTERED, authentication.clientIdScheme)
     }
 
     @Test
@@ -380,6 +405,7 @@ class MobileWalletTest {
             MobileWalletPresentationRequestContext(
                 clientId = " ",
                 verifierMetadata = null,
+                requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
                 responseUri = null,
                 state = null,
                 nonce = null,
@@ -390,6 +416,7 @@ class MobileWalletTest {
         val context = MobileWalletPresentationRequestContext(
             clientId = "https://verifier.example",
             verifierMetadata = null,
+            requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
             responseUri = null,
             state = null,
             nonce = null,
@@ -540,6 +567,7 @@ class MobileWalletTest {
                     policyUri = null,
                     termsOfServiceUri = null,
                 ),
+                requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
                 responseUri = "https://verifier.example/direct-post",
                 state = "state-1",
                 nonce = "nonce-1",
@@ -1662,6 +1690,7 @@ class MobileWalletTest {
             policyUri = null,
             termsOfServiceUri = null,
         ),
+        requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
         responseUri = "https://verifier.example/direct-post",
         state = null,
         nonce = nonce,
@@ -1712,7 +1741,10 @@ class MobileWalletTest {
                 put("response_uri", "https://verifier.example/direct-post")
                 put("dcql_query", buildJsonObject { put("credentials", buildJsonArray {}) })
             }.toString().encodeToByteArray(),
-            mapOf("typ" to JsonPrimitive("oauth-authz-req+jwt")),
+            mapOf(
+                "typ" to JsonPrimitive("oauth-authz-req+jwt"),
+                "kid" to JsonPrimitive(verifierKey.getKeyId()),
+            ),
         )
         return URLBuilder("openid4vp://authorize").apply {
             parameters.append("client_id", "verifier2")

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
 package id.walt.wallet2.mobile.swiftinterop
 
 import id.walt.credentials.CredentialParser
@@ -16,6 +18,9 @@ import id.walt.wallet2.mobile.MobileWalletKeyType
 import id.walt.wallet2.mobile.MobileWalletPersistence
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
 import id.walt.wallet2.mobile.WalletAttestationConfig
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKey
 import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKeyProvider
 import id.walt.wallet2.persistence.encryption.WalletPersistenceException
@@ -38,6 +43,7 @@ import kotlin.time.Instant
  * @property databaseKeyProvider Swift-owned database key provider used when [persistence] uses
  * [WalletBridgeDatabaseKeyConfiguration.Provided].
  * @property attestation Optional client-attestation configuration for issuers that require it.
+ * @property issuerMetadataTrustResolver Optional Swift-owned verifier for signed Credential Issuer Metadata.
  * @property preferredLocales Ordered BCP 47 locale preferences used to select display metadata.
  * @property transactionDataProfiles Transaction data profiles this wallet accepts.
  * @property clientIdTrustConfiguration Trust anchors used to authenticate verifier Request Objects.
@@ -50,6 +56,7 @@ public data class WalletBridgeConfiguration(
     public val persistence: WalletBridgePersistence = WalletBridgePersistence(),
     public val databaseKeyProvider: WalletBridgeDatabaseEncryptionKeyProvider? = null,
     public val attestation: WalletAttestationConfig? = null,
+    public val issuerMetadataTrustResolver: WalletBridgeIssuerMetadataTrustResolver? = null,
     public val preferredLocales: List<String> = emptyList(),
     public val transactionDataProfiles: List<MobileWalletTransactionDataProfile> = emptyList(),
     public val clientIdTrustConfiguration: WalletBridgeClientIdTrustConfiguration = WalletBridgeClientIdTrustConfiguration(),
@@ -79,6 +86,11 @@ internal fun WalletBridgeConfiguration.toMobileWalletConfig(): MobileWalletConfi
         walletId = walletId,
         defaultKeyType = defaultKeyType,
         attestationConfig = attestation,
+        credentialIssuerMetadataTrustResolver = issuerMetadataTrustResolver?.let { bridgeResolver ->
+            CredentialIssuerMetadataTrustResolver { compactJwt, expectedCredentialIssuer ->
+                bridgeResolver.verify(compactJwt, expectedCredentialIssuer).toMetadataSigner()
+            }
+        },
         persistence = persistence.toMobileWalletPersistence(databaseKeyProvider),
         preferredLocales = preferredLocales,
         transactionDataProfiles = transactionDataProfiles,
@@ -90,6 +102,51 @@ internal fun WalletBridgeConfiguration.toMobileWalletConfig(): MobileWalletConfi
         },
     )
 }
+
+/** Trusted signer details returned after Swift verifies signed Credential Issuer Metadata. */
+public data class WalletBridgeIssuerMetadataSigner(
+    /** Identifier of the trusted verification key, as reported by the trust resolver. */
+    public val keyId: String?,
+    /** JWS algorithm verified by the trust resolver. */
+    public val algorithm: String,
+    /** Authority category established by the trust resolver. */
+    public val trustType: WalletBridgeIssuerMetadataSignerTrustType,
+)
+
+/** Authority category assigned by Swift after it verifies the signed metadata JWS. */
+public enum class WalletBridgeIssuerMetadataSignerTrustType {
+    /** The signer is the trusted credential issuer. */
+    TrustedIssuer,
+    /** The signer is a trusted delegate of the credential issuer. */
+    TrustedDelegate,
+}
+
+/**
+ * Swift-facing trust boundary for signed Credential Issuer Metadata.
+ *
+ * Implementations must verify the JWS and establish that its signer is authorized for the requested issuer.
+ * Returning normally authorizes the metadata for wallet use.
+ */
+public interface WalletBridgeIssuerMetadataTrustResolver {
+    /**
+     * @param compactJwt Compact JWS returned by the Credential Issuer Metadata endpoint.
+     * @param expectedCredentialIssuer Credential issuer for which signer authority must be established.
+     * @return Trusted signer details used to retain metadata provenance.
+     */
+    public suspend fun verify(
+        compactJwt: String,
+        expectedCredentialIssuer: String,
+    ): WalletBridgeIssuerMetadataSigner
+}
+
+private fun WalletBridgeIssuerMetadataSigner.toMetadataSigner(): MetadataSigner = MetadataSigner(
+    keyId = keyId,
+    algorithm = algorithm,
+    trustType = when (trustType) {
+        WalletBridgeIssuerMetadataSignerTrustType.TrustedIssuer -> MetadataSignerTrustType.TRUSTED_ISSUER
+        WalletBridgeIssuerMetadataSignerTrustType.TrustedDelegate -> MetadataSignerTrustType.TRUSTED_DELEGATE
+    },
+)
 
 /**
  * Persistence configuration exposed to the Swift wallet bridge.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -6,6 +6,7 @@ import id.walt.credentials.CredentialParser
 import id.walt.credentials.formats.DigitalCredential
 import id.walt.credentials.signatures.sdjwt.SelectivelyDisclosableVerifiableCredential
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.walt.verifier.openid.models.authorization.ClientMetadata
 import id.walt.wallet2.data.StoredCredential
 import id.walt.wallet2.data.WalletCredentialStore
 import id.walt.wallet2.data.WalletDidEntry
@@ -68,14 +69,21 @@ public data class WalletBridgeConfiguration(
  * Verifier Request Object trust configuration exposed to the Swift wallet bridge.
  *
  * @property x509TrustAnchorsPem PEM-encoded trust anchors pinned by the hosting application.
+ * @property preRegisteredClientMetadataJson Explicit pre-registered client metadata, keyed by client ID.
  */
 public data class WalletBridgeClientIdTrustConfiguration(
     public val x509TrustAnchorsPem: List<String> = emptyList(),
+    public val preRegisteredClientMetadataJson: Map<String, String> = emptyMap(),
 )
 
 internal fun WalletBridgeClientIdTrustConfiguration.toClientIdTrustConfiguration(): ClientIdTrustConfiguration =
     ClientIdTrustConfiguration(
         x509TrustAnchors = x509TrustAnchorsPem.map(CertificateDer::fromPEMEncodedString),
+        preRegisteredClients = preRegisteredClientMetadataJson.mapValues { (clientId, metadataJson) ->
+            ClientMetadata.fromJson(metadataJson).getOrElse { cause ->
+                throw IllegalArgumentException("Malformed pre-registered client metadata for '$clientId'", cause)
+            }
+        },
     )
 
 internal fun WalletBridgeConfiguration.toMobileWalletConfig(): MobileWalletConfig {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -12,6 +12,7 @@ import id.walt.wallet2.mobile.MobileWalletKeyType
 import id.walt.wallet2.mobile.MobileWalletIssuanceRequest
 import id.walt.wallet2.mobile.MobileWalletBootstrapResult
 import id.walt.wallet2.mobile.MobileWalletConfig
+import id.walt.wallet2.mobile.MobileWalletClientIdScheme
 import id.walt.wallet2.mobile.MobileWalletCredential
 import id.walt.wallet2.mobile.MobileWalletMetadataDisplay
 import id.walt.wallet2.mobile.MobileWalletDatabaseKey
@@ -185,6 +186,34 @@ class WalletSdkBridgeTest {
         assertEquals(true, preview.credentialOptions.single().multiple)
         assertEquals(listOf(listOf("pid")), preview.credentialRequirements.single().options)
         assertEquals("openid4vp://request", operations.previewRequestUrl)
+    }
+
+    @Test
+    fun bridgePresentationPreviewPreservesAuthenticatedRequestFacts() = runTest {
+        val operations = FakeWalletSdkBridgeOperations(
+            requestAuthentication = MobileWalletRequestAuthentication.Authenticated(
+                compactRequestObject = "signed-request-object",
+                algorithm = "ES256",
+                keyId = "verifier-kid",
+                clientIdScheme = MobileWalletClientIdScheme.PRE_REGISTERED,
+            ),
+        )
+        val bridge = WalletSdkBridge.forOperations(operations)
+
+        val result = bridge.previewPresentation("openid4vp://request")
+
+        val preview = assertIs<MobileWalletPresentationPreviewResult.Ready>(
+            assertIs<WalletBridgeResult.Success<MobileWalletPresentationPreviewResult>>(result).value,
+        ).preview
+        assertEquals(
+            MobileWalletRequestAuthentication.Authenticated(
+                compactRequestObject = "signed-request-object",
+                algorithm = "ES256",
+                keyId = "verifier-kid",
+                clientIdScheme = MobileWalletClientIdScheme.PRE_REGISTERED,
+            ),
+            preview.request.requestAuthentication,
+        )
     }
 
     @Test
@@ -566,6 +595,8 @@ class WalletSdkBridgeTest {
 
     private class FakeWalletSdkBridgeOperations(
         private val previewResult: MobileWalletPresentationPreviewResult? = null,
+        private val requestAuthentication: MobileWalletRequestAuthentication =
+            MobileWalletRequestAuthentication.Unauthenticated,
     ) : WalletSdkBridgeOperations {
         var bootstrapKeyType: MobileWalletKeyType? = null
             private set
@@ -683,7 +714,7 @@ class WalletSdkBridgeTest {
                         policyUri = null,
                         termsOfServiceUri = null,
                     ),
-                    requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
+                    requestAuthentication = requestAuthentication,
                     responseUri = "https://verifier.example/direct-post",
                     state = "state-1",
                     nonce = "nonce-1",

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -36,6 +36,8 @@ import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKey
 import id.walt.wallet2.handlers.WalletIssuanceOutcome
 import id.walt.wallet2.handlers.WalletIssuanceAuthorization
 import id.walt.wallet2.mobile.WalletAttestationConfig
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.walt.x509.CertificateDer
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
@@ -214,6 +216,40 @@ class WalletSdkBridgeTest {
             ),
             preview.request.requestAuthentication,
         )
+    }
+
+    @Test
+    fun bridgeIssuerMetadataTrustResolverPreservesSignerFacts() = runTest {
+        listOf(
+            WalletBridgeIssuerMetadataSignerTrustType.TrustedIssuer to MetadataSignerTrustType.TRUSTED_ISSUER,
+            WalletBridgeIssuerMetadataSignerTrustType.TrustedDelegate to MetadataSignerTrustType.TRUSTED_DELEGATE,
+        ).forEach { (bridgeTrustType, expectedTrustType) ->
+            val configured = WalletBridgeConfiguration(
+                issuerMetadataTrustResolver = object : WalletBridgeIssuerMetadataTrustResolver {
+                    override suspend fun verify(
+                        compactJwt: String,
+                        expectedCredentialIssuer: String,
+                    ) = WalletBridgeIssuerMetadataSigner(
+                        keyId = "issuer-key",
+                        algorithm = "ES256",
+                        trustType = bridgeTrustType,
+                    ).also {
+                        assertEquals("signed-metadata-jwt", compactJwt)
+                        assertEquals("https://issuer.example", expectedCredentialIssuer)
+                    }
+                },
+            ).toMobileWalletConfig()
+
+            val signer = requireNotNull(configured.credentialIssuerMetadataTrustResolver).verify(
+                "signed-metadata-jwt",
+                "https://issuer.example",
+            )
+
+            assertEquals(
+                MetadataSigner("issuer-key", "ES256", expectedTrustType),
+                signer,
+            )
+        }
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
@@ -341,6 +342,7 @@ class WalletSdkBridgeTest {
     }
 
     @Test
+    @OptIn(ExperimentalSerializationApi::class)
     fun factoryMapsSwiftFriendlyConfigurationToMobileWalletConfig() = runTest {
         var capturedConfig: MobileWalletConfig? = null
         var capturedTrustConfiguration: ClientIdTrustConfiguration? = null
@@ -366,6 +368,9 @@ class WalletSdkBridgeTest {
                 ),
                 clientIdTrustConfiguration = WalletBridgeClientIdTrustConfiguration(
                     x509TrustAnchorsPem = listOf(trustAnchor),
+                    preRegisteredClientMetadataJson = mapOf(
+                        "demo-verifier" to """{"jwks":{"keys":[{"kty":"EC","crv":"P-256","x":"x","y":"y"}]}}""",
+                    ),
                 ),
                 preferredLocales = listOf("de-AT", "en"),
                 transactionDataProfiles = listOf(
@@ -390,6 +395,7 @@ class WalletSdkBridgeTest {
         assertEquals("token", capturedConfig?.attestationConfig?.bearerToken)
         assertEquals("attestation.example", capturedConfig?.attestationConfig?.hostHeader)
         assertEquals(listOf(CertificateDer(byteArrayOf(1, 2, 3))), capturedTrustConfiguration?.x509TrustAnchors)
+        assertEquals(setOf("demo-verifier"), capturedTrustConfiguration?.preRegisteredClients?.keys)
         assertEquals(listOf("de-AT", "en"), capturedConfig?.preferredLocales)
         assertEquals(
             listOf(

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeTest.kt
@@ -30,6 +30,7 @@ import id.walt.wallet2.mobile.MobileWalletResponseEncryption
 import id.walt.wallet2.mobile.MobileWalletPersistence
 import id.walt.wallet2.mobile.MobileWalletTransactionDataProfile
 import id.walt.wallet2.mobile.MobileWalletVerifierMetadata
+import id.walt.wallet2.mobile.MobileWalletRequestAuthentication
 import id.walt.wallet2.persistence.encryption.DatabaseEncryptionKey
 import id.walt.wallet2.handlers.WalletIssuanceOutcome
 import id.walt.wallet2.handlers.WalletIssuanceAuthorization
@@ -203,6 +204,7 @@ class WalletSdkBridgeTest {
                     policyUri = null,
                     termsOfServiceUri = null,
                 ),
+                requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
                 responseUri = "https://verifier.example/direct-post",
                 state = "state-1",
                 nonce = null,
@@ -681,6 +683,7 @@ class WalletSdkBridgeTest {
                         policyUri = null,
                         termsOfServiceUri = null,
                     ),
+                    requestAuthentication = MobileWalletRequestAuthentication.Unauthenticated,
                     responseUri = "https://verifier.example/direct-post",
                     state = "state-1",
                     nonce = "nonce-1",

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/models/ResolveOfferDetailedResponse.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/models/ResolveOfferDetailedResponse.kt
@@ -97,8 +97,8 @@ fun WalletOfferResolution.toDetailedResponse(
     tokenEndpoint = summary.tokenEndpoint,
     nonceEndpoint = summary.nonceEndpoint,
     issuer = OfferIssuerMetadata(
-        credentialIssuer = issuerMetadata.credentialIssuer,
-        display = issuerMetadata.display.selectPreferredByLocale(preferredLocales) { it.locale }?.toOfferDisplay(),
+        credentialIssuer = resolvedIssuerMetadata.metadata.credentialIssuer,
+        display = resolvedIssuerMetadata.metadata.display.selectPreferredByLocale(preferredLocales) { it.locale }?.toOfferDisplay(),
     ),
     offeredCredentials = offeredCredentials.map { offered ->
         val configuration = offered.configuration

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -35,6 +35,7 @@ import id.walt.webdatafetching.WebDataFetcherId
 import id.waltid.openid4vci.wallet.attestation.ClientAttestationAssembler
 import id.waltid.openid4vci.wallet.attestation.ClientAttestationHeaders
 import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
 import id.waltid.openid4vci.wallet.metadata.OfferedCredentialResolver
 import id.waltid.openid4vci.wallet.nonce.NonceRequestBuilder
 import id.waltid.openid4vci.wallet.oauth.ClientConfiguration
@@ -532,6 +533,7 @@ object WalletIssuanceHandler {
         /** Called with the exact response batch size before any credential of that batch is persisted. */
         beforeCredentialsStored: suspend (Int) -> Unit = {},
         onCredentialStored: suspend (StoredCredential) -> Unit = {},
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): Flow<StoredCredential> = receiveCredentialFlowInternal(
         wallet = wallet,
         request = request,
@@ -542,6 +544,7 @@ object WalletIssuanceHandler {
         onDeferredTransactionId = onDeferredTransactionId,
         beforeCredentialsStored = beforeCredentialsStored,
         onCredentialStored = onCredentialStored,
+        metadataTrustResolver = metadataTrustResolver,
     )
 
     /**
@@ -588,6 +591,7 @@ object WalletIssuanceHandler {
         onDeferredTransactionId: suspend (credentialConfigurationId: String, transactionId: String) -> Unit,
         beforeCredentialsStored: suspend (Int) -> Unit,
         onCredentialStored: suspend (StoredCredential) -> Unit,
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver?,
     ): Flow<StoredCredential> = channelFlow {
         val keyMaterial = request.key?.key?.let { WalletKeyStoreEntry(it.getKeyId(), it, null) }
             ?: wallet.resolveKeyMaterial(request.keyId, setOf(KeyUsage.SIGN))
@@ -607,6 +611,7 @@ object WalletIssuanceHandler {
         val effectiveResolvedOffer = resolvedOffer ?: resolveIssuanceOffer(
             request.toResolveOfferRequest(),
             httpClient,
+            metadataTrustResolver,
         )
 
         // 2. Reuse issuer metadata and offered configurations from that resolution.
@@ -737,6 +742,7 @@ object WalletIssuanceHandler {
         /** Called with the exact response batch size before any credential of that batch is persisted. */
         beforeCredentialsStored: suspend (Int) -> Unit = {},
         onCredentialStored: suspend (StoredCredential) -> Unit = {},
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): ReceiveCredentialResult {
         val ids = mutableListOf<String>()
         val deferredIds = mutableMapOf<String, String>()
@@ -749,6 +755,7 @@ object WalletIssuanceHandler {
             onDeferredTransactionId = { configId, txId -> deferredIds[configId] = txId },
             beforeCredentialsStored = beforeCredentialsStored,
             onCredentialStored = onCredentialStored,
+            metadataTrustResolver = metadataTrustResolver,
         ).collect { ids += it.id }
         return ReceiveCredentialResult(credentialIds = ids, deferredTransactionIds = deferredIds)
     }
@@ -794,8 +801,9 @@ object WalletIssuanceHandler {
         wallet: Wallet,
         request: ResolveOfferRequest,
         httpClient: HttpClient = WalletIssuanceHandler.httpClient,
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): WalletOfferPreviewResult {
-        val resolvedOffer = resolveIssuanceOffer(request, httpClient)
+        val resolvedOffer = resolveIssuanceOffer(request, httpClient, metadataTrustResolver)
         val previewHandle = IssuancePreviewHandle(
             previewedOffers.create(walletId = wallet.id, value = resolvedOffer)
         )
@@ -820,10 +828,11 @@ object WalletIssuanceHandler {
     private suspend fun resolveIssuanceOffer(
         request: ResolveOfferRequest,
         httpClient: HttpClient = WalletIssuanceHandler.httpClient,
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): ResolvedIssuanceOffer {
         val offer = resolveOffer(request, httpClient)
-        val metadataResolver = IssuerMetadataResolver(httpClient)
-        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val metadataResolver = IssuerMetadataResolver(httpClient, metadataTrustResolver)
+        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(offer.credentialIssuer).metadata
         val asMetadata = metadataResolver.resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
         val offeredCredentials = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata)
         return ResolvedIssuanceOffer(
@@ -916,7 +925,7 @@ object WalletIssuanceHandler {
         val credentialIssuer = request.credentialIssuer?.takeIf { it.isNotBlank() }
         val asMetadata = credentialIssuer?.let {
             val metadataResolver = IssuerMetadataResolver(httpClient)
-            val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(it)
+            val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(it).metadata
             metadataResolver.resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
         }
         val attestationHeaders = asMetadata?.let {
@@ -973,7 +982,7 @@ object WalletIssuanceHandler {
         httpClient: HttpClient = WalletIssuanceHandler.httpClient,
     ): RequestNonceResult {
         val issuerMetadata = IssuerMetadataResolver(httpClient)
-            .resolveCredentialIssuerMetadata(request.credentialIssuer.toString())
+            .resolveCredentialIssuerMetadata(request.credentialIssuer.toString()).metadata
         return RequestNonceResult(
             nonce = requestProofNonce(
                 httpClient = httpClient,
@@ -991,7 +1000,7 @@ object WalletIssuanceHandler {
             ?: wallet.resolveKeyMaterial(request.keyId, setOf(KeyUsage.SIGN))
             ?: error("No key available for signing proof")
         val issuerMetadata = IssuerMetadataResolver(httpClient)
-            .resolveCredentialIssuerMetadata(request.issuerUrl.toString())
+            .resolveCredentialIssuerMetadata(request.issuerUrl.toString()).metadata
         val configuration = issuerMetadata.credentialConfigurationsSupported[request.credentialConfigurationId]
             ?: error(
                 "Unknown credential configuration '${request.credentialConfigurationId}' " +
@@ -1236,7 +1245,7 @@ object WalletIssuanceHandler {
     ): CredentialStorageContext {
         val resolvedIssuerMetadata = issuerMetadata
             ?: credentialIssuerBaseUrl?.let {
-                IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(it)
+                IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(it).metadata
             }
         return CredentialStorageContext(
             label = labelOverride
@@ -1280,7 +1289,7 @@ object WalletIssuanceHandler {
         httpClient: HttpClient,
     ): AuthorizationServerMetadata {
         val metadataResolver = IssuerMetadataResolver(httpClient)
-        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(credentialIssuerBaseUrl)
+        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(credentialIssuerBaseUrl).metadata
         return metadataResolver.resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
     }
 
@@ -1346,7 +1355,7 @@ object WalletIssuanceHandler {
     suspend fun generateAuthorizationUrl(request: GenerateAuthorizationUrlRequest): GenerateAuthorizationUrlResult {
         val httpClient = defaultHttpClient()
         val offer = resolveOffer(request, httpClient)
-        val issuerMetadata = IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val issuerMetadata = IssuerMetadataResolver(httpClient).resolveCredentialIssuerMetadata(offer.credentialIssuer).metadata
         val asMetadata =
             IssuerMetadataResolver(httpClient).resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
 
@@ -1586,7 +1595,7 @@ object WalletIssuanceHandler {
 
         // Resolve issuer metadata again at continuation time and use only its advertised nonce endpoint.
         val issuerMetadata = IssuerMetadataResolver(httpClient)
-            .resolveCredentialIssuerMetadata(credentialIssuerBaseUrl)
+            .resolveCredentialIssuerMetadata(credentialIssuerBaseUrl).metadata
         nonceEndpoint?.let { expected ->
             require(expected == issuerMetadata.nonceEndpoint) {
                 "Provided nonce endpoint does not match credential issuer metadata"

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -582,6 +582,7 @@ object WalletIssuanceHandler {
                 onDeferredTransactionId = onDeferredTransactionId,
                 beforeCredentialsStored = beforeCredentialsStored,
                 onCredentialStored = onCredentialStored,
+                metadataTrustResolver = null,
             ).collect(::send)
         }
     }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -37,6 +37,7 @@ import id.waltid.openid4vci.wallet.attestation.ClientAttestationHeaders
 import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
 import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
 import id.waltid.openid4vci.wallet.metadata.OfferedCredentialResolver
+import id.waltid.openid4vci.wallet.metadata.ResolvedCredentialIssuerMetadata
 import id.waltid.openid4vci.wallet.nonce.NonceRequestBuilder
 import id.waltid.openid4vci.wallet.oauth.ClientConfiguration
 import id.waltid.openid4vci.wallet.offer.CredentialOfferParser
@@ -241,13 +242,14 @@ data class IssuancePreview(
  * consumers can project them into platform-safe API models without parsing raw JSON or refetching.
  *
  * @property previewHandle Opaque handle required to act on this retained preview.
- * @property issuerMetadata Credential issuer metadata used by the retained issuance snapshot.
- * @property offeredCredentials Offered credential configurations resolved against [issuerMetadata].
+ * @property resolvedIssuerMetadata Canonical issuer-metadata resolution retained for this preview.
+ * @property offeredCredentials Offered credential configurations resolved against
+ * [resolvedIssuerMetadata].metadata.
  * @property transactionCode Canonical OpenID4VCI transaction-code metadata, when required.
  */
 data class WalletOfferPreviewResult(
     val previewHandle: IssuancePreviewHandle,
-    val issuerMetadata: CredentialIssuerMetadata,
+    val resolvedIssuerMetadata: ResolvedCredentialIssuerMetadata,
     val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
     val transactionCode: TxCode?,
 )
@@ -263,13 +265,14 @@ data class WalletOfferPreviewResult(
  * stateless "resolve for display" endpoints where issuance is completed by re-sending the offer.
  *
  * @property summary App-facing offer summary (identical to [resolveOffer]'s result).
- * @property issuerMetadata Resolved credential issuer metadata.
- * @property offeredCredentials Offered credential configurations resolved against [issuerMetadata].
+ * @property resolvedIssuerMetadata Canonical issuer-metadata resolution returned with this result.
+ * @property offeredCredentials Offered credential configurations resolved against
+ * [resolvedIssuerMetadata].metadata.
  * @property transactionCode Canonical OpenID4VCI transaction-code metadata, when required.
  */
 data class WalletOfferResolution(
     val summary: ResolveOfferResult,
-    val issuerMetadata: CredentialIssuerMetadata,
+    val resolvedIssuerMetadata: ResolvedCredentialIssuerMetadata,
     val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
     val transactionCode: TxCode?,
 )
@@ -279,15 +282,17 @@ data class WalletOfferResolution(
  *
  * @property summary App-facing metadata derived from the resolution.
  * @property offer Exact parsed credential offer, including its grants.
- * @property issuerMetadata Credential issuer metadata used to validate the offered configurations.
+ * @property resolvedIssuerMetadata Canonical issuer-metadata resolution used to validate the
+ * offered configurations.
  * @property authorizationServerMetadata Authorization server metadata used for the token request.
- * @property offeredCredentials Offered configurations resolved against [issuerMetadata].
+ * @property offeredCredentials Offered configurations resolved against
+ * [resolvedIssuerMetadata].metadata.
  */
 internal class ResolvedIssuanceOffer(
     val source: ResolveOfferRequest,
     val summary: ResolveOfferResult,
     val offer: CredentialOffer,
-    val issuerMetadata: CredentialIssuerMetadata,
+    val resolvedIssuerMetadata: ResolvedCredentialIssuerMetadata,
     val authorizationServerMetadata: AuthorizationServerMetadata,
     val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
 )
@@ -616,7 +621,7 @@ object WalletIssuanceHandler {
 
         // 2. Reuse issuer metadata and offered configurations from that resolution.
         val offer = effectiveResolvedOffer.offer
-        val issuerMetadata = effectiveResolvedOffer.issuerMetadata
+        val issuerMetadata = effectiveResolvedOffer.resolvedIssuerMetadata.metadata
         val offeredCredentials = effectiveResolvedOffer.offeredCredentials
         val asMetadata = effectiveResolvedOffer.authorizationServerMetadata
         log.trace { "Resolved offer: issuer=${offer.credentialIssuer}, configIds=${offer.credentialConfigurationIds}" }
@@ -809,7 +814,7 @@ object WalletIssuanceHandler {
         )
         return WalletOfferPreviewResult(
             previewHandle = previewHandle,
-            issuerMetadata = resolvedOffer.issuerMetadata,
+            resolvedIssuerMetadata = resolvedOffer.resolvedIssuerMetadata,
             offeredCredentials = resolvedOffer.offeredCredentials,
             transactionCode = resolvedOffer.offer.grants?.preAuthorizedCode?.txCode,
         )
@@ -832,7 +837,8 @@ object WalletIssuanceHandler {
     ): ResolvedIssuanceOffer {
         val offer = resolveOffer(request, httpClient)
         val metadataResolver = IssuerMetadataResolver(httpClient, metadataTrustResolver)
-        val issuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(offer.credentialIssuer).metadata
+        val resolvedIssuerMetadata = metadataResolver.resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val issuerMetadata = resolvedIssuerMetadata.metadata
         val asMetadata = metadataResolver.resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
         val offeredCredentials = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata)
         return ResolvedIssuanceOffer(
@@ -850,7 +856,7 @@ object WalletIssuanceHandler {
                 nonceEndpoint = issuerMetadata.nonceEndpoint?.let { Url(it) },
             ),
             offer = offer,
-            issuerMetadata = issuerMetadata,
+            resolvedIssuerMetadata = resolvedIssuerMetadata,
             authorizationServerMetadata = asMetadata,
             offeredCredentials = offeredCredentials,
         )
@@ -902,7 +908,7 @@ object WalletIssuanceHandler {
         val resolved = resolveIssuanceOffer(request, httpClient)
         return WalletOfferResolution(
             summary = resolved.summary,
-            issuerMetadata = resolved.issuerMetadata,
+            resolvedIssuerMetadata = resolved.resolvedIssuerMetadata,
             offeredCredentials = resolved.offeredCredentials,
             transactionCode = resolved.offer.grants?.preAuthorizedCode?.txCode,
         )

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandler.kt
@@ -900,12 +900,19 @@ object WalletIssuanceHandler {
      *
      * Use this for stateless "resolve for display" flows that render an issuer/credential preview and then
      * complete issuance by re-sending the offer (e.g. via the pre-authorized or authorization-code endpoints).
+     *
+     * @param request Credential offer URL or inline offer JSON to resolve.
+     * @param httpClient HTTP client used for offer and metadata resolution.
+     * @param metadataTrustResolver Optional trust boundary for signed Credential Issuer Metadata. When
+     * absent, only unsigned metadata is accepted.
+     * @return Resolved offer summary, issuer metadata resolution, offered credentials, and transaction code.
      */
     suspend fun resolveOfferDetailed(
         request: ResolveOfferRequest,
         httpClient: HttpClient = defaultHttpClient(),
+        metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     ): WalletOfferResolution {
-        val resolved = resolveIssuanceOffer(request, httpClient)
+        val resolved = resolveIssuanceOffer(request, httpClient, metadataTrustResolver)
         return WalletOfferResolution(
             summary = resolved.summary,
             resolvedIssuerMetadata = resolved.resolvedIssuerMetadata,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
@@ -39,7 +39,10 @@ import id.waltid.openid4vci.wallet.authorization.AuthorizationRequestBuilder
 import id.waltid.openid4vci.wallet.authorization.AuthorizationResponseParser
 import id.waltid.openid4vci.wallet.dpop.DPoPProofBuilder
 import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.waltid.openid4vci.wallet.metadata.OfferedCredentialResolver
+import id.waltid.openid4vci.wallet.metadata.ResolvedCredentialIssuerMetadata
 import id.waltid.openid4vci.wallet.nonce.NonceRequestBuilder
 import id.waltid.openid4vci.wallet.nonce.NonceRequestError
 import id.waltid.openid4vci.wallet.nonce.NonceRequestException
@@ -125,7 +128,30 @@ data class WalletIssuanceIssuerPreview(
     val locale: String?,
     val logoUri: String?,
     val logoAltText: String?,
+    /** Whether the issuer metadata was unsigned or verified signed metadata. */
+    val metadataProvenance: WalletIssuanceMetadataProvenance,
 )
+
+/** Verification provenance of issuer metadata retained by an issuance session. */
+@Serializable
+sealed interface WalletIssuanceMetadataProvenance {
+    /** Metadata was received as an unsigned JSON document. */
+    @Serializable
+    data object Unsigned : WalletIssuanceMetadataProvenance
+
+    /** Metadata was received in a JWS verified by the configured trust resolver. */
+    @Serializable
+    data class Signed(
+        /** Exact compact JWS returned by the issuer. */
+        val compactJwt: String,
+        /** JWS algorithm verified by the configured trust resolver. */
+        val algorithm: String,
+        /** Identifier of the trusted verification key, as reported by the trust resolver. */
+        val keyId: String?,
+        /** Authority relationship established by the trust resolver. */
+        val trustType: MetadataSignerTrustType,
+    ) : WalletIssuanceMetadataProvenance
+}
 
 /** Offered credential information safe for an app review screen. */
 @Serializable
@@ -269,6 +295,7 @@ sealed interface WalletIssuanceOutcome {
 class WalletIssuanceSessionService(
     private val wallet: Wallet,
     private val attestationAssembler: ClientAttestationAssembler? = null,
+    private val metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
     private val onEvent: suspend (WalletSessionEvent) -> Unit = {},
     private val sessionStore: WalletIssuanceSessionStore? = null,
     httpClient: HttpClient? = null,
@@ -632,7 +659,7 @@ class WalletIssuanceSessionService(
             } catch (error: Exception) {
                 throw IssuanceStageException(WalletIssuanceErrorCode.CRYPTO, error)
             }
-            val proofNonce = if (proof.required) fetchNonce(active.resolved.issuerMetadata) else null
+            val proofNonce = if (proof.required) fetchNonce(active.resolved.issuerMetadata.metadata) else null
             val proofJwt = if (proof.required) {
                 try {
                     buildCredentialProof(
@@ -660,7 +687,7 @@ class WalletIssuanceSessionService(
                 }
             }.toString()
             val protected = postProtected(
-                endpoint = active.resolved.issuerMetadata.credentialEndpoint,
+                endpoint = active.resolved.issuerMetadata.metadata.credentialEndpoint,
                 accessToken = token.access_token,
                 tokenType = token.token_type,
                 dpop = dpopAlgorithms,
@@ -711,7 +738,7 @@ class WalletIssuanceSessionService(
                     }
                     val transactionId = response.transactionId
                         ?: throw IssuanceStageException(WalletIssuanceErrorCode.PROTOCOL)
-                    val deferredEndpoint = active.resolved.issuerMetadata.deferredCredentialEndpoint
+                    val deferredEndpoint = active.resolved.issuerMetadata.metadata.deferredCredentialEndpoint
                         ?: throw IssuanceStageException(WalletIssuanceErrorCode.PROTOCOL)
                     val public = WalletDeferredCredential(
                         id = Uuid.random().toString(),
@@ -942,9 +969,9 @@ class WalletIssuanceSessionService(
             val parsed = CredentialOfferParser.parseCredentialOfferUrl(request.getEffectiveOfferString())
             CredentialOfferResolver(httpClient).resolveCredentialOffer(parsed.credentialOffer, parsed.credentialOfferUri)
         }
-        val resolver = IssuerMetadataResolver(httpClient)
+        val resolver = IssuerMetadataResolver(httpClient, metadataTrustResolver)
         val issuerMetadata = resolver.resolveCredentialIssuerMetadata(offer.credentialIssuer)
-        require(issuerMetadata.credentialIssuer == offer.credentialIssuer) {
+        require(issuerMetadata.metadata.credentialIssuer == offer.credentialIssuer) {
             "Credential issuer metadata identifier does not match the offer"
         }
         val grantAuthorizationServer = when (offer.getGrantType()) {
@@ -952,12 +979,12 @@ class WalletIssuanceSessionService(
             is GrantType.PreAuthorizedCode -> offer.grants?.preAuthorizedCode?.authorizationServer
             else -> null
         }
-        val selectedAuthorizationServer = selectAuthorizationServer(issuerMetadata, grantAuthorizationServer)
+        val selectedAuthorizationServer = selectAuthorizationServer(issuerMetadata.metadata, grantAuthorizationServer)
         val authorizationServerMetadata = resolver.resolveAuthorizationServerMetadata(selectedAuthorizationServer)
         require(authorizationServerMetadata.issuer == selectedAuthorizationServer) {
             "Authorization server metadata issuer does not match the selected server"
         }
-        val offered = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata)
+        val offered = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata.metadata)
         require(offered.isNotEmpty()) { "Credential offer resolved no supported credentials" }
         return ResolvedOffer(offer, issuerMetadata, authorizationServerMetadata, offered)
     }
@@ -978,7 +1005,7 @@ class WalletIssuanceSessionService(
     }
 
     private fun ResolvedOffer.toPreview(grant: GrantType): WalletIssuanceOfferPreview {
-        val issuerDisplay = issuerMetadata.display?.firstOrNull()
+        val issuerDisplay = issuerMetadata.metadata.display?.firstOrNull()
         val txCode = offer.grants?.preAuthorizedCode?.txCode
         return WalletIssuanceOfferPreview(
             grant = when (grant) {
@@ -987,11 +1014,12 @@ class WalletIssuanceSessionService(
                 else -> error("Unsupported credential offer grant")
             },
             issuer = WalletIssuanceIssuerPreview(
-                identifier = offer.credentialIssuer,
+                identifier = issuerMetadata.metadata.credentialIssuer,
                 name = issuerDisplay?.name,
                 locale = issuerDisplay?.locale,
                 logoUri = issuerDisplay?.logo?.uri,
                 logoAltText = issuerDisplay?.logo?.altText,
+                metadataProvenance = issuerMetadata.toPreviewProvenance(),
             ),
             credentials = offeredCredentials.map { offered ->
                 val display = offered.configuration.credentialMetadata?.display?.firstOrNull()
@@ -1006,6 +1034,16 @@ class WalletIssuanceSessionService(
             transactionCode = txCode?.let {
                 WalletIssuanceTransactionCode(it.inputMode, it.length, it.description)
             },
+        )
+    }
+
+    private fun ResolvedCredentialIssuerMetadata.toPreviewProvenance(): WalletIssuanceMetadataProvenance = when (this) {
+        is ResolvedCredentialIssuerMetadata.Unsigned -> WalletIssuanceMetadataProvenance.Unsigned
+        is ResolvedCredentialIssuerMetadata.Signed -> WalletIssuanceMetadataProvenance.Signed(
+            compactJwt = compactJwt,
+            algorithm = signer.algorithm,
+            keyId = signer.keyId,
+            trustType = signer.trustType,
         )
     }
 
@@ -1277,10 +1315,10 @@ class WalletIssuanceSessionService(
         }
 
         val offer = json.decodeFromString<CredentialOffer>(persisted.offer)
-        val issuerMetadata = json.decodeFromString<CredentialIssuerMetadata>(persisted.issuerMetadata)
+        val issuerMetadata = json.decodeFromString<ResolvedCredentialIssuerMetadata>(persisted.issuerMetadata)
         val authorizationServerMetadata =
             json.decodeFromString<AuthorizationServerMetadata>(persisted.authorizationServerMetadata)
-        val offeredCredentials = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata)
+        val offeredCredentials = OfferedCredentialResolver.resolveOfferedCredentials(offer, issuerMetadata.metadata)
         val resolved = ResolvedOffer(offer, issuerMetadata, authorizationServerMetadata, offeredCredentials)
         validatePersistedResolution(persisted.public, resolved)
 
@@ -1345,10 +1383,10 @@ class WalletIssuanceSessionService(
         require(resolved.offer.credentialIssuer == public.offer.issuer.identifier) {
             "Stored issuance session issuer binding is invalid"
         }
-        require(resolved.issuerMetadata.credentialIssuer == resolved.offer.credentialIssuer) {
+        require(resolved.issuerMetadata.metadata.credentialIssuer == resolved.offer.credentialIssuer) {
             "Stored credential issuer metadata binding is invalid"
         }
-        require(resolved.authorizationServerMetadata.issuer in resolved.issuerMetadata.authorizationServerIssuers()) {
+        require(resolved.authorizationServerMetadata.issuer in resolved.issuerMetadata.metadata.authorizationServerIssuers()) {
             "Stored authorization server binding is invalid"
         }
         require(
@@ -1631,7 +1669,7 @@ class WalletIssuanceSessionService(
 
     private data class ResolvedOffer(
         val offer: CredentialOffer,
-        val issuerMetadata: CredentialIssuerMetadata,
+        val issuerMetadata: ResolvedCredentialIssuerMetadata,
         val authorizationServerMetadata: AuthorizationServerMetadata,
         val offeredCredentials: List<OfferedCredentialResolver.ResolvedCredentialOffer>,
     )

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletPresentationHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletPresentationHandler.kt
@@ -185,10 +185,13 @@ value class PresentationPreviewHandle(val value: String) {
 
 sealed interface PreviewPresentationResult {
     val handle: PresentationPreviewHandle
+    val resolvedAuthorizationRequest: ResolvedAuthorizationRequest
+    val authorizationRequest: AuthorizationRequest
+        get() = resolvedAuthorizationRequest.authorizationRequest
 
     data class Ready(
         override val handle: PresentationPreviewHandle,
-        val authorizationRequest: AuthorizationRequest,
+        override val resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
         /** Response-encryption selection derived from this authenticated request, or `null` for a plain response. */
         val responseEncryption: ResponseEncryption.Metadata?,
         val credentialOptions: List<PresentationCredentialOption>,
@@ -198,7 +201,7 @@ sealed interface PreviewPresentationResult {
 
     data class Invalid(
         override val handle: PresentationPreviewHandle,
-        val authorizationRequest: AuthorizationRequest,
+        override val resolvedAuthorizationRequest: ResolvedAuthorizationRequest,
         val error: PresentationRequestError,
     ) : PreviewPresentationResult
 }
@@ -704,7 +707,7 @@ object WalletPresentationHandler {
                     error = validation.error,
                 ),
             )
-            return PreviewPresentationResult.Invalid(handle, authorizationRequest, validation.error)
+            return PreviewPresentationResult.Invalid(handle, resolvedAuthorizationRequest, validation.error)
         }
 
         val valid = validation as PresentationRequestValidationResult.Valid
@@ -738,7 +741,7 @@ object WalletPresentationHandler {
                     error = availabilityError,
                 ),
             )
-            return PreviewPresentationResult.Invalid(handle, authorizationRequest, availabilityError)
+            return PreviewPresentationResult.Invalid(handle, resolvedAuthorizationRequest, availabilityError)
         }
         onEvent(WalletSessionEvent.presentation_credentials_selected)
         val credentialOptions = matched.flatMap { (queryId, results) ->
@@ -769,7 +772,7 @@ object WalletPresentationHandler {
         )
         return PreviewPresentationResult.Ready(
             handle = handle,
-            authorizationRequest = authorizationRequest,
+            resolvedAuthorizationRequest = resolvedAuthorizationRequest,
             responseEncryption = responseEncryption,
             credentialRequirements = query.requiredCredentialRequirements(),
             credentialOptions = credentialOptions,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerPreviewTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerPreviewTest.kt
@@ -269,6 +269,101 @@ class WalletIssuanceHandlerPreviewTest {
     }
 
     @Test
+    fun detailedOfferResolutionRetainsUnsignedMetadataWithoutTrustResolver() = runTest {
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respondJson(ISSUER_METADATA)
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val resolution = WalletIssuanceHandler.resolveOfferDetailed(
+            request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+            httpClient = client,
+        )
+
+        assertIs<ResolvedCredentialIssuerMetadata.Unsigned>(resolution.resolvedIssuerMetadata)
+        assertEquals(ISSUER, resolution.resolvedIssuerMetadata.metadata.credentialIssuer)
+        assertEquals("pid", resolution.offeredCredentials.single().credentialConfigurationId)
+    }
+
+    @Test
+    fun detailedOfferResolutionRetainsExactSignedMetadataAndSigner() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val compactJwt = signedIssuerMetadata().toSignedJwt(key)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respond(
+                            content = compactJwt,
+                            headers = headersOf(HttpHeaders.ContentType, "application/jwt"),
+                        )
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val signer = MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+        val resolution = WalletIssuanceHandler.resolveOfferDetailed(
+            request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+            httpClient = client,
+            metadataTrustResolver = { candidate, expectedIssuer ->
+                assertEquals(compactJwt, candidate)
+                assertEquals(ISSUER, expectedIssuer)
+                key.getPublicKey().verifyJws(candidate).getOrThrow()
+                signer
+            },
+        )
+
+        val signed = assertIs<ResolvedCredentialIssuerMetadata.Signed>(resolution.resolvedIssuerMetadata)
+        assertEquals(compactJwt, signed.compactJwt)
+        assertEquals(signer, signed.signer)
+        assertEquals(ISSUER, signed.metadata.credentialIssuer)
+    }
+
+    @Test
+    fun detailedOfferResolutionRejectsUntrustedSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val compactJwt = signedIssuerMetadata().toSignedJwt(key)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respond(
+                            content = compactJwt,
+                            headers = headersOf(HttpHeaders.ContentType, "application/jwt"),
+                        )
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        assertFails {
+            WalletIssuanceHandler.resolveOfferDetailed(
+                request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+                httpClient = client,
+                metadataTrustResolver = { _, _ -> error("untrusted signer") },
+            )
+        }
+    }
+
+    @Test
     fun successfulIssuanceConsumesPreview() = runTest {
         val client = HttpClient(MockEngine) {
             engine {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerPreviewTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceHandlerPreviewTest.kt
@@ -2,9 +2,16 @@ package id.walt.wallet2.handlers
 
 import id.walt.crypto.keys.KeyType
 import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.openid4vci.CredentialFormat
+import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.toSignedJwt
 import id.walt.wallet2.data.StoredCredential
 import id.walt.wallet2.data.Wallet
 import id.walt.wallet2.data.WalletCredentialStore
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
+import id.waltid.openid4vci.wallet.metadata.ResolvedCredentialIssuerMetadata
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -23,6 +30,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 
 class WalletIssuanceHandlerPreviewTest {
 
@@ -180,7 +188,8 @@ class WalletIssuanceHandlerPreviewTest {
             httpClient = client,
         )
 
-        assertEquals(ISSUER, preview.issuerMetadata.credentialIssuer)
+        assertEquals(ISSUER, preview.resolvedIssuerMetadata.metadata.credentialIssuer)
+        assertIs<ResolvedCredentialIssuerMetadata.Unsigned>(preview.resolvedIssuerMetadata)
         assertEquals("pid", preview.offeredCredentials.single().credentialConfigurationId)
         assertEquals("text", preview.transactionCode?.inputMode)
 
@@ -215,6 +224,48 @@ class WalletIssuanceHandlerPreviewTest {
         assertEquals(2, offerFetches)
         assertEquals(4, metadataFetches)
         assertEquals(3, tokenRequests)
+    }
+
+    @Test
+    fun signedPreviewRetainsExactMetadataResolutionAndSigner() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val compactJwt = signedIssuerMetadata().toSignedJwt(key)
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    when (request.url.toString()) {
+                        OFFER_URL -> respondJson(CREDENTIAL_OFFER)
+                        "$ISSUER/.well-known/openid-credential-issuer" -> respond(
+                            content = compactJwt,
+                            headers = headersOf(HttpHeaders.ContentType, "application/jwt"),
+                        )
+                        "$ISSUER/.well-known/oauth-authorization-server" -> respondJson(AUTHORIZATION_SERVER_METADATA)
+                        else -> error("Unexpected request: ${request.method.value} ${request.url}")
+                    }
+                }
+            }
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+        val preview = WalletIssuanceHandler.previewOffer(
+            wallet = Wallet(id = "signed-preview", staticKey = JWKKey.generate(KeyType.Ed25519)),
+            request = ResolveOfferRequest(offerUrl = Url(OFFER_DEEP_LINK)),
+            httpClient = client,
+            metadataTrustResolver = { candidate, expectedIssuer ->
+                assertEquals(compactJwt, candidate)
+                assertEquals(ISSUER, expectedIssuer)
+                key.getPublicKey().verifyJws(candidate).getOrThrow()
+                MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+            },
+        )
+
+        val signed = assertIs<ResolvedCredentialIssuerMetadata.Signed>(preview.resolvedIssuerMetadata)
+        assertEquals(compactJwt, signed.compactJwt)
+        assertEquals(
+            MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER),
+            signed.signer,
+        )
+        assertEquals(ISSUER, signed.metadata.credentialIssuer)
     }
 
     @Test
@@ -290,6 +341,14 @@ class WalletIssuanceHandlerPreviewTest {
           "response_types_supported": ["code"]
         }
     """
+
+    private fun signedIssuerMetadata() = CredentialIssuerMetadata(
+        credentialIssuer = ISSUER,
+        credentialEndpoint = "$ISSUER/credential",
+        credentialConfigurationsSupported = mapOf(
+            "pid" to CredentialConfiguration(CredentialFormat.SD_JWT_VC),
+        ),
+    )
 
     private companion object {
         const val ISSUER = "https://issuer.example"

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
@@ -1,25 +1,43 @@
 package id.waltid.openid4vci.wallet.metadata
 
 import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadataJwt
 import id.walt.openid4vci.metadata.oauth.AuthorizationServerMetadata
 import id.walt.openid4vci.metadata.oidc.OpenIDProviderMetadata
+import id.walt.openid4vci.tokens.jwt.JwtPayloadClaims
+import id.walt.crypto2.jose.CompactJws
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlin.time.Clock
 
 private val log = KotlinLogging.logger {}
 
 /**
- * Resolves issuer metadata from well-known endpoints.
- * Implements §11.2 of OpenID4VCI 1.0 specification (Credential Issuer Metadata).
- * 
- * @property httpClient The HTTP client to use for fetching metadata
+ * Resolves unsigned or signed Credential Issuer Metadata from its well-known endpoint.
+ *
+ * Implements OpenID4VCI 1.0 section 12.2 and signed metadata in section 12.2.3.
+ * A signed response is accepted only after [metadataTrustResolver] independently establishes
+ * both the JWS signature and the signer's authority for the credential issuer.
+ *
+ * @property httpClient HTTP client used to fetch metadata.
+ * @property metadataTrustResolver Optional trust boundary for signed metadata. Without it,
+ * only unsigned metadata is accepted.
  */
 class IssuerMetadataResolver(
     private val httpClient: HttpClient,
+    private val metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
 ) {
 
     companion object {
@@ -29,13 +47,14 @@ class IssuerMetadataResolver(
     }
 
     /**
-     * Resolves credential issuer metadata from the issuer's well-known endpoint
-     * 
-     * @param credentialIssuerUrl The credential issuer identifier URL
-     * @return CredentialIssuerMetadata
-     * @throws Exception if metadata cannot be fetched or parsed
+     * Resolves credential issuer metadata and retains its signed/unsigned provenance.
+     *
+     * @param credentialIssuerUrl Credential issuer identifier URL.
+     * @return Parsed metadata with explicit unsigned or verified signed provenance.
      */
-    suspend fun resolveCredentialIssuerMetadata(credentialIssuerUrl: String): CredentialIssuerMetadata {
+    suspend fun resolveCredentialIssuerMetadata(
+        credentialIssuerUrl: String,
+    ): ResolvedCredentialIssuerMetadata {
         require(credentialIssuerUrl.isNotBlank()) { "Credential issuer URL cannot be blank" }
 
         log.info { "Resolving credential issuer metadata" }
@@ -55,8 +74,16 @@ class IssuerMetadataResolver(
             log.debug { "Attempt ${index + 1}/${urlsToTry.size}: Fetching from $metadataUrl" }
 
             val response: HttpResponse = try {
-                httpClient.get(metadataUrl)
+                httpClient.get(metadataUrl) {
+                    header(
+                        HttpHeaders.Accept,
+                        metadataTrustResolver?.let {
+                            "${CredentialIssuerMetadataJwt.MEDIA_TYPE}, ${ContentType.Application.Json}"
+                        } ?: ContentType.Application.Json.toString(),
+                    )
+                }
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 log.warn(e) { "Network error fetching credential issuer metadata from: $metadataUrl" }
                 failures += ResolveFailure.Network(metadataUrl, e)
                 continue
@@ -65,15 +92,30 @@ class IssuerMetadataResolver(
             if (response.status.isSuccess()) {
                 log.trace { "Received successful response (${response.status.value}), parsing metadata" }
                 try {
-                    val metadata = response.body<CredentialIssuerMetadata>()
+                    val body = response.bodyAsText()
+                    val metadata = when (response.contentType()?.withoutParameters()) {
+                        ContentType.Application.Json -> ResolvedCredentialIssuerMetadata.Unsigned(
+                            parseAndValidateMetadata(body, credentialIssuerUrl),
+                        )
+                        ContentType.parse(CredentialIssuerMetadataJwt.MEDIA_TYPE),
+                        ContentType.parse(CredentialIssuerMetadataJwt.TYPED_MEDIA_TYPE) ->
+                            parseSignedMetadata(body, credentialIssuerUrl)
+                        else -> throw IllegalArgumentException(
+                            "Unsupported Credential Issuer Metadata content type: ${response.contentType()}",
+                        )
+                    }
                     log.info {
                         "Successfully resolved credential issuer metadata - " +
-                                "Issuer: ${metadata.credentialIssuer}, " +
-                                "Configurations: ${metadata.credentialConfigurationsSupported.size}"
+                                "Issuer: ${metadata.metadata.credentialIssuer}, " +
+                                "Configurations: ${metadata.metadata.credentialConfigurationsSupported.size}"
                     }
-                    log.trace { "Supported credential configurations: ${metadata.credentialConfigurationsSupported.keys.joinToString()}" }
+                    log.trace {
+                        "Supported credential configurations: " +
+                            metadata.metadata.credentialConfigurationsSupported.keys.joinToString()
+                    }
                     return metadata
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     val responseBody = runCatching { response.bodyAsText() }.getOrDefault("")
                     log.error(e) {
                         "Failed to parse credential issuer metadata from $metadataUrl - " +
@@ -105,6 +147,73 @@ class IssuerMetadataResolver(
         )
     }
 
+    private suspend fun parseSignedMetadata(
+        compactJwt: String,
+        expectedCredentialIssuer: String,
+    ): ResolvedCredentialIssuerMetadata.Signed {
+        val decoded = runCatching { CompactJws.decodeUnverified(compactJwt) }
+            .getOrElse { throw IllegalArgumentException("Invalid signed Credential Issuer Metadata", it) }
+        val algorithm = decoded.algorithm.identifier
+        require(!algorithm.equals("none", ignoreCase = true) && !algorithm.startsWith("HS", ignoreCase = true)) {
+            "Signed Credential Issuer Metadata must use an asymmetric JWS algorithm"
+        }
+        require(decoded.protectedHeader.requiredString("typ", "typ") == CredentialIssuerMetadataJwt.TYPE) {
+            "Signed Credential Issuer Metadata has an invalid typ"
+        }
+        val signer = requireNotNull(metadataTrustResolver) {
+            "Signed Credential Issuer Metadata requires a configured trust resolver"
+        }.verify(compactJwt, expectedCredentialIssuer)
+        require(signer.algorithm == algorithm) { "Trusted signer algorithm does not match JWS alg" }
+
+        val payload = runCatching {
+            lenientJson.parseToJsonElement(decoded.payload.decodeToString()).jsonObject
+        }.getOrElse { throw IllegalArgumentException("Signed Credential Issuer Metadata payload is not a JSON object", it) }
+        val subject = payload.requiredString(JwtPayloadClaims.SUBJECT, "sub")
+        payload.optionalString(JwtPayloadClaims.ISSUER, "iss")
+        val issuedAt = payload.requiredLong(JwtPayloadClaims.ISSUED_AT, "iat")
+        val now = Clock.System.now().epochSeconds
+        require(issuedAt <= now + 60) { "Signed Credential Issuer Metadata iat is in the future" }
+        payload.optionalLong(JwtPayloadClaims.EXPIRATION, "exp")?.let { expiry ->
+            require(now < expiry) { "Signed Credential Issuer Metadata has expired" }
+        }
+        val metadata = parseAndValidateMetadata(
+            JsonObject(payload.filterKeys { it !in signedMetadataReservedPayloadClaims }).toString(),
+            expectedCredentialIssuer,
+        )
+        require(subject == metadata.credentialIssuer) {
+            "Signed Credential Issuer Metadata sub must match credential_issuer"
+        }
+        return ResolvedCredentialIssuerMetadata.Signed(metadata, compactJwt, signer)
+    }
+
+    private fun JsonObject.requiredString(claim: String, label: String): String =
+        this[claim]?.jsonPrimitive?.takeIf { it.isString }?.content
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata is missing or malformed $label")
+
+    private fun JsonObject.requiredLong(claim: String, label: String): Long =
+        this[claim].strictLongOrNull()
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata is missing or malformed $label")
+
+    private fun JsonObject.optionalLong(claim: String, label: String): Long? = when (val value = this[claim]) {
+        null -> null
+        else -> value.strictLongOrNull()
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata has malformed $label")
+    }
+
+    private fun JsonObject.optionalString(claim: String, label: String): String? = when (val value = this[claim]) {
+        null -> null
+        else -> (value as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw IllegalArgumentException("Signed Credential Issuer Metadata has malformed $label")
+    }
+
+    private fun parseAndValidateMetadata(body: String, expectedCredentialIssuer: String): CredentialIssuerMetadata {
+        val metadata = lenientJson.decodeFromString(CredentialIssuerMetadata.serializer(), body)
+        require(metadata.credentialIssuer == expectedCredentialIssuer) {
+            "Credential Issuer Metadata credential_issuer does not match requested issuer"
+        }
+        return metadata
+    }
+
     /**
      * Resolves authorization server metadata from the well-known endpoint
      * 
@@ -127,6 +236,7 @@ class IssuerMetadataResolver(
             val response: HttpResponse = try {
                 httpClient.get(metadataUrl)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 log.warn(e) { "Network error fetching authorization server metadata from: $metadataUrl" }
                 failures += ResolveFailure.Network(metadataUrl, e)
                 continue
@@ -136,6 +246,7 @@ class IssuerMetadataResolver(
                 try {
                     return response.body<AuthorizationServerMetadata>()
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     val responseBody = runCatching { response.bodyAsText() }.getOrDefault("")
                     log.error(e) { "Failed to parse authorization server metadata from $metadataUrl. Body: $responseBody" }
                     failures += ResolveFailure.Parse(metadataUrl, e, bodyPreview(responseBody))
@@ -180,6 +291,7 @@ class IssuerMetadataResolver(
             val response: HttpResponse = try {
                 httpClient.get(metadataUrl)
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 log.warn(e) { "Network error fetching OpenID provider metadata from: $metadataUrl" }
                 failures += ResolveFailure.Network(metadataUrl, e)
                 continue
@@ -189,6 +301,7 @@ class IssuerMetadataResolver(
                 try {
                     return response.body<OpenIDProviderMetadata>()
                 } catch (e: Exception) {
+                    if (e is CancellationException) throw e
                     val responseBody = runCatching { response.bodyAsText() }.getOrDefault("")
                     log.error(e) { "Failed to parse OpenID provider metadata from $metadataUrl. Body: $responseBody" }
                     failures += ResolveFailure.Parse(metadataUrl, e, bodyPreview(responseBody))
@@ -248,6 +361,18 @@ class IssuerMetadataResolver(
         }
     }
 }
+
+private val signedMetadataReservedPayloadClaims = setOf(
+    JwtPayloadClaims.ISSUER,
+    JwtPayloadClaims.SUBJECT,
+    JwtPayloadClaims.ISSUED_AT,
+    JwtPayloadClaims.EXPIRATION,
+)
+
+private val lenientJson = Json { ignoreUnknownKeys = true }
+
+private fun JsonElement?.strictLongOrNull(): Long? =
+    (this as? JsonPrimitive)?.takeIf { !it.isString }?.longOrNull
 
 /**
  * Per-URL failure captured while iterating candidate well-known endpoints. Used to build the
@@ -329,5 +454,9 @@ private fun resolutionException(
         }
     }
     val cause = failures.firstNotNullOfOrNull { it.throwable }
-    return Exception(summary, cause)
+    return if (cause is IllegalArgumentException) {
+        IllegalArgumentException(summary, cause)
+    } else {
+        Exception(summary, cause)
+    }
 }

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
@@ -170,9 +170,8 @@ class IssuerMetadataResolver(
         }.getOrElse { throw IllegalArgumentException("Signed Credential Issuer Metadata payload is not a JSON object", it) }
         val subject = payload.requiredString(JwtPayloadClaims.SUBJECT, "sub")
         payload.optionalString(JwtPayloadClaims.ISSUER, "iss")
-        val issuedAt = payload.requiredLong(JwtPayloadClaims.ISSUED_AT, "iat")
+        payload.requiredLong(JwtPayloadClaims.ISSUED_AT, "iat")
         val now = Clock.System.now().epochSeconds
-        require(issuedAt <= now + 60) { "Signed Credential Issuer Metadata iat is in the future" }
         payload.optionalLong(JwtPayloadClaims.EXPIRATION, "exp")?.let { expiry ->
             require(now < expiry) { "Signed Credential Issuer Metadata has expired" }
         }

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/ResolvedCredentialIssuerMetadata.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/ResolvedCredentialIssuerMetadata.kt
@@ -1,0 +1,58 @@
+package id.waltid.openid4vci.wallet.metadata
+
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import kotlinx.serialization.Serializable
+
+/** Metadata resolution whose variant makes its verification state explicit. */
+@Serializable
+sealed interface ResolvedCredentialIssuerMetadata {
+    /** Parsed Credential Issuer Metadata. */
+    val metadata: CredentialIssuerMetadata
+
+    /** Metadata received as an unsigned JSON document. */
+    @Serializable
+    data class Unsigned(override val metadata: CredentialIssuerMetadata) : ResolvedCredentialIssuerMetadata
+
+    /** Metadata received in a compact JWS verified by the configured trust resolver. */
+    @Serializable
+    data class Signed(
+        override val metadata: CredentialIssuerMetadata,
+        /** Exact compact JWS returned by the metadata endpoint. */
+        val compactJwt: String,
+        /** Trusted signer details reported by the trust resolver. */
+        val signer: MetadataSigner,
+    ) : ResolvedCredentialIssuerMetadata
+}
+
+/** Stable provenance of the signer trusted by the embedding wallet. */
+@Serializable
+data class MetadataSigner(
+    /** Identifier of the trusted verification key, as reported by the trust resolver. */
+    val keyId: String?,
+    /** JWS algorithm verified by the trust resolver. */
+    val algorithm: String,
+    /** Authority relationship established by the trust resolver. */
+    val trustType: MetadataSignerTrustType,
+)
+
+/** Authority relationship established for a signed metadata signer. */
+@Serializable
+enum class MetadataSignerTrustType {
+    /** The signer is the trusted credential issuer. */
+    TRUSTED_ISSUER,
+    /** The signer is a trusted delegate of the credential issuer. */
+    TRUSTED_DELEGATE,
+}
+
+/**
+ * Verifies both the JWS signature and the signer's authority for an expected credential issuer.
+ * Returning normally is the trust boundary: callers never receive decoded-but-untrusted metadata.
+ */
+fun interface CredentialIssuerMetadataTrustResolver {
+    /**
+     * @param compactJwt Compact JWS returned by the Credential Issuer Metadata endpoint.
+     * @param expectedCredentialIssuer Credential issuer for which signer authority must be established.
+     * @return Trusted signer details retained with the resolved metadata.
+     */
+    suspend fun verify(compactJwt: String, expectedCredentialIssuer: String): MetadataSigner
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
@@ -65,8 +65,8 @@ class IssuerMetadataResolverTest {
         val resolver = IssuerMetadataResolver(client)
         val metadata = resolver.resolveCredentialIssuerMetadata(issuerUrl)
 
-        assertEquals(issuerUrl, metadata.credentialIssuer)
-        assertEquals(1, metadata.credentialConfigurationsSupported?.size)
+        assertEquals(issuerUrl, metadata.metadata.credentialIssuer)
+        assertEquals(1, metadata.metadata.credentialConfigurationsSupported.size)
     }
     @Test
     fun testResolveCredentialIssuerMetadataWithIssuerPath() = runTest {
@@ -101,8 +101,8 @@ class IssuerMetadataResolverTest {
         val resolver = IssuerMetadataResolver(client)
         val metadata = resolver.resolveCredentialIssuerMetadata(issuerUrl)
 
-        assertEquals(issuerUrl, metadata.credentialIssuer)
-        assertEquals("$issuerUrl/credential", metadata.credentialEndpoint)
+        assertEquals(issuerUrl, metadata.metadata.credentialIssuer)
+        assertEquals("$issuerUrl/credential", metadata.metadata.credentialEndpoint)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/SignedIssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/SignedIssuerMetadataResolverTest.kt
@@ -1,0 +1,207 @@
+package id.waltid.openid4vci.wallet.metadata
+
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
+import id.walt.openid4vci.CredentialFormat
+import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadataJwt
+import id.walt.openid4vci.metadata.issuer.toSignedJwt
+import id.walt.openid4vci.tokens.jwt.JwtHeaderParams
+import id.walt.openid4vci.tokens.jwt.JwtPayloadClaims
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.time.Clock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class SignedIssuerMetadataResolverTest {
+    private val issuer = "https://issuer.example"
+
+    @Test
+    fun trustedSignedMetadataRetainsTheExactJwtAndSignerAndAdvertisesJwt() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = validMetadata().toSignedJwt(key)
+        var accept: String? = null
+
+        val resolved = IssuerMetadataResolver(signedClient(jwt) { accept = it }) { compactJwt, expectedIssuer ->
+            key.getPublicKey().verifyJws(compactJwt).getOrThrow()
+            assertEquals(issuer, expectedIssuer)
+            MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+        }.resolveCredentialIssuerMetadata(issuer)
+
+        val signed = assertIs<ResolvedCredentialIssuerMetadata.Signed>(resolved)
+        assertEquals("application/jwt, application/json", accept)
+        assertEquals(jwt, signed.compactJwt)
+        assertEquals(issuer, signed.metadata.credentialIssuer)
+        assertEquals(
+            MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER),
+            signed.signer,
+        )
+    }
+
+    @Test
+    fun rejectedTrustResolverRejectsSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = validMetadata().toSignedJwt(key)
+
+        assertFailsWith<Exception> {
+            IssuerMetadataResolver(signedClient(jwt)) { _, _ -> error("untrusted signer") }
+                .resolveCredentialIssuerMetadata(issuer)
+        }
+    }
+
+    @Test
+    fun malformedOrExpiredExpirationRejectsSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        listOf(
+            JsonPrimitive("tomorrow"),
+            JsonPrimitive(Clock.System.now().epochSeconds),
+            JsonPrimitive(Clock.System.now().epochSeconds - 1),
+        ).forEach { expiry ->
+            val jwt = key.signJws(
+                payload(subject = issuer, expiry = expiry).toString().encodeToByteArray(),
+                headers = signedMetadataHeaders(),
+            )
+
+            assertFailsWith<Exception> {
+                trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+            }
+        }
+    }
+
+    @Test
+    fun quotedNumericClaimsAndMalformedOptionalIssuerAreRejected() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        listOf(
+            payload(issuedAt = JsonPrimitive(Clock.System.now().epochSeconds.toString())),
+            payload(expiry = JsonPrimitive((Clock.System.now().epochSeconds + 60).toString())),
+            payload(signedIssuer = JsonPrimitive(7)),
+        ).forEach { claims ->
+            val jwt = key.signJws(claims.toString().encodeToByteArray(), signedMetadataHeaders())
+
+            assertFailsWith<Exception> {
+                trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+            }
+        }
+    }
+
+    @Test
+    fun invalidTypeOrDisallowedAlgorithmRejectsBeforeTrust() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        listOf(
+            key.signJws(payload().toString().encodeToByteArray(), mapOf(JwtHeaderParams.TYPE to JsonPrimitive("wrong"))),
+            key.signJws(payload().toString().encodeToByteArray(), signedMetadataHeaders()),
+        ).forEachIndexed { index, jwt ->
+            var trustCalled = false
+            val candidate = if (index == 0) jwt else jwt.withAlgorithm("none")
+            assertFailsWith<Exception> {
+                IssuerMetadataResolver(signedClient(candidate)) { _, _ ->
+                    trustCalled = true
+                    MetadataSigner(null, "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+                }.resolveCredentialIssuerMetadata(issuer)
+            }
+            assertTrue(!trustCalled)
+        }
+    }
+
+    @Test
+    fun issuerAndSubjectMismatchRejectsSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val subjectMismatch = key.signJws(
+            payload(subject = "https://other.example").toString().encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+        val issuerMismatch = key.signJws(
+            payload(metadataIssuer = "https://other.example").toString().encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+
+        listOf(subjectMismatch, issuerMismatch).forEach { jwt ->
+            assertFailsWith<Exception> {
+                trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+            }
+        }
+    }
+
+    @Test
+    fun trustResolverRunsBeforeMalformedPayloadClaimsAreRead() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = key.signJws(
+            """{"sub":7,"iat":"not-a-number"}""".encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+        var trustResolverCalled = false
+
+        assertFailsWith<Exception> {
+            IssuerMetadataResolver(signedClient(jwt)) { _, _ ->
+                trustResolverCalled = true
+                error("untrusted signer")
+            }.resolveCredentialIssuerMetadata(issuer)
+        }
+
+        assertTrue(trustResolverCalled)
+    }
+
+    private fun validMetadata() = CredentialIssuerMetadata(
+        credentialIssuer = issuer,
+        credentialEndpoint = "$issuer/credential",
+        credentialConfigurationsSupported = mapOf("pid" to CredentialConfiguration(CredentialFormat.SD_JWT_VC)),
+    )
+
+    private fun payload(
+        metadataIssuer: String = issuer,
+        subject: String = issuer,
+        issuedAt: JsonPrimitive = JsonPrimitive(Clock.System.now().epochSeconds),
+        expiry: JsonPrimitive? = null,
+        signedIssuer: JsonPrimitive? = null,
+    ) = buildJsonObject {
+        put("credential_issuer", metadataIssuer)
+        put("credential_endpoint", "$metadataIssuer/credential")
+        put("credential_configurations_supported", buildJsonObject { })
+        put(JwtPayloadClaims.SUBJECT, subject)
+        put(JwtPayloadClaims.ISSUED_AT, issuedAt)
+        expiry?.let { put(JwtPayloadClaims.EXPIRATION, it) }
+        signedIssuer?.let { put(JwtPayloadClaims.ISSUER, it) }
+    }
+
+    private fun signedMetadataHeaders() = mapOf(
+        JwtHeaderParams.TYPE to JsonPrimitive(CredentialIssuerMetadataJwt.TYPE),
+    )
+
+    private fun signedClient(jwt: String, onRequest: (String?) -> Unit = {}): HttpClient = HttpClient(MockEngine) {
+        engine {
+            addHandler { request ->
+                onRequest(request.headers[HttpHeaders.Accept])
+                respond(jwt, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/jwt"))
+            }
+        }
+    }
+
+    private fun trustedResolver(key: JWKKey, jwt: String) = IssuerMetadataResolver(signedClient(jwt)) { compactJwt, _ ->
+        key.getPublicKey().verifyJws(compactJwt).getOrThrow()
+        MetadataSigner(key.getKeyId(), "EdDSA", MetadataSignerTrustType.TRUSTED_ISSUER)
+    }
+
+    private fun String.withAlgorithm(algorithm: String): String {
+        val parts = split('.')
+        val header = parts[0].decodeFromBase64Url().decodeToString()
+            .replace("\"alg\":\"EdDSA\"", "\"alg\":\"$algorithm\"")
+            .encodeToByteArray()
+            .encodeToBase64Url()
+        return "$header.${parts[1]}.${parts[2]}"
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/SignedIssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/SignedIssuerMetadataResolverTest.kt
@@ -84,6 +84,19 @@ class SignedIssuerMetadataResolverTest {
     }
 
     @Test
+    fun futureIssuedAtDoesNotApplyWalletSpecificClockSkewPolicy() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = key.signJws(
+            payload(issuedAt = JsonPrimitive(Clock.System.now().epochSeconds + 3_600)).toString().encodeToByteArray(),
+            signedMetadataHeaders(),
+        )
+
+        val resolved = trustedResolver(key, jwt).resolveCredentialIssuerMetadata(issuer)
+
+        assertIs<ResolvedCredentialIssuerMetadata.Signed>(resolved)
+    }
+
+    @Test
     fun quotedNumericClaimsAndMalformedOptionalIssuerAreRejected() = runTest {
         val key = JWKKey.generate(KeyType.Ed25519)
         listOf(

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestAuthentication.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestAuthentication.kt
@@ -1,0 +1,13 @@
+package id.waltid.openid4vp.wallet.request
+
+import id.walt.openid4vp.clientidprefix.prefixes.ClientId
+
+/** Authentication result established while resolving an OpenID4VP Request Object. */
+data class RequestObjectAuthentication(
+    /** Parsed client identifier, including the pre-registered representation when applicable. */
+    val clientId: ClientId,
+    /** JOSE algorithm from the authenticated Request Object. */
+    val algorithm: String,
+    /** JOSE key identifier from the authenticated Request Object, when supplied. */
+    val keyId: String?,
+)

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolver.kt
@@ -299,21 +299,35 @@ object AuthorizationRequestResolver {
             }
         }
         val jwtAlg = authReqJws.header["alg"]?.jsonPrimitive?.contentOrNull
-        if (jwtAlg.equals("none", ignoreCase = true)) {
+        val authentication = if (jwtAlg.equals("none", ignoreCase = true)) {
             if (unsignedRequestObjectPolicy != UnsignedRequestObjectPolicy.ALLOW_UNSIGNED) {
                 throw UnsignedAuthorizationRequestNotAllowedException()
             }
+            return ResolvedAuthorizationRequest.UnsignedRequestObject(
+                authorizationRequest = json.decodeFromJsonElement(
+                    deserializer = AuthorizationRequest.serializer(),
+                    element = authReqJws.payload,
+                ),
+                requestObject = requestObject,
+            )
         } else {
             log.trace { "Authenticating signed AuthorizationRequest object" }
-            authenticateSignedRequestObject(requestObject, authReqJws.payload, trustConfiguration)
+            authenticateSignedRequestObject(
+                requestObject = requestObject,
+                payload = authReqJws.payload,
+                algorithm = requireNotNull(jwtAlg) { "Signed AuthorizationRequest is missing alg" },
+                keyId = authReqJws.header["kid"]?.jsonPrimitive?.contentOrNull,
+                trustConfiguration = trustConfiguration,
+            )
         }
 
-        return ResolvedAuthorizationRequest.WithRequestObject(
+        return ResolvedAuthorizationRequest.AuthenticatedRequestObject(
             authorizationRequest = json.decodeFromJsonElement(
                 deserializer = AuthorizationRequest.serializer(),
                 element = authReqJws.payload,
             ),
             requestObject = requestObject,
+            authentication = authentication,
         )
     }
 
@@ -321,12 +335,14 @@ object AuthorizationRequestResolver {
     private suspend fun authenticateSignedRequestObject(
         requestObject: String,
         payload: JsonObject,
+        algorithm: String,
+        keyId: String?,
         trustConfiguration: ClientIdTrustConfiguration,
-    ) {
+    ): RequestObjectAuthentication {
         val clientId = requireNotNull(payload["client_id"]?.jsonPrimitive?.contentOrNull) {
             "Missing client_id for signed AuthorizationRequest"
         }
-        val clientIdPrefix = ClientIdPrefixParser.parse(clientId)
+        val parsedClientId = ClientIdPrefixParser.parse(clientId)
             .getOrElse { error -> throw IllegalArgumentException("Could not parse client_id prefix: $clientId", error) }
         val clientMetadata = payload["client_metadata"]?.let {
             ClientMetadata.fromJson(it)
@@ -342,7 +358,7 @@ object AuthorizationRequestResolver {
         )
 
         when (val validationResult = ClientIdPrefixAuthenticator.authenticate(
-            clientIdPrefix,
+            parsedClientId,
             context,
             preRegisteredMetadataProvider = { clientId ->
                 trustConfiguration.preRegisteredClients[clientId]?.let {
@@ -352,11 +368,16 @@ object AuthorizationRequestResolver {
             trustConfiguration = trustConfiguration,
         )) {
             is ClientValidationResult.Success -> {
-                log.trace { "Signed AuthorizationRequest authentication succeeded for client_id prefix ${clientIdPrefix::class.simpleName}" }
+                log.trace { "Signed AuthorizationRequest authentication succeeded for client_id scheme ${parsedClientId::class.simpleName}" }
             }
 
             is ClientValidationResult.Failure -> throw SignedAuthorizationRequestValidationException(validationResult.error)
         }
+        return RequestObjectAuthentication(
+            clientId = parsedClientId,
+            algorithm = algorithm,
+            keyId = keyId,
+        )
     }
 
     private fun parseRequestUriMethod(value: String): RequestUriHttpMethod = when (value) {

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/ResolvedAuthorizationRequest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonMain/kotlin/id/waltid/openid4vp/wallet/request/ResolvedAuthorizationRequest.kt
@@ -9,8 +9,15 @@ sealed class ResolvedAuthorizationRequest {
         override val authorizationRequest: AuthorizationRequest,
     ) : ResolvedAuthorizationRequest()
 
-    data class WithRequestObject(
+    data class UnsignedRequestObject(
         override val authorizationRequest: AuthorizationRequest,
         val requestObject: String,
+    ) : ResolvedAuthorizationRequest()
+
+    data class AuthenticatedRequestObject(
+        override val authorizationRequest: AuthorizationRequest,
+        val requestObject: String,
+        /** Authentication facts established by [AuthorizationRequestResolver]. */
+        val authentication: RequestObjectAuthentication,
     ) : ResolvedAuthorizationRequest()
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/PresentationRequestValidatorTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/commonTest/kotlin/id/waltid/openid4vp/wallet/PresentationRequestValidatorTest.kt
@@ -153,7 +153,7 @@ class PresentationRequestValidatorTest {
         )
 
         val result = PresentationRequestValidator.validate(
-            resolvedRequest = ResolvedAuthorizationRequest.WithRequestObject(
+            resolvedRequest = ResolvedAuthorizationRequest.UnsignedRequestObject(
                 authorizationRequest = request,
                 requestObject = "authenticated.request.object",
             ),
@@ -410,7 +410,7 @@ class PresentationRequestValidatorTest {
     private fun validate(
         request: AuthorizationRequest,
         transactionDataTypes: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
-        resolvedRequest: ResolvedAuthorizationRequest = ResolvedAuthorizationRequest.WithRequestObject(
+        resolvedRequest: ResolvedAuthorizationRequest = ResolvedAuthorizationRequest.UnsignedRequestObject(
             authorizationRequest = request,
             requestObject = "authenticated.request.object",
         ),

--- a/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolverJvmTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-wallet/src/jvmTest/kotlin/id/waltid/openid4vp/wallet/request/AuthorizationRequestResolverJvmTest.kt
@@ -177,7 +177,7 @@ class AuthorizationRequestResolverJvmTest {
             }
         }
 
-        assertIs<ResolvedAuthorizationRequest.WithRequestObject>(resolved)
+        assertIs<ResolvedAuthorizationRequest.UnsignedRequestObject>(resolved)
         assertEquals("verifier2", resolved.authorizationRequest.clientId)
         assertEquals(requestObject, resolved.requestObject)
     }
@@ -243,7 +243,11 @@ class AuthorizationRequestResolverJvmTest {
             ),
         )
 
-        assertIs<ResolvedAuthorizationRequest.WithRequestObject>(resolved)
+        val authenticated = assertIs<ResolvedAuthorizationRequest.AuthenticatedRequestObject>(resolved)
+        assertEquals(requestObject, authenticated.requestObject)
+        assertEquals("EdDSA", authenticated.authentication.algorithm)
+        assertEquals(trustedKey.getKeyId(), authenticated.authentication.keyId)
+        assertIs<id.walt.openid4vp.clientidprefix.prefixes.PreRegistered>(authenticated.authentication.clientId)
     }
 
     @Test
@@ -300,7 +304,10 @@ class AuthorizationRequestResolverJvmTest {
             put("client_id", "verifier2")
             put("nonce", "nonce-123")
         }.toString().encodeToByteArray(),
-        mapOf("typ" to JsonPrimitive("oauth-authz-req+jwt")),
+        mapOf(
+            "typ" to JsonPrimitive("oauth-authz-req+jwt"),
+            "kid" to JsonPrimitive(key.getKeyId()),
+        ),
     )
 
     private fun jsonObjectOf(vararg pairs: Pair<String, kotlinx.serialization.json.JsonElement>) =

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -908,7 +908,7 @@ private extension MobileWalletClientIdScheme {
             return .decentralizedIdentifier
         case .verifierAttestation:
             return .verifierAttestation
-        case .openIdFederation:
+        case .openidFederation:
             return .openIDFederation
         }
     }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -525,7 +525,10 @@ private extension MetadataTrustType {
 
 private extension WalletClientIDTrustConfiguration {
     func toKMPClientIDTrustConfiguration() -> WalletBridgeClientIdTrustConfiguration {
-        WalletBridgeClientIdTrustConfiguration(x509TrustAnchorsPem: x509TrustAnchorsPEM)
+        WalletBridgeClientIdTrustConfiguration(
+            x509TrustAnchorsPem: x509TrustAnchorsPEM,
+            preRegisteredClientMetadataJson: preRegisteredClientMetadataJSON
+        )
     }
 }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -348,8 +348,29 @@ private extension Waltid_openid4vc_walletWalletIssuanceIssuerPreview {
             name: name,
             locale: locale,
             logoURI: logoUri.flatMap(URL.init(string:)),
-            logoAltText: logoAltText
+            logoAltText: logoAltText,
+            metadataProvenance: metadataProvenance.toSwiftMetadataProvenance()
         )
+    }
+}
+
+private extension Waltid_openid4vc_walletWalletIssuanceMetadataProvenance {
+    func toSwiftMetadataProvenance() -> MetadataProvenance {
+        switch self {
+        case is Waltid_openid4vc_walletWalletIssuanceMetadataProvenanceUnsigned:
+            return .unsigned
+        case let signed as Waltid_openid4vc_walletWalletIssuanceMetadataProvenanceSigned:
+            return .signed(
+                SignedMetadataProvenance(
+                    compactJWT: signed.compactJwt,
+                    algorithm: signed.algorithm,
+                    keyID: signed.keyId,
+                    trustType: signed.trustType == .trustedIssuer ? .trustedIssuer : .trustedDelegate
+                )
+            )
+        default:
+            preconditionFailure("Unsupported issuer metadata provenance: \(type(of: self))")
+        }
     }
 }
 
@@ -459,12 +480,46 @@ private extension WalletConfiguration {
             persistence: persistence.toKMPPersistence(),
             databaseKeyProvider: persistence.toKMPDatabaseKeyProvider(),
             attestation: attestation?.toKMPAttestationConfiguration(),
+            issuerMetadataTrustResolver: issuerMetadataTrustResolver.map {
+                KMPIssuerMetadataTrustResolverAdapter(resolver: $0)
+            },
             preferredLocales: preferredLocales,
             transactionDataProfiles: transactionDataProfiles.map { $0.toKMPTransactionDataProfile() },
             clientIdTrustConfiguration: clientIDTrustConfiguration.toKMPClientIDTrustConfiguration(),
             appGroupIdentifier: crossProcessAccess?.appGroupIdentifier,
             keychainAccessGroup: crossProcessAccess?.keychainAccessGroup
         )
+    }
+}
+
+private final class KMPIssuerMetadataTrustResolverAdapter: WalletBridgeIssuerMetadataTrustResolver, @unchecked Sendable {
+    private let resolver: any IssuerMetadataTrustResolver
+
+    init(resolver: any IssuerMetadataTrustResolver) {
+        self.resolver = resolver
+    }
+
+    func __verify(compactJwt: String, expectedCredentialIssuer: String) async throws -> WalletBridgeIssuerMetadataSigner {
+        let signer = try await resolver.verify(
+            compactJWT: compactJwt,
+            expectedCredentialIssuer: expectedCredentialIssuer
+        )
+        return WalletBridgeIssuerMetadataSigner(
+            keyId: signer.keyID,
+            algorithm: signer.algorithm,
+            trustType: signer.trustType.toKMPTrustType()
+        )
+    }
+}
+
+private extension MetadataTrustType {
+    func toKMPTrustType() -> WalletBridgeIssuerMetadataSignerTrustType {
+        switch self {
+        case .trustedIssuer:
+            return .trustedIssuer
+        case .trustedDelegate:
+            return .trustedDelegate
+        }
     }
 }
 
@@ -795,6 +850,7 @@ private extension MobileWalletPresentationRequestContext {
         PresentationRequestContext(
             clientID: clientId,
             verifierMetadata: verifierMetadata?.toSwiftVerifierMetadata(),
+            requestAuthentication: requestAuthentication.toSwiftRequestAuthentication(),
             responseURI: responseUri.flatMap(URL.init(string:)),
             state: state,
             nonce: nonce,
@@ -808,6 +864,7 @@ private extension MobileWalletPresentationRequestInfo {
         PresentationRequestInfo(
             clientID: clientId,
             verifierMetadata: verifierMetadata?.toSwiftVerifierMetadata(),
+            requestAuthentication: requestAuthentication.toSwiftRequestAuthentication(),
             responseURI: responseUri.flatMap(URL.init(string:)),
             state: state,
             nonce: nonce,
@@ -815,6 +872,45 @@ private extension MobileWalletPresentationRequestInfo {
             transactionData: swiftArray(transactionData, of: MobileWalletTransactionDataItem.self)
                 .map { $0.toSwiftTransactionData() }
         )
+    }
+}
+
+private extension MobileWalletRequestAuthentication {
+    func toSwiftRequestAuthentication() -> PresentationRequestAuthentication {
+        switch self {
+        case is MobileWalletRequestAuthenticationUnauthenticated:
+            return .unauthenticated
+        case let authenticated as MobileWalletRequestAuthenticationAuthenticated:
+            return .authenticated(
+                compactRequestObject: authenticated.compactRequestObject,
+                algorithm: authenticated.algorithm,
+                keyID: authenticated.keyId,
+                clientIDScheme: authenticated.clientIdScheme.toSwiftClientIDScheme()
+            )
+        default:
+            preconditionFailure("Unsupported request authentication: \(type(of: self))")
+        }
+    }
+}
+
+private extension MobileWalletClientIdScheme {
+    func toSwiftClientIDScheme() -> PresentationClientIDScheme {
+        switch self {
+        case .preRegistered:
+            return .preRegistered
+        case .redirectUri:
+            return .redirectURI
+        case .x509SanDns:
+            return .x509SanDNS
+        case .x509Hash:
+            return .x509Hash
+        case .decentralizedIdentifier:
+            return .decentralizedIdentifier
+        case .verifierAttestation:
+            return .verifierAttestation
+        case .openIdFederation:
+            return .openIDFederation
+        }
     }
 }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -14,6 +14,9 @@ public struct WalletConfiguration: Sendable {
     /// Trust anchors used to authenticate verifier Request Objects.
     public var clientIDTrustConfiguration: WalletClientIDTrustConfiguration
 
+    /// Optional verifier for signed Credential Issuer Metadata.
+    public var issuerMetadataTrustResolver: (any IssuerMetadataTrustResolver)?
+
     /// Wallet-local persistence configuration.
     public var persistence: WalletPersistence
 
@@ -36,6 +39,8 @@ public struct WalletConfiguration: Sendable {
     ///     that require client attestation.
     ///   - clientIDTrustConfiguration: Trust anchors used to authenticate verifier
     ///     Request Objects. The default trusts no X.509 verifier by configuration.
+    ///   - issuerMetadataTrustResolver: Verifies signed Credential Issuer Metadata
+    ///     and establishes the signer's authority.
     ///   - persistence: Local persistence configuration for wallet-owned state.
     ///   - transactionDataProfiles: OpenID4VP transaction data profiles this
     ///     wallet accepts before previewing or submitting a presentation.
@@ -48,6 +53,7 @@ public struct WalletConfiguration: Sendable {
         defaultKeyType: WalletKeyType = .secp256r1,
         attestation: WalletAttestationConfiguration? = nil,
         clientIDTrustConfiguration: WalletClientIDTrustConfiguration = .init(),
+        issuerMetadataTrustResolver: (any IssuerMetadataTrustResolver)? = nil,
         persistence: WalletPersistence = WalletPersistence(),
         transactionDataProfiles: [WalletTransactionDataProfile] = [],
         preferredLocales: [String] = Locale.preferredLanguages,
@@ -57,6 +63,7 @@ public struct WalletConfiguration: Sendable {
         self.defaultKeyType = defaultKeyType
         self.attestation = attestation
         self.clientIDTrustConfiguration = clientIDTrustConfiguration
+        self.issuerMetadataTrustResolver = issuerMetadataTrustResolver
         self.persistence = persistence
         self.transactionDataProfiles = transactionDataProfiles
         self.preferredLocales = preferredLocales
@@ -82,6 +89,47 @@ public struct WalletCrossProcessAccess: Equatable, Sendable {
         self.appGroupIdentifier = appGroupIdentifier
         self.keychainAccessGroup = keychainAccessGroup
     }
+}
+
+/// Trusted signer details returned after verifying signed Credential Issuer Metadata.
+public struct IssuerMetadataSigner: Equatable, Sendable {
+    /// Identifier of the trusted verification key, as reported by the trust resolver.
+    public let keyID: String?
+    /// JWS algorithm verified by the trust resolver.
+    public let algorithm: String
+    /// Authority category established by the trust resolver.
+    public let trustType: MetadataTrustType
+
+    /// Creates trusted signer details.
+    ///
+    /// - Parameters:
+    ///   - keyID: Identifier of the trusted verification key, as reported by the trust resolver.
+    ///   - algorithm: JWS algorithm verified by the trust resolver.
+    ///   - trustType: Authority category established by the trust resolver.
+    public init(keyID: String?, algorithm: String, trustType: MetadataTrustType) {
+        self.keyID = keyID
+        self.algorithm = algorithm
+        self.trustType = trustType
+    }
+}
+
+/// Authority category established for a signer of Credential Issuer Metadata.
+public enum MetadataTrustType: Equatable, Sendable {
+    /// The signer is the trusted credential issuer.
+    case trustedIssuer
+    /// The signer is a trusted delegate of the credential issuer.
+    case trustedDelegate
+}
+
+/// Verifies signed Credential Issuer Metadata before the wallet reads its claims.
+public protocol IssuerMetadataTrustResolver: Sendable {
+    /// Verifies a compact JWS and establishes that its signer is authorized for the expected issuer.
+    ///
+    /// - Parameters:
+    ///   - compactJWT: Compact JWS returned by the Credential Issuer Metadata endpoint.
+    ///   - expectedCredentialIssuer: Credential issuer for which signer authority must be established.
+    /// - Returns: Trusted signer details used to retain metadata provenance.
+    func verify(compactJWT: String, expectedCredentialIssuer: String) async throws -> IssuerMetadataSigner
 }
 
 /// Trust configuration used to authenticate verifier Request Objects.
@@ -648,6 +696,9 @@ public struct IssuanceIssuerPreview: Equatable, Sendable {
     /// Alternative text for the issuer logo.
     public let logoAltText: String?
 
+    /// Source and verification provenance for this metadata.
+    public let metadataProvenance: MetadataProvenance
+
     /// Creates an issuer preview.
     ///
     /// - Parameters:
@@ -656,12 +707,55 @@ public struct IssuanceIssuerPreview: Equatable, Sendable {
     ///   - locale: Locale associated with the display entry.
     ///   - logoURI: Issuer logo URL.
     ///   - logoAltText: Alternative text for the issuer logo.
-    public init(identifier: String, name: String?, locale: String?, logoURI: URL?, logoAltText: String?) {
+    ///   - metadataProvenance: Source and verification provenance for this metadata.
+    public init(
+        identifier: String,
+        name: String?,
+        locale: String?,
+        logoURI: URL?,
+        logoAltText: String?,
+        metadataProvenance: MetadataProvenance
+    ) {
         self.identifier = identifier
         self.name = name
         self.locale = locale
         self.logoURI = logoURI
         self.logoAltText = logoAltText
+        self.metadataProvenance = metadataProvenance
+    }
+}
+
+/// Provenance for Credential Issuer Metadata used by the wallet.
+public enum MetadataProvenance: Equatable, Sendable {
+    /// Metadata was received as an unsigned JSON document.
+    case unsigned
+    /// Metadata was received in a JWS verified by the configured trust resolver.
+    case signed(SignedMetadataProvenance)
+}
+
+/// Verified signed Credential Issuer Metadata provenance.
+public struct SignedMetadataProvenance: Equatable, Sendable {
+    /// Exact compact JWS returned by the issuer.
+    public let compactJWT: String
+    /// JWS algorithm verified by the configured trust resolver.
+    public let algorithm: String
+    /// Identifier of the trusted verification key, as reported by the trust resolver.
+    public let keyID: String?
+    /// Authority category established by the trust resolver.
+    public let trustType: MetadataTrustType
+
+    /// Creates signed metadata provenance.
+    ///
+    /// - Parameters:
+    ///   - compactJWT: Exact compact JWS returned by the issuer.
+    ///   - algorithm: JWS algorithm verified by the trust resolver.
+    ///   - keyID: Identifier of the trusted verification key, as reported by the trust resolver.
+    ///   - trustType: Authority category established by the trust resolver.
+    public init(compactJWT: String, algorithm: String, keyID: String?, trustType: MetadataTrustType) {
+        self.compactJWT = compactJWT
+        self.algorithm = algorithm
+        self.keyID = keyID
+        self.trustType = trustType
     }
 }
 
@@ -1077,6 +1171,9 @@ public struct PresentationRequestContext: Equatable, Sendable {
     /// Typed metadata supplied by the OpenID4VP verifier when available.
     public let verifierMetadata: VerifierMetadata?
 
+    /// Authentication established for the authorization request or its Request Object.
+    public let requestAuthentication: PresentationRequestAuthentication
+
     /// Response URI used for direct-post responses when available.
     public let responseURI: URL?
 
@@ -1094,6 +1191,7 @@ public struct PresentationRequestContext: Equatable, Sendable {
     /// - Parameters:
     ///   - clientID: Validated OpenID4VP client identifier from the request.
     ///   - verifierMetadata: Typed metadata supplied by the verifier when available.
+    ///   - requestAuthentication: Authentication facts established while resolving the request.
     ///   - responseURI: Response URI to which the wallet would submit the presentation or error, when provided.
     ///   - state: OpenID state value from the request, when provided.
     ///   - nonce: OpenID nonce value from the request, when provided. May be nil if the missing nonce is the validation error.
@@ -1101,6 +1199,7 @@ public struct PresentationRequestContext: Equatable, Sendable {
     public init(
         clientID: String,
         verifierMetadata: VerifierMetadata? = nil,
+        requestAuthentication: PresentationRequestAuthentication,
         responseURI: URL? = nil,
         state: String? = nil,
         nonce: String? = nil,
@@ -1112,6 +1211,7 @@ public struct PresentationRequestContext: Equatable, Sendable {
         )
         self.clientID = clientID
         self.verifierMetadata = verifierMetadata
+        self.requestAuthentication = requestAuthentication
         self.responseURI = responseURI
         self.state = state
         self.nonce = nonce
@@ -1168,6 +1268,37 @@ public struct ResponseEncryptionDetails: Equatable, Sendable {
     }
 }
 
+/// Authentication established for an OpenID4VP authorization request.
+public enum PresentationRequestAuthentication: Equatable, Sendable {
+    /// No signed Request Object authenticated this request.
+    case unauthenticated
+    /// The Request Object was authenticated by the OpenID4VP client-ID layer.
+    case authenticated(
+        compactRequestObject: String,
+        algorithm: String,
+        keyID: String?,
+        clientIDScheme: PresentationClientIDScheme
+    )
+}
+
+/// Client identifier scheme established while authenticating a Request Object.
+public enum PresentationClientIDScheme: Equatable, Sendable {
+    /// The verifier is identified through pre-registered metadata.
+    case preRegistered
+    /// The verifier is identified by a redirect URI.
+    case redirectURI
+    /// The verifier is identified by an X.509 SAN DNS name.
+    case x509SanDNS
+    /// The verifier is identified by an X.509 certificate hash.
+    case x509Hash
+    /// The verifier is identified by a decentralized identifier.
+    case decentralizedIdentifier
+    /// The verifier is identified by a verifier attestation.
+    case verifierAttestation
+    /// The verifier is identified through OpenID Federation.
+    case openIDFederation
+}
+
 /// Verifier, transaction, and response-protection metadata extracted from a presentation request.
 public struct PresentationRequestInfo: Equatable, Sendable {
     /// OpenID4VP client identifier.
@@ -1175,6 +1306,9 @@ public struct PresentationRequestInfo: Equatable, Sendable {
 
     /// Typed metadata supplied by the OpenID4VP verifier when available.
     public let verifierMetadata: VerifierMetadata?
+
+    /// Authentication established for the authorization request or its Request Object.
+    public let requestAuthentication: PresentationRequestAuthentication
 
     /// Response URI used for direct-post responses when available.
     public let responseURI: URL?
@@ -1196,6 +1330,7 @@ public struct PresentationRequestInfo: Equatable, Sendable {
     /// - Parameters:
     ///   - clientID: OpenID4VP client identifier from the request.
     ///   - verifierMetadata: Typed metadata supplied by the verifier.
+    ///   - requestAuthentication: Authentication facts established while resolving the request.
     ///   - responseURI: Direct-post response URI when available.
     ///   - state: OpenID state value from the request.
     ///   - nonce: OpenID nonce value from the request.
@@ -1204,6 +1339,7 @@ public struct PresentationRequestInfo: Equatable, Sendable {
     public init(
         clientID: String,
         verifierMetadata: VerifierMetadata? = nil,
+        requestAuthentication: PresentationRequestAuthentication,
         responseURI: URL? = nil,
         state: String? = nil,
         nonce: String,
@@ -1216,6 +1352,7 @@ public struct PresentationRequestInfo: Equatable, Sendable {
         )
         self.clientID = clientID
         self.verifierMetadata = verifierMetadata
+        self.requestAuthentication = requestAuthentication
         self.responseURI = responseURI
         self.state = state
         self.nonce = nonce

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -137,12 +137,20 @@ public struct WalletClientIDTrustConfiguration: Sendable, Equatable {
     /// PEM-encoded X.509 trust anchors pinned by the hosting application.
     public var x509TrustAnchorsPEM: [String]
 
+    /// Explicit pre-registered client metadata JSON, keyed by client ID.
+    public var preRegisteredClientMetadataJSON: [String: String]
+
     /// Creates client-ID trust configuration.
     ///
-    /// - Parameter x509TrustAnchorsPEM: PEM-encoded X.509 trust anchors pinned
-    ///   by the hosting application.
-    public init(x509TrustAnchorsPEM: [String] = []) {
+    /// - Parameters:
+    ///   - x509TrustAnchorsPEM: PEM-encoded X.509 trust anchors pinned by the hosting application.
+    ///   - preRegisteredClientMetadataJSON: Client metadata JSON for explicit pre-registered verifiers.
+    public init(
+        x509TrustAnchorsPEM: [String] = [],
+        preRegisteredClientMetadataJSON: [String: String] = [:]
+    ) {
         self.x509TrustAnchorsPEM = x509TrustAnchorsPEM
+        self.preRegisteredClientMetadataJSON = preRegisteredClientMetadataJSON
     }
 }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -180,6 +180,44 @@ final class WalletAPITests: XCTestCase {
         XCTAssertEqual(preview.credentialRequirements.single?.options, [["pid"]])
     }
 
+    func testAuthenticatedRequestAuthenticationRetainsExactSecurityFacts() {
+        let authentication = PresentationRequestAuthentication.authenticated(
+            compactRequestObject: "signed-request-object",
+            algorithm: "ES256",
+            keyID: "verifier-kid",
+            clientIDScheme: .preRegistered
+        )
+
+        guard case let .authenticated(compactRequestObject, algorithm, keyID, clientIDScheme) = authentication else {
+            return XCTFail("Expected authenticated request object")
+        }
+
+        XCTAssertEqual(compactRequestObject, "signed-request-object")
+        XCTAssertEqual(algorithm, "ES256")
+        XCTAssertEqual(keyID, "verifier-kid")
+        XCTAssertEqual(clientIDScheme, .preRegistered)
+    }
+
+    func testSignedIssuerMetadataProvenanceRetainsTrustResolverFacts() {
+        let provenance = MetadataProvenance.signed(
+            SignedMetadataProvenance(
+                compactJWT: "signed-metadata-jwt",
+                algorithm: "EdDSA",
+                keyID: "issuer-key",
+                trustType: .trustedIssuer
+            )
+        )
+
+        guard case let .signed(signed) = provenance else {
+            return XCTFail("Expected signed issuer metadata provenance")
+        }
+
+        XCTAssertEqual(signed.compactJWT, "signed-metadata-jwt")
+        XCTAssertEqual(signed.algorithm, "EdDSA")
+        XCTAssertEqual(signed.keyID, "issuer-key")
+        XCTAssertEqual(signed.trustType, .trustedIssuer)
+    }
+
     func testWalletHasAsyncFacadeShape() async {
         let wallet = Wallet(configuration: .init(), bridge: FakeWalletCoreBridge())
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -139,6 +139,7 @@ final class WalletAPITests: XCTestCase {
             request: .init(
                 clientID: "https://verifier.example",
                 verifierMetadata: testVerifierMetadata,
+                requestAuthentication: .unauthenticated,
                 responseURI: URL(string: "https://verifier.example/direct-post"),
                 state: "state-1",
                 nonce: "nonce-1",
@@ -331,6 +332,7 @@ final class WalletAPITests: XCTestCase {
                 request: .init(
                     clientID: "https://verifier.example",
                     verifierMetadata: testVerifierMetadata,
+                    requestAuthentication: .unauthenticated,
                     responseURI: nil,
                     state: nil,
                     nonce: "nonce-1",
@@ -387,6 +389,7 @@ final class WalletAPITests: XCTestCase {
         let requestInfo = PresentationRequestContext(
             clientID: "https://verifier.example",
             verifierMetadata: testVerifierMetadata,
+            requestAuthentication: .unauthenticated,
             responseEncryption: .notRequired
         )
         let bridge = FakeWalletCoreBridge()
@@ -770,7 +773,14 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
         id: "issuance-session-1",
         offer: IssuanceOfferPreview(
             grant: .preAuthorizedCode,
-            issuer: .init(identifier: "https://issuer.example", name: nil, locale: nil, logoURI: nil, logoAltText: nil),
+            issuer: .init(
+                identifier: "https://issuer.example",
+                name: nil,
+                locale: nil,
+                logoURI: nil,
+                logoAltText: nil,
+                metadataProvenance: .unsigned
+            ),
             credentials: [],
             transactionCode: nil
         )
@@ -783,6 +793,7 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
             previewHandle: PresentationPreviewHandle(value: "fake-presentation-preview"),
             request: .init(
                 clientID: "https://verifier.example",
+                requestAuthentication: .unauthenticated,
                 nonce: "nonce-1",
                 responseEncryption: .notRequired,
             ),

--- a/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/testsupport/Issuer2WalletFlowDriver.kt
+++ b/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/testsupport/Issuer2WalletFlowDriver.kt
@@ -61,7 +61,9 @@ class Issuer2WalletFlowDriver(
             credentialOffer = offerRequest.credentialOffer,
             credentialOfferUri = offerRequest.credentialOfferUri,
         )
-        val issuerMetadata = IssuerMetadataResolver(client).resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val issuerMetadata = IssuerMetadataResolver(client)
+            .resolveCredentialIssuerMetadata(offer.credentialIssuer)
+            .metadata
         val authorizationServerMetadata = IssuerMetadataResolver(client)
             .resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
 
@@ -174,7 +176,9 @@ class Issuer2WalletFlowDriver(
         requestMode: Issuer2AuthorizationRequestMode,
         credentialIssuer: String = DEFAULT_CREDENTIAL_ISSUER,
     ): String {
-        val issuerMetadata = IssuerMetadataResolver(client).resolveCredentialIssuerMetadata(credentialIssuer)
+        val issuerMetadata = IssuerMetadataResolver(client)
+            .resolveCredentialIssuerMetadata(credentialIssuer)
+            .metadata
         val authorizationServerMetadata = IssuerMetadataResolver(client)
             .resolveAuthorizationServerMetadataWithFallback(issuerMetadata)
         val authorizationUrl = buildAuthorizationRequestUrl(

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/OpenId4VpPresentationService.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/OpenId4VpPresentationService.kt
@@ -86,7 +86,8 @@ class OpenId4VpPresentationService(
         resolvedRequest: ResolvedAuthorizationRequest,
     ): Url = when (resolvedRequest) {
         is ResolvedAuthorizationRequest.Plain -> buildWalletPresentationRequest(request, resolvedRequest.authorizationRequest)
-        is ResolvedAuthorizationRequest.WithRequestObject -> buildWalletPresentationRequest(request, resolvedRequest.requestObject)
+        is ResolvedAuthorizationRequest.UnsignedRequestObject -> buildWalletPresentationRequest(request, resolvedRequest.requestObject)
+        is ResolvedAuthorizationRequest.AuthenticatedRequestObject -> buildWalletPresentationRequest(request, resolvedRequest.requestObject)
     }
 
     suspend fun matchCredentialsForPresentationRequest(


### PR DESCRIPTION
## Summary

Adds the stacked public Android/iOS journey for [WAL-1211](https://linear.app/walt-new/issue/WAL-1211/add-support-for-signed-metadata), proving that trusted issuer metadata and authenticated verifier Request Object state survive one complete wallet flow.

This companion is stacked on [walt-id/waltid-identity#2011](https://github.com/walt-id/waltid-identity/pull/2011), with functional Enterprise adaptation in [walt-id/waltid-identity-enterprise#596](https://github.com/walt-id/waltid-identity-enterprise/pull/596), the coordinated private license-test companion in [walt-id/waltid-identity-enterprise-license#3](https://github.com/walt-id/waltid-identity-enterprise-license/pull/3), and the explicit marker companion in [walt-id/waltid-identity-enterprise#597](https://github.com/walt-id/waltid-identity-enterprise/pull/597). Deterministic resolver and bridge coverage lives in #2011; this PR exercises the public issuer2/verifier2 services on both mobile platforms.

## What Changed

- Adds one combined Android/KMP journey: resolve a signed issuer offer, assert signed provenance, continue issuance from the reviewed session, preview a signed verifier Request Object, assert authenticated request state, submit the presentation, and wait for verifier success.
- Adds the equivalent native iOS journey and Swift assertions.
- Pins the public issuer signing key and public verifier request-object JWK independently; neither JWT selects its own trust anchor.
- Creates signed verifier sessions with the required explicit client ID, while preserving the unsigned helper payload and rejecting the invalid combination of a response-bound redirect URI client ID with a signed request.
- Uses crypto2/Jose in the shared test trust fixture for JWS parsing and verification.

## Architecture Notes

The test maps the established mobile requestAuthentication result and checks the pre-registered client-ID scheme, expected algorithm, presence of a kid, and signed issuer trust type. It contains no backend production implementation or deployment change. The Enterprise companion #597 contains no functional delta beyond the #2011 adapter in #596.

## Caveats and Follow-Ups

This remains an external public E2E: issuer2/verifier2 must continue to serve compatible signed responses and the independently pinned signing keys. The PR contains no backend deployment change. Route-level regression coverage remains in [walt-id/waltid-identity#2015](https://github.com/walt-id/waltid-identity/pull/2015) and [walt-id/waltid-identity-enterprise#565](https://github.com/walt-id/waltid-identity-enterprise/pull/565).

## Breaking

None.