### PR TITLE
[WAL-1296] feat(wallet2): wire transaction-data profiles and discovery

### DIFF
--- a/docker-compose/wallet-api2/config/transaction-data-profiles.conf
+++ b/docker-compose/wallet-api2/config/transaction-data-profiles.conf
@@ -1,0 +1,20 @@
+transactionDataProfiles = [
+  {
+    type = "org.waltid.transaction-data.payment-authorization"
+    displayName = "Payment Authorization"
+    # Current AndroidX matcher uses merchant_name and amount for generic payment entries.
+    fields = ["merchant_name", "amount", "currency"]
+  },
+  {
+    type = "org.waltid.transaction-data.account-access"
+    displayName = "Account Access"
+    fields = ["account_identifier", "access_scope"]
+  },
+  {
+    # EUDI TS-12 SCA payment type. Its payload nests, so the Credential Manager matcher reads
+    # payload.payee.name, payload.currency and payload.amount rather than flat fields.
+    type = "urn:eudi:sca:payment:1"
+    displayName = "SCA Payment"
+    fields = ["payload"]
+  }
+]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
@@ -181,11 +181,13 @@ object Wallet2RouteHandler {
          */
         getAccountId: (suspend RoutingCall.() -> String?)? = null,
         attestationAssembler: ClientAttestationAssembler? = null,
+        transactionDataTypeRegistry: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
     ) = registerWallet2Routes(
         resolver,
         getAccountId,
         attestationAssembler,
         ClientIdTrustConfiguration(),
+        transactionDataTypeRegistry,
     )
 
     fun Route.registerWallet2Routes(
@@ -193,9 +195,16 @@ object Wallet2RouteHandler {
         getAccountId: (suspend RoutingCall.() -> String?)?,
         attestationAssembler: ClientAttestationAssembler?,
         clientIdTrustConfiguration: ClientIdTrustConfiguration,
+        transactionDataTypeRegistry: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
     ) {
         route("/wallet", { tags = listOf(WALLET_MANAGEMENT_TAG) }) {
-            registerWalletManagementRoutes(resolver, getAccountId, attestationAssembler, clientIdTrustConfiguration)
+            registerWalletManagementRoutes(
+                resolver = resolver,
+                getAccountId = getAccountId,
+                attestationAssembler = attestationAssembler,
+                clientIdTrustConfiguration = clientIdTrustConfiguration,
+                transactionDataTypeRegistry = transactionDataTypeRegistry,
+            )
         }
         if (getAccountId == null) {
             route("/stores", { tags = listOf("Named Store Management") }) {
@@ -213,6 +222,7 @@ object Wallet2RouteHandler {
         getAccountId: (suspend RoutingCall.() -> String?)?,
         attestationAssembler: ClientAttestationAssembler?,
         clientIdTrustConfiguration: ClientIdTrustConfiguration,
+        transactionDataTypeRegistry: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
     ) {
 
         post("", Wallet2OpenApiDocs.createWallet()) {
@@ -791,7 +801,7 @@ object Wallet2RouteHandler {
                             WalletPresentationHandler.presentCredentialWithTrust(
                                 wallet = wallet,
                                 request = req,
-                                transactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
+                                transactionDataTypeRegistry = transactionDataTypeRegistry,
                                 clientIdTrustConfiguration = clientIdTrustConfiguration,
                             )
                         )
@@ -808,7 +818,7 @@ object Wallet2RouteHandler {
                             WalletPresentationHandler.presentCredentialIsolatedWithTrust(
                                 wallet = wallet,
                                 request = req,
-                                transactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
+                                transactionDataTypeRegistry = transactionDataTypeRegistry,
                                 clientIdTrustConfiguration = clientIdTrustConfiguration,
                             )
                         )
@@ -865,6 +875,7 @@ object Wallet2RouteHandler {
                             WalletPresentationHandler.buildVpToken(
                                 wallet = wallet,
                                 request = req,
+                                transactionDataTypeRegistry = transactionDataTypeRegistry,
                                 clientIdTrustConfiguration = clientIdTrustConfiguration,
                             )
                         )
@@ -886,6 +897,7 @@ object Wallet2RouteHandler {
                             WalletPresentationHandler.sendAuthorizationResponse(
                                 wallet = wallet,
                                 request = req,
+                                transactionDataTypeRegistry = transactionDataTypeRegistry,
                                 clientIdTrustConfiguration = clientIdTrustConfiguration,
                             )
                         )
@@ -912,7 +924,7 @@ object Wallet2RouteHandler {
                         val result = WalletPresentationHandler.previewPresentationStateless(
                             wallet = wallet,
                             request = req,
-                            transactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
+                            transactionDataTypeRegistry = transactionDataTypeRegistry,
                             clientIdTrustConfiguration = clientIdTrustConfiguration,
                         )
                         call.respond(result.toPreviewResponse())

--- a/waltid-services/waltid-wallet-api2/config/transaction-data-profiles.conf
+++ b/waltid-services/waltid-wallet-api2/config/transaction-data-profiles.conf
@@ -1,0 +1,20 @@
+transactionDataProfiles = [
+  {
+    type = "org.waltid.transaction-data.payment-authorization"
+    displayName = "Payment Authorization"
+    # Current AndroidX matcher uses merchant_name and amount for generic payment entries.
+    fields = ["merchant_name", "amount", "currency"]
+  },
+  {
+    type = "org.waltid.transaction-data.account-access"
+    displayName = "Account Access"
+    fields = ["account_identifier", "access_scope"]
+  },
+  {
+    # EUDI TS-12 SCA payment type. Its payload nests, so the Credential Manager matcher reads
+    # payload.payee.name, payload.currency and payload.amount rather than flat fields.
+    type = "urn:eudi:sca:payment:1"
+    displayName = "SCA Payment"
+    fields = ["payload"]
+  }
+]

--- a/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/Main.kt
+++ b/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/Main.kt
@@ -99,6 +99,7 @@ fun Application.wallet2Api(authConfig: OSSWallet2AuthConfig? = null) {
                 walletResolver = OSSWallet2Service.resolver,
             )
         }
+        registerTransactionDataProfilesRoute()
         OSSWallet2Service.run { registerRoutes() }
     }
 }

--- a/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/OSSWallet2FeatureCatalog.kt
+++ b/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/OSSWallet2FeatureCatalog.kt
@@ -1,5 +1,6 @@
 package id.walt.wallet2
 
+import id.walt.commons.config.list.TransactionDataProfilesConfig
 import id.walt.commons.featureflag.BaseFeature
 import id.walt.commons.featureflag.OptionalFeature
 import id.walt.commons.featureflag.ServiceFeatureCatalog
@@ -21,6 +22,17 @@ object OSSWallet2FeatureCatalog : ServiceFeatureCatalog {
     val persistenceFeature =
         OptionalFeature("wallet2-persistence", "SQL persistence for wallets, credentials, keys and DIDs", Wallet2PersistenceConfig::class, default = false)
 
+    val transactionDataProfilesFeature = OptionalFeature(
+        name = "transaction-data-profiles",
+        description = "Transaction data type profiles for OpenID4VP",
+        config = TransactionDataProfilesConfig::class,
+        default = true,
+    )
+
     override val baseFeatures = listOf(walletService)
-    override val optionalFeatures: List<OptionalFeature> = listOf(authFeature, persistenceFeature)
+    override val optionalFeatures: List<OptionalFeature> = listOf(
+        authFeature,
+        persistenceFeature,
+        transactionDataProfilesFeature,
+    )
 }

--- a/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/OSSWallet2Service.kt
+++ b/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/OSSWallet2Service.kt
@@ -1,9 +1,11 @@
 package id.walt.wallet2
 
 import id.walt.commons.config.ConfigManager
+import id.walt.commons.config.list.TransactionDataProfilesConfig
 import id.walt.commons.featureflag.FeatureManager
 import id.walt.ktorauthnz.auth.getAuthenticatedAccount
 import id.walt.openid4vp.clientidprefix.ClientIdTrustConfiguration
+import id.walt.verifier.openid.transactiondata.TransactionDataTypeRegistry
 import id.walt.wallet2.data.WalletCredentialStore
 import id.walt.wallet2.data.WalletDidStore
 import id.walt.wallet2.data.WalletKeyStore
@@ -186,6 +188,7 @@ object OSSWallet2Service {
     fun Route.registerRoutes() {
         val attestationAssembler = createAttestationAssembler()
         val clientIdTrustConfiguration = configuredClientIdTrustConfiguration()
+        val transactionDataTypeRegistry = configuredTransactionDataTypeRegistry()
         val authEnabled = runCatching {
             FeatureManager.isFeatureEnabled(OSSWallet2FeatureCatalog.authFeature)
         }.getOrElse { false }
@@ -199,6 +202,7 @@ object OSSWallet2Service {
                     getAccountId = getAccountId,
                     attestationAssembler = attestationAssembler,
                     clientIdTrustConfiguration = clientIdTrustConfiguration,
+                    transactionDataTypeRegistry = transactionDataTypeRegistry,
                 )
             }
         } else {
@@ -207,6 +211,7 @@ object OSSWallet2Service {
                 getAccountId = null,
                 attestationAssembler = attestationAssembler,
                 clientIdTrustConfiguration = clientIdTrustConfiguration,
+                transactionDataTypeRegistry = transactionDataTypeRegistry,
             )
         }
     }
@@ -219,6 +224,14 @@ object OSSWallet2Service {
 
     internal fun configuredClientIdTrustConfiguration(): ClientIdTrustConfiguration =
         ConfigManager.getConfig<OSSWallet2ServiceConfig>().clientIdTrust.toDomain()
+
+    internal fun configuredTransactionDataTypeRegistry(): TransactionDataTypeRegistry {
+        val enabled = runCatching {
+            FeatureManager.isFeatureEnabled(OSSWallet2FeatureCatalog.transactionDataProfilesFeature)
+        }.getOrElse { false }
+        if (!enabled) return TransactionDataTypeRegistry(emptySet())
+        return ConfigManager.getConfig<TransactionDataProfilesConfig>().toTypeRegistry()
+    }
 
     private fun createAttestationAssembler(): ClientAttestationAssembler? {
         val config = ConfigManager.getConfig<OSSWallet2ServiceConfig>().attestationConfig ?: return null

--- a/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/TransactionDataProfilesRoute.kt
+++ b/waltid-services/waltid-wallet-api2/src/main/kotlin/id/walt/wallet2/TransactionDataProfilesRoute.kt
@@ -1,0 +1,27 @@
+package id.walt.wallet2
+
+import id.walt.commons.config.ConfigManager
+import id.walt.commons.config.list.TransactionDataProfile
+import id.walt.commons.config.list.TransactionDataProfilesConfig
+import id.walt.commons.featureflag.FeatureManager
+import io.github.smiley4.ktoropenapi.get
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+
+/**
+ * Lists configured OpenID4VP transaction-data type profiles when the
+ * `transaction-data-profiles` feature is enabled.
+ */
+fun Route.registerTransactionDataProfilesRoute() {
+    if (!FeatureManager.isFeatureEnabled(OSSWallet2FeatureCatalog.transactionDataProfilesFeature)) return
+
+    get("transaction-data-profiles", {
+        tags = listOf("Transaction Data")
+        summary = "List available transaction data type profiles"
+        response { HttpStatusCode.OK to { body<List<TransactionDataProfile>>() } }
+    }) {
+        val config = ConfigManager.getConfig<TransactionDataProfilesConfig>()
+        call.respond(config.transactionDataProfiles)
+    }
+}

--- a/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/TransactionDataProfilesIntegrationTest.kt
+++ b/waltid-services/waltid-wallet-api2/src/test/kotlin/id/walt/wallet2/TransactionDataProfilesIntegrationTest.kt
@@ -1,0 +1,287 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package id.walt.wallet2
+
+import id.walt.commons.config.ConfigManager
+import id.walt.commons.config.list.TransactionDataProfile
+import id.walt.commons.config.list.TransactionDataProfilesConfig
+import id.walt.commons.featureflag.FeatureConfig
+import id.walt.commons.featureflag.FeatureManager
+import id.walt.commons.testing.E2ETest
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.TypedKeyGenerationRequest
+import id.walt.crypto.utils.Base64Utils.encodeToBase64Url
+import id.walt.did.dids.DidService
+import id.walt.wallet2.data.WalletKeyInfo
+import id.walt.wallet2.handlers.PreviewPresentationRequest
+import id.walt.wallet2.server.handlers.CreateWalletRequest
+import id.walt.wallet2.server.handlers.WalletCreatedResponse
+import id.walt.wallet2.server.models.PresentationPreviewResponse
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.contentType
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TransactionDataProfilesIntegrationTest {
+
+    private val host = "127.0.0.1"
+    private val port = 17080
+
+    private val paymentType = "org.waltid.transaction-data.payment-authorization"
+    private val scaType = "urn:eudi:sca:payment:1"
+    private val accountType = "org.waltid.transaction-data.account-access"
+
+    private val profiles = listOf(
+        TransactionDataProfile(
+            type = paymentType,
+            displayName = "Payment Authorization",
+            fields = listOf("merchant_name", "amount", "currency"),
+        ),
+        TransactionDataProfile(
+            type = accountType,
+            displayName = "Account Access",
+            fields = listOf("account_identifier", "access_scope"),
+        ),
+        TransactionDataProfile(
+            type = scaType,
+            displayName = "SCA Payment",
+            fields = listOf("payload"),
+        ),
+    )
+
+    @Test
+    fun `discovery and preview accept configured transaction data types`() {
+        try {
+            E2ETest(host, port, failEarly = true).testBlock(
+                features = listOf(OSSWallet2FeatureCatalog),
+                preload = {
+                    ConfigManager.preloadConfig(
+                        "wallet-service",
+                        OSSWallet2ServiceConfig(publicBaseUrl = Url("http://$host:$port")),
+                    )
+                    ConfigManager.preloadConfig(
+                        "transaction-data-profiles",
+                        TransactionDataProfilesConfig(transactionDataProfiles = profiles),
+                    )
+                },
+                init = {
+                    DidService.minimalInit()
+                    OSSWallet2Service.configureInMemory()
+                },
+                module = { wallet2Module(withPlugins = false) },
+            ) {
+                val http = testHttpClient()
+
+                testAndReturn("Discovery returns configured profiles") {
+                    val discovered = http.get("/transaction-data-profiles")
+                        .also { assertEquals(HttpStatusCode.OK, it.status, it.bodyAsText()) }
+                        .body<List<TransactionDataProfile>>()
+                    assertEquals(profiles.map { it.type }.toSet(), discovered.map { it.type }.toSet())
+                    assertTrue(discovered.any { it.type == scaType })
+                    discovered
+                }
+
+                testAndReturn("Service registry knows configured types") {
+                    val registry = OSSWallet2Service.configuredTransactionDataTypeRegistry()
+                    registry.requireKnown(paymentType)
+                    registry.requireKnown(scaType)
+                    assertFailsWith<IllegalArgumentException> {
+                        registry.requireKnown("org.example.unknown-type")
+                    }
+                    registry
+                }
+
+                val walletId = testAndReturn("Create wallet") {
+                    http.post("/wallet") {
+                        contentType(ContentType.Application.Json)
+                        setBody(CreateWalletRequest())
+                    }.also { assertEquals(HttpStatusCode.Created, it.status) }
+                        .body<WalletCreatedResponse>()
+                        .walletId
+                }
+
+                testAndReturn("Generate signing key") {
+                    http.post("/wallet/$walletId/keys/generate") {
+                        contentType(ContentType.Application.Json)
+                        setBody<TypedKeyGenerationRequest>(TypedKeyGenerationRequest.Jwk(keyType = KeyType.Ed25519))
+                    }.also { assertEquals(HttpStatusCode.Created, it.status, it.bodyAsText()) }
+                        .body<WalletKeyInfo>()
+                }
+
+                testAndReturn("Preview accepts payment-authorization type") {
+                    val preview = http.post("/wallet/$walletId/credentials/present/preview") {
+                        contentType(ContentType.Application.Json)
+                        setBody(PreviewPresentationRequest(requestUrl = presentationRequestUrl(paymentType)))
+                    }.also { assertEquals(HttpStatusCode.OK, it.status, it.bodyAsText()) }
+                        .body<PresentationPreviewResponse>()
+                    assertTypeAcceptedByRegistry(preview, paymentType)
+                    preview
+                }
+
+                testAndReturn("Preview accepts SCA payment type") {
+                    val preview = http.post("/wallet/$walletId/credentials/present/preview") {
+                        contentType(ContentType.Application.Json)
+                        setBody(PreviewPresentationRequest(requestUrl = presentationRequestUrl(scaType)))
+                    }.also { assertEquals(HttpStatusCode.OK, it.status, it.bodyAsText()) }
+                        .body<PresentationPreviewResponse>()
+                    assertTypeAcceptedByRegistry(preview, scaType)
+                    preview
+                }
+
+                testAndReturn("Preview rejects unknown transaction data type") {
+                    val preview = http.post("/wallet/$walletId/credentials/present/preview") {
+                        contentType(ContentType.Application.Json)
+                        setBody(
+                            PreviewPresentationRequest(
+                                requestUrl = presentationRequestUrl("org.example.unknown-type"),
+                            ),
+                        )
+                    }.also { assertEquals(HttpStatusCode.OK, it.status, it.bodyAsText()) }
+                        .body<PresentationPreviewResponse>()
+                    assertFalse(preview.valid)
+                    assertEquals("invalid_transaction_data", preview.error?.code)
+                    assertTrue(
+                        preview.error?.message.orEmpty().contains("Unsupported transaction_data type", ignoreCase = true),
+                        "Expected unsupported-type rejection, got: ${preview.error}",
+                    )
+                    preview
+                }
+            }
+        } finally {
+            ConfigManager.preclear()
+            FeatureManager.preclear()
+        }
+    }
+
+    @Test
+    fun `disabled feature yields empty registry and no discovery route`() {
+        try {
+            E2ETest(host, port + 1, failEarly = true).testBlock(
+                features = listOf(OSSWallet2FeatureCatalog),
+                preload = {
+                    ConfigManager.preloadConfig(
+                        "_features",
+                        FeatureConfig(disabledFeatures = listOf("transaction-data-profiles")),
+                    )
+                    ConfigManager.preloadConfig(
+                        "wallet-service",
+                        OSSWallet2ServiceConfig(publicBaseUrl = Url("http://$host:${port + 1}")),
+                    )
+                    ConfigManager.preloadConfig(
+                        "transaction-data-profiles",
+                        TransactionDataProfilesConfig(transactionDataProfiles = profiles),
+                    )
+                },
+                init = {
+                    DidService.minimalInit()
+                    OSSWallet2Service.configureInMemory()
+                },
+                module = { wallet2Module(withPlugins = false) },
+            ) {
+                val http = testHttpClient()
+
+                testAndReturn("Discovery route is absent when feature disabled") {
+                    val response = http.get("/transaction-data-profiles")
+                    assertEquals(HttpStatusCode.NotFound, response.status, response.bodyAsText())
+                    response
+                }
+
+                testAndReturn("Registry is empty when feature disabled") {
+                    val registry = OSSWallet2Service.configuredTransactionDataTypeRegistry()
+                    assertTrue(registry.types.isEmpty())
+                    assertFailsWith<IllegalArgumentException> { registry.requireKnown(paymentType) }
+                    registry
+                }
+            }
+        } finally {
+            ConfigManager.preclear()
+            FeatureManager.preclear()
+        }
+    }
+
+    /**
+     * Type-registry acceptance is what this parity pass wires. Without a matching stored credential,
+     * preview may still return invalid_transaction_data for credential availability — that proves the
+     * type itself was accepted (unknown types fail earlier with "Unsupported transaction_data type").
+     */
+    private fun assertTypeAcceptedByRegistry(preview: PresentationPreviewResponse, expectedType: String) {
+        if (preview.valid) {
+            assertEquals(expectedType, preview.transactionData.single().type)
+            return
+        }
+        assertEquals("invalid_transaction_data", preview.error?.code, "Unexpected preview error: ${preview.error}")
+        assertFalse(
+            preview.error?.message.orEmpty().contains("Unsupported transaction_data type", ignoreCase = true),
+            "Type $expectedType should be accepted by the registry, got: ${preview.error}",
+        )
+    }
+
+    private fun presentationRequestUrl(transactionDataType: String): Url {
+        val encodedTransactionData = buildJsonObject {
+            put("type", transactionDataType)
+            put("credential_ids", buildJsonArray { add(JsonPrimitive("pid")) })
+            put("require_cryptographic_holder_binding", true)
+            put("transaction_data_hashes_alg", buildJsonArray { add(JsonPrimitive("sha-256")) })
+            if (transactionDataType == scaType) {
+                put(
+                    "payload",
+                    buildJsonObject {
+                        put("transaction_id", "tx-1")
+                        put("payee", buildJsonObject { put("name", "Super Store") })
+                        put("currency", "EUR")
+                        put("amount", 11.56)
+                    },
+                )
+            } else {
+                put("merchant_name", "ACME Corp")
+                put("amount", "42.00")
+                put("currency", "EUR")
+            }
+        }.toString().encodeToByteArray().encodeToBase64Url()
+
+        val dcqlQuery = buildJsonObject {
+            put(
+                "credentials",
+                buildJsonArray {
+                    add(
+                        buildJsonObject {
+                            put("id", "pid")
+                            put("format", "dc+sd-jwt")
+                            put(
+                                "meta",
+                                buildJsonObject {
+                                    put("vct_values", buildJsonArray { add(JsonPrimitive("https://example.com/identity")) })
+                                },
+                            )
+                        },
+                    )
+                },
+            )
+        }.toString()
+
+        return URLBuilder("openid4vp://authorize").apply {
+            parameters.append("client_id", "redirect_uri:https://verifier.example/callback")
+            parameters.append("redirect_uri", "https://verifier.example/callback")
+            parameters.append("response_type", "vp_token")
+            parameters.append("response_mode", "fragment")
+            parameters.append("nonce", "nonce-td-test")
+            parameters.append("dcql_query", dcqlQuery)
+            parameters.append("transaction_data", "[\"$encodedTransactionData\"]")
+        }.build()
+    }
+}


### PR DESCRIPTION
## Summary

Wires OpenID4VP transaction-data type profiles into OSS Wallet API 2 so present / preview / build / send accept configured types (including `urn:eudi:sca:payment:1`) instead of always using an empty registry. Also adds profile discovery parity with wallet-api v1 and Verifier2.

Stacked on [walt-id/waltid-identity#2076](https://github.com/walt-id/waltid-identity/pull/2076) (`feature/wal-752-demo-extensions`).

Related PRs:
- [walt-id/waltid-identity-enterprise#601](https://github.com/walt-id/waltid-identity-enterprise/pull/601)
- [walt-id/waltid-docs#354](https://github.com/walt-id/waltid-docs/pull/354)

Ticket: [WAL-1296](https://linear.app/walt-new/issue/WAL-1296/wire-transaction-data-in-wallet-api-2)

## What Changed

### Shared Wallet2 HTTP server
- `registerWallet2Routes` / `registerWalletManagementRoutes` take an injectable `TransactionDataTypeRegistry` (default remains empty for callers that do not opt in).
- Present, isolated present, preview, build-vp-token, and send-response all use that registry instead of hardcoding `TransactionDataTypeRegistry(emptySet())`.

### OSS wallet-api2 service wiring
- Optional feature `transaction-data-profiles` (default enabled) backed by `TransactionDataProfilesConfig`.
- Service resolves the registry from config when the feature is on and passes it into Wallet2 routes.
- Adds `GET /transaction-data-profiles` discovery when the feature is enabled.
- Ships `transaction-data-profiles.conf` (service + docker-compose), including payment-authorization, account-access, and SCA payment.

### Tests
- Integration coverage for discovery, registry acceptance of payment + SCA types, unknown-type rejection, and disabled-feature behavior (empty registry, no discovery route).

## Architecture Notes

- Presentation crypto already lived in shared libs; this PR only closes the OSS Wallet2 service wiring gap that left the registry empty.
- Feature-disabled / empty-registry behavior is preserved for library call sites and explicit `_features` disable.

## Caveats and Follow-Ups

- Nested SCA schema validation beyond type-registry membership remains out of scope (neither stack does this today).
- SD-JWT TS-12 SCA demo work stays on [WAL-1295](https://linear.app/walt-new/issue/WAL-1295/follow-up-ts-12-sca-payment-for-sd-jwt-vc-via-kb-jwt).
- Docs for Wallet2 profiles / discovery land in [waltid-docs#354](https://github.com/walt-id/waltid-docs/pull/354).

## Breaking

- None. New optional feature defaults to enabled for wallet-api2; library route registration keeps an empty-registry default.