### PR TITLE
feat(ci): run issuer conformance tests selectively

### DIFF
--- a/.github/workflows/android-eligibility.yml
+++ b/.github/workflows/android-eligibility.yml
@@ -53,6 +53,7 @@ jobs:
       pr-head-repo: ${{ inputs.pr-head-repo }}
       pr-labels: ${{ inputs.pr-labels }}
       pr-draft: ${{ inputs.pr-draft }}
+      additional-labels: '["ci:mobile"]'
       platform-name: Android
       platform-label: ci:android
       path-patterns: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,15 @@ jobs:
       pr-head-repo: ${{ github.event.pull_request.head.repo.full_name || '' }}
       pr-labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
       pr-draft: ${{ github.event.pull_request.draft || false }}
+  issuer-conformance-eligibility:
+    uses: ./.github/workflows/issuer-conformance-eligibility.yml
+    with:
+      event-name: ${{ github.event_name }}
+      ref: ${{ github.ref }}
+      pr-number: ${{ github.event.pull_request.number || '' }}
+      pr-head-repo: ${{ github.event.pull_request.head.repo.full_name || '' }}
+      pr-labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
+      pr-draft: ${{ github.event.pull_request.draft || false }}
   crypto2-eligibility:
     uses: ./.github/workflows/platform-eligibility.yml
     with:
@@ -102,9 +111,9 @@ jobs:
   gradle-build:
     uses: ./.github/workflows/gradle.yml
     secrets: inherit
-    needs: android-eligibility
+    needs: [android-eligibility, issuer-conformance-eligibility]
     with:
       enable-android-build: ${{ needs.android-eligibility.outputs.should-run == 'true' }}
       report-check-name: 'gradle-build / gradle (ubuntu-22.04)'
-      run-issuer-conformance: true
-      run-haip-conformance: true
+      run-issuer-conformance: ${{ needs.issuer-conformance-eligibility.outputs.should-run == 'true' }}
+      run-haip-conformance: ${{ needs.issuer-conformance-eligibility.outputs.should-run == 'true' }}

--- a/.github/workflows/issuer-conformance-eligibility.yml
+++ b/.github/workflows/issuer-conformance-eligibility.yml
@@ -74,10 +74,13 @@ jobs:
           "waltid-services/waltid-service-commons/*",
           "waltid-libraries/protocols/waltid-openid4vci*/*",
           "waltid-libraries/crypto/waltid-crypto*/*",
+          "waltid-libraries/crypto/waltid-cose/*",
           "waltid-libraries/crypto/waltid-jose/*",
           "waltid-libraries/crypto/waltid-x509/*",
+          "waltid-libraries/credentials/waltid-credential-key-resolver/*",
           "waltid-libraries/credentials/waltid-mdoc-credentials*/*",
+          "waltid-libraries/credentials/waltid-w3c-credentials/*",
           "waltid-libraries/sdjwt/waltid-sdjwt/*",
           "waltid-libraries/waltid-did/*",
-          "waltid-libraries/web/waltid-ktor-notifications/*"
+          "waltid-libraries/web/waltid-ktor-notifications*/*"
         ]

--- a/.github/workflows/issuer-conformance-eligibility.yml
+++ b/.github/workflows/issuer-conformance-eligibility.yml
@@ -55,6 +55,8 @@ jobs:
       pr-draft: ${{ inputs.pr-draft }}
       platform-name: Issuer conformance
       platform-label: ci:issuer-conformance
