### PR TITLE
[WAL-752] test(android): modernize Portal2 DC API browser E2Es

### DIFF
--- a/.github/scripts/mobile-ci/configure-android-device-phase.sh
+++ b/.github/scripts/mobile-ci/configure-android-device-phase.sh
@@ -19,6 +19,8 @@ case "$phase" in
     # instrumentation discovery; their class-level assumption would otherwise
     # collapse the reported test count and make Gradle fail the phase.
     compose_demo_excluded_classes="id.walt.walletdemo.compose.android.DigitalCredentialSharingE2ETest,id.walt.walletdemo.compose.android.DigitalCredentialIssuanceE2ETest"
+    compose_demo_excluded_classes+=",id.walt.walletdemo.compose.android.DigitalCredentialPortalPresentationE2ETest"
+    compose_demo_excluded_classes+=",id.walt.walletdemo.compose.android.DigitalCredentialPortalIssuanceE2ETest"
     script="ANDROID_TEST_NOT_CLASS=$compose_demo_excluded_classes ./waltid-identity/.github/scripts/mobile-ci/run-android-compose-demo-tests.sh"
     emulator_options="-no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim"
     report_paths="waltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/outputs/androidTest-results/**/*.xml"
@@ -39,6 +41,19 @@ case "$phase" in
     emulator_api_level="37.0"
     emulator_profile="pixel_7"
     emulator_target="google_apis"
+    ;;
+  dc-api-browser)
+    # Browser-origin coverage has its own Play Store/Chrome userdata baseline.
+    # It must never restore or mutate the native google_apis DC API cache.
+    dc_api_browser_test_classes="id.walt.walletdemo.compose.android.DigitalCredentialPortalPresentationE2ETest,id.walt.walletdemo.compose.android.DigitalCredentialPortalIssuanceE2ETest"
+    script="DC_API_BROWSER_TESTS=true ANDROID_TEST_CLASS=$dc_api_browser_test_classes EXPECTED_ANDROID_TEST_CASE_COUNT=3 ./waltid-identity/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh"
+    emulator_options="-no-snapshot -no-snapshot-save -no-window -gpu auto -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator"
+    emulator_avd_name="dc-api-browser-api37-pixel7-playstore"
+    report_paths="waltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/outputs/androidTest-results/**/*.xml"
+    artifact_paths=$'waltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/reports/androidTests/**\nwaltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/outputs/androidTest-results/**'
+    emulator_api_level="37.0"
+    emulator_profile="pixel_7"
+    emulator_target="google_apis_playstore_ps16k"
     ;;
   enterprise-mobile)
     script="./waltid-identity/.github/scripts/mobile-ci/run-enterprise-android-mobile-tests.sh"

--- a/.github/scripts/mobile-ci/prepare-android-dc-api-browser-avd.sh
+++ b/.github/scripts/mobile-ci/prepare-android-dc-api-browser-avd.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+export DC_API_CHROME_VALIDATE_PORTAL_DURING_PREPARE=true
+source "$script_dir/prepare-android-dc-api-browser-device.sh"
+
+DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS="${DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS:-60}"
+
+run_bounded_adb() {
+  local timeout_seconds="$1"
+  shift
+  local command=("$ADB_BIN")
+  if [[ -n "$ANDROID_SERIAL" ]]; then
+    command+=(-s "$ANDROID_SERIAL")
+  fi
+  timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" "${command[@]}" "$@"
+}
+
+echo "DC API browser AVD preparation: freezing updates before inspecting Chrome"
+disable_android_browser_play_store_updates
+prepare_android_dc_api_device
+assert_android_browser_expected_gms_identity
+prepare_android_dc_api_chrome
+validate_android_dc_api_chrome
+
+write_android_dc_api_baseline_manifest
+assert_android_dc_api_baseline_manifest
+write_android_dc_api_browser_baseline_manifest
+assert_android_dc_api_browser_baseline_manifest
+
+echo "DC API browser AVD preparation: draining Android broadcast and application work before caching"
+if ! barrier_output="$(
+  run_bounded_adb "$DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS" \
+    shell am wait-for-broadcast-barrier \
+    --flush-broadcast-loopers \
+    --flush-application-threads
+)"; then
+  echo "::error::Android broadcast/application quiescence command failed" >&2
+  exit 1
+fi
+printf '%s\n' "$barrier_output"
+if [[ "$barrier_output" != *"Finished application barriers!"* ]]; then
+  echo "::error::Android application work did not reach the quiescence barrier" >&2
+  exit 1
+fi
+echo "DC API browser AVD preparation: flushing the guest filesystem"
+run_bounded_adb "$DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS" shell sync
+echo "DC API browser AVD preparation: immutable Android and Chrome baselines passed"

--- a/.github/scripts/mobile-ci/prepare-android-dc-api-browser-device.sh
+++ b/.github/scripts/mobile-ci/prepare-android-dc-api-browser-device.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+# Browser-only state layered on top of the native DC API device baseline. The
+# Play Store image and cache are separate from the native google_apis substrate.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$script_dir/prepare-android-dc-api-device.sh"
+source "$script_dir/prepare-android-dc-api-chrome.sh"
+
+DC_API_BROWSER_BASELINE_SCHEMA="${DC_API_BROWSER_BASELINE_SCHEMA:-1}"
+DC_API_BROWSER_BASELINE_MANIFEST="$DC_API_AVD_DIR/waltid-dc-api-browser-baseline.manifest"
+DC_API_BROWSER_READY_TIMEOUT_SECONDS="${DC_API_BROWSER_READY_TIMEOUT_SECONDS:-120}"
+DC_API_BROWSER_EXPECTED_GMS_VERSION_NAME="${DC_API_BROWSER_EXPECTED_GMS_VERSION_NAME:-}"
+DC_API_BROWSER_EXPECTED_GMS_VERSION_CODE="${DC_API_BROWSER_EXPECTED_GMS_VERSION_CODE:-}"
+
+wait_for_android_browser_package_manager() {
+  local deadline=$((SECONDS + DC_API_BROWSER_READY_TIMEOUT_SECONDS))
+  local boot_completed
+
+  echo "DC API browser device: waiting to freeze Play Store updates"
+  while (( SECONDS < deadline )); do
+    if adb_cmd get-state >/dev/null 2>&1; then
+      boot_completed="$(adb_shell getprop sys.boot_completed 2>/dev/null || true)"
+      if [[ "$boot_completed" == "1" ]] && adb_shell pm list packages >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+    sleep "$DC_API_POLL_SECONDS"
+  done
+
+  echo "::error::DC API browser device package manager was not ready within ${DC_API_BROWSER_READY_TIMEOUT_SECONDS}s" >&2
+  return 1
+}
+
+disable_android_browser_play_store_updates() {
+  wait_for_android_browser_package_manager
+  adb_shell am force-stop "$DC_API_CHROME_PLAY_STORE_PACKAGE" >/dev/null 2>&1 || true
+  adb_shell pm disable-user --user 0 "$DC_API_CHROME_PLAY_STORE_PACKAGE"
+  assert_android_browser_play_store_disabled
+  echo "DC API browser device: Play Store disabled for user 0"
+}
+
+assert_android_browser_play_store_disabled() {
+  if ! adb_shell pm list packages -d "$DC_API_CHROME_PLAY_STORE_PACKAGE" 2>/dev/null |
+    grep -Fxq "package:$DC_API_CHROME_PLAY_STORE_PACKAGE"; then
+    echo "::error::Play Store is not disabled for user 0; browser versions may update during the suite" >&2
+    return 1
+  fi
+}
+
+assert_android_browser_expected_gms_identity() {
+  local version code
+  version="$(gms_version_name)"
+  code="$(gms_version_code)"
+
+  if [[ -z "$DC_API_BROWSER_EXPECTED_GMS_VERSION_NAME" ||
+    ! "$DC_API_BROWSER_EXPECTED_GMS_VERSION_CODE" =~ ^[0-9]+$
+  ]]; then
+    echo "::error::Exact x86_64 browser GMS version name/code pins are required" >&2
+    return 1
+  fi
+  if [[ "$version" != "$DC_API_BROWSER_EXPECTED_GMS_VERSION_NAME" ||
+    "$code" != "$DC_API_BROWSER_EXPECTED_GMS_VERSION_CODE"
+  ]]; then
+    echo "::error::Browser GMS identity mismatch: expected=${DC_API_BROWSER_EXPECTED_GMS_VERSION_NAME}/${DC_API_BROWSER_EXPECTED_GMS_VERSION_CODE} actual=${version:-<missing>}/${code:-<missing>}" >&2
+    return 1
+  fi
+  echo "DC API browser device: exact GMS identity $version/$code"
+}
+
+android_dc_api_browser_manifest_current_values() {
+  local chrome_version chrome_code chrome_path locale chrome_helper_sha browser_helper_sha
+  assert_android_browser_play_store_disabled
+  assert_android_browser_expected_gms_identity
+  chrome_assert_identity
+
+  chrome_version="$(chrome_version_name)"
+  chrome_code="$(chrome_version_code)"
+  chrome_path="$(chrome_apk_path)"
+  locale="$(adb_shell getprop persist.sys.locale 2>/dev/null || true)"
+  [[ -n "$locale" ]] || locale="$(adb_shell getprop ro.product.locale 2>/dev/null || true)"
+  chrome_helper_sha="$(sha256sum "$script_dir/prepare-android-dc-api-chrome.sh" | awk '{print $1}')"
+  browser_helper_sha="$(sha256sum "$script_dir/prepare-android-dc-api-browser-device.sh" | awk '{print $1}')"
+
+  if [[ -z "$chrome_version" || ! "$chrome_code" =~ ^[0-9]+$ || -z "$chrome_path" ||
+    -z "$locale" || ! "$chrome_helper_sha" =~ ^[0-9a-f]{64}$ ||
+    ! "$browser_helper_sha" =~ ^[0-9a-f]{64}$
+  ]]; then
+    echo "::error::DC API browser baseline identity is incomplete" >&2
+    return 1
+  fi
+
+  printf 'schema=%s\n' "$DC_API_BROWSER_BASELINE_SCHEMA"
+  printf 'gms_version_name=%s\n' "$DC_API_BROWSER_EXPECTED_GMS_VERSION_NAME"
+  printf 'gms_version_code=%s\n' "$DC_API_BROWSER_EXPECTED_GMS_VERSION_CODE"
+  printf 'chrome_package=%s\n' "$DC_API_CHROME_PACKAGE"
+  printf 'chrome_version_name=%s\n' "$chrome_version"
+  printf 'chrome_version_code=%s\n' "$chrome_code"
+  printf 'chrome_apk_path=%s\n' "$chrome_path"
+  printf 'chrome_minimum_major=%s\n' "$DC_API_CHROME_MINIMUM_MAJOR"
+  printf 'chrome_first_run_complete=true\n'
+  printf 'chrome_issuance_flag_id=%s\n' "$DC_API_CHROME_FLAG_ID"
+  printf 'chrome_issuance_flag_state=Enabled\n'
+  printf 'chrome_profile_locale=%s\n' "$locale"
+  printf 'chrome_helper_sha256=%s\n' "$chrome_helper_sha"
+  printf 'browser_helper_sha256=%s\n' "$browser_helper_sha"
+  printf 'play_store_disabled_for_user_0=true\n'
+}
+
+write_android_dc_api_browser_baseline_manifest() {
+  [[ -d "$DC_API_AVD_DIR" ]] || {
+    echo "::error::Cannot write DC API browser baseline; AVD directory is missing: $DC_API_AVD_DIR" >&2
+    return 1
+  }
+  local temporary_manifest="$DC_API_BROWSER_BASELINE_MANIFEST.tmp.$$"
+  android_dc_api_browser_manifest_current_values > "$temporary_manifest"
+  mv "$temporary_manifest" "$DC_API_BROWSER_BASELINE_MANIFEST"
+  echo "DC API browser baseline manifest: wrote $DC_API_BROWSER_BASELINE_MANIFEST"
+  cat "$DC_API_BROWSER_BASELINE_MANIFEST"
+}
+
+assert_android_dc_api_browser_baseline_manifest() {
+  [[ -f "$DC_API_BROWSER_BASELINE_MANIFEST" ]] || {
+    echo "::error::DC API browser baseline manifest is missing: $DC_API_BROWSER_BASELINE_MANIFEST" >&2
+    return 1
+  }
+
+  local expected current
+  expected="$(cat "$DC_API_BROWSER_BASELINE_MANIFEST")"
+  current="$(android_dc_api_browser_manifest_current_values)"
+  if [[ "$expected" != "$current" ]]; then
+    echo "::error::Restored DC API browser AVD does not match its immutable Chrome baseline" >&2
+    diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$current") || true
+    return 1
+  fi
+  echo "DC API browser baseline manifest: exact Chrome/profile identity match"
+}

