### PR TITLE
fix external kms usage and did generation for external kms

### DIFF
--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
@@ -1,6 +1,7 @@
 package id.walt.w3c.issuance
 
 import id.walt.crypto.keys.Key
+import id.walt.crypto.keys.PublicKeyIds.publicKeyId
 import id.walt.crypto2.jose.JwsAlgorithm
 import id.walt.crypto2.keys.Key as Crypto2Key
 import id.walt.crypto.utils.JsonUtils.toJsonElement
@@ -316,7 +317,7 @@ object Issuer {
     @JsPromise
     @JsExport.Ignore
     suspend fun getKidHeader(issuerKey: Key, issuerDid: String? = null): String {
-        return qualifyDidKeyId(issuerKey.getKeyId(), issuerDid)
+        return qualifyDidKeyId(issuerKey.publicKeyId(), issuerDid)
     }
 
     @JsExport.Ignore

--- a/waltid-libraries/crypto/waltid-crypto-azure/src/main/kotlin/id/walt/crypto/keys/azure/AzureKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto-azure/src/main/kotlin/id/walt/crypto/keys/azure/AzureKey.kt
@@ -38,15 +38,13 @@ class AzureKey(
 
     override fun toString(): String = "[Azure ${keyType.name} key @KeyVault - $id]"
 
-    override suspend fun getKeyId(): String = getPublicKey().getKeyId()
+    override suspend fun getKeyId(): String = getPublicKey().getThumbprint()
 
-    override suspend fun getThumbprint(): String {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getThumbprint(): String = getPublicKey().getThumbprint()
 
-    override suspend fun exportJWK(): String = throw NotImplementedError("JWK export is not available for remote keys.")
+    override suspend fun exportJWK(): String = getPublicKey().exportJWK()
 
-    override suspend fun exportJWKObject(): JsonObject = Json.parseToJsonElement(_publicKey!!.toString()).jsonObject
+    override suspend fun exportJWKObject(): JsonObject = PublicKeyIds.run { publicJwkForPublish() }
 
     override suspend fun exportPEM(): String = throw NotImplementedError("PEM export is not available for remote keys.")
 
@@ -217,15 +215,23 @@ class AzureKey(
             val azureKeyType =
                 publicKeyJson["kty"]?.jsonPrimitive?.content ?: error("Missing key type in public key response")
             val crvFromResponse = publicKeyJson["crv"]?.jsonPrimitive?.content
-            val publicKeyJsonModified = publicKeyJson.toMutableMap()
-            publicKeyJsonModified.remove("key_ops")
-            val publicKey = JWKKey.importJWK(publicKeyJsonModified.toMap().toJsonElement().toString())
+            val publicKeyJsonModified = publicKeyJson.toMutableMap().apply {
+                remove("key_ops")
+                remove("kid")
+            }
+            val materialOnly = JWKKey.importJWK(publicKeyJsonModified.toMap().toJsonElement().toString())
                 .getOrElse { exception ->
                     throw IllegalArgumentException(
                         "Invalid JWK in public key: $publicKeyJson",
                         exception
                     )
                 }
+            val thumbprint = materialOnly.getThumbprint()
+            val publicKey = JWKKey.importJWK(
+                JsonObject(materialOnly.exportJWKObject() + ("kid" to JsonPrimitive(thumbprint))).toString()
+            ).getOrElse { exception ->
+                throw IllegalArgumentException("Failed to assign public thumbprint kid: $publicKeyJson", exception)
+            }
 
             val keyType = azureKeyToKeyTypeMapping(crvFromResponse ?: "", azureKeyType)
 
@@ -294,8 +300,8 @@ class AzureKey(
 
                 val jwk = keyVaultKey.key
                 val jwkJson = jwk.toString() // Azure SDK's JsonWebKey has a toString that outputs JWK JSON
-
-                JWKKey.importJWK(jwkJson).getOrThrow()
+                val imported = JWKKey.importJWK(jwkJson).getOrThrow()
+                parseAzurePublicKey(imported.exportJWKObject()).publicKey
             } catch (e: ResourceNotFoundException) {
                 throw KeyNotFoundException(keyName, "Key not found in Azure Key Vault", e)
             } catch (e: com.azure.core.exception.HttpResponseException) {

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/PublicKeyIds.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/PublicKeyIds.kt
@@ -1,0 +1,52 @@
+package id.walt.crypto.keys
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Public-facing key identifiers vs KMS locators.
+ *
+ * Azure Key Vault (and similar) expose `https://…` URLs as JWK `kid`. Those are
+ * operational locators and must never be published as JWT/JAR/JWKS/DID kids.
+ * The default public id is the RFC 7638 JWK thumbprint of the public key.
+ */
+object PublicKeyIds {
+
+    fun isHttpKeyId(id: String): Boolean =
+        id.startsWith("http://") || id.startsWith("https://")
+
+    /**
+     * Stable public key id for JWKS entries, JWT/JAR headers, and DID fragments
+     * (when the DID method does not mandate a different VM id, e.g. did:key).
+     */
+    suspend fun Key.publicKeyId(): String {
+        val publicKey = getPublicKey()
+        val id = publicKey.getKeyId()
+        return if (isHttpKeyId(id)) publicKey.getThumbprint() else id
+    }
+
+    /**
+     * Public JWK suitable for DID documents / JWKS: material plus a non-HTTP `kid`
+     * (RFC 7638 thumbprint when the source kid was a vault/URL locator).
+     */
+    suspend fun Key.publicJwkForPublish(): JsonObject {
+        val publicKey = getPublicKey()
+        val thumbprint = publicKey.getThumbprint()
+        val jwk = publicKey.exportJWKObject().toMutableMap()
+        val existingKid = jwk["kid"]?.jsonPrimitive?.contentOrNull
+        if (existingKid == null || isHttpKeyId(existingKid)) {
+            jwk["kid"] = JsonPrimitive(thumbprint)
+        }
+        return JsonObject(jwk)
+    }
+
+    fun sanitizePublicJwk(jwk: JsonObject, thumbprint: String): JsonObject {
+        val existingKid = jwk["kid"]?.jsonPrimitive?.contentOrNull
+        if (existingKid != null && !isHttpKeyId(existingKid)) return jwk
+        return JsonObject(jwk.toMutableMap().apply {
+            put("kid", JsonPrimitive(thumbprint))
+        })
+    }
+}

--- a/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/azure/AzureKeyRestApi.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/commonMain/kotlin/id/walt/crypto/keys/azure/AzureKeyRestApi.kt
@@ -42,11 +42,19 @@ private const val AZURE_KEY_VAULT_PROVIDER = "Azure Key Vault"
 @Serializable
 @SerialName("azure-rest-api")
 class AzureKeyRestApi(
+    /**
+     * Azure Key Vault key URL used for REST operations
+     * (`https://{vault}.vault.azure.net/keys/{name}/{version}`).
+     * This is an ops locator, not a public kid — use [getKeyId] for publishing.
+     */
     val id: String,
     var auth: AzureAuth? = null,
     private var _keyType: KeyType? = null,
     var _publicKey: DirectSerializedKey? = null,
 ) : Key() {
+
+    /** Vault URL for Azure Key Vault HTTP operations. */
+    val keyIdUrl: String get() = id
 
     @Transient
     private lateinit var accessToken: String
@@ -54,13 +62,17 @@ class AzureKeyRestApi(
     @Transient
     private lateinit var accessTokenExpiration: Instant
 
+    @Transient
+    private var cachedPublicKeyId: String? = null
+
     private fun updateKeyType() {
         _keyType = _publicKey?.key?.keyType
     }
 
     @JsExport.Ignore
     suspend fun fetchAndUpdatePublicKey() {
-        _publicKey = DirectSerializedKey(getPublicKeyFromAzureKms(getKeyId()))
+        _publicKey = DirectSerializedKey(getPublicKeyFromAzureKms(keyIdUrl))
+        cachedPublicKeyId = null
     }
 
     @JsExport.Ignore
@@ -105,37 +117,42 @@ class AzureKeyRestApi(
     override val hasPrivateKey: Boolean
         get() = true
 
-    override fun toString(): String = "[Azure ${keyType.name} key @ ${auth?.keyVaultUrl} - $id]"
+    override fun toString(): String = "[Azure ${keyType.name} key @ ${auth?.keyVaultUrl} - $keyIdUrl]"
 
     @JvmBlocking
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun getKeyId(): String = id
+    override suspend fun getKeyId(): String {
+        cachedPublicKeyId?.let { return it }
+        val publicKeyId = getPublicKey().getThumbprint()
+        cachedPublicKeyId = publicKeyId
+        return publicKeyId
+    }
 
     @JvmBlocking
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun getThumbprint(): String = throw UnsupportedOperationException("No private key available")
+    override suspend fun getThumbprint(): String = getPublicKey().getThumbprint()
 
     @JvmBlocking
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun exportJWK(): String = throw UnsupportedOperationException("No private key available")
+    override suspend fun exportJWK(): String = getPublicKey().exportJWK()
 
     @JvmBlocking
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun exportJWKObject(): JsonObject = throw UnsupportedOperationException("No private key available")
+    override suspend fun exportJWKObject(): JsonObject = PublicKeyIds.run { publicJwkForPublish() }
 
     @JvmBlocking
     @JvmAsync
     @JsPromise
     @JsExport.Ignore
-    override suspend fun exportPEM(): String = throw UnsupportedOperationException("No private key available")
+    override suspend fun exportPEM(): String = throw UnsupportedOperationException("PEM export is not available for remote Azure keys")
 
     @JvmBlocking
     @JvmAsync
@@ -158,7 +175,7 @@ class AzureKeyRestApi(
             put("alg", JsonPrimitive(signingAlgorithm))
             put("value", JsonPrimitive(base64UrlEncoded))
         }
-        val signatureResponse = client.post("$id/sign?api-version=7.4") {
+        val signatureResponse = client.post("$keyIdUrl/sign?api-version=7.4") {
             contentType(ContentType.Application.Json)
             bearerAuth(accessToken)
             setBody(body)
@@ -244,7 +261,7 @@ class AzureKeyRestApi(
     @JsExport.Ignore
     override suspend fun deleteKey(): Boolean {
         ensureAccessTokenValid()
-        val response = client.delete("$id?api-version=7.4") {
+        val response = client.delete("$keyIdUrl?api-version=7.4") {
             contentType(ContentType.Application.Json)
             bearerAuth(accessToken)
         }
@@ -303,10 +320,19 @@ class AzureKeyRestApi(
             val kid = publicKeyJson["kid"]?.jsonPrimitive?.content ?: error("No key id in key response")
             val azureKeyType = publicKeyJson["kty"]?.jsonPrimitive?.content ?: error("Missing key type in public key response")
             val crvFromResponse = publicKeyJson["crv"]?.jsonPrimitive?.content
-            val publicKeyJsonModified = publicKeyJson.toMutableMap()
-            publicKeyJsonModified.remove("key_ops")
-            val publicKey = JWKKey.importJWK(publicKeyJsonModified.toMap().toJsonElement().toString())
+            // Vault URL kids are ops locators — strip before import so getKeyId()/exports use thumbprint.
+            val publicKeyJsonModified = publicKeyJson.toMutableMap().apply {
+                remove("key_ops")
+                remove("kid")
+            }
+            val materialOnly = JWKKey.importJWK(publicKeyJsonModified.toMap().toJsonElement().toString())
                 .getOrElse { exception -> throw IllegalArgumentException("Invalid JWK in public key: $publicKeyJson", exception) }
+            val thumbprint = materialOnly.getThumbprint()
+            val publicKey = JWKKey.importJWK(
+                JsonObject(materialOnly.exportJWKObject() + ("kid" to JsonPrimitive(thumbprint))).toString()
+            ).getOrElse { exception ->
+                throw IllegalArgumentException("Failed to assign public thumbprint kid: $publicKeyJson", exception)
+            }
 
             val keyType = if (azureKeyType == "RSA") {
                 publicKey.keyType
@@ -442,10 +468,8 @@ class AzureKeyRestApi(
 
                 val parsedAzurePublicKey = parseAzurePublicKey(response.jsonObject["key"]?.jsonObject!!)
 
-                val keyId = parsedAzurePublicKey.kid
-
                 val createdKey = AzureKeyRestApi(
-                    id = keyId,
+                    id = parsedAzurePublicKey.kid, // vault URL for ops
                     auth = metadata.auth,
                     // Prefer requested type: Azure kty/crv cannot distinguish RSA key sizes.
                     _keyType = type,

--- a/waltid-libraries/crypto/waltid-crypto/src/jvmAndroidTest/kotlin/id/walt/crypto/keys/PublicKeyIdsTest.kt
+++ b/waltid-libraries/crypto/waltid-crypto/src/jvmAndroidTest/kotlin/id/walt/crypto/keys/PublicKeyIdsTest.kt
@@ -1,0 +1,63 @@
+package id.walt.crypto.keys
+
+import id.walt.crypto.keys.PublicKeyIds.publicJwkForPublish
+import id.walt.crypto.keys.PublicKeyIds.publicKeyId
+import id.walt.crypto.keys.azure.AzureKeyRestApi
+import id.walt.crypto.keys.jwk.JWKKey
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PublicKeyIdsTest {
+
+    @Test
+    fun publicKeyIdUsesThumbprintWhenJwkKidIsHttpUrl() = runTest {
+        val material = JWKKey.generate(KeyType.secp256r1).getPublicKey()
+        val thumbprint = material.getThumbprint()
+        val withVaultKid = JWKKey.importJWK(
+            JsonObject(
+                material.exportJWKObject() + ("kid" to JsonPrimitive("https://example.vault.azure.net/keys/k/v1"))
+            ).toString()
+        ).getOrThrow()
+
+        assertTrue(PublicKeyIds.isHttpKeyId(withVaultKid.getKeyId()))
+        assertEquals(thumbprint, withVaultKid.publicKeyId())
+        val published = withVaultKid.publicJwkForPublish()
+        assertEquals(thumbprint, published["kid"]!!.jsonPrimitive.content)
+        assertFalse(published["kid"]!!.jsonPrimitive.content.contains("vault.azure.net"))
+    }
+
+    @Test
+    fun parseAzurePublicKeyStripsVaultKidAndExposesThumbprint() = runTest {
+        val material = JWKKey.generate(KeyType.secp256r1).getPublicKey()
+        val thumbprint = material.getThumbprint()
+        val vaultUrl = "https://example.vault.azure.net/keys/demo/version-1"
+        val azureStyleJwk = JsonObject(
+            material.exportJWKObject().toMutableMap().apply {
+                put("kid", JsonPrimitive(vaultUrl))
+                put("key_ops", JsonPrimitive("sign"))
+            }
+        )
+
+        val parsed = AzureKeyRestApi.AzureKeyFunctions.parseAzurePublicKey(azureStyleJwk)
+        assertEquals(vaultUrl, parsed.kid)
+        assertEquals(thumbprint, parsed.publicKey.getKeyId())
+        assertEquals(thumbprint, parsed.publicKey.getThumbprint())
+        assertFalse(parsed.publicKey.exportJWKObject()["kid"]!!.jsonPrimitive.content.contains("https://"))
+
+        val azureKey = AzureKeyRestApi(
+            id = vaultUrl,
+            _keyType = KeyType.secp256r1,
+            _publicKey = DirectSerializedKey(parsed.publicKey),
+        )
+        assertEquals(vaultUrl, azureKey.keyIdUrl)
+        assertEquals(thumbprint, azureKey.getKeyId())
+        assertEquals(thumbprint, azureKey.getThumbprint())
+        assertEquals(thumbprint, azureKey.exportJWKObject()["kid"]!!.jsonPrimitive.content)
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/prefixes/DecentralizedIdentifier.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/prefixes/DecentralizedIdentifier.kt
@@ -2,15 +2,17 @@
 
 package id.walt.openid4vp.clientidprefix.prefixes
 
-import id.walt.crypto.utils.JwsUtils.decodeJws
+import id.walt.crypto.keys.Key
+import id.walt.crypto.keys.PublicKeyIds
 import id.walt.crypto2.jose.CompactJws
 import id.walt.crypto2.jose.JwsAlgorithm
+import id.walt.crypto2.keys.Key as Crypto2Key
 import id.walt.did.dids.DidService
 import id.walt.openid4vp.clientidprefix.ClientIdError
 import id.walt.openid4vp.clientidprefix.ClientValidationResult
 import id.walt.openid4vp.clientidprefix.RequestContext
-import kotlinx.serialization.Serializable
 import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
@@ -42,21 +44,11 @@ data class DecentralizedIdentifier(val did: String, override val rawValue: Strin
 
             if (decoded.algorithm == JwsAlgorithm.ES256K) {
                 val keys = DidService.resolveToKeys(clientId.did).getOrThrow()
-                val verificationKey = keys.find { key ->
-                    val keyId = key.getKeyId()
-                    keyId == kid || kid.endsWith("#$keyId") || kid.endsWith("/$keyId")
-                } ?: keys.singleOrNull()?.takeIf {
-                    kid == clientId.did || kid.startsWith("${clientId.did}#")
-                } ?: throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
+                val verificationKey = selectLegacyVerificationKey(clientId.did, kid, keys)
                 verificationKey.verifyJws(jws).getOrThrow()
             } else {
                 val keys = DidService.resolveToCrypto2Keys(clientId.did).getOrThrow()
-                val verificationKey = keys.find { key ->
-                    val keyId = key.id.value
-                    keyId == kid || kid.endsWith("#$keyId") || kid.endsWith("/$keyId")
-                } ?: keys.singleOrNull()?.takeIf {
-                    kid == clientId.did || kid.startsWith("${clientId.did}#")
-                } ?: throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
+                val verificationKey = selectCrypto2VerificationKey(clientId.did, kid, keys)
                 ClientIdCrypto2.verify(jws, verificationKey)
             }
 
@@ -68,5 +60,57 @@ data class DecentralizedIdentifier(val did: String, override val rawValue: Strin
         } catch (cause: Exception) {
             ClientValidationResult.Failure(ClientIdError.DidResolutionFailed(cause.message ?: "DID verification failed"))
         }
+    }
+
+    /**
+     * Key selection for OpenID4VP decentralized_identifier:
+     * 1. JAR kid is a DID URL for this DID (verification method id) — match fragment to key id/thumbprint
+     * 2. Otherwise match RFC 7638 thumbprint / public key id
+     * 3. Last resort: single-key DID with a DID-URL kid for this DID (e.g. did:key:<mb>#<mb>)
+     */
+    private suspend fun selectLegacyVerificationKey(did: String, kid: String, keys: Set<Key>): Key {
+        if (kid == did || kid.startsWith("$did#")) {
+            val fragment = kid.substringAfter('#', missingDelimiterValue = "")
+            if (fragment.isNotEmpty()) {
+                keys.find { key ->
+                    val publicId = PublicKeyIds.run { key.publicKeyId() }
+                    val thumbprint = key.getThumbprint()
+                    fragment == publicId || fragment == thumbprint || fragment == key.getKeyId()
+                }?.let { return it }
+            }
+            keys.singleOrNull()?.let { return it }
+        }
+
+        keys.find { key ->
+            val publicId = PublicKeyIds.run { key.publicKeyId() }
+            val thumbprint = key.getThumbprint()
+            publicId == kid || thumbprint == kid ||
+                kid.endsWith("#$publicId") || kid.endsWith("#$thumbprint") ||
+                kid.endsWith("/$publicId") || kid.endsWith("/$thumbprint")
+        }?.let { return it }
+
+        throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
+    }
+
+    private fun selectCrypto2VerificationKey(did: String, kid: String, keys: Set<Crypto2Key>): Crypto2Key {
+        if (kid == did || kid.startsWith("$did#")) {
+            val fragment = kid.substringAfter('#', missingDelimiterValue = "")
+            if (fragment.isNotEmpty()) {
+                keys.find { key ->
+                    val keyId = key.id.value
+                    !PublicKeyIds.isHttpKeyId(keyId) && (fragment == keyId)
+                }?.let { return it }
+            }
+            keys.singleOrNull()?.let { return it }
+        }
+
+        keys.find { key ->
+            val keyId = key.id.value
+            !PublicKeyIds.isHttpKeyId(keyId) && (
+                keyId == kid || kid.endsWith("#$keyId") || kid.endsWith("/$keyId")
+                )
+        }?.let { return it }
+
+        throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
     }
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/prefixes/DecentralizedIdentifier.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/prefixes/DecentralizedIdentifier.kt
@@ -64,21 +64,27 @@ data class DecentralizedIdentifier(val did: String, override val rawValue: Strin
 
     /**
      * Key selection for OpenID4VP decentralized_identifier:
-     * 1. JAR kid is a DID URL for this DID (verification method id) — match fragment to key id/thumbprint
-     * 2. Otherwise match RFC 7638 thumbprint / public key id
-     * 3. Last resort: single-key DID with a DID-URL kid for this DID (e.g. did:key:<mb>#<mb>)
+     * 1. JAR kid is a DID URL for this DID — match fragment to public key id / thumbprint
+     * 2. did:key method id `did:key:<multibase>#<multibase>` may not equal the KMS key id
+     *    (e.g. Azure vault URL); accept the single key only for that method fragment
+     * 3. Otherwise match RFC 7638 thumbprint / public key id
+     * 4. Unknown fragments (e.g. `did:…#missing`) must not authenticate
      */
     private suspend fun selectLegacyVerificationKey(did: String, kid: String, keys: Set<Key>): Key {
         if (kid == did || kid.startsWith("$did#")) {
-            val fragment = kid.substringAfter('#', missingDelimiterValue = "")
+            val fragment = kid.removePrefix("$did#").takeIf { kid != did }.orEmpty()
             if (fragment.isNotEmpty()) {
                 keys.find { key ->
                     val publicId = PublicKeyIds.run { key.publicKeyId() }
                     val thumbprint = key.getThumbprint()
                     fragment == publicId || fragment == thumbprint || fragment == key.getKeyId()
                 }?.let { return it }
+                if (isDidKeyMethodFragment(did, fragment)) {
+                    keys.singleOrNull()?.let { return it }
+                }
+            } else {
+                keys.singleOrNull()?.let { return it }
             }
-            keys.singleOrNull()?.let { return it }
         }
 
         keys.find { key ->
@@ -94,14 +100,18 @@ data class DecentralizedIdentifier(val did: String, override val rawValue: Strin
 
     private fun selectCrypto2VerificationKey(did: String, kid: String, keys: Set<Crypto2Key>): Crypto2Key {
         if (kid == did || kid.startsWith("$did#")) {
-            val fragment = kid.substringAfter('#', missingDelimiterValue = "")
+            val fragment = kid.removePrefix("$did#").takeIf { kid != did }.orEmpty()
             if (fragment.isNotEmpty()) {
                 keys.find { key ->
                     val keyId = key.id.value
                     !PublicKeyIds.isHttpKeyId(keyId) && (fragment == keyId)
                 }?.let { return it }
+                if (isDidKeyMethodFragment(did, fragment)) {
+                    keys.singleOrNull()?.let { return it }
+                }
+            } else {
+                keys.singleOrNull()?.let { return it }
             }
-            keys.singleOrNull()?.let { return it }
         }
 
         keys.find { key ->
@@ -113,4 +123,7 @@ data class DecentralizedIdentifier(val did: String, override val rawValue: Strin
 
         throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
     }
+
+    private fun isDidKeyMethodFragment(did: String, fragment: String): Boolean =
+        did.startsWith("did:key:") && fragment == did.removePrefix("did:key:")
 }

--- a/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/prefixes/DecentralizedIdentifier.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/prefixes/DecentralizedIdentifier.kt
@@ -41,14 +41,22 @@ data class DecentralizedIdentifier(val did: String, override val rawValue: Strin
                 ?: throw IllegalStateException("Missing 'kid' header in JWS for key selection.")
 
             if (decoded.algorithm == JwsAlgorithm.ES256K) {
-                val verificationKey = DidService.resolveToKeys(clientId.did).getOrThrow()
-                    .find { it.getKeyId() == kid }
-                    ?: throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
+                val keys = DidService.resolveToKeys(clientId.did).getOrThrow()
+                val verificationKey = keys.find { key ->
+                    val keyId = key.getKeyId()
+                    keyId == kid || kid.endsWith("#$keyId") || kid.endsWith("/$keyId")
+                } ?: keys.singleOrNull()?.takeIf {
+                    kid == clientId.did || kid.startsWith("${clientId.did}#")
+                } ?: throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
                 verificationKey.verifyJws(jws).getOrThrow()
             } else {
-                val verificationKey = DidService.resolveToCrypto2Keys(clientId.did).getOrThrow()
-                    .find { it.id.value == kid }
-                    ?: throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
+                val keys = DidService.resolveToCrypto2Keys(clientId.did).getOrThrow()
+                val verificationKey = keys.find { key ->
+                    val keyId = key.id.value
+                    keyId == kid || kid.endsWith("#$keyId") || kid.endsWith("/$keyId")
+                } ?: keys.singleOrNull()?.takeIf {
+                    kid == clientId.did || kid.startsWith("${clientId.did}#")
+                } ?: throw IllegalArgumentException("Key ID '$kid' from JWS not found in DID document.")
                 ClientIdCrypto2.verify(jws, verificationKey)
             }
 

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/VerificationSessionSetupData.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/data/VerificationSessionSetupData.kt
@@ -3,6 +3,7 @@
 package id.walt.verifier2.data
 
 import id.walt.crypto.keys.DirectSerializedKey
+import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyManager
 import id.walt.dcql.models.ClaimsQuery
 import id.walt.dcql.models.CredentialFormat
@@ -88,6 +89,22 @@ sealed interface VerificationSessionSetup {
     val core: GeneralFlowConfig
 }
 
+/**
+ * Persist the effective signing key on the session setup so `request_uri_method=post`
+ * can re-sign with `wallet_nonce` (OID4VP 1.0 §5.6). Keys resolved via KMS
+ * `keyReference` are otherwise only passed as a create-time argument and lost.
+ */
+fun VerificationSessionSetup.withCoreKeyIfMissing(key: Key): VerificationSessionSetup {
+    if (core.key != null) return this
+    val newCore = core.copy(key = DirectSerializedKey(key))
+    return when (this) {
+        is CrossDeviceFlowSetup -> copy(core = newCore)
+        is SameDeviceFlowSetup -> copy(core = newCore)
+        is DcApiAnnexDFlowSetup -> copy(core = newCore)
+        is DcApiAnnexCFlowSetup -> copy(coreFlow = coreFlow.copy(key = DirectSerializedKey(key)))
+    }
+}
+
 internal fun VerificationSessionSetup.publicView(): VerificationSessionSetup = when (this) {
     is CrossDeviceFlowSetup -> copy(core = core.publicView())
     is SameDeviceFlowSetup -> copy(core = core.publicView())
@@ -110,6 +127,7 @@ internal fun KtorSessionNotifications.publicView(): KtorSessionNotifications = c
         bearerToken = null,
     )
 )
+
 
 /** Flows that use URLs*/
 sealed interface UrlBearingDeviceFlowSetup : VerificationSessionSetup {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestObjectKid.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestObjectKid.kt
@@ -1,0 +1,62 @@
+package id.walt.verifier2.handlers.authrequest
+
+import id.walt.crypto.keys.Key
+import id.walt.crypto2.jose.Jwk
+import id.walt.crypto2.keys.EncodedKey
+import id.walt.crypto2.keys.Key as Crypto2Key
+
+/**
+ * Builds the JAR `kid` header for signed authorization requests.
+ *
+ * For `decentralized_identifier:did:key:…`, the verification method id is
+ * `did:key:<multibase>#<multibase>` (DID Key method). Using the raw KMS key id
+ * (e.g. an Azure Key Vault URL) produces a DID URL wallets reject.
+ *
+ * For other DIDs, prefer a stable public-key identifier and avoid absolute URLs
+ * (Azure embeds vault URLs as JWK `kid`) so the fragment remains a valid DID URL.
+ */
+internal object Verifier2RequestObjectKid {
+
+    suspend fun forClient(clientId: String?, key: Key): String =
+        forClient(clientId) { fragmentKeyId(key) }
+
+    suspend fun forClient(clientId: String?, key: Crypto2Key): String =
+        forClient(clientId) { fragmentKeyId(key) }
+
+    private suspend fun forClient(clientId: String?, fragment: suspend () -> String): String {
+        val prefix = "decentralized_identifier:"
+        val did = clientId
+            ?.takeIf { it.startsWith(prefix) }
+            ?.substringAfter(prefix)
+            ?.takeIf { it.isNotBlank() }
+            ?: return fragment()
+
+        if (did.startsWith("did:key:")) {
+            val identifier = did.removePrefix("did:key:")
+            return "$did#$identifier"
+        }
+
+        return "$did#${fragment()}"
+    }
+
+    private suspend fun fragmentKeyId(key: Key): String {
+        val publicKey = key.getPublicKey()
+        val keyId = publicKey.getKeyId()
+        return if (keyId.startsWith("http://") || keyId.startsWith("https://")) {
+            publicKey.getThumbprint()
+        } else {
+            keyId
+        }
+    }
+
+    private suspend fun fragmentKeyId(key: Crypto2Key): String {
+        val keyId = key.id.value
+        return if (keyId.startsWith("http://") || keyId.startsWith("https://")) {
+            val publicJwk = key.capabilities.publicKeyExporter
+                ?.exportPublicKey() as? EncodedKey.Jwk
+            if (publicJwk != null) Jwk.sha256Thumbprint(publicJwk) else keyId
+        } else {
+            keyId
+        }
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestUriPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestUriPostHandler.kt
@@ -2,10 +2,12 @@ package id.walt.verifier2.handlers.authrequest
 
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.PublicKeyIds
 import id.walt.crypto.keys.jwk.JWKKey
 import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
 import id.walt.crypto2.CryptoRuntime
 import id.walt.crypto2.jose.CompactJws
+import id.walt.crypto2.jose.Jwk
 import id.walt.crypto2.jose.JwsAlgorithm
 import id.walt.crypto2.keys.*
 import id.walt.crypto2.providers.cryptography.defaultSoftwareKeyProviders
@@ -156,6 +158,7 @@ object Verifier2RequestUriPostHandler {
         payload: JsonObject,
         headers: JsonObject,
     ): String {
+        requireMatchingKeyId(headers, signingKey)
         val crypto2Key = resolveCrypto2Key(signingKey, setOf(KeyUsage.SIGN))
         return if (crypto2Key != null) {
             val algorithm = JwsAlgorithm.parse(
@@ -175,6 +178,7 @@ object Verifier2RequestUriPostHandler {
     @Deprecated("Use the Crypto2Key overload")
     internal suspend fun verifyExistingRequestObject(jwt: String, signingKey: Key) {
         val decoded = CompactJws.decodeUnverified(jwt)
+        requireMatchingKeyId(decoded.protectedHeader, signingKey)
         val algorithm = JwsAlgorithm.parse(
             requireNotNull(decoded.protectedHeader["alg"]?.jsonPrimitive?.contentOrNull) {
                 "Existing signed request JWT is missing alg"
@@ -193,6 +197,7 @@ object Verifier2RequestUriPostHandler {
         payload: JsonObject,
         headers: JsonObject,
     ): String {
+        requireMatchingKeyId(headers, signingKey)
         val algorithm = JwsAlgorithm.parse(
             requireNotNull(headers["alg"]?.jsonPrimitive?.contentOrNull) {
                 "Existing signed request JWT is missing alg"
@@ -208,6 +213,7 @@ object Verifier2RequestUriPostHandler {
 
     internal suspend fun verifyExistingRequestObject(jwt: String, signingKey: Crypto2Key) {
         val decoded = CompactJws.decodeUnverified(jwt)
+        requireMatchingKeyId(decoded.protectedHeader, signingKey)
         val algorithm = decoded.algorithm
         val publicJwk = requireNotNull(signingKey.capabilities.publicKeyExporter) {
             "Request signing key does not export public material"
@@ -222,6 +228,43 @@ object Verifier2RequestUriPostHandler {
             )
         )
         CompactJws.verify(jwt, verificationKey, algorithm)
+    }
+
+    /**
+     * Bind re-sign / verify to the JAR kid when it is a raw key id.
+     * DID URL kids (`did:key:…#…`) are not KMS locators — they are checked against
+     * [Verifier2RequestObjectKid] in [respondRequestUriPost].
+     */
+    private suspend fun requireMatchingKeyId(headers: JsonObject, signingKey: Key) {
+        val publicId = PublicKeyIds.run { signingKey.publicKeyId() }
+        requireMatchingPublicKeyId(headers, publicId, signingKey.getKeyId())
+    }
+
+    private suspend fun requireMatchingKeyId(headers: JsonObject, signingKey: Crypto2Key) {
+        val keyId = signingKey.id.value
+        val publicId = if (PublicKeyIds.isHttpKeyId(keyId)) {
+            val publicJwk = signingKey.capabilities.publicKeyExporter
+                ?.exportPublicKey() as? EncodedKey.Jwk
+            if (publicJwk != null) Jwk.sha256Thumbprint(publicJwk) else keyId
+        } else {
+            keyId
+        }
+        requireMatchingPublicKeyId(headers, publicId, keyId)
+    }
+
+    private fun requireMatchingPublicKeyId(headers: JsonObject, publicId: String, rawKeyId: String) {
+        val protectedKeyId = requireNotNull(headers["kid"]?.jsonPrimitive?.contentOrNull) {
+            "Existing signed request JWT is missing kid"
+        }
+        if (protectedKeyId.startsWith("did:")) return
+        require(
+            protectedKeyId == publicId ||
+                protectedKeyId == rawKeyId ||
+                protectedKeyId.endsWith("#$publicId") ||
+                protectedKeyId.endsWith("#$rawKeyId")
+        ) {
+            "Resolved signing key does not match the existing signed request kid"
+        }
     }
 
     private suspend fun resolveCrypto2Key(signingKey: Key, usages: Set<KeyUsage>) =

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestUriPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestUriPostHandler.kt
@@ -111,6 +111,20 @@ object Verifier2RequestUriPostHandler {
         val existingHeaders = Json.parseToJsonElement(existingHeaderBytes.decodeToString()).jsonObject
         val existingPayload = Json.parseToJsonElement(existingPayloadBytes.decodeToString()).jsonObject
 
+        val clientId = verificationSession.authorizationRequest.clientId
+            ?: verificationSession.setup.core.clientId
+        val expectedKid = if (crypto2SigningKey != null) {
+            Verifier2RequestObjectKid.forClient(clientId, crypto2SigningKey)
+        } else {
+            Verifier2RequestObjectKid.forClient(clientId, requireNotNull(signingKey))
+        }
+        val existingKid = requireNotNull(existingHeaders["kid"]?.jsonPrimitive?.contentOrNull) {
+            "Existing signed request JWT is missing kid"
+        }
+        require(existingKid == expectedKid) {
+            "Existing signed request kid does not match session client_id / signing key"
+        }
+
         // Inject wallet_nonce into the payload (per spec §5.6 §response §wallet_nonce)
         val newPayload = buildJsonObject {
             existingPayload.forEach { (k, v) -> put(k, v) }
@@ -142,7 +156,6 @@ object Verifier2RequestUriPostHandler {
         payload: JsonObject,
         headers: JsonObject,
     ): String {
-        requireMatchingKeyId(headers, signingKey.getKeyId())
         val crypto2Key = resolveCrypto2Key(signingKey, setOf(KeyUsage.SIGN))
         return if (crypto2Key != null) {
             val algorithm = JwsAlgorithm.parse(
@@ -162,7 +175,6 @@ object Verifier2RequestUriPostHandler {
     @Deprecated("Use the Crypto2Key overload")
     internal suspend fun verifyExistingRequestObject(jwt: String, signingKey: Key) {
         val decoded = CompactJws.decodeUnverified(jwt)
-        requireMatchingKeyId(decoded.protectedHeader, signingKey.getKeyId())
         val algorithm = JwsAlgorithm.parse(
             requireNotNull(decoded.protectedHeader["alg"]?.jsonPrimitive?.contentOrNull) {
                 "Existing signed request JWT is missing alg"
@@ -181,7 +193,6 @@ object Verifier2RequestUriPostHandler {
         payload: JsonObject,
         headers: JsonObject,
     ): String {
-        requireMatchingKeyId(headers, signingKey.id.value)
         val algorithm = JwsAlgorithm.parse(
             requireNotNull(headers["alg"]?.jsonPrimitive?.contentOrNull) {
                 "Existing signed request JWT is missing alg"
@@ -197,7 +208,6 @@ object Verifier2RequestUriPostHandler {
 
     internal suspend fun verifyExistingRequestObject(jwt: String, signingKey: Crypto2Key) {
         val decoded = CompactJws.decodeUnverified(jwt)
-        requireMatchingKeyId(decoded.protectedHeader, signingKey.id.value)
         val algorithm = decoded.algorithm
         val publicJwk = requireNotNull(signingKey.capabilities.publicKeyExporter) {
             "Request signing key does not export public material"
@@ -212,15 +222,6 @@ object Verifier2RequestUriPostHandler {
             )
         )
         CompactJws.verify(jwt, verificationKey, algorithm)
-    }
-
-    private fun requireMatchingKeyId(headers: JsonObject, actualKeyId: String) {
-        val protectedKeyId = requireNotNull(headers["kid"]?.jsonPrimitive?.contentOrNull) {
-            "Existing signed request JWT is missing kid"
-        }
-        require(protectedKeyId == actualKeyId || protectedKeyId.endsWith("#$actualKeyId")) {
-            "Resolved signing key does not match the existing signed request kid"
-        }
     }
 
     private suspend fun resolveCrypto2Key(signingKey: Key, usages: Set<KeyUsage>) =

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
@@ -83,16 +83,52 @@ object VerificationSessionCreator {
     ): List<Policy> =
         if (!shouldInclude || any { it.id == policy.id || it.id in equivalentPolicyIds }) this else this + policy
 
+    /**
+     * Builds the JAR `kid` header for signed authorization requests.
+     *
+     * For `decentralized_identifier:did:key:…`, the verification method id is
+     * `did:key:<multibase>#<multibase>` (DID Key method). Using the raw KMS key id
+     * (e.g. an Azure Key Vault URL) produces a DID URL wallets reject.
+     *
+     * For other DIDs, prefer a stable public-key identifier and avoid absolute URLs
+     * (Azure embeds vault URLs as JWK `kid`) so the fragment remains a valid DID URL.
+     */
     private suspend fun getKid(clientId: String?, key: VerifierSigningKey): String {
-        val keyId = when (key) {
-            is VerifierSigningKey.Legacy -> key.key.getKeyId()
-            is VerifierSigningKey.Crypto2 -> key.key.id.value
-        }
         val prefix = "decentralized_identifier:"
-        return clientId
-            ?.takeIf { it.startsWith(prefix) && it.substringAfter(prefix).isNotBlank() }
-            ?.let { "${it.substringAfter(prefix)}#$keyId" }
-            ?: keyId
+        val did = clientId
+            ?.takeIf { it.startsWith(prefix) }
+            ?.substringAfter(prefix)
+            ?.takeIf { it.isNotBlank() }
+            ?: return fragmentKeyId(key)
+
+        if (did.startsWith("did:key:")) {
+            val identifier = did.removePrefix("did:key:")
+            return "$did#$identifier"
+        }
+
+        return "$did#${fragmentKeyId(key)}"
+    }
+
+    private suspend fun fragmentKeyId(key: VerifierSigningKey): String = when (key) {
+        is VerifierSigningKey.Legacy -> {
+            val publicKey = key.key.getPublicKey()
+            val keyId = publicKey.getKeyId()
+            if (keyId.startsWith("http://") || keyId.startsWith("https://")) {
+                publicKey.getThumbprint()
+            } else {
+                keyId
+            }
+        }
+        is VerifierSigningKey.Crypto2 -> {
+            val keyId = key.key.id.value
+            if (keyId.startsWith("http://") || keyId.startsWith("https://")) {
+                val publicJwk = key.key.capabilities.publicKeyExporter
+                    ?.exportPublicKey() as? EncodedKey.Jwk
+                if (publicJwk != null) Jwk.sha256Thumbprint(publicJwk) else keyId
+            } else {
+                keyId
+            }
+        }
     }
 
     @Deprecated("Use the crypto2 Key overload with explicit JWS and COSE algorithms for signed sessions")
@@ -583,10 +619,13 @@ object VerificationSessionCreator {
             else -> null
         }
 
+        val setupForSession =
+            if (isSignedRequest && key != null) setup.withCoreKeyIfMissing(key) else setup
+
         @Suppress("SENSELESS_COMPARISON") // TODO
         val newSession = Verification2Session(
             id = sessionId,
-            setup = setup,
+            setup = setupForSession,
             data = customData?.let { Json.encodeToJsonElement(it) },
 
             creationDate = now,

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
@@ -35,6 +35,7 @@ import id.walt.verifier.openid.models.openid.OpenID4VPResponseMode
 import id.walt.verifier.openid.models.openid.OpenID4VPResponseType
 import id.walt.verifier.openid.transactiondata.validateRequestTransactionDataStructure
 import id.walt.verifier2.data.*
+import id.walt.verifier2.handlers.authrequest.Verifier2RequestObjectKid
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.*
 import kotlinx.datetime.DateTimeUnit
@@ -83,52 +84,9 @@ object VerificationSessionCreator {
     ): List<Policy> =
         if (!shouldInclude || any { it.id == policy.id || it.id in equivalentPolicyIds }) this else this + policy
 
-    /**
-     * Builds the JAR `kid` header for signed authorization requests.
-     *
-     * For `decentralized_identifier:did:key:…`, the verification method id is
-     * `did:key:<multibase>#<multibase>` (DID Key method). Using the raw KMS key id
-     * (e.g. an Azure Key Vault URL) produces a DID URL wallets reject.
-     *
-     * For other DIDs, prefer a stable public-key identifier and avoid absolute URLs
-     * (Azure embeds vault URLs as JWK `kid`) so the fragment remains a valid DID URL.
-     */
-    private suspend fun getKid(clientId: String?, key: VerifierSigningKey): String {
-        val prefix = "decentralized_identifier:"
-        val did = clientId
-            ?.takeIf { it.startsWith(prefix) }
-            ?.substringAfter(prefix)
-            ?.takeIf { it.isNotBlank() }
-            ?: return fragmentKeyId(key)
-
-        if (did.startsWith("did:key:")) {
-            val identifier = did.removePrefix("did:key:")
-            return "$did#$identifier"
-        }
-
-        return "$did#${fragmentKeyId(key)}"
-    }
-
-    private suspend fun fragmentKeyId(key: VerifierSigningKey): String = when (key) {
-        is VerifierSigningKey.Legacy -> {
-            val publicKey = key.key.getPublicKey()
-            val keyId = publicKey.getKeyId()
-            if (keyId.startsWith("http://") || keyId.startsWith("https://")) {
-                publicKey.getThumbprint()
-            } else {
-                keyId
-            }
-        }
-        is VerifierSigningKey.Crypto2 -> {
-            val keyId = key.key.id.value
-            if (keyId.startsWith("http://") || keyId.startsWith("https://")) {
-                val publicJwk = key.key.capabilities.publicKeyExporter
-                    ?.exportPublicKey() as? EncodedKey.Jwk
-                if (publicJwk != null) Jwk.sha256Thumbprint(publicJwk) else keyId
-            } else {
-                keyId
-            }
-        }
+    private suspend fun getKid(clientId: String?, key: VerifierSigningKey): String = when (key) {
+        is VerifierSigningKey.Legacy -> Verifier2RequestObjectKid.forClient(clientId, key.key)
+        is VerifierSigningKey.Crypto2 -> Verifier2RequestObjectKid.forClient(clientId, key.key)
     }
 
     @Deprecated("Use the crypto2 Key overload with explicit JWS and COSE algorithms for signed sessions")

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorSignedRequestTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorSignedRequestTest.kt
@@ -1,0 +1,112 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package id.walt.verifier2.handlers.sessioncreation
+
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
+import id.walt.dcql.models.CredentialFormat
+import id.walt.dcql.models.CredentialQuery
+import id.walt.dcql.models.DcqlQuery
+import id.walt.dcql.models.meta.JwtVcJsonMeta
+import id.walt.verifier.openid.models.authorization.RequestUriHttpMethod
+import id.walt.verifier2.data.CrossDeviceFlowSetup
+import id.walt.verifier2.data.GeneralFlowConfig
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class VerificationSessionCreatorSignedRequestTest {
+
+    private val azureStyleKid = "https://example.vault.azure.net/keys/verifier-signing-key/abc123"
+
+    private suspend fun keyWithAzureStyleKid(): JWKKey {
+        val key = JWKKey.generate(KeyType.secp256r1)
+        val jwk = JsonObject(key.exportJWKObject() + ("kid" to JsonPrimitive(azureStyleKid)))
+        return JWKKey.importJWK(jwk.toString()).getOrThrow()
+    }
+
+    private fun signedSetupWithoutKey() = CrossDeviceFlowSetup(
+        core = GeneralFlowConfig(
+            dcqlQuery = DcqlQuery(
+                credentials = listOf(
+                    CredentialQuery(
+                        id = "example_openbadge_jwt_vc",
+                        format = CredentialFormat.JWT_VC_JSON,
+                        meta = JwtVcJsonMeta(typeValues = listOf(listOf("OpenBadgeCredential"))),
+                    )
+                )
+            ),
+            signedRequest = true,
+        )
+    )
+
+    private fun decodeJwtPart(jwt: String, index: Int) =
+        Json.parseToJsonElement(jwt.split(".")[index].decodeFromBase64Url().decodeToString()).jsonObject
+
+    @Test
+    fun `did key kid uses multibase fragment not vault url`() = runTest {
+        val key = keyWithAzureStyleKid()
+        val did = "did:key:zDnaerx9CtbPJEvXAZVZtX4cK6e3vY8dYx9mK9xqK9xqK9x"
+        val session = VerificationSessionCreator.createVerificationSession(
+            setup = signedSetupWithoutKey(),
+            clientId = "decentralized_identifier:$did",
+            urlPrefix = "https://verifier.example.com/v1/org.tenant.verifier/verifier2-service-api",
+            urlHost = "openid4vp://authorize",
+            key = key,
+        )
+
+        val jwt = assertNotNull(session.signedAuthorizationRequestJwt)
+        val kid = decodeJwtPart(jwt, 0)["kid"]!!.jsonPrimitive.content
+        assertEquals("$did#${did.removePrefix("did:key:")}", kid)
+        assertFalse(kid.contains("vault.azure.net"))
+        assertFalse(kid.contains("https://"))
+    }
+
+    @Test
+    fun `non did-key client id avoids https key id fragment`() = runTest {
+        val key = keyWithAzureStyleKid()
+        val did = "did:web:verifier.example.com"
+        val session = VerificationSessionCreator.createVerificationSession(
+            setup = signedSetupWithoutKey(),
+            clientId = "decentralized_identifier:$did",
+            urlPrefix = "https://verifier.example.com/v1/org.tenant.verifier/verifier2-service-api",
+            urlHost = "openid4vp://authorize",
+            key = key,
+        )
+
+        val jwt = assertNotNull(session.signedAuthorizationRequestJwt)
+        val kid = decodeJwtPart(jwt, 0)["kid"]!!.jsonPrimitive.content
+        val expectedThumbprint = key.getPublicKey().getThumbprint()
+        assertEquals("$did#$expectedThumbprint", kid)
+        assertFalse(kid.contains("vault.azure.net"))
+    }
+
+    @Test
+    fun `create-time signing key is persisted on session setup for request_uri post`() = runTest {
+        val key = JWKKey.generate(KeyType.secp256r1)
+        val setup = signedSetupWithoutKey()
+        assertNull(setup.core.key)
+
+        val session = VerificationSessionCreator.createVerificationSession(
+            setup = setup,
+            clientId = "decentralized_identifier:did:key:zDnaeTest",
+            urlPrefix = "https://verifier.example.com/v1/org.tenant.verifier/verifier2-service-api",
+            urlHost = "openid4vp://authorize",
+            key = key,
+        )
+
+        assertNotNull(session.setup.core.key) {
+            "Signing key must be stored on session.setup.core.key so request_uri POST can re-sign with wallet_nonce"
+        }
+        assertEquals(RequestUriHttpMethod.POST, session.bootstrapAuthorizationRequest?.requestUriMethod)
+    }
+}

--- a/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/Crypto2DidPublicKey.kt
+++ b/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/Crypto2DidPublicKey.kt
@@ -1,12 +1,15 @@
 package id.walt.did.dids.registrar
 
+import id.walt.crypto.keys.PublicKeyIds
 import id.walt.crypto2.keys.EncodedKey
 import id.walt.crypto2.keys.Key
 import id.walt.crypto2.keys.publicOnly
 import id.walt.crypto2.keys.toPublicJwk
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 private val privateJwkMembers = setOf("d", "p", "q", "dp", "dq", "qi", "oth", "k")
 
@@ -20,5 +23,11 @@ internal suspend fun Key.exportPublicJwkObject(): JsonObject {
     }
     val json = Json.parseToJsonElement(publicJwk.data.toByteArray().decodeToString()).jsonObject
     require(privateJwkMembers.none(json::containsKey)) { "Public-key export contains private JWK material" }
-    return json
+    val kid = json["kid"]?.jsonPrimitive?.contentOrNull
+    // Vault/HTTP kids are ops locators — never embed them in DID documents.
+    return if (kid != null && PublicKeyIds.isHttpKeyId(kid)) {
+        JsonObject(json.toMutableMap().apply { remove("kid") })
+    } else {
+        json
+    }
 }

--- a/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/dids/DidDocConfig.kt
+++ b/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/dids/DidDocConfig.kt
@@ -2,6 +2,8 @@ package id.walt.did.dids.registrar.dids
 
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.PublicKeyIds.publicJwkForPublish
+import id.walt.crypto.keys.PublicKeyIds.publicKeyId
 import id.walt.crypto.utils.UuidUtils.randomUUIDString
 import id.walt.did.dids.DidUtils
 import id.walt.did.dids.document.DidDocument
@@ -82,14 +84,14 @@ data class DidDocConfig(
             rootCustomProperties: Map<String, JsonElement>? = null,
         ) = DidDocConfig(
             context = context,
-            publicKeyMap = publicKeySet.associateBy { it.getKeyId() },
+            publicKeyMap = publicKeySet.associateBy { it.publicKeyId() },
             verificationConfigurationMap = publicKeySet.takeIf { it.isNotEmpty() }?.let {
                 VerificationRelationshipType
                     .entries
                     .associateWith {
                         publicKeySet.map { publicKey ->
                             VerificationMethodConfiguration(
-                                publicKeyId = publicKey.getKeyId(),
+                                publicKeyId = publicKey.publicKeyId(),
                             )
                         }.toSet()
                     }
@@ -114,7 +116,7 @@ data class DidDocConfig(
             verificationKeySetConfiguration: Map<VerificationRelationshipType, Set<Key>> = emptyMap(),
             serviceConfigurationSet: Set<ServiceConfiguration> = emptySet(),
             rootCustomProperties: Map<String, JsonElement>? = null,
-        ) = verificationKeySetConfiguration.values.flatten().associateBy { it.getKeyId() }.let { publicKeyMap ->
+        ) = verificationKeySetConfiguration.values.flatten().associateBy { it.publicKeyId() }.let { publicKeyMap ->
             DidDocConfig(
                 context = context,
                 publicKeyMap = publicKeyMap,
@@ -124,7 +126,7 @@ data class DidDocConfig(
                     .associate { (verRelType, verRelPublicKeySet) ->
                         verRelType to verRelPublicKeySet.map { publicKey ->
                             VerificationMethodConfiguration(
-                                publicKeyId = publicKey.getKeyId(),
+                                publicKeyId = publicKey.publicKeyId(),
                             )
                         }.toSet()
                     },
@@ -208,7 +210,7 @@ data class DidDocConfig(
             VerificationMethod(
                 id = "$did#${verConf.publicKeyId}",
                 type = VerificationMethodType.JsonWebKey2020,
-                material = VerificationMaterialType.PublicKeyJwk to key.exportJWKObject(),
+                material = VerificationMaterialType.PublicKeyJwk to key.publicJwkForPublish(),
                 controller = did,
                 customProperties = verConf.customProperties,
             )

--- a/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/local/key/DidKeyRegistrar.kt
+++ b/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/local/key/DidKeyRegistrar.kt
@@ -2,6 +2,7 @@ package id.walt.did.dids.registrar.local.key
 
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.PublicKeyIds.publicJwkForPublish
 import id.walt.crypto.keys.jwk.JWKKey
 import id.walt.crypto.utils.JsonCanonicalizationUtils
 import id.walt.crypto.utils.MultiBaseUtils.convertRawKeyToMultiBase58Btc
@@ -40,7 +41,7 @@ class DidKeyRegistrar : LocalRegistrarMethod("key") {
         val pubKey = key.getPublicKey()
         val identifierComponents = getIdentifierComponents(pubKey, it)
         val identifier = convertRawKeyToMultiBase58Btc(identifierComponents.pubKeyBytes, identifierComponents.multiCodecKeyCode)
-        createDid(identifier, pubKey.exportJWKObject())
+        createDid(identifier, pubKey.publicJwkForPublish())
     }
 
     private suspend fun getIdentifierComponents(key: Key, options: DidCreateOptions): IdentifierComponents =

--- a/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/local/web/DidWebRegistrar.kt
+++ b/waltid-libraries/waltid-did/src/commonMain/kotlin/id/walt/did/dids/registrar/local/web/DidWebRegistrar.kt
@@ -2,6 +2,8 @@ package id.walt.did.dids.registrar.local.web
 
 import id.walt.crypto.keys.Key
 import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.PublicKeyIds.publicJwkForPublish
+import id.walt.crypto.keys.PublicKeyIds.publicKeyId
 import id.walt.crypto.keys.jwk.JWKKey
 import id.walt.crypto.utils.UuidUtils.randomUUIDString
 import id.walt.did.dids.document.DidDocument
@@ -44,8 +46,8 @@ class DidWebRegistrar : LocalRegistrarMethod("web") {
             DidDocument(
                 DidWebDocument(
                     did = did,
-                    keyId = key.getKeyId(),
-                    didKey = key.getPublicKey().exportJWKObject()
+                    keyId = key.publicKeyId(),
+                    didKey = key.publicJwkForPublish()
                 ).toMap()
             ),
         )

--- a/waltid-libraries/waltid-did/src/jvmTest/kotlin/id/walt/did/dids/registrar/AzureStylePublicKeyDidTest.kt
+++ b/waltid-libraries/waltid-did/src/jvmTest/kotlin/id/walt/did/dids/registrar/AzureStylePublicKeyDidTest.kt
@@ -1,0 +1,60 @@
+package id.walt.did.dids.registrar
+
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.did.dids.registrar.dids.DidDocConfig
+import id.walt.did.dids.registrar.dids.DidKeyCreateOptions
+import id.walt.did.dids.registrar.local.key.DidKeyRegistrar
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AzureStylePublicKeyDidTest {
+
+    @Test
+    fun didKeyDocumentPublicJwkKidIsNeverVaultUrl() = runTest {
+        val material = JWKKey.generate(KeyType.secp256r1).getPublicKey()
+        val thumbprint = material.getThumbprint()
+        val azureStyle = JWKKey.importJWK(
+            JsonObject(
+                material.exportJWKObject() +
+                    ("kid" to JsonPrimitive("https://example.vault.azure.net/keys/k/v1"))
+            ).toString()
+        ).getOrThrow()
+
+        val result = DidKeyRegistrar().registerByKey(azureStyle, DidKeyCreateOptions(useJwkJcsPub = true))
+        assertTrue(result.did.startsWith("did:key:"))
+        val vm = result.didDocument["verificationMethod"]!!.jsonArray.first().jsonObject
+        val vmId = vm["id"]!!.jsonPrimitive.content
+        val jwkKid = vm["publicKeyJwk"]!!.jsonObject["kid"]!!.jsonPrimitive.content
+        assertEquals("${result.did}#${result.did.removePrefix("did:key:")}", vmId)
+        assertEquals(thumbprint, jwkKid)
+        assertFalse(jwkKid.contains("https://"))
+        assertFalse(vmId.contains("vault.azure.net"))
+    }
+
+    @Test
+    fun didDocConfigFragmentUsesThumbprintNotVaultUrl() = runTest {
+        val material = JWKKey.generate(KeyType.secp256r1).getPublicKey()
+        val thumbprint = material.getThumbprint()
+        val azureStyle = JWKKey.importJWK(
+            JsonObject(
+                material.exportJWKObject() +
+                    ("kid" to JsonPrimitive("https://example.vault.azure.net/keys/k/v1"))
+            ).toString()
+        ).getOrThrow()
+
+        val config = DidDocConfig.buildFromPublicKeySet(publicKeySet = setOf(azureStyle))
+        val doc = config.toDidDocument("did:web:example.com")
+        val vm = doc["verificationMethod"]!!.jsonArray.first().jsonObject
+        assertEquals("did:web:example.com#$thumbprint", vm["id"]!!.jsonPrimitive.content)
+        assertEquals(thumbprint, vm["publicKeyJwk"]!!.jsonObject["kid"]!!.jsonPrimitive.content)
+    }
+}


### PR DESCRIPTION
## Summary

This stops Azure Key Vault URLs from being published as JWT, JAR, JWKS, or DID `kid` values so wallets can verify signed OpenID4VP requests when the verifier uses an external KMS and `client_id` is `did:key`. Enterprise 0.23.0 deployments were failing presentation because the JAR `kid` was a vault URL, which is not a valid DID URL.

Fixes [WAL-1261](https://linear.app/walt-new/issue/WAL-1261/support-verification-failure-with-waltid-v0230-during-credential) (Freshdesk 338).

Enterprise counterpart: [walt-id/waltid-identity-enterprise#575](https://github.com/walt-id/waltid-identity-enterprise/pull/575).

## What Changed

### Public key identifiers
- New `PublicKeyIds` helper treats `http(s)://…` key ids as operational locators and publishes RFC 7638 JWK thumbprints instead.

### Azure keys
- `AzureKey` / `AzureKeyRestApi` keep the vault URL for REST (`keyIdUrl`) and return the thumbprint from `getKeyId()`, `getThumbprint()`, and public JWK export.
- Import strips Azure `kid` / `key_ops` so the public JWK never carries the vault URL.

### Verifier2 signed requests
- JAR `kid` is built by `Verifier2RequestObjectKid`: `did:key:<mb>#<mb>` for did:key client ids; otherwise `<did>#<publicKeyId>`.
- Signed sessions persist the resolved signing key so `request_uri_method=post` can re-sign `wallet_nonce` (OID4VP §5.6).
- Re-sign binds DID URL kids via `Verifier2RequestObjectKid`, and raw kids via public key id rather than the KMS locator.

### DID documents
- `did:key`, `did:web`, and `DidDocConfig` publish `publicJwkForPublish()` so verification-method ids and JWK `kid`s are not vault URLs.

### Client authentication
- `decentralized_identifier` key selection matches DID URL fragments to public ids / thumbprints, accepts the did:key method fragment when the KMS id differs, and still rejects unknown fragments (`#missing`).

### Issuance
- W3C issuer JWT `kid` uses `publicKeyId()` instead of the raw KMS id.

## Architecture Notes

- Public identifiers and KMS locators are split on purpose: wallets and DID documents must not see vault URLs, while Azure REST still needs the full key URL.
- did:key JAR kids follow the DID Key method (`did:key:<mb>#<mb>`) rather than `#<thumbprint>`, because that is the verification-method id wallets resolve.

## Caveats and Follow-Ups

- Crypto2 DID public JWK export strips HTTP `kid` rather than replacing it with a thumbprint; crypto1 paths stamp the thumbprint.
- There is no unified-build or docs counterpart for this ticket.

## Breaking

- Published `kid` values for HTTP/Azure-backed keys change from Key Vault URLs to RFC 7638 thumbprints, or to `did:key:<mb>#<mb>` on did:key JARs. Callers that treated the previous `kid` as a vault locator should use the KMS key reference instead.