+      # Keep this aligned with Issuer2/OpenID4VCI conformance-sensitive implementation dependencies;
+      # intentionally not a complete transitive Gradle dependency closure.
       path-patterns: |
         [
           ".github/workflows/build.yml",

--- a/.github/workflows/issuer-conformance-eligibility.yml
+++ b/.github/workflows/issuer-conformance-eligibility.yml
@@ -1,0 +1,83 @@
+name: Issuer conformance eligibility
+
+on:
+  workflow_call:
+    inputs:
+      event-name:
+        description: "Caller event name"
+        required: true
+        type: string
+      ref:
+        description: "Caller git ref"
+        required: true
+        type: string
+      pr-number:
+        description: "Pull request number, if the caller is a PR event"
+        required: false
+        type: string
+        default: ""
+      pr-head-repo:
+        description: "Pull request head repository, if the caller is a PR event"
+        required: false
+        type: string
+        default: ""
+      pr-labels:
+        description: "JSON array of pull request label names"
+        required: false
+        type: string
+        default: "[]"
+      pr-draft:
+        description: "Whether the pull request is currently a draft"
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      should-run:
+        description: "Whether issuer conformance jobs should run"
+        value: ${{ jobs.decide.outputs.should-run }}
+      reason:
+        description: "Human-readable decision reason"
+        value: ${{ jobs.decide.outputs.reason }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  decide:
+    uses: ./.github/workflows/platform-eligibility.yml
+    with:
+      event-name: ${{ inputs.event-name }}
+      ref: ${{ inputs.ref }}
+      pr-number: ${{ inputs.pr-number }}
+      pr-head-repo: ${{ inputs.pr-head-repo }}
+      pr-labels: ${{ inputs.pr-labels }}
+      pr-draft: ${{ inputs.pr-draft }}
+      platform-name: Issuer conformance
+      platform-label: ci:issuer-conformance
+      path-patterns: |
+        [
+          ".github/workflows/build.yml",
+          ".github/workflows/gradle.yml",
+          ".github/workflows/issuer-conformance-eligibility.yml",
+          ".github/workflows/platform-eligibility.yml",
+          ".github/actions/checkout-repos/*",
+          ".github/actions/gradle-setup-action/*",
+          "build-logic/*",
+          "build.gradle.kts",
+          "settings.gradle.kts",
+          "gradle.properties",
+          "gradle/*",
+          "gradlew",
+          "waltid-services/waltid-issuer-api2/*",
+          "waltid-services/waltid-openid4vp-conformance-runners/*",
+          "waltid-services/waltid-service-commons/*",
+          "waltid-libraries/protocols/waltid-openid4vci*/*",
+          "waltid-libraries/crypto/waltid-crypto*/*",
+          "waltid-libraries/crypto/waltid-jose/*",
+          "waltid-libraries/crypto/waltid-x509/*",
+          "waltid-libraries/credentials/waltid-mdoc-credentials*/*",
+          "waltid-libraries/sdjwt/waltid-sdjwt/*",
+          "waltid-libraries/waltid-did/*",
+          "waltid-libraries/web/waltid-ktor-notifications/*"
+        ]

--- a/.github/workflows/macos-eligibility.yml
+++ b/.github/workflows/macos-eligibility.yml
@@ -53,6 +53,7 @@ jobs:
       pr-head-repo: ${{ inputs.pr-head-repo }}
       pr-labels: ${{ inputs.pr-labels }}
       pr-draft: ${{ inputs.pr-draft }}
+      additional-labels: '["ci:mobile"]'
       platform-name: iOS
       platform-label: ci:macos
       path-patterns: |

--- a/.github/workflows/platform-eligibility.yml
+++ b/.github/workflows/platform-eligibility.yml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: false
+      additional-labels:
+        description: "JSON array of additional labels that force this CI group"
+        required: false
+        type: string
+        default: "[]"
       platform-name:
         description: "Human-readable platform name for log messages"
         required: true
@@ -66,6 +71,7 @@ jobs:
         id: decide
         env:
           EVENT_NAME: ${{ inputs.event-name }}
+          ADDITIONAL_LABELS: ${{ inputs.additional-labels }}
           GH_TOKEN: ${{ github.token }}
           PATH_PATTERNS: ${{ inputs.path-patterns }}
           PLATFORM_LABEL: ${{ inputs.platform-label }}
@@ -82,6 +88,8 @@ jobs:
           set_decision() {
             echo "should-run=$1" >> "$GITHUB_OUTPUT"
             echo "reason=$2" >> "$GITHUB_OUTPUT"
+            echo "${PLATFORM_NAME} eligibility: $1"
+            echo "Reason: $2"
           }
 
           is_relevant_path() {
@@ -121,20 +129,30 @@ jobs:
               fi
 
               label_match="$(
-                jq -er --arg platform_label "$PLATFORM_LABEL" '
-                  if index($platform_label) != null then "platform"
-                  elif index("ci:mobile") != null then "mobile"
-                  else "none"
-                  end
-                ' <<< "$PR_LABELS"
+                jq -er \
+                  --arg platform_label "$PLATFORM_LABEL" \
+                  --argjson additional_labels "$ADDITIONAL_LABELS" '
+                    . as $pr_labels |
+                    if ($pr_labels | index($platform_label)) != null then "platform"
+                    elif any($additional_labels[]; . as $additional_label | ($pr_labels | index($additional_label)) != null) then "additional"
+                    else "none"
+                    end
+                  ' <<< "$PR_LABELS"
               )"
+              additional_label_names="$(jq -r 'join(", ")' <<< "$ADDITIONAL_LABELS")"
+              if [[ -n "$additional_label_names" ]]; then
+                label_requirement="$PLATFORM_LABEL or $additional_label_names"
+              else
+                label_requirement="$PLATFORM_LABEL"
+              fi
+
               case "$label_match" in
                 platform) set_decision true "$PLATFORM_LABEL label"; exit 0 ;;
-                mobile) set_decision true "ci:mobile label"; exit 0 ;;
+                additional) set_decision true "$additional_label_names label"; exit 0 ;;
               esac
 
               if [[ "$PR_DRAFT" == "true" ]]; then
