### PR TITLE
fix(wal-1285): normalise AzureKey signRaw to ASN.1 DER for EC keys

### DIFF
--- a/waltid-libraries/crypto/waltid-crypto-azure/src/main/kotlin/id/walt/crypto/keys/azure/AzureKey.kt
+++ b/waltid-libraries/crypto/waltid-crypto-azure/src/main/kotlin/id/walt/crypto/keys/azure/AzureKey.kt
@@ -76,8 +76,18 @@ class AzureKey(
 
             val cryptoClient = KeyVaultClientFactory.cryptoClient(config.auth.keyVaultUrl, id)
             val signResult = cryptoClient.sign(azureSignatureAlgorithm, digest).awaitSingle()
+            val rawSignature = signResult.signature
+                ?: throw SigningException("Azure Key Vault returned null signature")
 
-            signResult.signature ?: throw SigningException("Azure Key Vault returned null signature")
+            // Azure Key Vault returns EC signatures in IEEE P1363 (R||S) format, but the
+            // waltid-crypto contract for signRaw is ASN.1 DER for EC (matches JWKKey, AWSKey,
+            // OCIKey, and AzureKeyRestApi). Consumers like BouncyCastle's ContentSigner used
+            // for X.509 issuance decode the result as DER, so convert here to keep parity.
+            if (keyType in KeyTypes.EC_KEYS) {
+                EccUtils.convertP1363toDER(rawSignature)
+            } else {
+                rawSignature
+            }
         } catch (e: ResourceNotFoundException) {
             throw KeyNotFoundException(id, "Key not found in Azure Key Vault", e)
         } catch (e: com.azure.core.exception.HttpResponseException) {
@@ -101,9 +111,14 @@ class AzureKey(
         val header = Json.encodeToString(appendedHeader).encodeToByteArray().encodeToBase64Url()
         val payload = plaintext.encodeToBase64Url()
 
-        var rawSignature = signRaw("$header.$payload".encodeToByteArray())
+        val rawDerOrRsaSignature = signRaw("$header.$payload".encodeToByteArray())
+        val jwsSignature = if (keyType in KeyTypes.EC_KEYS) {
+            EccUtils.convertDERtoIEEEP1363(rawDerOrRsaSignature)
+        } else {
+            rawDerOrRsaSignature
+        }
 
-        val encodedSignature = rawSignature.encodeToBase64Url()
+        val encodedSignature = jwsSignature.encodeToBase64Url()
         return "$header.$payload.$encodedSignature"
     }
 


### PR DESCRIPTION
## Summary

Azure Key Vault returns EC signatures in **IEEE P1363 (R||S)** format. The rest of the crypto layer treats `Key.signRaw` as returning **ASN.1 DER** for EC keys — every other backend produces DER (natively from JCA/AWS KMS/OCI, or via explicit `convertP1363toDER` inside `signRaw` for `AzureKeyRestApi` and `OCIKey.jvm`).

The SDK-based `AzureKey` (used with `DefaultAzureCredential` — Managed Identity — as well as the SDK-driven client secret path) is the only backend that returned the raw P1363 bytes unchanged. Consumers that decode the result as DER then blow up on the first EC signing operation. The most visible symptom is BouncyCastle's `ContentSigner`, used by the X.509 issuance path, raising:

```
org.bouncycastle.asn1.ASN1Exception: Unsupported length >2^8 (was: 36 length bytes)
```

## Approach

- In `AzureKey.signRaw`, convert the returned P1363 signature to DER for EC keys before returning, mirroring what `AzureKeyRestApi` already does. RSA is untouched.
- In `AzureKey.signJws`, rebalance by converting the (now DER) `signRaw` output back to P1363 before base64url-encoding the JWS signature segment. This mirrors the pattern in `JWKKey.jvm` and `OCIKey.jvm`.
- `EccUtils.convertDERtoIEEEP1363` treats an already-P1363 input as a no-op, so the reverse conversion is idempotent and safe.

No public API changes. RSA behaviour is unchanged.

## Why not make the output format configurable?

Every non-test consumer of `signRaw` in the codebase already expects DER for EC — the X.509 `KeyContentSignerWrapper` (BC), the enterprise `/keys/{id}/sign` endpoint (documented as a testing endpoint, format is whatever the driver returns — DER everywhere else), and the cheqd DID registrar (Ed25519 in practice, so N/A). When a caller wants P1363 (JWS assembly in `signJws`, COSE signing in `CoseCrypto`), it already does `EccUtils.convertDERtoIEEEP1363(...)` on top. Adding a configuration knob would change a public method signature across every backend on every target for no in-tree benefit.

## Test plan

- [x] `./gradlew :waltid-libraries:crypto:waltid-crypto:compileKotlinJvm :waltid-libraries:crypto:waltid-crypto-azure:compileKotlin :waltid-libraries:crypto:waltid-x509:compileKotlinJvm` — clean.
- [x] `./gradlew :waltid-enterprise-api:compileKotlin` — clean.
- [ ] Regression: X.509 self-signed generic certificate issuance against an Azure Key Vault EC (`P-256`) key using the SDK backend (`backend = "azure"`, both `DefaultAzureCredential`/MI and client-secret via SDK) — reproduces the ASN.1 exception without the patch, succeeds with it.
- [ ] Regression: `signJws` against an Azure Key Vault EC key still produces a JWS that verifies with the co-located public key (JWS wire format still IEEE P1363).

Made with [Cursor](https://cursor.com)