### PR TITLE
fix(crypto2): align ABI baselines for non-Android builds

### DIFF
--- a/waltid-libraries/crypto/waltid-crypto2-kms/api/waltid-crypto2-kms.api
+++ b/waltid-libraries/crypto/waltid-crypto2-kms/api/waltid-crypto2-kms.api
@@ -285,6 +285,8 @@ public final class id/walt/crypto2/kms/vault/VaultTransitKeyProvider : id/walt/c
 	public fun generate (Lid/walt/crypto2/providers/GenerateManagedKeyRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getId-v1VkqW4 ()Ljava/lang/String;
 	public fun restore (Lid/walt/crypto2/keys/StoredKey$Managed;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun storedKeyForExisting-FO05kzI (Ljava/lang/String;Lid/walt/crypto2/keys/KeySpec;Ljava/util/Set;Lid/walt/crypto2/kms/vault/VaultTransitOptions;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun storedKeyForExisting-FO05kzI$default (Lid/walt/crypto2/kms/vault/VaultTransitKeyProvider;Ljava/lang/String;Lid/walt/crypto2/keys/KeySpec;Ljava/util/Set;Lid/walt/crypto2/kms/vault/VaultTransitOptions;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class id/walt/crypto2/kms/vault/VaultTransitKeyProvider$Companion {

--- a/waltid-libraries/crypto/waltid-crypto2-migration-v1/api/waltid-crypto2-migration-v1.api
+++ b/waltid-libraries/crypto/waltid-crypto2-migration-v1/api/waltid-crypto2-migration-v1.api
@@ -1,0 +1,65 @@
+public final class id/walt/crypto2/migration/v1/V1KeyMigration {
+	public static final field Companion Lid/walt/crypto2/migration/v1/V1KeyMigration$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun migrate-1locDDc (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun migrate-1locDDc (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class id/walt/crypto2/migration/v1/V1KeyMigration$Companion {
+}
+
+public abstract class id/walt/crypto2/migration/v1/V1KeyMigrationException : java/lang/IllegalArgumentException {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class id/walt/crypto2/migration/v1/V1KeyMigrationException$MissingManagedMigrator : id/walt/crypto2/migration/v1/V1KeyMigrationException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class id/walt/crypto2/migration/v1/V1KeyMigrationKt {
+	public static final field V1_LEGACY_KEY_ID_METADATA_KEY Ljava/lang/String;
+	public static final fun legacyKeyId (Lid/walt/crypto2/keys/StoredKey;)Ljava/lang/String;
+	public static final fun v1PublicKeyReference (Ljava/lang/String;)Lid/walt/crypto2/migration/v1/V1PublicKeyReference;
+	public static final fun v1PublicKeyReference (Lkotlinx/serialization/json/JsonObject;)Lid/walt/crypto2/migration/v1/V1PublicKeyReference;
+}
+
+public abstract interface class id/walt/crypto2/migration/v1/V1ManagedKeyMigrator {
+	public abstract fun migrate (Lid/walt/crypto2/migration/v1/V1ManagedKeyRecord;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class id/walt/crypto2/migration/v1/V1ManagedKeyRecord {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lid/walt/crypto2/keys/KeySpec;Lkotlinx/serialization/json/JsonObject;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-1AhpoWA ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component4 ()Lid/walt/crypto2/keys/KeySpec;
+	public final fun component5 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component6 ()Ljava/util/Set;
+	public final fun copy-A3IiLVg (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lid/walt/crypto2/keys/KeySpec;Lkotlinx/serialization/json/JsonObject;Ljava/util/Set;)Lid/walt/crypto2/migration/v1/V1ManagedKeyRecord;
+	public static synthetic fun copy-A3IiLVg$default (Lid/walt/crypto2/migration/v1/V1ManagedKeyRecord;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lid/walt/crypto2/keys/KeySpec;Lkotlinx/serialization/json/JsonObject;Ljava/util/Set;ILjava/lang/Object;)Lid/walt/crypto2/migration/v1/V1ManagedKeyRecord;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId-1AhpoWA ()Ljava/lang/String;
+	public final fun getPublicJwk ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getSource ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getSpec ()Lid/walt/crypto2/keys/KeySpec;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUsages ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class id/walt/crypto2/migration/v1/V1PublicKeyReference {
+	public fun <init> (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;)Lid/walt/crypto2/migration/v1/V1PublicKeyReference;
+	public static synthetic fun copy$default (Lid/walt/crypto2/migration/v1/V1PublicKeyReference;Lkotlinx/serialization/json/JsonObject;Ljava/lang/String;ILjava/lang/Object;)Lid/walt/crypto2/migration/v1/V1PublicKeyReference;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyId ()Ljava/lang/String;
+	public final fun getPublicJwk ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/waltid-libraries/crypto/waltid-crypto2/api/waltid-crypto2.api
+++ b/waltid-libraries/crypto/waltid-crypto2/api/waltid-crypto2.api
@@ -2165,7 +2165,7 @@ public final class id/walt/crypto2/providers/cryptography/CryptographySoftwareKe
 public final class id/walt/crypto2/providers/cryptography/CryptographySoftwareKeyProvider$Companion {
 }
 
-public final class id/walt/crypto2/providers/cryptography/DefaultSoftwareKeyProviders_jvmKt {
+public final class id/walt/crypto2/providers/cryptography/DefaultSoftwareKeyProvidersKt {
 	public static final fun defaultSoftwareKeyProviders ()Ljava/util/List;
 }
 


### PR DESCRIPTION
## Summary

Make Crypto2 ABI validation deterministic when the Android target is omitted.

The checked-in common ABI declarations were incomplete or stale for three Crypto2 modules. As a result, the non-Android build matrix failed while the full Android-enabled build passed. This PR updates the generated ABI metadata only and applies independently to all builds using these modules.

The discrepancy was exposed by [walt-id/waltid-identity#2015](https://github.com/walt-id/waltid-identity/pull/2015).

## What Changed

- Correct the `waltid-crypto2` common ABI facade declaration.
- Add `VaultTransitKeyProvider.storedKeyForExisting` to the common KMS ABI baseline.
- Add the missing common ABI baseline for `waltid-crypto2-migration-v1`.

## Scope

- Generated API baselines only.
- No runtime or implementation changes.
- No CI eligibility changes.