--- a/.github/scripts/mobile-ci/prepare-android-dc-api-chrome.sh
+++ b/.github/scripts/mobile-ci/prepare-android-dc-api-chrome.sh
@@ -1,0 +1,663 @@
+#!/usr/bin/env bash
+
+# Prepares and validates the Chrome userdata needed by Android Digital Credentials browser E2Es.
+# This file is deliberately standalone: callers may source it next to the existing DC API device
+# helper, but it neither sources nor changes that helper's Android/GMS baseline policy.
+
+CHROME_ADB_BIN="${ADB_BIN:-adb}"
+CHROME_ANDROID_SERIAL="${ANDROID_SERIAL:-}"
+DC_API_CHROME_PACKAGE="${DC_API_CHROME_PACKAGE:-com.android.chrome}"
+DC_API_CHROME_MAIN_ACTIVITY="${DC_API_CHROME_MAIN_ACTIVITY:-com.google.android.apps.chrome.Main}"
+DC_API_CHROME_FIRST_RUN_ACTIVITY="${DC_API_CHROME_FIRST_RUN_ACTIVITY:-org.chromium.chrome.browser.firstrun.FirstRunActivity}"
+DC_API_CHROME_TABBED_ACTIVITY="${DC_API_CHROME_TABBED_ACTIVITY:-org.chromium.chrome.browser.ChromeTabbedActivity}"
+DC_API_CHROME_MINIMUM_MAJOR="${DC_API_CHROME_MINIMUM_MAJOR:-143}"
+DC_API_CHROME_EXPECTED_VERSION_NAME="${DC_API_CHROME_EXPECTED_VERSION_NAME:-${EXPECTED_CHROME_VERSION_NAME:-}}"
+DC_API_CHROME_EXPECTED_VERSION_CODE="${DC_API_CHROME_EXPECTED_VERSION_CODE:-${EXPECTED_CHROME_VERSION_CODE:-}}"
+DC_API_CHROME_REQUIRE_PLAY_STORE_DISABLED="${DC_API_CHROME_REQUIRE_PLAY_STORE_DISABLED:-true}"
+DC_API_CHROME_PLAY_STORE_PACKAGE="${DC_API_CHROME_PLAY_STORE_PACKAGE:-com.android.vending}"
+DC_API_CHROME_FLAG_URI="${DC_API_CHROME_FLAG_URI:-chrome://flags/#web-identity-digital-credentials-creation}"
+DC_API_CHROME_FLAG_ID="${DC_API_CHROME_FLAG_ID:-web-identity-digital-credentials-creation}"
+DC_API_CHROME_FLAG_HINT="${DC_API_CHROME_FLAG_HINT:-DigitalCredentialsCreation}"
+DC_API_CHROME_PORTAL_URL="${DC_API_CHROME_PORTAL_URL:-https://portal2.demo.walt.id/}"
+DC_API_CHROME_PORTAL_URL_BAR_PATTERN="${DC_API_CHROME_PORTAL_URL_BAR_PATTERN:-^(https://)?portal2[.]demo[.]walt[.]id/?$}"
+DC_API_CHROME_PORTAL_RENDER_TEXT_PATTERN="${DC_API_CHROME_PORTAL_RENDER_TEXT_PATTERN:-Demo Portal|Issue credential|Verify credential}"
+DC_API_CHROME_PORTAL_ERROR_TEXT_PATTERN="${DC_API_CHROME_PORTAL_ERROR_TEXT_PATTERN:-Aw, Snap|This site can.t be reached|ERR_}"
+DC_API_CHROME_READY_TIMEOUT_SECONDS="${DC_API_CHROME_READY_TIMEOUT_SECONDS:-45}"
+DC_API_CHROME_FLAG_TIMEOUT_SECONDS="${DC_API_CHROME_FLAG_TIMEOUT_SECONDS:-60}"
+DC_API_CHROME_PORTAL_TIMEOUT_SECONDS="${DC_API_CHROME_PORTAL_TIMEOUT_SECONDS:-90}"
+DC_API_CHROME_PORTAL_STABILITY_SECONDS="${DC_API_CHROME_PORTAL_STABILITY_SECONDS:-4}"
+DC_API_CHROME_POLL_SECONDS="${DC_API_CHROME_POLL_SECONDS:-2}"
+DC_API_CHROME_OMNIBOX_ATTEMPTS="${DC_API_CHROME_OMNIBOX_ATTEMPTS:-3}"
+DC_API_CHROME_VALIDATE_PORTAL_DURING_PREPARE="${DC_API_CHROME_VALIDATE_PORTAL_DURING_PREPARE:-false}"
+DC_API_CHROME_ARTIFACT_DIR="${DC_API_CHROME_ARTIFACT_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/waltid-dc-api-chrome-artifacts}"
+DC_API_CHROME_REMOTE_UI_DUMP="${DC_API_CHROME_REMOTE_UI_DUMP:-/sdcard/waltid-dc-api-chrome.xml}"
+CHROME_LAST_UI_DUMP=""
+
+chrome_log() {
+  echo "DC API Chrome: $*" >&2
+}
+
+chrome_error() {
+  echo "::error title=DC API Chrome substrate::$*" >&2
+}
+
+chrome_adb_cmd() {
+  if [[ -n "$CHROME_ANDROID_SERIAL" ]]; then
+    "$CHROME_ADB_BIN" -s "$CHROME_ANDROID_SERIAL" "$@"
+  else
+    "$CHROME_ADB_BIN" "$@"
+  fi
+}
+
+chrome_adb_shell() {
+  chrome_adb_cmd shell "$@" | tr -d '\r'
+}
+
+chrome_initialize_work_dir() {
+  mkdir -p "$DC_API_CHROME_ARTIFACT_DIR"
+  if [[ -z "$CHROME_LAST_UI_DUMP" ]]; then
+    CHROME_LAST_UI_DUMP="$DC_API_CHROME_ARTIFACT_DIR/latest-ui.xml"
+  fi
+}
+
+chrome_dump_ui() {
+  chrome_initialize_work_dir || return 1
+  if ! chrome_adb_cmd shell uiautomator dump --compressed "$DC_API_CHROME_REMOTE_UI_DUMP" \
+    >"$DC_API_CHROME_ARTIFACT_DIR/uiautomator-command.log" 2>&1; then
+    return 1
+  fi
+  if ! chrome_adb_cmd exec-out cat "$DC_API_CHROME_REMOTE_UI_DUMP" >"$CHROME_LAST_UI_DUMP"; then
+    return 1
+  fi
+  grep -q '<hierarchy' "$CHROME_LAST_UI_DUMP"
+}
+
+# Query the most recent UiAutomator XML with Python's standard library.
+#
+# Usage:
+#   chrome_ui_query count _ key=value ...
+#   chrome_ui_query value text key=value ...
+#   chrome_ui_query center _ key=value ...
+#
+# Supported filters: resource-id, resource-id-suffix, text, text-regex, content-desc, hint,
+# package, class, enabled, focused, clickable, checkable, selected, and visible. `value` and
+# `center` require exactly one match so selector drift cannot silently click an arbitrary node.
+chrome_ui_query() {
+  local mode="${1:?query mode is required}"
+  local output_attribute="${2:-_}"
+  shift 2
+  python3 - "$CHROME_LAST_UI_DUMP" "$mode" "$output_attribute" "$@" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+xml_path, mode, output_attribute, *raw_filters = sys.argv[1:]
+filters = []
+for raw_filter in raw_filters:
+    if "=" not in raw_filter:
+        raise SystemExit(f"invalid filter: {raw_filter}")
+    key, value = raw_filter.split("=", 1)
+    filters.append((key, value))
+
+def boolean(value):
+    return value.lower() == "true"
+
+def bounds(node):
+    match = re.fullmatch(r"\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]", node.get("bounds", ""))
+    if not match:
+        return None
+    return tuple(map(int, match.groups()))
+
+def matches(node):
+    for key, expected in filters:
+        if key == "resource-id-suffix":
+            if not node.get("resource-id", "").endswith(expected):
+                return False
+        elif key == "text-regex":
+            if re.search(expected, node.get("text", "")) is None:
+                return False
+        elif key == "visible":
+            node_bounds = bounds(node)
+            visible = node_bounds is not None and node_bounds[2] > node_bounds[0] and node_bounds[3] > node_bounds[1]
+            if visible != boolean(expected):
+                return False
+        elif key in {"enabled", "focused", "clickable", "checkable", "selected"}:
+            if boolean(node.get(key, "false")) != boolean(expected):
+                return False
+        elif node.get(key, "") != expected:
+            return False
+    return True
+
+nodes = [node for node in ET.parse(xml_path).iter("node") if matches(node)]
+if mode == "count":
+    print(len(nodes))
+    raise SystemExit(0)
+if len(nodes) != 1:
+    print(f"expected exactly one UI node, found {len(nodes)}", file=sys.stderr)
+    raise SystemExit(1)
+node = nodes[0]
+if mode == "value":
+    print(node.get(output_attribute, ""))
+elif mode == "center":
+    node_bounds = bounds(node)
+    if node_bounds is None or node_bounds[2] <= node_bounds[0] or node_bounds[3] <= node_bounds[1]:
+        raise SystemExit("matched node has no visible bounds")
+    x1, y1, x2, y2 = node_bounds
+    print(f"{(x1 + x2) // 2} {(y1 + y2) // 2}")
+else:
+    raise SystemExit(f"unknown query mode: {mode}")
+PY
+}
+
+chrome_ui_count() {
+  chrome_ui_query count _ "$@"
+}
+
+chrome_ui_value() {
+  local attribute="${1:?attribute is required}"
+  shift
+  chrome_ui_query value "$attribute" "$@"
+}
+
+chrome_wait_for_ui_center() {
+  local description="${1:?description is required}"
+  local timeout_seconds="${2:?timeout is required}"
+  shift 2
+  local deadline=$((SECONDS + timeout_seconds))
+  local center=""
+  while (( SECONDS < deadline )); do
+    if chrome_dump_ui && center="$(chrome_ui_query center _ "$@" 2>/dev/null)"; then
+      printf '%s\n' "$center"
+      return 0
+    fi
+    sleep "$DC_API_CHROME_POLL_SECONDS"
+  done
+  chrome_error "Timed out waiting for $description"
+  return 1
+}
+
+chrome_wait_for_ui_value() {
+  local description="${1:?description is required}"
+  local timeout_seconds="${2:?timeout is required}"
+  local attribute="${3:?attribute is required}"
+  shift 3
+  local deadline=$((SECONDS + timeout_seconds))
+  local value=""
+  while (( SECONDS < deadline )); do
+    if chrome_dump_ui && value="$(chrome_ui_query value "$attribute" "$@" 2>/dev/null)"; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+    sleep "$DC_API_CHROME_POLL_SECONDS"
+  done
+  chrome_error "Timed out waiting for $description"
+  return 1
+}
+
+chrome_tap_center() {
+  local center="${1:?center is required}"
+  local x y
+  read -r x y <<<"$center"
+  [[ "$x" =~ ^[0-9]+$ && "$y" =~ ^[0-9]+$ ]] || {
+    chrome_error "Invalid UI center: $center"
+    return 1
+  }
+  chrome_adb_shell input tap "$x" "$y" >/dev/null
+}
+
+chrome_current_activity() {
+  chrome_adb_shell dumpsys activity activities 2>/dev/null |
+    sed -n -E 's/.*(topResumedActivity|mResumedActivity|ResumedActivity)[=:].* u0 ([^ ]+).*/\2/p' |
+    head -n 1
+}
+
+chrome_package_details() {
+  chrome_adb_shell dumpsys package "$DC_API_CHROME_PACKAGE" 2>/dev/null || true
+}
+
+chrome_version_name() {
+  chrome_package_details | sed -n 's/.*versionName=\([^[:space:]]*\).*/\1/p' | head -n 1
+}
+
+chrome_version_code() {
+  chrome_package_details | sed -n 's/.*versionCode=\([0-9]*\).*/\1/p' | head -n 1
+}
+
+chrome_apk_path() {
+  chrome_adb_shell pm path "$DC_API_CHROME_PACKAGE" 2>/dev/null |
+    sed -n 's/^package:\(.*\)$/\1/p' |
+    head -n 1
+}
+
+chrome_play_store_is_disabled() {
+  chrome_adb_shell pm list packages -d "$DC_API_CHROME_PLAY_STORE_PACKAGE" 2>/dev/null |
+    grep -Fxq "package:$DC_API_CHROME_PLAY_STORE_PACKAGE"
+}
+
+chrome_assert_identity() {
+  chrome_adb_cmd wait-for-device || return 1
+  local apk_path version_name version_code major resolved_activity
+  apk_path="$(chrome_apk_path)"
+  version_name="$(chrome_version_name)"
+  version_code="$(chrome_version_code)"
+  resolved_activity="$(chrome_adb_shell cmd package resolve-activity --brief \
+    -a android.intent.action.VIEW -d "$DC_API_CHROME_PORTAL_URL" "$DC_API_CHROME_PACKAGE" 2>/dev/null |
+    awk '/\// { print $NF }' | tail -n 1)"
+
+  [[ -n "$apk_path" ]] || {
+    chrome_error "Chrome APK is missing for $DC_API_CHROME_PACKAGE"
+    return 1
+  }
+  [[ -n "$version_name" && -n "$version_code" ]] || {
+    chrome_error "Chrome package identity is incomplete: version=$version_name versionCode=$version_code"
+    return 1
+  }
+  [[ -n "$resolved_activity" ]] || {
+    chrome_error "Chrome cannot resolve an HTTPS VIEW Activity"
+    return 1
+  }
+  if ! chrome_adb_shell pm list packages -e "$DC_API_CHROME_PACKAGE" 2>/dev/null |
+    grep -Fxq "package:$DC_API_CHROME_PACKAGE"; then
+    chrome_error "Chrome is not enabled for user 0"
+    return 1
+  fi
+
+  major="${version_name%%.*}"
+  if [[ ! "$DC_API_CHROME_MINIMUM_MAJOR" =~ ^[0-9]+$ ]]; then
+    chrome_error "DC_API_CHROME_MINIMUM_MAJOR must be numeric: $DC_API_CHROME_MINIMUM_MAJOR"
+    return 1
+  fi
+  if [[ ! "$major" =~ ^[0-9]+$ ]] || (( major < DC_API_CHROME_MINIMUM_MAJOR )); then
+    chrome_error "Chrome $version_name does not meet the required major >= $DC_API_CHROME_MINIMUM_MAJOR"
+    return 1
+  fi
+  if [[ -n "$DC_API_CHROME_EXPECTED_VERSION_NAME" && "$version_name" != "$DC_API_CHROME_EXPECTED_VERSION_NAME" ]]; then
+    chrome_error "Chrome version mismatch: expected=$DC_API_CHROME_EXPECTED_VERSION_NAME actual=$version_name"
+    return 1
+  fi
+  if [[ -n "$DC_API_CHROME_EXPECTED_VERSION_CODE" && "$version_code" != "$DC_API_CHROME_EXPECTED_VERSION_CODE" ]]; then
+    chrome_error "Chrome versionCode mismatch: expected=$DC_API_CHROME_EXPECTED_VERSION_CODE actual=$version_code"
+    return 1
+  fi
+  if [[ "$DC_API_CHROME_REQUIRE_PLAY_STORE_DISABLED" == "true" ]] && ! chrome_play_store_is_disabled; then
+    chrome_error "Play Store must be disabled before Chrome preparation/validation"
+    return 1
+  fi
+
+  chrome_log "identity package=$DC_API_CHROME_PACKAGE version=$version_name versionCode=$version_code apk=$apk_path activity=$resolved_activity"
+}
+
+chrome_start_main() {
+  chrome_adb_shell am start -W -n "$DC_API_CHROME_PACKAGE/$DC_API_CHROME_MAIN_ACTIVITY" >/dev/null
+}
+
+chrome_click_ui_node() {
+  local description="${1:?description is required}"
+  local timeout_seconds="${2:?timeout is required}"
+  shift 2
+  local center
+  center="$(chrome_wait_for_ui_center "$description" "$timeout_seconds" "$@")" || return 1
+  chrome_tap_center "$center"
+}
+
+chrome_wait_for_tabbed_ui() {
+  local deadline=$((SECONDS + DC_API_CHROME_READY_TIMEOUT_SECONDS))
+  local activity toolbar_count
+  while (( SECONDS < deadline )); do
+    activity="$(chrome_current_activity)"
+    if [[ "$activity" == *"$DC_API_CHROME_FIRST_RUN_ACTIVITY"* ]]; then
+      sleep "$DC_API_CHROME_POLL_SECONDS"
+      continue
+    fi
+    if chrome_dump_ui; then
+      toolbar_count="$(chrome_ui_count resource-id-suffix=url_bar visible=true 2>/dev/null || printf 0)"
+      if (( toolbar_count == 1 )) && [[ "$activity" == *"$DC_API_CHROME_TABBED_ACTIVITY"* || "$activity" == *"$DC_API_CHROME_MAIN_ACTIVITY"* ]]; then
+        return 0
+      fi
+    fi
+    sleep "$DC_API_CHROME_POLL_SECONDS"
+  done
+  chrome_error "Chrome did not reach its tabbed UI; activity=$(chrome_current_activity)"
+  return 1
+}
+
+chrome_complete_first_run() {
+  chrome_start_main || return 1
+  local dismiss_count=0 negative_count=0 toolbar_count=0 activity deadline
+  deadline=$((SECONDS + DC_API_CHROME_READY_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    activity="$(chrome_current_activity)"
+    if chrome_dump_ui; then
+      dismiss_count="$(chrome_ui_count resource-id-suffix=signin_fre_dismiss_button text='Use without an account' enabled=true visible=true 2>/dev/null || printf 0)"
+      if (( dismiss_count == 1 )); then
+        chrome_click_ui_node "Chrome Use without an account button" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" \
+          resource-id-suffix=signin_fre_dismiss_button text='Use without an account' enabled=true clickable=true visible=true || return 1
+        break
+      fi
+      negative_count="$(chrome_ui_count resource-id-suffix=negative_button text='No thanks' enabled=true visible=true 2>/dev/null || printf 0)"
+      if (( negative_count == 1 )); then
+        chrome_click_ui_node "Chrome No thanks notification button" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" \
+          resource-id-suffix=negative_button text='No thanks' enabled=true clickable=true visible=true || return 1
+        chrome_wait_for_tabbed_ui || return 1
+        chrome_log "completed a partially finished first run without adding an account"
+        return 0
+      fi
+      toolbar_count="$(chrome_ui_count resource-id-suffix=url_bar visible=true 2>/dev/null || printf 0)"
+      if [[ "$activity" != *"$DC_API_CHROME_FIRST_RUN_ACTIVITY"* ]] && (( toolbar_count == 1 )); then
+        chrome_log "first run was already complete"
+        return 0
+      fi
+    fi
+    sleep "$DC_API_CHROME_POLL_SECONDS"
+  done
+  if (( dismiss_count != 1 )); then
+    chrome_error "Chrome first-run Activity exposed no recognized dismissal control"
+    return 1
+  fi
+
+  # Chrome 145 shows an in-app notification education dialog after account dismissal. It is optional,
+  # but when present it must be dismissed without granting notification permission.
+  deadline=$((SECONDS + DC_API_CHROME_READY_TIMEOUT_SECONDS))
+  while (( SECONDS < deadline )); do
+    if chrome_dump_ui; then
+      if [[ "$(chrome_ui_count resource-id-suffix=negative_button text='No thanks' enabled=true visible=true 2>/dev/null || printf 0)" == "1" ]]; then
+        chrome_click_ui_node "Chrome No thanks notification button" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" \
+          resource-id-suffix=negative_button text='No thanks' enabled=true clickable=true visible=true || return 1
+        break
+      fi
+      if [[ "$(chrome_ui_count resource-id-suffix=url_bar visible=true 2>/dev/null || printf 0)" == "1" ]]; then
+        break
+      fi
+    fi
+    sleep "$DC_API_CHROME_POLL_SECONDS"
+  done
+  chrome_wait_for_tabbed_ui || return 1
+  chrome_log "first run completed without adding an account"
+}
+
+chrome_assert_first_run_complete() {
+  chrome_start_main || return 1
+  local deadline=$((SECONDS + DC_API_CHROME_READY_TIMEOUT_SECONDS))
+  local activity first_run_controls toolbar_count
+  while (( SECONDS < deadline )); do
+    activity="$(chrome_current_activity)"
+    if chrome_dump_ui; then
+      first_run_controls="$(chrome_ui_count resource-id-suffix=signin_fre_dismiss_button visible=true 2>/dev/null || printf 0)"
+      toolbar_count="$(chrome_ui_count resource-id-suffix=url_bar visible=true 2>/dev/null || printf 0)"
+      if [[ "$activity" == *"$DC_API_CHROME_FIRST_RUN_ACTIVITY"* ]] || (( first_run_controls > 0 )); then
+        chrome_error "Chrome first run recurred on a baseline that must already be prepared"
+        return 1
+      fi
+      if (( toolbar_count == 1 )); then
+        chrome_log "first-run validation passed"
+        return 0
+      fi
+    fi
+    sleep "$DC_API_CHROME_POLL_SECONDS"
+  done
+  chrome_error "Chrome first-run validation timed out; activity=$activity"
+  return 1
+}
+
+chrome_focus_and_type_url() {
+  local url="${1:?URL is required}"
+  local attempt typed_count
+  for ((attempt = 1; attempt <= DC_API_CHROME_OMNIBOX_ATTEMPTS; attempt++)); do
+    chrome_adb_shell input keycombination KEYCODE_CTRL_LEFT KEYCODE_L >/dev/null || return 1
+    if ! chrome_wait_for_ui_value "focused Chrome omnibox" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" text \
+      resource-id-suffix=url_bar focused=true visible=true >/dev/null; then
+      continue
+    fi
+    chrome_adb_shell input text "$url" >/dev/null || return 1
+    sleep 1
+    if chrome_dump_ui; then
+      typed_count="$(chrome_ui_count resource-id-suffix=url_bar text="$url" focused=true visible=true 2>/dev/null || printf 0)"
+      if (( typed_count == 1 )); then
+        chrome_adb_shell input keyevent KEYCODE_ENTER >/dev/null || return 1
+        return 0
+      fi
+    fi
+    chrome_log "omnibox text did not match on attempt $attempt; retrying from a fresh Ctrl+L selection"
+  done
+  chrome_error "Could not type the exact internal URL after $DC_API_CHROME_OMNIBOX_ATTEMPTS attempts: $url"
+  return 1
+}
+
+chrome_open_flag_page() {
+  chrome_wait_for_tabbed_ui || return 1
+  chrome_focus_and_type_url "$DC_API_CHROME_FLAG_URI" || return 1
+  chrome_wait_for_ui_value "Digital Credentials issuance flag" "$DC_API_CHROME_FLAG_TIMEOUT_SECONDS" text \
+    hint="$DC_API_CHROME_FLAG_HINT" clickable=true visible=true
+}
+
+chrome_flag_state() {
+  chrome_dump_ui || return 1
+  chrome_ui_value text hint="$DC_API_CHROME_FLAG_HINT" clickable=true visible=true
+}
+
+chrome_assert_flag_enabled() {
+  local state
+  state="$(chrome_open_flag_page)" || return 1
+  if [[ "$state" != "Enabled" ]]; then
+    chrome_error "Chrome issuance flag $DC_API_CHROME_FLAG_ID is $state, expected Enabled"
+    return 1
+  fi
+  if [[ "$(chrome_ui_count content-desc="#$DC_API_CHROME_FLAG_ID" visible=true 2>/dev/null || printf 0)" != "1" ]]; then
+    chrome_error "Chrome issuance flag anchor is missing: #$DC_API_CHROME_FLAG_ID"
+    return 1
+  fi
+  chrome_log "issuance flag is enabled and visible after relaunch"
+}
+
+chrome_enable_issuance_flag() {
+  local state selector_center enabled_center relaunch_center
+  state="$(chrome_open_flag_page)" || return 1
+  if [[ "$state" == "Enabled" ]]; then
+    chrome_log "issuance flag was already enabled"
+    return 0
+  fi
+  if [[ "$state" != "Default" && "$state" != "Disabled" ]]; then
+    chrome_error "Unexpected Chrome issuance flag state: $state"
+    return 1
+  fi
+
+  selector_center="$(chrome_ui_query center _ hint="$DC_API_CHROME_FLAG_HINT" text="$state" clickable=true visible=true)" || return 1
+  chrome_tap_center "$selector_center" || return 1
+  enabled_center="$(chrome_wait_for_ui_center "native Enabled flag choice" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" \
+    resource-id-suffix=text1 text=Enabled enabled=true checkable=true visible=true)" || return 1
+  chrome_tap_center "$enabled_center" || return 1
+
+  if [[ "$(chrome_wait_for_ui_value "enabled issuance flag row" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" text \
+    hint="$DC_API_CHROME_FLAG_HINT" text=Enabled clickable=true visible=true)" != "Enabled" ]]; then
+    chrome_error "Chrome issuance flag did not change to Enabled"
+    return 1
+  fi
+  relaunch_center="$(chrome_wait_for_ui_center "Chrome Relaunch button" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" \
+    resource-id-suffix=experiment-restart-button text=Relaunch enabled=true clickable=true visible=true)" || return 1
+  chrome_tap_center "$relaunch_center" || return 1
+  chrome_wait_for_tabbed_ui || return 1
+  chrome_assert_flag_enabled
+}
+
+chrome_host_portal_probe() {
+  command -v curl >/dev/null 2>&1 || {
+    chrome_error "curl is required for the Portal2 host probe"
+    return 1
+  }
+  curl --fail --silent --show-error --location \
+    --connect-timeout 15 --max-time "$DC_API_CHROME_PORTAL_TIMEOUT_SECONDS" \
+    --output /dev/null "$DC_API_CHROME_PORTAL_URL"
+}
+
+chrome_launch_portal() {
+  chrome_adb_shell am start -W -a android.intent.action.VIEW \
+    -d "$DC_API_CHROME_PORTAL_URL" \
+    -n "$DC_API_CHROME_PACKAGE/$DC_API_CHROME_MAIN_ACTIVITY" >/dev/null
+}
+
+chrome_assert_portal_rendered() {
+  chrome_host_portal_probe || return 1
+  chrome_launch_portal || return 1
+  local deadline=$((SECONDS + DC_API_CHROME_PORTAL_TIMEOUT_SECONDS))
+  local stable_for=0 activity url_count rendered_count error_count
+  while (( SECONDS < deadline )); do
+    activity="$(chrome_current_activity)"
+    if [[ "$activity" == *"$DC_API_CHROME_FIRST_RUN_ACTIVITY"* ]]; then
+      chrome_error "Chrome first run blocked Portal2 validation"
+      return 1
+    fi
+    if chrome_dump_ui; then
+      url_count="$(chrome_ui_count resource-id-suffix=url_bar text-regex="$DC_API_CHROME_PORTAL_URL_BAR_PATTERN" visible=true 2>/dev/null || printf 0)"
+      error_count="$(chrome_ui_count package="$DC_API_CHROME_PACKAGE" text-regex="$DC_API_CHROME_PORTAL_ERROR_TEXT_PATTERN" visible=true 2>/dev/null || printf 0)"
+      rendered_count="$(chrome_ui_count package="$DC_API_CHROME_PACKAGE" text-regex="$DC_API_CHROME_PORTAL_RENDER_TEXT_PATTERN" visible=true 2>/dev/null || printf 0)"
+      if (( error_count > 0 )); then
+        chrome_error "Chrome rendered an error page instead of Portal2"
+        return 1
+      fi
+      if (( url_count == 1 && rendered_count > 0 )) && [[ "$activity" == *"$DC_API_CHROME_TABBED_ACTIVITY"* || "$activity" == *"$DC_API_CHROME_MAIN_ACTIVITY"* ]]; then
+        stable_for=$((stable_for + DC_API_CHROME_POLL_SECONDS))
+        chrome_log "Portal2 render stableFor=${stable_for}s activity=$activity"
+        if (( stable_for >= DC_API_CHROME_PORTAL_STABILITY_SECONDS )); then
+          return 0
+        fi
+      else
+        stable_for=0
+      fi
+    fi
+    sleep "$DC_API_CHROME_POLL_SECONDS"
+  done
+  chrome_error "Portal2 did not render stable page content within ${DC_API_CHROME_PORTAL_TIMEOUT_SECONDS}s; activity=$(chrome_current_activity)"
+  return 1
+}
+
+chrome_return_home() {
+  chrome_adb_shell am force-stop "$DC_API_CHROME_PACKAGE" >/dev/null 2>&1 || true
+  chrome_adb_shell am start -W -a android.intent.action.MAIN -c android.intent.category.HOME \
+    -f 0x10000000 >/dev/null 2>&1 || true
+}
+
+chrome_capture_failure_diagnostics() {
+  local label="${1:-failure}"
+  local timestamp safe_label prefix
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  safe_label="$(tr -cs '[:alnum:]_.-' '-' <<<"$label" | sed 's/^-*//; s/-*$//')"
+  prefix="$DC_API_CHROME_ARTIFACT_DIR/${timestamp}-${safe_label:-failure}"
+  mkdir -p "$DC_API_CHROME_ARTIFACT_DIR" || return 0
+
+  chrome_adb_cmd exec-out screencap -p >"$prefix-screen.png" 2>/dev/null || true
+  chrome_dump_ui || true
+  [[ -f "$CHROME_LAST_UI_DUMP" ]] && cp "$CHROME_LAST_UI_DUMP" "$prefix-ui.xml" || true
+  chrome_adb_shell dumpsys activity activities >"$prefix-activities.txt" 2>&1 || true
+  chrome_adb_shell dumpsys window windows >"$prefix-windows.txt" 2>&1 || true
+  chrome_package_details >"$prefix-chrome-package.txt" 2>&1 || true
+  chrome_adb_shell dumpsys package "$DC_API_CHROME_PLAY_STORE_PACKAGE" >"$prefix-play-store-package.txt" 2>&1 || true
+  chrome_adb_shell dumpsys package com.google.android.gms >"$prefix-gms-package.txt" 2>&1 || true
+  chrome_adb_shell dumpsys connectivity >"$prefix-connectivity.txt" 2>&1 || true
+  chrome_adb_cmd logcat -d -v threadtime -t 4000 >"$prefix-logcat.txt" 2>&1 || true
+  grep -Ei 'chromium|cr_|chrome|renderer|sandbox|credential|identity' "$prefix-logcat.txt" \
+    >"$prefix-logcat-focused.txt" 2>/dev/null || true
+  {
+    echo "portal_url=$DC_API_CHROME_PORTAL_URL"
+    echo "current_activity=$(chrome_current_activity || true)"
+    echo "chrome_version=$(chrome_version_name || true)"
+    echo "chrome_version_code=$(chrome_version_code || true)"
+    echo "chrome_apk=$(chrome_apk_path || true)"
+    echo "play_store_disabled=$(chrome_play_store_is_disabled && echo true || echo false)"
+  } >"$prefix-summary.txt"
+  if command -v curl >/dev/null 2>&1; then
+    curl --silent --show-error --location --connect-timeout 15 --max-time 30 \
+      --dump-header "$prefix-portal-headers.txt" --output /dev/null "$DC_API_CHROME_PORTAL_URL" \
+      >"$prefix-portal-curl.txt" 2>&1 || true
+  fi
+  chrome_log "failure diagnostics written with prefix $prefix"
+}
+
+chrome_prepare_impl() {
+  chrome_initialize_work_dir || return 1
+  chrome_assert_identity || return 1
+  chrome_complete_first_run || return 1
+  chrome_assert_identity || return 1
+  chrome_enable_issuance_flag || return 1
+  chrome_assert_identity || return 1
+  if [[ "$DC_API_CHROME_VALIDATE_PORTAL_DURING_PREPARE" == "true" ]]; then
+    chrome_assert_portal_rendered || return 1
+  fi
+  chrome_return_home
+  chrome_log "preparation passed"
+}
+
+chrome_validate_impl() {
+  chrome_initialize_work_dir || return 1
+  chrome_assert_identity || return 1
+  chrome_assert_first_run_complete || return 1
+  chrome_assert_flag_enabled || return 1
+  chrome_assert_portal_rendered || return 1
+  chrome_assert_identity || return 1
+  chrome_return_home
+  chrome_log "validation passed"
+}
+
+prepare_android_dc_api_chrome() {
+  if chrome_prepare_impl; then
+    return 0
+  else
+    local status=$?
+    chrome_capture_failure_diagnostics prepare
+    return "$status"
+  fi
+}
+
+validate_android_dc_api_chrome() {
+  if chrome_validate_impl; then
+    return 0
+  else
+    local status=$?
+    chrome_capture_failure_diagnostics validate
+    return "$status"
+  fi
+}
+
+chrome_self_test() {
+  local self_test_dir
+  self_test_dir="$(mktemp -d "${TMPDIR:-/tmp}/waltid-chrome-self-test.XXXXXX")"
+  CHROME_LAST_UI_DUMP="$self_test_dir/ui.xml"
+  trap 'rm -rf -- "$self_test_dir"; trap - RETURN' RETURN
+  cat >"$CHROME_LAST_UI_DUMP" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <node text="DigitalCredentialsCreation" resource-id="web-identity-digital-credentials-creation_name" class="android.view.View" package="com.android.chrome" content-desc="" enabled="true" focused="false" clickable="false" checkable="false" selected="false" bounds="[49,458][498,511]" />
+  <node text="" resource-id="" class="android.view.View" package="com.android.chrome" content-desc="#web-identity-digital-credentials-creation" enabled="true" focused="false" clickable="true" checkable="false" selected="false" bounds="[49,577][672,619]" />
+  <node text="Enabled" resource-id="" class="android.view.View" package="com.android.chrome" content-desc="" hint="DigitalCredentialsCreation" enabled="true" focused="false" clickable="true" checkable="false" selected="false" bounds="[57,674][454,745]" />
+  <node text="portal2.demo.walt.id" resource-id="com.android.chrome:id/url_bar" class="android.widget.EditText" package="com.android.chrome" content-desc="" enabled="true" focused="false" clickable="true" checkable="false" selected="false" bounds="[211,136][691,283]" />
+  <node text="Verify credential" resource-id="portal-action" class="android.widget.Button" package="com.android.chrome" content-desc="" enabled="true" focused="false" clickable="true" checkable="false" selected="false" bounds="[100,900][900,1000]" />
+  <node text="Default" resource-id="" class="android.view.View" package="com.android.chrome" content-desc="" hint="OtherFlag" enabled="true" focused="false" clickable="true" checkable="false" selected="false" bounds="[57,2337][454,2337]" />
+</hierarchy>
+XML
+
+  [[ "$(chrome_ui_query value text hint=DigitalCredentialsCreation clickable=true visible=true)" == "Enabled" ]]
+  [[ "$(chrome_ui_query center _ hint=DigitalCredentialsCreation text=Enabled visible=true)" == "255 709" ]]
+  [[ "$(chrome_ui_count content-desc='#web-identity-digital-credentials-creation' visible=true)" == "1" ]]
+  [[ "$(chrome_ui_count resource-id-suffix=url_bar text-regex='^(https://)?portal2[.]demo[.]walt[.]id/?$' visible=true)" == "1" ]]
+  [[ "$(chrome_ui_count text-regex='Demo Portal|Issue credential|Verify credential' visible=true)" == "1" ]]
+  [[ "$(chrome_ui_count hint=OtherFlag visible=true)" == "0" ]]
+  chrome_log "self-test passed"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  set -euo pipefail
+  case "${1:-}" in
+    prepare)
+      prepare_android_dc_api_chrome
+      ;;
+    validate)
+      validate_android_dc_api_chrome
+      ;;
+    --self-test)
+      chrome_self_test
+      ;;
+    *)
+      echo "Usage: $0 {prepare|validate|--self-test}" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/.github/scripts/mobile-ci/prepare-android-dc-api-chrome.sh
+++ b/.github/scripts/mobile-ci/prepare-android-dc-api-chrome.sh
@@ -302,7 +302,7 @@ chrome_click_ui_node() {
 
 chrome_wait_for_tabbed_ui() {
   local deadline=$((SECONDS + DC_API_CHROME_READY_TIMEOUT_SECONDS))
-  local activity toolbar_count
+  local activity omnibox_count search_box_count
   while (( SECONDS < deadline )); do
     activity="$(chrome_current_activity)"
     if [[ "$activity" == *"$DC_API_CHROME_FIRST_RUN_ACTIVITY"* ]]; then
@@ -310,8 +310,10 @@ chrome_wait_for_tabbed_ui() {
       continue
     fi
     if chrome_dump_ui; then
-      toolbar_count="$(chrome_ui_count resource-id-suffix=url_bar visible=true 2>/dev/null || printf 0)"
-      if (( toolbar_count == 1 )) && [[ "$activity" == *"$DC_API_CHROME_TABBED_ACTIVITY"* || "$activity" == *"$DC_API_CHROME_MAIN_ACTIVITY"* ]]; then
+      omnibox_count="$(chrome_ui_count resource-id-suffix=url_bar visible=true 2>/dev/null || printf 0)"
+      search_box_count="$(chrome_ui_count resource-id-suffix=search_box_text visible=true 2>/dev/null || printf 0)"
+      if (( omnibox_count + search_box_count == 1 )) && \
+        [[ "$activity" == *"$DC_API_CHROME_TABBED_ACTIVITY"* || "$activity" == *"$DC_API_CHROME_MAIN_ACTIVITY"* ]]; then
         return 0
       fi
     fi
@@ -328,10 +330,12 @@ chrome_complete_first_run() {
   while (( SECONDS < deadline )); do
     activity="$(chrome_current_activity)"
     if chrome_dump_ui; then
-      dismiss_count="$(chrome_ui_count resource-id-suffix=signin_fre_dismiss_button text='Use without an account' enabled=true visible=true 2>/dev/null || printf 0)"
+      # Chrome uses different localized/campaign labels for this stable control (for example,
+      # "Use without an account" and "Stay signed out") across otherwise identical builds.
+      dismiss_count="$(chrome_ui_count resource-id-suffix=signin_fre_dismiss_button enabled=true visible=true 2>/dev/null || printf 0)"
       if (( dismiss_count == 1 )); then
-        chrome_click_ui_node "Chrome Use without an account button" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" \
-          resource-id-suffix=signin_fre_dismiss_button text='Use without an account' enabled=true clickable=true visible=true || return 1
+        chrome_click_ui_node "Chrome first-run account dismissal button" "$DC_API_CHROME_READY_TIMEOUT_SECONDS" \
+          resource-id-suffix=signin_fre_dismiss_button enabled=true clickable=true visible=true || return 1
         break
       fi
       negative_count="$(chrome_ui_count resource-id-suffix=negative_button text='No thanks' enabled=true visible=true 2>/dev/null || printf 0)"

--- a/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh
+++ b/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh
@@ -5,9 +5,23 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 identity_dir="$(cd "$script_dir/../../.." && pwd -P)"
 source "$script_dir/prepare-android-dc-api-device.sh"
 
+dc_api_browser_tests="${DC_API_BROWSER_TESTS:-false}"
+if [[ "$dc_api_browser_tests" == "true" ]]; then
+  source "$script_dir/prepare-android-dc-api-browser-device.sh"
+fi
+
 # The preparation job caches an unmodified factory-image AVD. Test jobs validate
 # that exact baseline and fail before Gradle if the restored device has drifted.
 validate_android_dc_api_device
+if [[ "$dc_api_browser_tests" == "true" ]]; then
+  assert_android_dc_api_browser_baseline_manifest
+  validate_android_dc_api_chrome
+  assert_android_dc_api_browser_baseline_manifest
+  # Chrome validation returns HOME after exercising the prepared profile. Recheck
+  # the launcher immediately before instrumentation so no browser/system overlay
+  # can obscure the wallet's first UI interaction.
+  assert_android_dc_api_launcher_health
+fi
 
 instrumentation_args=()
 if [[ -n "${ANDROID_TEST_CLASS:-}" ]]; then
@@ -56,6 +70,9 @@ fi
 
 postflight_status=0
 assert_android_dc_api_device_unchanged || postflight_status=$?
+if [[ "$dc_api_browser_tests" == "true" ]]; then
+  assert_android_dc_api_browser_baseline_manifest || postflight_status=$?
+fi
 log_android_dc_api_launcher_diagnostic
 
 if (( test_status != 0 )); then

--- a/.github/workflows/android-device-tests.yml
+++ b/.github/workflows/android-device-tests.yml
@@ -36,14 +36,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        phase: ${{ fromJSON(inputs.dc_api_only && '["dc-api-compose"]' || inputs.run_dc_api && '["wallet-mobile","compose-demo","dc-api-compose","enterprise-mobile"]' || '["wallet-mobile","compose-demo","enterprise-mobile"]') }}
+        phase: ${{ fromJSON(inputs.dc_api_only && '["dc-api-compose","dc-api-browser"]' || inputs.run_dc_api && '["wallet-mobile","compose-demo","dc-api-compose","dc-api-browser","enterprise-mobile"]' || '["wallet-mobile","compose-demo","enterprise-mobile"]') }}
     env:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
       MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
       MIN_GMS_VERSION: '24.31.0'
-      DC_API_SYSTEM_IMAGE_PACKAGE: 'system-images;android-37.0;google_apis;x86_64'
+      DC_API_SYSTEM_IMAGE_PACKAGE: ${{ matrix.phase == 'dc-api-browser' && 'system-images;android-37.0;google_apis_playstore_ps16k;x86_64' || 'system-images;android-37.0;google_apis;x86_64' }}
       DC_API_SYSTEM_IMAGE_REVISION: '6.5.11'
-      DC_API_AVD_NAME: 'dc-api-api37-pixel7-google-apis'
+      DC_API_AVD_NAME: ${{ matrix.phase == 'dc-api-browser' && 'dc-api-browser-api37-pixel7-playstore' || 'dc-api-api37-pixel7-google-apis' }}
+      DC_API_BROWSER_EXPECTED_GMS_VERSION_NAME: ${{ matrix.phase == 'dc-api-browser' && '26.11.36' || '' }}
+      DC_API_BROWSER_EXPECTED_GMS_VERSION_CODE: ${{ matrix.phase == 'dc-api-browser' && '261136038' || '' }}
+      DC_API_CHROME_EXPECTED_VERSION_NAME: ${{ matrix.phase == 'dc-api-browser' && '145.0.7632.218' || '' }}
+      DC_API_CHROME_EXPECTED_VERSION_CODE: ${{ matrix.phase == 'dc-api-browser' && '763221838' || '' }}
     steps:
       - name: Checkout all repos with ref fallback
         uses: walt-id/waltid-identity/.github/actions/checkout-repos@d123dc039bd55e193b3d54350791868fcfa6ac04
@@ -93,12 +97,32 @@ jobs:
         run: |
           echo "DC API AVD cache hit: ${{ steps.dc-api-avd-cache.outputs.cache-hit || 'false' }}"
 
+      - name: Restore configured DC API browser AVD
+        if: matrix.phase == 'dc-api-browser'
+        id: dc-api-browser-avd-cache
+        uses: actions/cache/restore@v4
+        with:
+          # Browser state is isolated from the native DC API cache. The cached userdata contains
+          # Chrome first-run completion, the issuance flag, a disabled Play Store, and the matching
+          # host ADB authorization key, but never a Quick Boot snapshot.
+          path: |
+            ~/.android/avd/dc-api-browser-api37-pixel7-playstore.ini
+            ~/.android/avd/dc-api-browser-api37-pixel7-playstore.avd
+            ~/.android/adbkey
+            ~/.android/adbkey.pub
+          key: dc-api-browser-avd-v1-${{ runner.os }}-api37-x86_64-pixel7-disk6g-emulator-37.1.11-platform-tools-37.0.1-playstore-image-6.5.11-gms-26.11.36-261136038-chrome-145.0.7632.218-763221838-flag-v1-${{ hashFiles('waltid-identity/.github/workflows/android-device-tests.yml', 'waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-chrome.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-browser-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-browser-avd.sh') }}
+
+      - name: Report DC API browser AVD cache state
+        if: matrix.phase == 'dc-api-browser'
+        run: |
+          echo "DC API browser AVD cache hit: ${{ steps.dc-api-browser-avd-cache.outputs.cache-hit || 'false' }}"
+
       - name: Configure Android device test phase
         id: android-device-phase
         run: ./waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh "${{ matrix.phase }}"
 
       - name: Preinstall Android emulator SDK packages
-        if: matrix.phase != 'dc-api-compose'
+        if: matrix.phase != 'dc-api-compose' && matrix.phase != 'dc-api-browser'
         shell: bash
         run: |
           set -euo pipefail
@@ -156,8 +180,36 @@ jobs:
             ~/.android/adbkey.pub
           key: dc-api-avd-v6-minimal-${{ runner.os }}-api37-x86_64-pixel7-disk6g-emulator-37.1.11-platform-tools-37.0.1-system-image-6.5.11-${{ hashFiles('waltid-identity/.github/workflows/android-device-tests.yml', 'waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh') }}
 
+      - name: Prepare configured DC API browser AVD baseline
+        if: matrix.phase == 'dc-api-browser' && steps.dc-api-browser-avd-cache.outputs.cache-hit != 'true'
+        id: dc-api-browser-avd-preparation
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: ${{ steps.android-device-phase.outputs.emulator_api_level }}
+          arch: x86_64
+          avd-name: ${{ steps.android-device-phase.outputs.emulator_avd_name }}
+          force-avd-creation: false
+          profile: ${{ steps.android-device-phase.outputs.emulator_profile }}
+          target: ${{ steps.android-device-phase.outputs.emulator_target }}
+          emulator-boot-timeout: 600
+          disk-size: 6G
+          emulator-options: ${{ steps.android-device-phase.outputs.emulator_options }}
+          disable-animations: true
+          script: ./waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-browser-avd.sh
+
+      - name: Save configured DC API browser AVD baseline
+        if: matrix.phase == 'dc-api-browser' && steps.dc-api-browser-avd-cache.outputs.cache-hit != 'true' && steps.dc-api-browser-avd-preparation.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.android/avd/dc-api-browser-api37-pixel7-playstore.ini
+            ~/.android/avd/dc-api-browser-api37-pixel7-playstore.avd
+            ~/.android/adbkey
+            ~/.android/adbkey.pub
+          key: dc-api-browser-avd-v1-${{ runner.os }}-api37-x86_64-pixel7-disk6g-emulator-37.1.11-platform-tools-37.0.1-playstore-image-6.5.11-gms-26.11.36-261136038-chrome-145.0.7632.218-763221838-flag-v1-${{ hashFiles('waltid-identity/.github/workflows/android-device-tests.yml', 'waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-chrome.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-browser-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-browser-avd.sh') }}
+
       - name: Run Android device tests
-        if: matrix.phase != 'dc-api-compose'
+        if: matrix.phase != 'dc-api-compose' && matrix.phase != 'dc-api-browser'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ steps.android-device-phase.outputs.emulator_api_level }}
@@ -170,6 +222,22 @@ jobs:
 
       - name: Run Digital Credentials device test
         if: matrix.phase == 'dc-api-compose'
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: ${{ steps.android-device-phase.outputs.emulator_api_level }}
+          arch: x86_64
+          avd-name: ${{ steps.android-device-phase.outputs.emulator_avd_name }}
+          force-avd-creation: false
+          profile: ${{ steps.android-device-phase.outputs.emulator_profile }}
+          target: ${{ steps.android-device-phase.outputs.emulator_target }}
+          emulator-boot-timeout: 600
+          disk-size: 6G
+          emulator-options: ${{ steps.android-device-phase.outputs.emulator_options }}
+          disable-animations: true
+          script: ${{ steps.android-device-phase.outputs.script }}
+
+      - name: Run Digital Credentials browser test
+        if: matrix.phase == 'dc-api-browser'
         uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: ${{ steps.android-device-phase.outputs.emulator_api_level }}
@@ -203,4 +271,13 @@ jobs:
         with:
           name: android-device-test-reports-${{ matrix.phase }}
           path: ${{ steps.android-device-phase.outputs.artifact_paths }}
+          retention-days: 30
+
+      - name: Upload DC API browser substrate diagnostics
+        if: always() && matrix.phase == 'dc-api-browser'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dc-api-browser-substrate-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/waltid-dc-api-chrome-artifacts
+          if-no-files-found: ignore
           retention-days: 30

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialPortalIssuanceE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialPortalIssuanceE2ETest.kt
@@ -1,0 +1,56 @@
+package id.walt.walletdemo.compose.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import id.walt.mobile.test.backend.DemoTestBackend
+import id.walt.walletdemo.compose.android.Portal2DigitalCredentialE2EHelper.Labels
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Pre-authorized mDL issuance through portal2 and Chrome's Digital Credentials create API. */
+@RunWith(AndroidJUnit4::class)
+class DigitalCredentialPortalIssuanceE2ETest {
+
+    @Test
+    fun issuesPreAuthorizedMdlThroughPortalDigitalCredentialsApi() = runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val device = UiDevice.getInstance(instrumentation)
+        val capabilities = Portal2DigitalCredentialE2EHelper.requireIssuanceCapabilities(context)
+        val cardsBefore = Portal2DigitalCredentialE2EHelper.snapshotCredentialCards(context, device)
+
+        Portal2DigitalCredentialE2EHelper.openPortal(context, device, capabilities)
+        Portal2DigitalCredentialE2EHelper.selectPortalTab(
+            device,
+            Labels.ISSUE_TAB,
+            Labels.ISSUE_HEADING,
+        )
+        Portal2DigitalCredentialE2EHelper.clickPortalControl(device, Labels.MDL_ISSUE_OPTION)
+        // PRE_AUTHORIZED is the portal's default; selecting it explicitly makes the intended profile
+        // visible in the test and protects against a persisted/hydrated UI state changing it.
+        Portal2DigitalCredentialE2EHelper.clickPortalControl(device, Labels.PRE_AUTHORIZED)
+        Portal2DigitalCredentialE2EHelper.clickPortalControl(device, Labels.DC_API_DELIVERY)
+        Portal2DigitalCredentialE2EHelper.requirePortalCapability(
+            device,
+            Labels.CREATE_OFFER,
+            Labels.ISSUANCE_UNAVAILABLE,
+            capabilities,
+            "Enable chrome://flags/#web-identity-digital-credentials-creation, relaunch Chrome, " +
+                "and require DigitalCredential.userAgentAllowsProtocol(\"openid4vci-v1\") plus " +
+                "navigator.credentials.create.",
+        )
+        Portal2DigitalCredentialE2EHelper.clickPortalControl(device, Labels.CREATE_OFFER)
+        Portal2DigitalCredentialE2EHelper.acceptChromeTrustPromptIfPresent(device)
+        Portal2DigitalCredentialE2EHelper.driveIssuancePicker(device)
+
+        val issuerSessionId = Portal2DigitalCredentialE2EHelper.awaitPortalCompletion(device)
+        DemoTestBackend.waitForIssuerIssuanceSuccess(issuerSessionId)
+        Portal2DigitalCredentialE2EHelper.assertNewMdlCredentialStored(
+            context,
+            device,
+            cardsBefore,
+        )
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialPortalPresentationE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialPortalPresentationE2ETest.kt
@@ -32,7 +32,11 @@ class DigitalCredentialPortalPresentationE2ETest {
         val device = UiDevice.getInstance(instrumentation)
         val capabilities = Portal2DigitalCredentialE2EHelper.requirePresentationCapabilities(context)
 
-        val wallet = createAndroidDemoMobileWallet(context, demoWalletConfig()).wallet
+        val wallet = createAndroidDemoMobileWallet(
+            context = context,
+            // Match the native DC fixture: this emulator cannot enforce protected signing keys.
+            config = demoWalletConfig().copy(biometricEnabled = false),
+        ).wallet
         wallet.bootstrap()
         wallet.credentials().forEach { credential ->
             check(wallet.deleteCredential(credential.id)) {

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialPortalPresentationE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialPortalPresentationE2ETest.kt
@@ -1,0 +1,145 @@
+package id.walt.walletdemo.compose.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import id.walt.mobile.test.backend.DemoTestBackend
+import id.walt.wallet2.handlers.WalletIssuanceOutcome
+import id.walt.wallet2.mobile.MobileWallet
+import id.walt.wallet2.mobile.MobileWalletCredentialOffer
+import id.walt.wallet2.mobile.MobileWalletIssuanceRequest
+import id.walt.walletdemo.compose.android.Portal2DigitalCredentialE2EHelper.Labels
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.launchAndUnlock
+import id.walt.walletdemo.compose.logic.createAndroidDemoMobileWallet
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Browser-origin presentation coverage through portal2's phone-sized Simple mode. */
+@RunWith(AndroidJUnit4::class)
+class DigitalCredentialPortalPresentationE2ETest {
+
+    private lateinit var fixture: Fixture
+
+    @Before
+    fun provisionMdlAndOpenPortal() = runBlocking {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val device = UiDevice.getInstance(instrumentation)
+        val capabilities = Portal2DigitalCredentialE2EHelper.requirePresentationCapabilities(context)
+
+        val wallet = createAndroidDemoMobileWallet(context, demoWalletConfig()).wallet
+        wallet.bootstrap()
+        wallet.credentials().forEach { credential ->
+            check(wallet.deleteCredential(credential.id)) {
+                "Failed to delete stale credential ${credential.id}"
+            }
+        }
+        val registrationWithoutCredentials = wallet.refreshDigitalCredentialRegistration()
+        assertTrue(
+            "Credential Manager registration was unavailable after clearing the wallet: " +
+                registrationWithoutCredentials.reason,
+            registrationWithoutCredentials.available,
+        )
+
+        val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
+        issueFromDemoIssuer(wallet, scenario)
+        val registration = wallet.refreshDigitalCredentialRegistration()
+        assertTrue(
+            "Credential Manager registration was unavailable after mDL provisioning: ${registration.reason}",
+            registration.available,
+        )
+        assertEquals("Expected one registered mDL", 1, registration.registeredEntryCount)
+
+        launchAndUnlock(context, device)
+        Portal2DigitalCredentialE2EHelper.openPortal(context, device, capabilities)
+        Portal2DigitalCredentialE2EHelper.selectPortalTab(
+            device,
+            Labels.VERIFY_TAB,
+            Labels.VERIFY_HEADING,
+        )
+        Portal2DigitalCredentialE2EHelper.clickPortalControl(device, Labels.MDL_VERIFY_OPTION)
+        fixture = Fixture(device, capabilities)
+    }
+
+    @Test
+    fun presentsMdlThroughPortalOpenId4VpDcApi() = runBlocking {
+        presentAndAssert(
+            actionLabel = Labels.VERIFY_OPENID4VP,
+            requiredPolicyIds = MDOC_REQUIRED_POLICIES,
+        )
+    }
+
+    @Test
+    fun presentsMdlThroughPortalIso180137DcApi() = runBlocking {
+        presentAndAssert(
+            actionLabel = Labels.VERIFY_ANNEX_C,
+            requiredPolicyIds = MDOC_REQUIRED_POLICIES,
+        )
+    }
+
+    private suspend fun presentAndAssert(actionLabel: String, requiredPolicyIds: Set<String>) {
+        Portal2DigitalCredentialE2EHelper.requirePortalCapability(
+            fixture.device,
+            actionLabel,
+            Labels.PRESENTATION_UNAVAILABLE,
+            fixture.capabilities,
+            "Chrome 141+ must expose window.DigitalCredential and navigator.credentials.get on HTTPS.",
+        )
+        Portal2DigitalCredentialE2EHelper.clickPortalControl(fixture.device, actionLabel)
+        Portal2DigitalCredentialE2EHelper.acceptChromeTrustPromptIfPresent(fixture.device)
+        Portal2DigitalCredentialE2EHelper.drivePresentationPicker(fixture.device)
+
+        val sessionId = Portal2DigitalCredentialE2EHelper.awaitPortalCompletion(fixture.device)
+        val info = Portal2DigitalCredentialE2EHelper.verifierSessionInfo(sessionId)
+        assertEquals(
+            "Verifier did not accept the portal presentation: $info",
+            "SUCCESSFUL",
+            info["status"]?.jsonPrimitive?.content,
+        )
+        val policyResults = info["policy_results"]
+            ?: error("Verifier session has no policy_results: $info")
+        val executed = Portal2DigitalCredentialE2EHelper.executedPolicyIds(policyResults)
+        requiredPolicyIds.forEach { policyId ->
+            assertTrue("$policyId did not run. Executed: $executed", policyId in executed)
+        }
+        val failed = Portal2DigitalCredentialE2EHelper.failedPolicies(policyResults)
+        assertTrue("Verifier policies failed: $failed", failed.isEmpty())
+    }
+
+    private suspend fun issueFromDemoIssuer(
+        wallet: MobileWallet,
+        scenario: DemoTestBackend.CredentialScenario,
+    ) {
+        val offer = DemoTestBackend.createOffer(scenario)
+        val session = wallet.startIssuance(
+            MobileWalletIssuanceRequest(offer = MobileWalletCredentialOffer.Uri(offer.offerUrl)),
+        )
+        when (val outcome = wallet.continuePreAuthorizedIssuance(session.id, offer.txCode)) {
+            is WalletIssuanceOutcome.Stored -> assertEquals(1, outcome.credentialIds.size)
+            is WalletIssuanceOutcome.Deferred -> error(
+                "Live issuer deferred mDL provisioning: " +
+                    "stored=${outcome.storedCredentialIds}, deferred=${outcome.credentials}",
+            )
+            is WalletIssuanceOutcome.Failed -> error(
+                "Live issuer failed mDL provisioning: ${outcome.error.code}: ${outcome.error.message}",
+            )
+            is WalletIssuanceOutcome.Cancelled -> error(
+                "Live issuer cancelled mDL provisioning for ${outcome.sessionId}",
+            )
+        }
+    }
+
+    private data class Fixture(
+        val device: UiDevice,
+        val capabilities: Portal2DigitalCredentialE2EHelper.DeviceCapabilities,
+    )
+
+    private companion object {
+        val MDOC_REQUIRED_POLICIES = setOf("mso_mdoc/device-auth", "mso_mdoc/issuer_auth")
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/Portal2DigitalCredentialE2EHelper.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/Portal2DigitalCredentialE2EHelper.kt
@@ -1,0 +1,527 @@
+package id.walt.walletdemo.compose.android
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.SystemClock
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.CREDENTIAL_OPERATION_TIMEOUT
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.UI_ELEMENT_TIMEOUT
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.assertClaimValueVisibleAfterScrolling
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.clickByTag
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.relaunchAndUnlock
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.scrollDown
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.scrollUp
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForResource
+import id.walt.walletdemo.compose.ui.WalletDemoSharingReviewTestTags
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.util.regex.Pattern
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+
+/** Shared, visible-label-only driver for portal2's mobile Simple mode. */
+internal object Portal2DigitalCredentialE2EHelper {
+
+    object Labels {
+        const val PORTAL_TITLE = "Demo Portal"
+        const val ISSUE_TAB = "Issue"
+        const val VERIFY_TAB = "Verify"
+        const val ISSUE_HEADING = "Choose what to issue"
+        const val VERIFY_HEADING = "Choose what to verify"
+        const val MDL_ISSUE_OPTION = "Mobile Drivers License"
+        const val MDL_VERIFY_OPTION = "mDL over DC API"
+        const val PRE_AUTHORIZED = "Pre-authorized"
+        const val DC_API_DELIVERY = "Digital Credentials API"
+        const val CREATE_OFFER = "Create Offer"
+        const val VERIFY_OPENID4VP = "Verify with DC API (OpenID4VP)"
+        const val VERIFY_ANNEX_C = "Verify with DC API (ISO 18013-7)"
+        const val PRESENTATION_UNAVAILABLE = "Digital Credentials API presentation is not available"
+        const val ISSUANCE_UNAVAILABLE = "Digital Credentials API issuance is not available"
+        const val PRESENTATION_COMPLETED = "Completed successfully"
+        const val ISSUANCE_COMPLETED = "COMPLETED"
+    }
+
+    data class DeviceCapabilities(
+        val googlePlayServices: String,
+        val chrome: String,
+    ) {
+        override fun toString(): String = "GMS=$googlePlayServices, Chrome=$chrome"
+    }
+
+    fun requirePresentationCapabilities(context: Context): DeviceCapabilities =
+        requireDeviceCapabilities(
+            context = context,
+            minimumChromeMajor = 141,
+            purpose = "Digital Credentials API presentation",
+        )
+
+    fun requireIssuanceCapabilities(context: Context): DeviceCapabilities =
+        requireDeviceCapabilities(
+            context = context,
+            minimumChromeMajor = 143,
+            purpose = "Digital Credentials API issuance",
+        )
+
+    private fun requireDeviceCapabilities(
+        context: Context,
+        minimumChromeMajor: Int,
+        purpose: String,
+    ): DeviceCapabilities {
+        val gms = packageVersion(context, GMS_PACKAGE)
+            ?: error("Portal2 DC API E2E requires $GMS_PACKAGE, but it is not installed or visible")
+        val chrome = packageVersion(context, CHROME_PACKAGE)
+            ?: error("Portal2 DC API E2E requires $CHROME_PACKAGE, but it is not installed or visible")
+        val chromeMajor = chrome.substringBefore('.').toIntOrNull()
+            ?: error("Could not parse the installed Chrome version '$chrome' for $purpose")
+        check(chromeMajor >= minimumChromeMajor) {
+            "$purpose requires Chrome $minimumChromeMajor+, but installed Chrome is $chrome (GMS=$gms)"
+        }
+        return DeviceCapabilities(gms, chrome)
+    }
+
+    fun openPortal(context: Context, device: UiDevice, capabilities: DeviceCapabilities) {
+        context.startActivity(
+            Intent(Intent.ACTION_VIEW, Uri.parse(PORTAL_URL))
+                .setPackage(CHROME_PACKAGE)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+        val title = device.wait(
+            Until.findObject(By.pkg(CHROME_PACKAGE).text(Labels.PORTAL_TITLE)),
+            CREDENTIAL_OPERATION_TIMEOUT,
+        )
+        assertNotNull(
+            "portal2.demo did not load in Chrome ($capabilities). " +
+                "Current package=${device.currentPackageName}; visible page text:\n${pageText(device)}",
+            title,
+        )
+    }
+
+    fun selectPortalTab(device: UiDevice, label: String, confirmedBy: String) {
+        repeat(MAX_HYDRATION_ATTEMPTS) {
+            clickPortalControl(device, label)
+            if (device.wait(
+                    Until.findObject(By.pkg(CHROME_PACKAGE).text(confirmedBy)),
+                    HYDRATION_CONFIRM_TIMEOUT,
+                ) != null
+            ) return
+        }
+        error("Clicking portal tab '$label' never revealed '$confirmedBy'.\n${pageText(device)}")
+    }
+
+    fun clickPortalControl(device: UiDevice, label: String) {
+        val control = findPortalControlAfterScrolling(device, label)
+            ?: error("Portal control '$label' was not found.\n${pageText(device)}")
+        assertTrue("Portal control '$label' is disabled.\n${pageText(device)}", control.isEnabled)
+        control.click()
+        device.waitForIdle(PAGE_SETTLE_TIMEOUT)
+    }
+
+    fun requirePortalCapability(
+        device: UiDevice,
+        actionLabel: String,
+        unavailableText: String,
+        capabilities: DeviceCapabilities,
+        remediation: String,
+    ) {
+        val action = findPortalControlAfterScrolling(device, actionLabel)
+        val unavailable = findPortalText(device, unavailableText, contains = true)
+        assertNotNull(
+            "Portal2 did not render '$actionLabel' ($capabilities).\n${pageText(device)}",
+            action,
+        )
+        assertTrue(
+            "Portal2 reports '$unavailableText' ($capabilities). $remediation\n${pageText(device)}",
+            unavailable == null && requireNotNull(action).isEnabled,
+        )
+    }
+
+    /** Chrome only shows this per-site prompt before the first browser-mediated call. */
+    fun acceptChromeTrustPromptIfPresent(device: UiDevice) {
+        val deadline = SystemClock.uptimeMillis() + TRUST_OR_PICKER_TIMEOUT
+        while (SystemClock.uptimeMillis() < deadline) {
+            device.findObject(By.res("$CHROME_PACKAGE:id/positive_button"))?.let {
+                it.click()
+                device.waitForIdle()
+                return
+            }
+            if (device.findObject(By.pkg(GMS_PACKAGE)) != null) return
+            Thread.sleep(POLL_INTERVAL)
+        }
+    }
+
+    fun drivePresentationPicker(device: UiDevice) {
+        val picker = By.pkg(GMS_PACKAGE)
+        val candidate = device.wait(
+            Until.findObject(By.copy(picker).text(MDL_DOC_TYPE)),
+            UI_ELEMENT_TIMEOUT,
+        )
+        assertNotNull(
+            "Credential Manager did not surface the mDL candidate.\n${foregroundText(device)}",
+            candidate,
+        )
+        requireNotNull(candidate).interactiveAncestorOrSelf().click()
+        confirmCredentialManagerIfAsked(device)
+        confirmBrowserPresentationDisclosureIfAsked(device)
+
+        assertNotNull(
+            "Wallet sharing review did not open.\n${foregroundText(device)}",
+            waitForResource(device, WalletDemoSharingReviewTestTags.Review, UI_ELEMENT_TIMEOUT),
+        )
+        clickPresentationShare(device)
+    }
+
+    fun driveIssuancePicker(device: UiDevice) {
+        val picker = By.pkg(GMS_PACKAGE)
+        val candidate = device.wait(
+            Until.findObject(By.copy(picker).textContains("walt.id")),
+            UI_ELEMENT_TIMEOUT,
+        ) ?: device.wait(
+            Until.findObject(By.copy(picker).textContains("Wallet")),
+            UI_ELEMENT_TIMEOUT,
+        )
+        assertNotNull(
+            "Credential Manager did not surface the wallet create option.\n${foregroundText(device)}",
+            candidate,
+        )
+        requireNotNull(candidate).interactiveAncestorOrSelf().click()
+        confirmCredentialManagerIfAsked(device)
+
+        assertNotNull(
+            "Wallet create-offer review did not open.\n${foregroundText(device)}",
+            waitForResource(device, "wallet.offerReview", UI_ELEMENT_TIMEOUT),
+        )
+        clickByTag(device, "wallet.offerAcceptButton")
+        assertTrue(
+            "Wallet create provider did not finish after accepting the portal offer.\n" +
+                foregroundText(device),
+            device.wait(Until.gone(By.res("wallet.offerReview")), UI_ELEMENT_TIMEOUT),
+        )
+    }
+
+    fun awaitPortalCompletion(device: UiDevice): String {
+        val completionLabels = listOf(Labels.PRESENTATION_COMPLETED, Labels.ISSUANCE_COMPLETED)
+        val completed = awaitPortalText(device, completionLabels)
+        assertNotNull(
+            "Portal2 did not report one of $completionLabels.\n${pageText(device)}",
+            completed,
+        )
+        return readSessionId(device)
+    }
+
+    suspend fun verifierSessionInfo(sessionId: String): JsonObject {
+        HttpClient().use { client ->
+            val response = client.get("$PORTAL_VERIFIER_BASE/verification-session/$sessionId/info") {
+                accept(ContentType.Application.Json)
+            }
+            val body = response.bodyAsText()
+            if (!response.status.isSuccess()) {
+                error("HTTP ${response.status.value} from portal verifier session $sessionId: $body")
+            }
+            return json.parseToJsonElement(body).jsonObject
+        }
+    }
+
+    fun executedPolicyIds(element: JsonElement): Set<String> = buildSet {
+        fun walk(current: JsonElement) {
+            when (current) {
+                is JsonObject -> {
+                    current["policy_executed"]?.jsonObject?.get("id")?.jsonPrimitive?.content
+                        ?.let(::add)
+                    current.values.forEach(::walk)
+                }
+                is JsonArray -> current.forEach(::walk)
+                else -> Unit
+            }
+        }
+        walk(element)
+    }
+
+    fun failedPolicies(element: JsonElement): List<String> = buildList {
+        fun walk(current: JsonElement, path: String) {
+            when (current) {
+                is JsonObject -> {
+                    val id = current["policy_executed"]?.jsonObject?.get("id")?.jsonPrimitive?.content
+                    if (id != null && current["success"]?.jsonPrimitive?.booleanOrNull == false) {
+                        add("$path/$id: ${current["errors"]}")
+                    }
+                    current.forEach { (key, value) -> walk(value, "$path/$key") }
+                }
+                is JsonArray -> current.forEachIndexed { index, value -> walk(value, "$path[$index]") }
+                else -> Unit
+            }
+        }
+        walk(element, "")
+    }
+
+    fun snapshotCredentialCards(context: Context, device: UiDevice): Set<String> {
+        WalletComposeE2EHelper.launchAndUnlock(context, device)
+        clickByTag(device, "wallet.tab.credentials")
+        return device.credentialCardTags()
+    }
+
+    fun assertNewMdlCredentialStored(
+        context: Context,
+        device: UiDevice,
+        preexistingCardTags: Set<String>,
+    ) {
+        relaunchAndUnlock(context, device)
+        clickByTag(device, "wallet.tab.credentials")
+        val card = device.waitForNewCredentialCard(preexistingCardTags)
+        if (card == null) {
+            fail(
+                "Wallet stored no new credential after portal issuance " +
+                    "(before=$preexistingCardTags, after=${device.credentialCardTags()})",
+            )
+            return
+        }
+        val cardTag = requireNotNull(card.resourceName) { "Credential card is missing its test tag" }
+        clickByTag(device, cardTag)
+        assertNotNull(
+            "Credential details did not open for $cardTag",
+            waitForResource(
+                device,
+                cardTag.replace("wallet.credentialCard.", "wallet.credentialDetails."),
+                UI_ELEMENT_TIMEOUT,
+            ),
+        )
+        assertClaimValueVisibleAfterScrolling(
+            device = device,
+            path = "docType",
+            label = "Doc type",
+            expectedValues = listOf(MDL_DOC_TYPE),
+            message = "Portal issuance stored a credential other than an mDL",
+        )
+    }
+
+    private fun confirmCredentialManagerIfAsked(device: UiDevice) {
+        val picker = By.pkg(GMS_PACKAGE)
+        val confirm = device.wait(
+            Until.findObject(By.copy(picker).res("continue_button")),
+            OPTIONAL_CONFIRM_TIMEOUT,
+        ) ?: device.wait(
+            Until.findObject(By.copy(picker).text("Continue")),
+            OPTIONAL_CONFIRM_TIMEOUT,
+        )
+        confirm?.interactiveAncestorOrSelf()?.click()
+        device.waitForIdle()
+    }
+
+    private fun confirmBrowserPresentationDisclosureIfAsked(device: UiDevice) {
+        val picker = By.pkg(GMS_PACKAGE)
+        val disclosureTitle = By.copy(picker).textStartsWith("Share info with ")
+        device.wait(
+            Until.findObject(disclosureTitle),
+            OPTIONAL_CONFIRM_TIMEOUT,
+        ) ?: return
+        repeat(MAX_PAGE_SCROLLS) {
+            val confirmSelector = By.copy(picker).text("Agree and continue")
+            device.findObject(confirmSelector)?.let {
+                device.waitForIdle(PAGE_SETTLE_TIMEOUT)
+                val settledConfirm = device.findObject(confirmSelector)
+                    ?: error("Credential Manager presentation confirmation disappeared while settling")
+                settledConfirm.interactiveAncestorOrSelf().click()
+                assertTrue(
+                    "Credential Manager presentation disclosure remained after confirmation.\n" +
+                        foregroundText(device),
+                    device.wait(Until.gone(disclosureTitle), UI_ELEMENT_TIMEOUT),
+                )
+                device.waitForIdle()
+                return
+            }
+            device.scrollDown()
+        }
+        error(
+            "Credential Manager presentation disclosure did not expose its confirmation.\n" +
+                foregroundText(device),
+        )
+    }
+
+    private fun clickPresentationShare(device: UiDevice) {
+        repeat(MAX_PAGE_SCROLLS * 2) {
+            device.findObject(By.res(WalletDemoSharingReviewTestTags.ShareButton))?.let { share ->
+                assertTrue(
+                    "${WalletDemoSharingReviewTestTags.ShareButton} is disabled.\n" +
+                        foregroundText(device),
+                    share.isEnabled,
+                )
+                share.interactiveAncestorOrSelf().click()
+                device.waitForIdle()
+                return
+            }
+            device.scrollDown()
+        }
+        error(
+            "${WalletDemoSharingReviewTestTags.ShareButton} was not found after scrolling " +
+                "the complete presentation review.\n${foregroundText(device)}",
+        )
+    }
+
+    private fun findPortalControlAfterScrolling(device: UiDevice, label: String): UiObject2? {
+        findPortalControl(device, label)?.let { return it }
+        repeat(MAX_PAGE_SCROLLS) {
+            device.scrollDown()
+            findPortalControl(device, label)?.let { return it }
+        }
+        repeat(MAX_PAGE_SCROLLS * 2) {
+            device.scrollUp()
+            findPortalControl(device, label)?.let { return it }
+        }
+        return null
+    }
+
+    private fun findPortalControl(device: UiDevice, label: String): UiObject2? =
+        (
+            device.findObjects(By.pkg(CHROME_PACKAGE).text(label)) +
+                device.findObjects(By.pkg(CHROME_PACKAGE).textStartsWith("$label "))
+            )
+            .mapNotNull { runCatching { it.controlAncestorOrSelf() }.getOrNull() }
+            .firstOrNull()
+
+    private fun findPortalText(device: UiDevice, text: String, contains: Boolean): UiObject2? =
+        if (contains) {
+            device.findObject(By.pkg(CHROME_PACKAGE).textContains(text))
+        } else {
+            device.findObject(By.pkg(CHROME_PACKAGE).text(text))
+        }
+
+    private fun awaitPortalText(device: UiDevice, texts: List<String>): UiObject2? {
+        val deadline = SystemClock.uptimeMillis() + CREDENTIAL_OPERATION_TIMEOUT
+        while (SystemClock.uptimeMillis() < deadline) {
+            texts.firstNotNullOfOrNull { text ->
+                findPortalText(device, text, contains = true)
+            }?.let { return it }
+            device.scrollDown()
+            Thread.sleep(POLL_INTERVAL)
+        }
+        return null
+    }
+
+    private fun readSessionId(device: UiDevice): String {
+        repeat(MAX_PAGE_SCROLLS * 2) {
+            SESSION_ID_PATTERN.find(pageText(device))?.let { return it.value }
+            device.scrollUp()
+        }
+        error("Could not read the portal session id.\n${pageText(device)}")
+    }
+
+    private fun pageText(device: UiDevice): String =
+        device.findObjects(By.pkg(CHROME_PACKAGE))
+            .mapNotNull { runCatching { it.text }.getOrNull() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .joinToString("\n")
+            .ifEmpty { "(no visible Chrome text)" }
+
+    private fun foregroundText(device: UiDevice): String =
+        device.findObjects(By.depth(0))
+            .flatMap { root -> runCatching { root.flatten() }.getOrDefault(emptyList()) }
+            .mapNotNull { runCatching { it.text }.getOrNull() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .take(MAX_DIAGNOSTIC_TEXTS)
+            .joinToString("\n")
+            .ifEmpty { "(no visible foreground text; package=${device.currentPackageName})" }
+
+    private fun UiObject2.controlAncestorOrSelf(): UiObject2? {
+        var node: UiObject2? = this
+        while (node != null) {
+            if (node.isClickable || node.className == "android.widget.Button") return node
+            node = node.parent
+        }
+        return null
+    }
+
+    private fun UiObject2.interactiveAncestorOrSelf(): UiObject2 {
+        var node: UiObject2? = this
+        while (node != null) {
+            if (node.isClickable) return node
+            node = node.parent
+        }
+        return this
+    }
+
+    private fun UiObject2.flatten(): List<UiObject2> =
+        listOf(this) + children.orEmpty().flatMap { it.flatten() }
+
+    private fun packageVersion(context: Context, packageName: String): String? = runCatching {
+        val info = context.packageManager.getPackageInfo(packageName, 0)
+        val versionCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+        "${info.versionName ?: "<unknown>"} ($versionCode)"
+    }.getOrNull()
+
+    private fun UiDevice.waitForNewCredentialCard(known: Set<String>): UiObject2? {
+        val deadline = SystemClock.uptimeMillis() + UI_ELEMENT_TIMEOUT
+        while (SystemClock.uptimeMillis() < deadline) {
+            newCredentialCard(known)?.let { return it }
+            repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) {
+                scrollDown()
+                newCredentialCard(known)?.let { return it }
+            }
+            repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) { scrollUp() }
+            Thread.sleep(POLL_INTERVAL)
+        }
+        return null
+    }
+
+    private fun UiDevice.newCredentialCard(known: Set<String>): UiObject2? =
+        findObjects(By.res(CREDENTIAL_CARD_TAG))
+            .firstOrNull { runCatching { it.resourceName !in known }.getOrDefault(false) }
+
+    private fun UiDevice.credentialCardTags(): Set<String> {
+        val tags = mutableSetOf<String>()
+        fun collect() {
+            findObjects(By.res(CREDENTIAL_CARD_TAG))
+                .mapNotNullTo(tags) { runCatching { it.resourceName }.getOrNull() }
+        }
+        collect()
+        repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) {
+            scrollDown()
+            collect()
+        }
+        repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) { scrollUp() }
+        return tags
+    }
+
+    const val CHROME_PACKAGE = "com.android.chrome"
+    const val GMS_PACKAGE = "com.google.android.gms"
+    const val PORTAL_URL = "https://portal2.demo.walt.id/"
+    const val PORTAL_VERIFIER_BASE = "https://verifier2.demo.walt.id"
+    const val MDL_DOC_TYPE = "org.iso.18013.5.1.mDL"
+
+    private const val MAX_HYDRATION_ATTEMPTS = 4
+    private const val MAX_PAGE_SCROLLS = 12
+    private const val MAX_DIAGNOSTIC_TEXTS = 80
+    private const val CREDENTIAL_LIST_SCROLL_ATTEMPTS = 6
+    private const val PAGE_SETTLE_TIMEOUT = 2_000L
+    private const val HYDRATION_CONFIRM_TIMEOUT = 5_000L
+    private const val OPTIONAL_CONFIRM_TIMEOUT = 3_000L
+    private const val TRUST_OR_PICKER_TIMEOUT = 15_000L
+    private const val POLL_INTERVAL = 500L
+    private val CREDENTIAL_CARD_TAG: Pattern = Pattern.compile("wallet\\.credentialCard\\..*")
+    private val SESSION_ID_PATTERN = Regex(
+        """[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}""",
+    )
+    private val json = Json { ignoreUnknownKeys = true }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/debug/AndroidManifest.xml
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/debug/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!--
+      Debug only, for the portal2 DC API E2Es: Android 11+ package visibility otherwise hides Chrome
+      from their explicit capability diagnostics. The wallet itself never queries browsers.
+    -->
+    <queries>
+        <package android:name="com.android.chrome" />
+    </queries>
+
     <application>
         <activity
             android:name=".DigitalCredentialTestVerifierActivity"


### PR DESCRIPTION
## Summary

This modernizes the browser-mediated Android Digital Credentials E2Es for WAL-752 around the deployed [Portal2 demo](https://portal2.demo.walt.id/). It removes the obsolete standalone harness and old portal assumptions, then covers the three Portal2 mobile flows that are currently viable: OpenID4VP presentation, ISO 18013-7 Annex C presentation, and pre-authorized mDL issuance.

This draft is stacked on the stabilized native DC API infrastructure in [walt-id/waltid-identity#2134](https://github.com/walt-id/waltid-identity/pull/2134). The `ci:mobile-dc-api` label now schedules both the existing native phase and a separate browser phase. The browser phase is intentionally isolated on its own Play Store/Chrome AVD and cache; it does not change the native Google APIs baseline.

x86_64 qualification is now exercising the three real browser tests with zero skips. Issuance passes, while both presentation variants currently reproduce a Chrome/Portal return-path failure. This PR therefore remains draft and is not merge-ready.

## What Changed

### Portal2 coverage

- Adds browser-origin mDL presentation through Portal2's OpenID4VP DC API action.
- Adds browser-origin mDL presentation through Portal2's ISO 18013-7 Annex C action.
- Adds pre-authorized mDL issuance through Chrome's Digital Credentials create API.
- Asserts the Portal2 completion state, current verifier or issuer session, policy execution, and wallet storage outcome instead of stopping at the wallet handoff.

### Browser driver

- Targets only `https://portal2.demo.walt.id/`; the old `digital-credentials.walt.id` harness and test-portal workarounds are gone.
- Fails explicitly when Chrome, GMS, the issuance developer flag, or the deployed Portal2 capability is unavailable. There are no ignored or assumption-based green paths in the new tests.
- Uses package-scoped accessibility selectors and wallet review tags, with bounded handling for Chrome/GMS disclosure and provider-review scrolling.
- Requires the GMS presentation disclosure to disappear after confirmation, covering the exact transition that failed during a cold-reboot repeat.
- Adds the Chrome package query only to the debug manifest used by instrumentation.

### Browser CI substrate

- Adds a dedicated API 37 x86_64 `google_apis_playstore_ps16k` phase with 4 GB memory and a separate 6 GB AVD/cache.
- Disables Play Store updates before preparing Chrome, completes Chrome first run without an account, enables the Digital Credentials issuance flag, and verifies a rendered Portal2 page.
- Records exact Android, GMS, Chrome, locale, helper, flag, and Play Store state in immutable manifests; restored runs validate that state without repairing it.
- Runs only the two Portal2 classes and fails unless exactly three test cases execute with zero skips.
- Uploads JUnit reports and browser-substrate diagnostics independently from the native phase.

## Architecture Notes

- These tests supplement the native DC API suite. They prove the HTTPS web origin, Chrome mediation, deployed Portal2 request construction, and browser-to-wallet return path; they do not replace the native APK-origin, negative-envelope, multi-alternative, cancellation/back, or direct-response assertions.
- Browser state lives in a separate Play Store/Chrome AVD cache. It never restores or mutates the native `google_apis` cache used by the stabilized 12-test suite.
- `ci:mobile` alone still runs the ordinary mobile matrix. The manual `ci:mobile-dc-api` opt-in runs both DC API phases on pull requests, while main retains the parent workflow's default DC API coverage.
- No Portal2 source, configuration, selector, route, or deployment change is included.

## Evidence

- Before the 2026-08-23 history-only rebase, the Android instrumentation sources compiled on `5ca4ca6ff`, stacked directly above PR #2134. The native DC API lane was green on that exact head.
- On the 2026-08-23 rebased head, [the first browser rerun](https://github.com/walt-id/waltid-identity/actions/runs/32644523690/job/97206623267) restored the browser AVD but failed during preparation because the helper could not type the exact Chrome issuance-flag URL after three attempts. The browser tests did not execute, so this is setup/driver evidence rather than presentation-behavior evidence.
- GitHub-hosted x86_64 preparation passed with API 37, GMS `26.11.36 / 261136038`, Chrome `145.0.7632.218 / 763221838`, the issuance flag enabled, and a stable Portal2 render. That clean baseline was saved and then restored successfully by the next run.
- On restored x86_64 CI, all three browser tests executed with zero skips. Pre-authorized mDL issuance passed. Both presentation variants reached Credential Manager, selected the mDL, opened the wallet review, and returned after sharing, but Portal2 never reported completion; the result was `1/3` with two bounded presentation failures.
- The presentation logcats record Chrome/Trichrome x86_64 process failures around the provider return, including failure to reserve enough address space for `libmonochrome_64.so`, followed by Chrome process recreation. This is the strongest current lead for the lost Portal2 state, but it is not yet proven as the sole cause.
- On an API 37 ARM64 Play Store AVD with the same Chrome and factory GMS family, all three Portal2 tests passed together once in `103.798s`. After a cold reboot, Annex C and issuance passed while OpenID4VP remained on the GMS disclosure, producing `2/3`. ARM64 evidence does not substitute for the required GitHub-hosted x86_64 qualification.

## Caveats and Follow-Ups

- Keep this PR draft while the x86_64 presentation return-path failure is investigated. Do not mask it with retries, skips, or longer completion timeouts: both presentations already reached their bounded completion wait with the wrong Portal2 state.
- Isolate Chrome process survival and Portal2 state restoration around provider return, including the Trichrome linker/crash evidence, before changing the browser driver.
- Require exact `3/3`, zero-skip results on a fresh cache, a cache hit, and another restored cold-boot repeat before marking this PR ready for review.
- Chrome presentation requires Chrome 141 or newer. Issuance requires Chrome 143 or newer and currently needs `chrome://flags/#web-identity-digital-credentials-creation` in this development setup.
- Portal2 is a live external dependency and its current controls do not expose stable test IDs; selector drift fails diagnostically rather than being hidden by fallback clicks.

## Breaking

No product or runtime behavior changes. The `ci:mobile-dc-api` label now schedules an additional browser E2E phase.