-                set_decision false "draft PR without $PLATFORM_LABEL or ci:mobile label"
+                set_decision false "draft PR without $label_requirement label"
                 exit 0
               fi
 
@@ -152,7 +170,7 @@ jobs:
                 fi
               done
 
-              set_decision false "no ${PLATFORM_NAME}-relevant path changes, $PLATFORM_LABEL label, or ci:mobile label"
+              set_decision false "no ${PLATFORM_NAME}-relevant path changes, $label_requirement label"
               exit 0
               ;;
           esac


### PR DESCRIPTION
## Summary

This PR makes Issuer2 OpenID4VCI and HAIP conformance CI selective because these suites are expensive and environment-sensitive. Same-repository pull requests run them only when explicitly opted in or when the change crosses the issuer/conformance-sensitive boundary; draft pull requests remain suppressed by default.

The shared eligibility workflow remains the single decision engine. Mobile wrappers now opt into `ci:mobile` explicitly, while issuer conformance has its own label and boundary. `build.yml` only consumes the resulting boolean.

## Rules

- Draft same-repository PR → skip unless it has `ci:issuer-conformance`.
- Ready same-repository PR + relevant path → run automatically.
- Same-repository PR + `ci:issuer-conformance` → force run, including drafts.
- Main pushes and manual dispatches → preserve the existing unconditional behavior.
- Fork PRs → preserve the existing manual-dispatch policy; the fork check occurs before labels and changed-path evaluation.

## What Changed

### Shared eligibility

- Generalized the old hard-coded `ci:mobile` override into configurable `additional-labels`.
- Preserved the decision order: platform label, configured additional label, draft suppression, relevant paths, then skip.
- Added explicit eligibility and reason log lines for Actions diagnostics.
- Passed `ci:mobile` only from the Android and macOS wrappers.

### Issuer conformance

- Added `issuer-conformance-eligibility.yml` with the `ci:issuer-conformance` opt-in label.
- Wired both Issuer2 conformance jobs in `build.yml` to the wrapper output.
- Defined an explicit conformance-sensitive impact boundary covering Issuer2, the conformance runner, CI/build infrastructure, OpenID4VCI, credential resolver and W3C credentials, crypto/JOSE/X.509/COSE, DID, SD-JWT, mdoc, and notification service/core paths.
- Left the reusable conformance jobs and their action pins unchanged.

## Architecture Notes

- The issuer path list is intentionally a conformance-sensitive implementation boundary, not a complete transitive Gradle dependency closure.
- Keep the boundary aligned with Issuer2/OpenID4VCI implementation dependencies as those dependencies evolve; do not expand it to every library that merely compiles into the test harness.
- The issuer wrapper does not pass mobile labels, so `ci:mobile`, `ci:android`, and `ci:macos` cannot opt these suites in.

## Breaking

- No product API or runtime behavior changes. Workflow scheduling changes are intentional: issuer conformance is no longer unconditional on every build workflow run.