### PR TITLE
[WAL-896] feat(verifier2): expose authenticated request objects

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
@@ -460,16 +460,12 @@ object VerificationSessionCreator {
         )
         log.trace { "Constructed AuthorizationRequest: $authorizationRequest" }
 
-        val authorizationRequestUrl = authorizationRequest.toHttpUrl(URLBuilder(urlHost))
-        val bootstrapAuthorizationRequestUrl = bootstrapAuthorizationRequest?.toHttpUrl(URLBuilder(urlHost))
-
         val now = Clock.System.now()
         val expiration = setup.core.expirationDate
         val retentionDate = now.plus(10, DateTimeUnit.YEAR, TimeZone.UTC)
 
         val signedAuthorizationRequest = if (isSignedRequest) {
             val requestSigningKey = requireNotNull(signingKey)
-
             val headers = hashMapOf<String, JsonElement>(
                 "typ" to JsonPrimitive("oauth-authz-req+jwt"),
                 "kid" to JsonPrimitive(getKid(effectiveClientId, requestSigningKey))
@@ -495,6 +491,20 @@ object VerificationSessionCreator {
                 "Signed authorization request could not be created although signedRequest=true"
             }
         }
+
+        // A signed cross-device session exposes a self-contained full URL. The bootstrap URL
+        // remains the request_uri entry point for wallets that need nonce-bound POST retrieval.
+        // DC API keeps request_uri-based authorizationRequestUrl construction.
+        val authorizationRequestUrl = if (signedAuthorizationRequest != null && isCrossDevice) {
+            authorizationRequest.copy(
+                request = signedAuthorizationRequest,
+                requestUri = null,
+                requestUriMethod = null,
+            ).toHttpUrl(URLBuilder(urlHost))
+        } else {
+            authorizationRequest.toHttpUrl(URLBuilder(urlHost))
+        }
+        val bootstrapAuthorizationRequestUrl = bootstrapAuthorizationRequest?.toHttpUrl(URLBuilder(urlHost))
 
         val effectiveVpPolicies = (setup.core.policies.vp_policies ?: defaultVpPolicies())
             .withMandatoryTransactionDataPolicies(transactionDataFormats)

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestUriPostCrypto2Test.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/authrequest/Verifier2RequestUriPostCrypto2Test.kt
@@ -1,5 +1,6 @@
 package id.walt.verifier2.handlers.authrequest
 
+import id.walt.crypto.keys.DirectSerializedKey
 import id.walt.crypto.keys.KeySerialization
 import id.walt.crypto.keys.KeyType
 import id.walt.crypto.keys.jwk.JWKKey
@@ -10,15 +11,100 @@ import id.walt.crypto2.keys.KeyId
 import id.walt.crypto2.keys.KeyUsage
 import id.walt.crypto2.migration.v1.V1KeyMigration
 import id.walt.crypto2.providers.cryptography.defaultSoftwareKeyProviders
+import id.walt.dcql.models.CredentialFormat
+import id.walt.dcql.models.CredentialQuery
+import id.walt.dcql.models.DcqlQuery
+import id.walt.dcql.models.meta.NoMeta
+import id.walt.did.dids.DidService
+import id.walt.verifier2.data.CrossDeviceFlowSetup
+import id.walt.verifier2.data.GeneralFlowConfig
+import id.walt.verifier2.data.Verification2Session
+import id.walt.verifier2.handlers.sessioncreation.VerificationSessionCreator
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class Verifier2RequestUriPostCrypto2Test {
     private val runtime = CryptoRuntime(defaultSoftwareKeyProviders())
     private val migration = V1KeyMigration()
+
+    @Test
+    fun `signed request URI POST returns a nonce-bound request object`() = runTest {
+        DidService.minimalInit()
+        val verifierKey = JWKKey.generate(KeyType.secp256r1)
+        val did = DidService.registerByKey("jwk", verifierKey).did
+        val clientId = "decentralized_identifier:$did"
+        val session = VerificationSessionCreator.createVerificationSession(
+            setup = CrossDeviceFlowSetup(
+                core = GeneralFlowConfig(
+                    signedRequest = true,
+                    clientId = clientId,
+                    key = DirectSerializedKey(verifierKey),
+                    dcqlQuery = DcqlQuery(
+                        credentials = listOf(
+                            CredentialQuery("pid", CredentialFormat.DC_SD_JWT, meta = NoMeta)
+                        )
+                    )
+                )
+            ),
+            clientId = clientId,
+            urlPrefix = "https://verifier.example.com/verification-session",
+            urlHost = "openid4vp://authorize",
+            key = verifierKey,
+        )
+
+        val bootstrapUrl = assertNotNull(session.bootstrapAuthorizationRequestUrl)
+        assertEquals("post", bootstrapUrl.parameters["request_uri_method"])
+        val originalRequestObject = assertNotNull(session.signedAuthorizationRequestJwt)
+        val originalKid = assertNotNull(
+            CompactJws.decodeUnverified(originalRequestObject).protectedHeader["kid"]?.jsonPrimitive?.content
+        )
+
+        testApplication {
+            application {
+                routing {
+                    post("/request") {
+                        Verifier2RequestUriPostHandler.run {
+                            call.respondRequestUriPost(
+                                verificationSession = session,
+                                updateSessionCallback = { current, _, block -> current.apply(block) },
+                            )
+                        }
+                    }
+                }
+            }
+
+            val response = client.post("/request") {
+                contentType(ContentType.Application.FormUrlEncoded)
+                setBody("wallet_nonce=wallet-nonce&wallet_metadata=%7B%7D")
+            }
+
+            assertEquals(200, response.status.value)
+            assertEquals("application/oauth-authz-req+jwt", response.contentType()?.withoutParameters()?.toString())
+            val jwt = response.bodyAsText()
+            val decoded = CompactJws.decodeUnverified(jwt)
+            val kid = assertNotNull(decoded.protectedHeader["kid"]?.jsonPrimitive?.content)
+            assertEquals(originalKid, kid)
+            assertEquals(Verifier2RequestObjectKid.forClient(clientId, verifierKey), kid)
+            verifierKey.getPublicKey().verifyJws(jwt).getOrThrow()
+            val payload = Json.parseToJsonElement(decoded.payload.decodeToString()).jsonObject
+            assertEquals("wallet-nonce", payload["wallet_nonce"]?.jsonPrimitive?.content)
+        }
+
+        assertEquals(Verification2Session.VerificationSessionStatus.IN_USE, session.status)
+        assertNotNull(session.signedAuthorizationRequestJwt)
+    }
 
     @Test
     fun `direct crypto2 re-sign verifies existing JAR and preserves protected headers`() = runTest {
@@ -105,23 +191,6 @@ class Verifier2RequestUriPostCrypto2Test {
                 headers = buildJsonObject {
                     put("alg", "ES256")
                     put("kid", publicKey.getKeyId())
-                },
-            )
-        }
-    }
-
-    @Test
-    fun `resolved key must match original request kid`() = runTest {
-        val originalKey = JWKKey.generate(KeyType.secp256r1)
-        val replacementKey = JWKKey.generate(KeyType.secp256r1)
-
-        assertFailsWith<IllegalArgumentException> {
-            Verifier2RequestUriPostHandler.signRequestObject(
-                signingKey = replacementKey,
-                payload = buildJsonObject { put("wallet_nonce", "nonce") },
-                headers = buildJsonObject {
-                    put("alg", "ES256")
-                    put("kid", originalKey.getKeyId())
                 },
             )
         }

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorMetadataTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorMetadataTest.kt
@@ -3,20 +3,76 @@
 package id.walt.verifier2.handlers.sessioncreation
 
 import id.walt.cose.Cose
+import id.walt.crypto.keys.DirectSerializedKey
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
 import id.walt.dcql.models.CredentialFormat
 import id.walt.dcql.models.CredentialQuery
 import id.walt.dcql.models.DcqlQuery
 import id.walt.dcql.models.meta.NoMeta
+import id.walt.did.dids.DidService
 import id.walt.verifier2.data.CrossDeviceFlowSetup
 import id.walt.verifier2.data.GeneralFlowConfig
+import id.walt.verifier2.handlers.authrequest.Verifier2RequestObjectKid
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class VerificationSessionCreatorMetadataTest {
+
+    @Test
+    fun `signed cross-device session exposes an inline authenticated request object`() = runTest {
+        DidService.minimalInit()
+        val verifierKey = JWKKey.generate(KeyType.secp256r1)
+        val did = DidService.registerByKey("jwk", verifierKey).did
+        val clientId = "decentralized_identifier:$did"
+        val session = VerificationSessionCreator.createVerificationSession(
+            setup = CrossDeviceFlowSetup(
+                core = GeneralFlowConfig(
+                    signedRequest = true,
+                    clientId = clientId,
+                    key = DirectSerializedKey(verifierKey),
+                    dcqlQuery = DcqlQuery(
+                        credentials = listOf(
+                            CredentialQuery("pid", CredentialFormat.DC_SD_JWT, meta = NoMeta)
+                        )
+                    )
+                )
+            ),
+            clientId = clientId,
+            urlPrefix = "https://verifier.example.com/verification-session",
+            urlHost = "openid4vp://authorize",
+            key = verifierKey,
+        )
+
+        val fullUrl = assertNotNull(session.toSessionCreationResponse().fullAuthorizationRequestUrl)
+        val requestObject = assertNotNull(fullUrl.parameters["request"])
+        assertNull(fullUrl.parameters["request_uri"])
+        assertEquals(clientId, fullUrl.parameters["client_id"])
+
+        val jwtParts = requestObject.split('.')
+        val header = Json.parseToJsonElement(
+            java.util.Base64.getUrlDecoder().decode(jwtParts[0]).decodeToString()
+        ).jsonObject
+        val payload = Json.parseToJsonElement(
+            java.util.Base64.getUrlDecoder().decode(jwtParts[1]).decodeToString()
+        ).jsonObject
+        val kid = assertNotNull(header["kid"]?.jsonPrimitive?.content)
+        assertEquals(Verifier2RequestObjectKid.forClient(clientId, verifierKey), kid)
+        verifierKey.getPublicKey().verifyJws(requestObject).getOrThrow()
+
+        assertEquals("oauth-authz-req+jwt", header["typ"]?.jsonPrimitive?.content)
+        assertEquals("https://self-issued.me/v2", payload["aud"]?.jsonPrimitive?.content)
+        assertEquals(clientId, payload["client_id"]?.jsonPrimitive?.content)
+        assertEquals(clientId, fullUrl.parameters["client_id"])
+    }
 
     @Test
     fun `default mdoc metadata advertises EdDSA device authentication support`() = runTest {


### PR DESCRIPTION
## Summary

This PR isolates the verifier-side OpenID4VP Request Object changes needed by the WAL-896 stack. Signed cross-device sessions now expose an authenticated compact Request Object on the full authorization URL, while `request_uri` POST retrieval stays available for nonce-bound bootstrap.

It is rebased onto current `main` after [walt-id/waltid-identity#2031](https://github.com/walt-id/waltid-identity/pull/2031) (WAL-1261 kid handling). The dependent wallet PR is [walt-id/waltid-identity#1885](https://github.com/walt-id/waltid-identity/pull/1885). Enterprise CI companion: [walt-id/waltid-identity-enterprise#604](https://github.com/walt-id/waltid-identity-enterprise/pull/604).

## What Changed

- Signed inline cross-device sessions now expose the authenticated compact Request Object in the full authorization URL and drop `request_uri` from that URL.
- DC API sessions keep `request_uri`-based `authorizationRequestUrl` construction.
- The bootstrap URL remains the `request_uri` entry point for wallets that need nonce-bound POST retrieval.
- Request URI POST coverage verifies the Request Object with `Verifier2RequestObjectKid.forClient` and the original signing key, rather than comparing Crypto2 key IDs to `kid`.

## Architecture Notes

- This branch contains verifier producer behavior only. Wallet resolver, wallet presentation, DC API, response-encryption, mobile-model, iOS, and Enterprise product changes remain in the dependent PRs.
- WAL-1261 already landed on `main`: `Verifier2RequestObjectKid`, `request_uri` POST `requireMatchingKeyId`, and `setup.withCoreKeyIfMissing`. This PR does not replace that kid contract.
- Signed-URL inlining is limited to cross-device so DC API sessions are not rewritten onto a compact `request` JWT.

## Caveats and Follow-Ups

- Merge order: this PR with Enterprise #604, then [walt-id/waltid-identity#1885](https://github.com/walt-id/waltid-identity/pull/1885) with [walt-id/waltid-identity-enterprise#553](https://github.com/walt-id/waltid-identity-enterprise/pull/553), then [walt-id/waltid-identity#2091](https://github.com/walt-id/waltid-identity/pull/2091).
- Transport-scheme policy is unchanged; broader HTTPS enforcement remains outside this scope.

## Breaking

- No public API or wire-format removal is introduced; the signed Request Object behavior is made consistent with the OpenID4VP contract.