### PR TITLE
[WAL-1211] feat(wallet): support signed issuer metadata in legacy wallet API

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/build.gradle.kts
@@ -37,6 +37,8 @@ kotlin {
             // OpenID4VCI 1.0 — wallet-side client logic (offer parsing, token, proof)
             // package: id.waltid.openid4vci.wallet.*
             api(project(":waltid-libraries:protocols:waltid-openid4vci-wallet"))
+            // Legacy OpenID4VC models used by wallet1 compatibility flows.
+            api(project(":waltid-libraries:protocols:waltid-openid4vc"))
 
             // OpenID4VP 1.0 — core protocol types (AuthorizationRequest, response modes, etc.)
             // package: id.walt.verifier.openid.*

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/waltid/openid4vc/wallet/legacy/LegacyIssuerMetadataResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/waltid/openid4vc/wallet/legacy/LegacyIssuerMetadataResolver.kt
@@ -1,0 +1,192 @@
+package id.waltid.openid4vc.wallet.legacy
+
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.crypto.utils.JwsUtils.decodeJws
+import id.walt.oid4vc.data.CredentialFormat as LegacyCredentialFormat
+import id.walt.oid4vc.data.CredentialSupported
+import id.walt.oid4vc.data.CredentialDefinition as LegacyCredentialDefinition
+import id.walt.oid4vc.data.CredSignAlgValues
+import id.walt.oid4vc.data.DisplayProperties
+import id.walt.oid4vc.data.GrantType as LegacyGrantType
+import id.walt.oid4vc.data.LogoProperties
+import id.walt.oid4vc.data.OpenIDProviderMetadata
+import id.walt.oid4vc.data.ProofType as LegacyProofType
+import id.walt.oid4vc.data.ProofTypeMetadata as LegacyProofTypeMetadata
+import id.walt.oid4vc.data.ResponseMode as LegacyResponseMode
+import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.CredentialDisplay
+import id.walt.openid4vci.metadata.issuer.IssuerDisplay
+import id.walt.openid4vci.metadata.issuer.SigningAlgId
+import id.walt.openid4vci.metadata.oauth.AuthorizationServerMetadata
+import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
+import id.waltid.openid4vci.wallet.metadata.MetadataSigner
+import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
+import io.ktor.client.HttpClient
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * A verification key trusted for one credential issuer's signed metadata.
+ * The key is supplied by the embedding service, never by the metadata JWT.
+ */
+data class TrustedIssuerMetadataSigner(
+    val issuer: String,
+    val publicJwk: String,
+    val keyId: String? = null,
+    val algorithm: String? = null,
+    val trustType: MetadataSignerTrustType = MetadataSignerTrustType.TRUSTED_ISSUER,
+)
+
+/**
+ * Trust resolver backed by an explicit issuer-to-public-key allow-list.
+ *
+ * The resolver verifies with the configured public key and optionally binds
+ * both the JWS `kid` and `alg` headers to the configured entry.
+ */
+class ConfiguredIssuerMetadataTrustResolver(
+    private val trustedSigners: List<TrustedIssuerMetadataSigner>,
+) : CredentialIssuerMetadataTrustResolver {
+    override suspend fun verify(compactJwt: String, expectedCredentialIssuer: String): MetadataSigner {
+        val decoded = compactJwt.decodeJws()
+        val algorithm = decoded.header["alg"]?.jsonPrimitive?.takeIf { it.isString }?.content
+            ?: error("Signed issuer metadata is missing a string alg header")
+        val headerKeyId = decoded.header["kid"]?.jsonPrimitive?.let { primitive ->
+            primitive.takeIf { primitive.isString }?.content
+                ?: error("Signed issuer metadata kid must be a string")
+        }
+        val signer = trustedSigners.singleOrNull { candidate ->
+            candidate.issuer == expectedCredentialIssuer &&
+                    (headerKeyId == null || candidate.keyId == null || candidate.keyId == headerKeyId)
+        } ?: error("No trusted metadata signer configured for issuer '$expectedCredentialIssuer' and kid '$headerKeyId'")
+
+        require(signer.algorithm == null || signer.algorithm == algorithm) {
+            "Configured metadata signer algorithm does not match JWS alg"
+        }
+        require(signer.keyId == null || headerKeyId == null || signer.keyId == headerKeyId) {
+            "Configured metadata signer key ID does not match JWS kid"
+        }
+
+        val verificationKey = JWKKey.importJWK(signer.publicJwk).getOrThrow()
+        verificationKey.verifyJws(compactJwt).getOrElse {
+            error("Signed issuer metadata signature verification failed")
+        }
+
+        return MetadataSigner(
+            keyId = signer.keyId ?: verificationKey.getKeyId().takeIf { it.isNotBlank() },
+            algorithm = algorithm,
+            trustType = signer.trustType,
+        )
+    }
+}
+
+/**
+ * Resolves modern Credential Issuer Metadata once and projects it to the
+ * legacy [OpenIDProviderMetadata] model used by wallet1 issuance flows.
+ * Authorization Server metadata is fetched separately when required by the
+ * legacy token client; the issuer metadata endpoint itself is never re-read.
+ */
+class LegacyIssuerMetadataResolver(
+    httpClient: HttpClient,
+    metadataTrustResolver: CredentialIssuerMetadataTrustResolver? = null,
+) {
+    private val resolver = IssuerMetadataResolver(httpClient, metadataTrustResolver)
+
+    suspend fun resolve(credentialIssuer: String): OpenIDProviderMetadata.Draft13 {
+        val metadata = resolver.resolveCredentialIssuerMetadata(credentialIssuer).metadata
+        val authorizationServer = resolver.resolveAuthorizationServerMetadataWithFallback(metadata)
+        return metadata.toLegacyMetadata(authorizationServer)
+    }
+}
+
+private fun CredentialIssuerMetadata.toLegacyMetadata(
+    authorizationServer: AuthorizationServerMetadata,
+): OpenIDProviderMetadata.Draft13 = OpenIDProviderMetadata.Draft13(
+    issuer = authorizationServer.issuer,
+    authorizationEndpoint = authorizationServer.authorizationEndpoint,
+    tokenEndpoint = authorizationServer.tokenEndpoint,
+    jwksUri = authorizationServer.jwksUri,
+    registrationEndpoint = authorizationServer.registrationEndpoint,
+    scopesSupported = authorizationServer.scopesSupported ?: setOf("openid"),
+    responseTypesSupported = authorizationServer.responseTypesSupported,
+    responseModesSupported = authorizationServer.responseModesSupported
+        ?.mapNotNull { runCatching { LegacyResponseMode.fromString(it) }.getOrNull() }
+        ?.toSet()
+        ?: setOf(LegacyResponseMode.query, LegacyResponseMode.fragment),
+    grantTypesSupported = authorizationServer.grantTypesSupported
+        ?.mapNotNull(LegacyGrantType::fromValue)
+        ?.toSet()
+        ?: setOf(LegacyGrantType.authorization_code, LegacyGrantType.pre_authorized_code),
+    tokenEndpointAuthMethodsSupported = authorizationServer.tokenEndpointAuthMethodsSupported,
+    tokenEndpointAuthSigningAlgValuesSupported = authorizationServer.tokenEndpointAuthSigningAlgValuesSupported,
+    uiLocalesSupported = authorizationServer.uiLocalesSupported,
+    serviceDocumentation = authorizationServer.serviceDocumentation,
+    opPolicyUri = authorizationServer.opPolicyUri,
+    opTosUri = authorizationServer.opTosUri,
+    codeChallengeMethodsSupported = authorizationServer.codeChallengeMethodsSupported,
+    requirePushedAuthorizationRequests = authorizationServer.requirePushedAuthorizationRequests,
+    credentialIssuer = credentialIssuer,
+    credentialEndpoint = credentialEndpoint,
+    deferredCredentialEndpoint = deferredCredentialEndpoint,
+    display = display?.mapNotNull { it.toLegacyDisplay() },
+    credentialConfigurationsSupported = credentialConfigurationsSupported.mapValues { (_, configuration) ->
+        configuration.toLegacyCredentialSupported()
+    },
+    authorizationServers = authorizationServerIssuers().toSet(),
+)
+
+private fun CredentialConfiguration.toLegacyCredentialSupported(): CredentialSupported {
+    val format = LegacyCredentialFormat.fromValue(format.value)
+        ?: error("Unsupported legacy credential format: ${format.value}")
+    return CredentialSupported(
+        format = format,
+        scope = scope,
+        vct = vct,
+        cryptographicBindingMethodsSupported = cryptographicBindingMethodsSupported
+            ?.map { it.value }
+            ?.toSet(),
+        credentialSigningAlgValuesSupported = credentialSigningAlgValuesSupported
+            ?.mapNotNull { it.toLegacySigningAlgorithm() }
+            ?.toSet(),
+        proofTypesSupported = proofTypesSupported?.mapNotNull { (name, proof) ->
+            runCatching { LegacyProofType.valueOf(name) }
+                .getOrNull()
+                ?.let { it to LegacyProofTypeMetadata(proof.proofSigningAlgValuesSupported) }
+        }?.toMap(),
+        display = credentialMetadata?.display?.mapNotNull { it.toLegacyDisplay() },
+        credentialDefinition = credentialDefinition?.let {
+            LegacyCredentialDefinition(type = it.type)
+        },
+        docType = doctype,
+        customParameters = customParameters,
+    )
+}
+
+private fun SigningAlgId.toLegacySigningAlgorithm(): CredSignAlgValues? = when (this) {
+    is SigningAlgId.Jose -> CredSignAlgValues.Named(value)
+    is SigningAlgId.LdSuite -> CredSignAlgValues.Named(value)
+    is SigningAlgId.CoseName -> CredSignAlgValues.Named(value)
+    is SigningAlgId.CoseValue -> CredSignAlgValues.Numeric(value)
+}
+
+private fun IssuerDisplay.toLegacyDisplay(): DisplayProperties? =
+    name?.takeIf { it.isNotBlank() }?.let { displayName ->
+        DisplayProperties(
+            name = displayName,
+            locale = locale,
+            logo = logo?.let { LogoProperties(url = it.uri, altText = it.altText) },
+        )
+    }
+
+private fun CredentialDisplay.toLegacyDisplay(): DisplayProperties? =
+    name.takeIf { it.isNotBlank() }?.let { displayName ->
+        DisplayProperties(
+            name = displayName,
+            locale = locale,
+            logo = logo?.let { LogoProperties(url = it.uri, altText = it.altText) },
+            description = description,
+            backgroundColor = backgroundColor,
+            backgroundImage = backgroundImage?.let { LogoProperties(url = it.uri) },
+            textColor = textColor,
+        )
+    }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/waltid/openid4vc/wallet/legacy/LegacyIssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/waltid/openid4vc/wallet/legacy/LegacyIssuerMetadataResolverTest.kt
@@ -1,0 +1,114 @@
+package id.waltid.openid4vc.wallet.legacy
+
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.openid4vci.CredentialFormat
+import id.walt.openid4vci.metadata.issuer.CredentialConfiguration
+import id.walt.openid4vci.metadata.issuer.CredentialIssuerMetadata
+import id.walt.openid4vci.metadata.issuer.toSignedJwt
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class LegacyIssuerMetadataResolverTest {
+    private val issuer = "https://issuer.example"
+    private val credentialIssuerMetadata = CredentialIssuerMetadata(
+        credentialIssuer = issuer,
+        credentialEndpoint = "$issuer/credential",
+        credentialConfigurationsSupported = mapOf(
+            "pid" to CredentialConfiguration(CredentialFormat.SD_JWT_VC),
+        ),
+    )
+
+    @Test
+    fun projectsUnsignedModernMetadataToLegacyProviderMetadata() = runTest {
+        val metadata = LegacyIssuerMetadataResolver(client(credentialIssuerMetadataJson())).resolve(issuer)
+
+        assertEquals(issuer, metadata.credentialIssuer)
+        assertEquals("$issuer/token", metadata.tokenEndpoint)
+        assertEquals("$issuer/credential", metadata.credentialEndpoint)
+        assertEquals(CredentialFormat.SD_JWT_VC.value, metadata.credentialConfigurationsSupported?.get("pid")?.format?.value)
+    }
+
+    @Test
+    fun verifiesConfiguredSignerBeforeProjectingSignedMetadata() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = credentialIssuerMetadata.toSignedJwt(key)
+        val resolver = LegacyIssuerMetadataResolver(
+            client(jwt, signed = true),
+            ConfiguredIssuerMetadataTrustResolver(
+                listOf(
+                    TrustedIssuerMetadataSigner(
+                        issuer = issuer,
+                        publicJwk = key.getPublicKey().exportJWK(),
+                        keyId = key.getKeyId(),
+                        algorithm = "EdDSA",
+                    ),
+                ),
+            ),
+        )
+
+        val metadata = resolver.resolve(issuer)
+
+        assertEquals(issuer, metadata.credentialIssuer)
+        assertNotNull(metadata.credentialConfigurationsSupported?.get("pid"))
+    }
+
+    @Test
+    fun rejectsSignedMetadataWithoutConfiguredSigner() = runTest {
+        val key = JWKKey.generate(KeyType.Ed25519)
+        val jwt = credentialIssuerMetadata.toSignedJwt(key)
+
+        assertFailsWith<Exception> {
+            LegacyIssuerMetadataResolver(client(jwt, signed = true)).resolve(issuer)
+        }
+    }
+
+    private fun credentialIssuerMetadataJson() = Json.encodeToString(
+        CredentialIssuerMetadata.serializer(),
+        credentialIssuerMetadata,
+    )
+
+    private fun client(metadataBody: String, signed: Boolean = false): HttpClient = HttpClient(MockEngine) {
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        engine {
+            addHandler { request ->
+                if (request.url.encodedPath.endsWith("openid-credential-issuer")) {
+                    respond(
+                        content = metadataBody,
+                        status = HttpStatusCode.OK,
+                        headers = io.ktor.http.headersOf(
+                            "Content-Type",
+                            if (signed) "application/jwt" else ContentType.Application.Json.toString(),
+                        ),
+                    )
+                } else {
+                    respond(
+                        content = authorizationServerMetadataJson(),
+                        status = HttpStatusCode.OK,
+                        headers = io.ktor.http.headersOf("Content-Type", ContentType.Application.Json.toString()),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun authorizationServerMetadataJson() = """
+        {
+          "issuer": "$issuer",
+          "token_endpoint": "$issuer/token",
+          "response_types_supported": ["code"],
+          "grant_types_supported": ["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
+        }
+    """.trimIndent()
+}

--- a/waltid-services/waltid-wallet-api/build.gradle.kts
+++ b/waltid-services/waltid-wallet-api/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
 
     // walt.id
     implementation(project(":waltid-libraries:protocols:waltid-openid4vc"))
+    implementation(project(":waltid-libraries:protocols:waltid-openid4vc-wallet"))
     implementation(project(":waltid-libraries:protocols:waltid-openid4vp"))
     implementation(project(":waltid-libraries:protocols:waltid-openid4vp-clientidprefix"))
     implementation(project(":waltid-libraries:protocols:waltid-openid4vp-wallet"))

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/TrustConfig.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/config/TrustConfig.kt
@@ -6,11 +6,23 @@ import kotlinx.serialization.Serializable
 data class TrustConfig(
     val issuersRecord: TrustRecord,
     val verifiersRecord: TrustRecord,
+    /** Trusted public keys used to verify signed Credential Issuer Metadata. */
+    val issuerMetadataSigners: Map<String, List<IssuerMetadataSignerConfig>> = emptyMap(),
 ) : WalletConfig() {
     @Serializable
     data class TrustRecord(
         val baseUrl: String,
         val trustRecordPath: String,
         val governanceRecordPath: String,
+    )
+
+    @Serializable
+    data class IssuerMetadataSignerConfig(
+        /** Public JWK used for verification; private key material is not accepted. */
+        val publicJwk: String,
+        /** Optional JWS `kid` value bound to this configured key. */
+        val keyId: String? = null,
+        /** Optional JWS `alg` value bound to this configured key. */
+        val algorithm: String? = null,
     )
 }

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceService.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceService.kt
@@ -5,7 +5,6 @@ import id.walt.oid4vc.OpenID4VCI
 import id.walt.oid4vc.data.CredentialFormat
 import id.walt.oid4vc.data.CredentialOffer
 import id.walt.oid4vc.data.GrantType
-import id.walt.oid4vc.data.OpenIDProviderMetadata
 import id.walt.oid4vc.providers.TokenTarget
 import id.walt.oid4vc.requests.AuthorizationRequest
 import id.walt.oid4vc.requests.CredentialRequest
@@ -90,7 +89,7 @@ object IssuanceService : IssuanceServiceBase() {
 
         logger.debug { "credentialOffer: $credentialOffer" }
 
-        val providerMetadata = OpenID4VCI.resolveCIProviderMetadata(credentialOffer)
+        val providerMetadata = legacyIssuerMetadataResolver.resolve(credentialOffer.credentialIssuer)
 
         logger.debug { "providerMetadata: $providerMetadata" }
 
@@ -112,7 +111,7 @@ object IssuanceService : IssuanceServiceBase() {
                 preAuthorizedCode
             )
 
-            providerMetadata is OpenIDProviderMetadata.Draft11 -> TokenRequest.PreAuthorizedCode(
+            credentialOffer is CredentialOffer.Draft11 -> TokenRequest.PreAuthorizedCode(
                 preAuthorizedCode = preAuthorizedCode,
                 userPIN = pinOrTxCode
             )

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceBase.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceBase.kt
@@ -1,6 +1,7 @@
 package id.walt.webwallet.service.exchange
 
 import cbor.Cbor
+import id.walt.commons.config.ConfigManager
 import id.walt.crypto.utils.Base64Utils.base64UrlDecode
 import id.walt.crypto.utils.JwsUtils.decodeJwsOrSdjwt
 import id.walt.crypto.utils.UuidUtils.randomUUIDString
@@ -15,7 +16,6 @@ import id.walt.webwallet.utils.WalletHttpClients
 import id.waltid.openid4vc.wallet.legacy.ConfiguredIssuerMetadataTrustResolver
 import id.waltid.openid4vc.wallet.legacy.LegacyIssuerMetadataResolver
 import id.waltid.openid4vc.wallet.legacy.TrustedIssuerMetadataSigner
-import id.walt.commons.config.ConfigManager
 import io.klogging.Klogger
 import io.ktor.client.call.*
 import io.ktor.client.request.*

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceBase.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceBase.kt
@@ -10,7 +10,12 @@ import id.walt.mdoc.issuersigned.IssuerSigned
 import id.walt.oid4vc.data.CredentialFormat
 import id.walt.oid4vc.data.OfferedCredential
 import id.walt.sdjwt.metadata.type.SdJwtVcTypeMetadataDraft04
+import id.walt.webwallet.config.TrustConfig
 import id.walt.webwallet.utils.WalletHttpClients
+import id.waltid.openid4vc.wallet.legacy.ConfiguredIssuerMetadataTrustResolver
+import id.waltid.openid4vc.wallet.legacy.LegacyIssuerMetadataResolver
+import id.waltid.openid4vc.wallet.legacy.TrustedIssuerMetadataSigner
+import id.walt.commons.config.ConfigManager
 import io.klogging.Klogger
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -25,6 +30,24 @@ import kotlinx.serialization.json.jsonPrimitive
 abstract class IssuanceServiceBase {
 
     protected val http = WalletHttpClients.getHttpClient()
+    protected val legacyIssuerMetadataResolver by lazy {
+        val trustConfig = runCatching { ConfigManager.getConfig<TrustConfig>() }.getOrNull()
+        val trustedSigners = trustConfig?.issuerMetadataSigners.orEmpty().flatMap { (issuer, signers) ->
+            signers.map { signer ->
+                TrustedIssuerMetadataSigner(
+                    issuer = issuer,
+                    publicJwk = signer.publicJwk,
+                    keyId = signer.keyId,
+                    algorithm = signer.algorithm,
+                )
+            }
+        }
+        LegacyIssuerMetadataResolver(
+            httpClient = http,
+            metadataTrustResolver = trustedSigners.takeIf { it.isNotEmpty() }
+                ?.let(::ConfiguredIssuerMetadataTrustResolver),
+        )
+    }
     protected abstract val logger: Klogger
 
     protected fun parseOfferParams(offerURL: String) = Url(offerURL).parameters.toMap()

--- a/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceExternalSignatures.kt
+++ b/waltid-services/waltid-wallet-api/src/main/kotlin/id/walt/webwallet/service/exchange/IssuanceServiceExternalSignatures.kt
@@ -45,7 +45,7 @@ object IssuanceServiceExternalSignatures : IssuanceServiceBase() {
         didAuthKeyId: String,
         publicKey: Key,
     ): PrepareExternalClaimResult {
-        val providerMetadata = OpenID4VCI.resolveCIProviderMetadata(credentialOffer)
+        val providerMetadata = legacyIssuerMetadataResolver.resolve(credentialOffer.credentialIssuer)
 
         logger.debug { "providerMetadata: $providerMetadata" }
 
@@ -140,7 +140,7 @@ object IssuanceServiceExternalSignatures : IssuanceServiceBase() {
         accessToken: String?,
     ): List<ProcessedCredentialOffer> {
         logger.debug { "// get issuer metadata" }
-        val providerMetadata = OpenID4VCI.resolveCIProviderMetadata(credentialIssuerURL)
+        val providerMetadata = legacyIssuerMetadataResolver.resolve(credentialIssuerURL)
 
         logger.debug { "providerMetadata: $providerMetadata" }
         logger.debug { "Using issuer URL: $credentialIssuerURL" }


### PR DESCRIPTION
## Summary

This follow-up brings the signed issuer-metadata trust boundary to the legacy `waltid-wallet-api` wallet1 issuance flows. It covers both ordinary issuance and externally signed issuance, so those active paths no longer bypass the resolver introduced by [walt-id/waltid-identity#2011](https://github.com/walt-id/waltid-identity/pull/2011).

The matched Enterprise companion is [walt-id/waltid-identity-enterprise#585](https://github.com/walt-id/waltid-identity-enterprise/pull/585).

## What Changed

- Added a shared modern-to-legacy metadata adapter for wallet1's `OpenIDProviderMetadata.Draft13` model.
- Added explicit issuer-to-public-JWK trust configuration, with optional `kid` and `alg` binding.
- Routed normal issuance plus external-signature prepare/submit through one configured resolver.
- Reused the resolved provider metadata across each issuance flow instead of resolving it again.
- Added focused adapter coverage for unsigned projection, trusted signed metadata, and rejected signed metadata.

## Architecture Notes

- The legacy adapter lives beside the modern wallet protocol code and is the compatibility boundary for wallet1 callers.
- A JWK supplied by a JWT is not treated as trusted authority; trust comes only from the embedding service's issuer-specific configuration.
- Existing deployments remain unsigned-only unless `TrustConfig.issuerMetadataSigners` is populated.

## Caveats and Follow-Ups

- This PR intentionally does not change the modern wallet2/mobile API or Enterprise wallet1 wiring. The matched Enterprise companion applies the same adapter and trust boundary to `WalletOldImplementation`.
- Public signed-metadata journeys still depend on the issuer services publishing signed metadata and suitable trust configuration.

## Breaking

- No existing wallet1 request shape changes. The new trust configuration is optional and defaults to the previous unsigned-metadata behavior.
