### PR TITLE
Public API overloads in Wallet2RouteHandler now match the pre-#2084 c…

### DIFF
--- a/docker-compose/wallet-api2/config/transaction-data-profiles.conf
+++ b/docker-compose/wallet-api2/config/transaction-data-profiles.conf
@@ -2,7 +2,7 @@ transactionDataProfiles = [
   {
     type = "org.waltid.transaction-data.payment-authorization"
     displayName = "Payment Authorization"
-    # Current AndroidX matcher uses merchant_name and amount for generic payment entries.
+    # Generic payment type with flat merchant_name, amount, and currency fields.
     fields = ["merchant_name", "amount", "currency"]
   },
   {
@@ -11,8 +11,8 @@ transactionDataProfiles = [
     fields = ["account_identifier", "access_scope"]
   },
   {
-    # EUDI TS-12 SCA payment type. Its payload nests, so the Credential Manager matcher reads
-    # payload.payee.name, payload.currency and payload.amount rather than flat fields.
+    # EUDI TS-12 SCA payment type. Its payload nests, so matching uses payload.payee.name,
+    # payload.currency and payload.amount rather than flat fields.
     type = "urn:eudi:sca:payment:1"
     displayName = "SCA Payment"
     fields = ["payload"]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-server/src/main/kotlin/id/walt/wallet2/server/handlers/Wallet2RouteHandler.kt
@@ -181,13 +181,11 @@ object Wallet2RouteHandler {
          */
         getAccountId: (suspend RoutingCall.() -> String?)? = null,
         attestationAssembler: ClientAttestationAssembler? = null,
-        transactionDataTypeRegistry: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
     ) = registerWallet2Routes(
         resolver,
         getAccountId,
         attestationAssembler,
         ClientIdTrustConfiguration(),
-        transactionDataTypeRegistry,
     )
 
     fun Route.registerWallet2Routes(
@@ -195,7 +193,20 @@ object Wallet2RouteHandler {
         getAccountId: (suspend RoutingCall.() -> String?)?,
         attestationAssembler: ClientAttestationAssembler?,
         clientIdTrustConfiguration: ClientIdTrustConfiguration,
-        transactionDataTypeRegistry: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
+    ) = registerWallet2Routes(
+        resolver,
+        getAccountId,
+        attestationAssembler,
+        clientIdTrustConfiguration,
+        TransactionDataTypeRegistry(emptySet()),
+    )
+
+    fun Route.registerWallet2Routes(
+        resolver: WalletResolver,
+        getAccountId: (suspend RoutingCall.() -> String?)?,
+        attestationAssembler: ClientAttestationAssembler?,
+        clientIdTrustConfiguration: ClientIdTrustConfiguration,
+        transactionDataTypeRegistry: TransactionDataTypeRegistry,
     ) {
         route("/wallet", { tags = listOf(WALLET_MANAGEMENT_TAG) }) {
             registerWalletManagementRoutes(
@@ -222,7 +233,7 @@ object Wallet2RouteHandler {
         getAccountId: (suspend RoutingCall.() -> String?)?,
         attestationAssembler: ClientAttestationAssembler?,
         clientIdTrustConfiguration: ClientIdTrustConfiguration,
-        transactionDataTypeRegistry: TransactionDataTypeRegistry = TransactionDataTypeRegistry(emptySet()),
+        transactionDataTypeRegistry: TransactionDataTypeRegistry,
     ) {
 
         post("", Wallet2OpenApiDocs.createWallet()) {

--- a/waltid-services/waltid-wallet-api2/config/transaction-data-profiles.conf
+++ b/waltid-services/waltid-wallet-api2/config/transaction-data-profiles.conf
@@ -2,7 +2,7 @@ transactionDataProfiles = [
   {
     type = "org.waltid.transaction-data.payment-authorization"
     displayName = "Payment Authorization"
-    # Current AndroidX matcher uses merchant_name and amount for generic payment entries.
+    # Generic payment type with flat merchant_name, amount, and currency fields.
     fields = ["merchant_name", "amount", "currency"]
   },
   {
@@ -11,8 +11,8 @@ transactionDataProfiles = [
     fields = ["account_identifier", "access_scope"]
   },
   {
-    # EUDI TS-12 SCA payment type. Its payload nests, so the Credential Manager matcher reads
-    # payload.payee.name, payload.currency and payload.amount rather than flat fields.
+    # EUDI TS-12 SCA payment type. Its payload nests, so matching uses payload.payee.name,
+    # payload.currency and payload.amount rather than flat fields.
     type = "urn:eudi:sca:payment:1"
     displayName = "SCA Payment"
     fields = ["payload"]


### PR DESCRIPTION
Public API overloads in Wallet2RouteHandler now match the pre-#2084 compatibility pattern:

- 3-parameter registerWallet2Routes is unchanged
- 4-parameter overload (with ClientIdTrustConfiguration) is unchanged and delegates with an empty registry
- new 5-parameter overload takes a mandatory TransactionDataTypeRegistry
- internal registerWalletManagementRoutes also requires the registry (no silent empty default)

That keeps JVM binary compatibility