### PR TITLE
fix: accept issuer2 authorizedTransactionDataTypes offer overrides

### DIFF
--- a/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/controller/openapi/Issuer2ManagementRoutesDocs.kt
+++ b/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/controller/openapi/Issuer2ManagementRoutesDocs.kt
@@ -18,8 +18,8 @@ object Issuer2ManagementRoutesDocs {
             Profiles are deployment templates used by credential-offer creation. Use the
             returned profileId in POST /issuer2/credential-offers. Runtime overrides may
             provide credential data, mappings, selective disclosure, mDoc namespace data
-            mappings, ID token claim mappings, x5 chains, and webhook URLs for a single
-            issuance session.
+            mappings, authorized transaction data types, ID token claim mappings, x5 chains,
+            and webhook URLs for a single issuance session.
         """.trimIndent()
         response {
             HttpStatusCode.OK to {
@@ -69,7 +69,8 @@ object Issuer2ManagementRoutesDocs {
             Supports pre-authorized and authorization-code issuance flows. The offer can be returned
             by reference or by value. Runtime overrides can be applied for one offer only. Supported
             override fields are: issuerDid, credentialData, mapping, selectiveDisclosure,
-            idTokenClaimsMapping, mDocNameSpacesDataMappingConfig, x5Chain, and notifications.
+            idTokenClaimsMapping, mDocNameSpacesDataMappingConfig, authorizedTransactionDataTypes,
+            x5Chain, and notifications.
             credentialData is applied as a partial object patch over the configured profile data:
             nested objects are merged, while primitive, array, and null values replace the configured value.
             Authorization-code offers include issuer_state by default. Set issuerStateMode to OMIT only
@@ -118,6 +119,9 @@ object Issuer2ManagementRoutesDocs {
                 }
                 example("[pre-authorized][by-reference][override mDoc photo ID credentialData]") {
                     value = Issuer2RequestExamples.PRE_AUTHORIZED_MDOC_PHOTO_ID_OFFER_WITH_CREDENTIAL_DATA_OVERRIDE
+                }
+                example("[pre-authorized][by-reference][override authorizedTransactionDataTypes]") {
+                    value = Issuer2RequestExamples.PROFILE_PRE_AUTHORIZED_OFFER_WITH_AUTHORIZED_TRANSACTION_DATA_TYPES_OVERRIDE
                 }
                 example("[authorized][by-reference][override mDoc mDL credentialData]") {
                     value = Issuer2RequestExamples.AUTHORIZED_MDOC_MDL_OFFER_WITH_CREDENTIAL_DATA_OVERRIDE

--- a/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/controller/openapi/Issuer2RequestExamples.kt
+++ b/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/controller/openapi/Issuer2RequestExamples.kt
@@ -148,6 +148,16 @@ object Issuer2RequestExamples {
         ),
     )
 
+    val PROFILE_PRE_AUTHORIZED_OFFER_WITH_AUTHORIZED_TRANSACTION_DATA_TYPES_OVERRIDE =
+        CredentialOfferCreateRequest(
+            profileId = EU_AGE_VERIFICATION_PROFILE_ID,
+            authMethod = AuthenticationMethod.PRE_AUTHORIZED,
+            valueMode = CredentialOfferValueMode.BY_REFERENCE,
+            runtimeOverrides = CredentialOfferRuntimeOverrides(
+                authorizedTransactionDataTypes = listOf(SCA_PAYMENT_TRANSACTION_DATA_TYPE),
+            ),
+        )
+
     val AUTHORIZED_MDOC_MDL_OFFER_WITH_CREDENTIAL_DATA_OVERRIDE = CredentialOfferCreateRequest(
         profileId = MDOC_MDL_PROFILE_ID,
         authMethod = AuthenticationMethod.AUTHORIZED,
@@ -249,6 +259,8 @@ object Issuer2RequestExamples {
     private const val W3C_PROFILE_ID = "openBadgeCredential"
     private const val MDOC_PHOTO_ID_PROFILE_ID = "isoPhotoId"
     private const val MDOC_MDL_PROFILE_ID = "isoMdl"
+    private const val EU_AGE_VERIFICATION_PROFILE_ID = "euAgeVerificationMdoc"
+    private const val SCA_PAYMENT_TRANSACTION_DATA_TYPE = "urn:eudi:sca:payment:1"
     private const val W3C_CREDENTIAL_CONFIGURATION_ID = "OpenBadgeCredential_jwt_vc_json"
     private const val EXAMPLE_CREDENTIAL_ISSUER = "http://localhost:7002/openid4vci"
     private const val EXAMPLE_OFFER_ID = "018f8d6e-8df4-7b73-9f3d-f3df21a4374a"

--- a/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/models/CredentialOfferModels.kt
+++ b/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/models/CredentialOfferModels.kt
@@ -23,6 +23,8 @@ data class CredentialOfferRuntimeOverrides(
     val selectiveDisclosure: SDMap? = null,
     val idTokenClaimsMapping: Map<String, String>? = null,
     val mDocNameSpacesDataMappingConfig: Map<String, JsonObjectToCborMappingConfig>? = null,
+    /** OpenID4VP transaction_data types the issued key may sign, embedded in the mdoc MSO. */
+    val authorizedTransactionDataTypes: List<String>? = null,
     val x5Chain: List<String>? = null,
     val notifications: IssuanceNotifications? = null,
     val credentialStatus: JsonElement? = null,

--- a/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/service/CredentialOfferService.kt
+++ b/waltid-services/waltid-issuer-api2/src/main/kotlin/id/walt/issuer2/service/CredentialOfferService.kt
@@ -98,7 +98,8 @@ class CredentialOfferService(
             idTokenClaimsMapping = idTokenClaimsMapping,
             mDocNameSpacesDataMappingConfig =
                 overrides?.mDocNameSpacesDataMappingConfig ?: profile.mDocNameSpacesDataMappingConfig,
-            authorizedTransactionDataTypes = profile.authorizedTransactionDataTypes,
+            authorizedTransactionDataTypes = overrides?.authorizedTransactionDataTypes
+                ?: profile.authorizedTransactionDataTypes,
             x5Chain = overrides?.x5Chain ?: profile.x5Chain,
             issuerDid = issuerDid,
             credentialOffer = credentialOffer,

--- a/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/openid4vci/Issuer2CredentialOfferEndpointTest.kt
+++ b/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/openid4vci/Issuer2CredentialOfferEndpointTest.kt
@@ -283,6 +283,31 @@ class Issuer2CredentialOfferEndpointTest {
     }
 
     @Test
+    fun shouldApplyAuthorizedTransactionDataTypesRuntimeOverrideToOfferSession() = testApplication {
+        installIssuer2WithConfigFiles()
+        val client = apiClient()
+        val profile = client.getProfile(EU_AGE_VERIFICATION_PROFILE_ID)
+        assertNull(
+            profile.authorizedTransactionDataTypes,
+            "euAgeVerificationMdoc must not authorize transaction data at the profile, so the offer override is the grant",
+        )
+
+        val response = client.createCredentialOffer(
+            CredentialOfferCreateRequest(
+                profileId = profile.profileId,
+                authMethod = AuthenticationMethod.PRE_AUTHORIZED,
+                runtimeOverrides = CredentialOfferRuntimeOverrides(
+                    authorizedTransactionDataTypes = listOf(SCA_PAYMENT_TRANSACTION_DATA_TYPE),
+                ),
+            )
+        )
+
+        val session = client.getSession(response.offerId)
+        assertEquals(listOf(SCA_PAYMENT_TRANSACTION_DATA_TYPE), session.authorizedTransactionDataTypes)
+        assertNull(client.getProfile(profile.profileId).authorizedTransactionDataTypes)
+    }
+
+    @Test
     fun shouldMergeCredentialDataRuntimeOverridesWithConfiguredProfileData() = testApplication {
         installIssuer2WithConfigFiles()
         val client = apiClient()
@@ -896,6 +921,8 @@ class Issuer2CredentialOfferEndpointTest {
         const val ISO_PHOTO_ID_CONFIGURATION_ID = "org.iso.23220.photoid.1"
         const val IDENTITY_SD_JWT_PROFILE_ID = "identityCredentialSdJwt"
         const val TAX_ID_SD_JWT_PROFILE_ID = "taxIdCredentialSdJwt"
+        const val EU_AGE_VERIFICATION_PROFILE_ID = "euAgeVerificationMdoc"
+        const val SCA_PAYMENT_TRANSACTION_DATA_TYPE = "urn:eudi:sca:payment:1"
         const val TX_CODE_VALUE = "123456"
         const val TWO_MINUTES_SECONDS = 120L
 

--- a/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/openid4vci/Issuer2TransactionDataAuthorizationTest.kt
+++ b/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/openid4vci/Issuer2TransactionDataAuthorizationTest.kt
@@ -2,6 +2,7 @@ package id.walt.issuer2.openid4vci
 
 import id.walt.cose.coseCompliantCbor
 import id.walt.crypto.utils.Base64Utils.decodeFromBase64Url
+import id.walt.issuer2.models.CredentialOfferRuntimeOverrides
 import id.walt.issuer2.testsupport.Issuer2CredentialScenario
 import id.walt.issuer2.testsupport.Issuer2CredentialScenarios
 import id.walt.issuer2.testsupport.Issuer2TxCodeMode
@@ -30,7 +31,8 @@ import kotlin.test.assertNull
 /**
  * Transaction data presentation is gated on the MSO's `KeyAuthorizations`, so an mdoc issued
  * without it can never sign transaction data. These tests pin that grant at the issuer2 boundary:
- * a profile that authorizes a type gets exactly the hash elements, and one that does not gets nothing.
+ * a profile that authorizes a type gets exactly the hash elements, one that does not gets nothing,
+ * and an offer-scoped runtime override can grant a type the profile itself does not authorize.
  */
 class Issuer2TransactionDataAuthorizationTest {
 
@@ -71,14 +73,37 @@ class Issuer2TransactionDataAuthorizationTest {
         )
     }
 
+    @Test
+    fun runtimeOverrideAuthorizesTransactionDataOnProfileWithoutGrant() = testApplication {
+        installIssuer2WithConfigFiles()
+
+        val keyAuthorizations = assertNotNull(
+            apiClient().issueAndReadKeyAuthorizations(
+                scenario = euAgeVerificationScenario,
+                runtimeOverrides = CredentialOfferRuntimeOverrides(
+                    authorizedTransactionDataTypes = listOf(SCA_PAYMENT_TYPE),
+                ),
+            ),
+            "Expected keyAuthorizations from an offer-scoped authorizedTransactionDataTypes override",
+        )
+
+        assertNull(keyAuthorizations.namespaces, "Expected no blanket nameSpaces grant")
+        assertEquals(
+            mapOf(SCA_PAYMENT_TYPE to TRANSACTION_DATA_HASH_ELEMENTS),
+            keyAuthorizations.dataElements,
+        )
+    }
+
     private suspend fun HttpClient.issueAndReadKeyAuthorizations(
         scenario: Issuer2CredentialScenario = scaPaymentCardScenario,
+        runtimeOverrides: CredentialOfferRuntimeOverrides? = null,
     ): KeyAuthorization? {
         val walletFlow = Issuer2WalletFlowDriver(this)
         val createdOffer = createWalletFlowCredentialOffer(
             scenario = scenario,
             authenticationMethod = AuthenticationMethod.PRE_AUTHORIZED,
             txCodeMode = Issuer2TxCodeMode.NONE,
+            runtimeOverrides = runtimeOverrides,
         )
 
         val resolvedOffer = walletFlow.resolve(createdOffer)
@@ -102,11 +127,14 @@ class Issuer2TransactionDataAuthorizationTest {
 
     private companion object {
         const val SCA_PROFILE_ID = "scaPaymentCardMdoc"
+        const val EU_AGE_VERIFICATION_PROFILE_ID = "euAgeVerificationMdoc"
         const val SCA_PAYMENT_TYPE = "urn:eudi:sca:payment:1"
 
         val TRANSACTION_DATA_HASH_ELEMENTS = listOf("transaction_data_hash", "transaction_data_hash_alg")
 
         val scaPaymentCardScenario =
             Issuer2CredentialScenarios.configured.single { it.profileId == SCA_PROFILE_ID }
+        val euAgeVerificationScenario =
+            Issuer2CredentialScenarios.configured.single { it.profileId == EU_AGE_VERIFICATION_PROFILE_ID }
     }
 }

--- a/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/testsupport/Issuer2ApiClient.kt
+++ b/waltid-services/waltid-issuer-api2/src/test/kotlin/id/walt/issuer2/testsupport/Issuer2ApiClient.kt
@@ -2,6 +2,7 @@ package id.walt.issuer2.testsupport
 
 import id.walt.issuer2.models.CredentialOfferCreateRequest
 import id.walt.issuer2.models.CredentialOfferCreateResponse
+import id.walt.issuer2.models.CredentialOfferRuntimeOverrides
 import id.walt.issuer2.domain.CredentialProfile
 import id.walt.issuer2.domain.IssuanceSession
 import id.walt.openid4vci.offers.AuthenticationMethod
@@ -69,6 +70,7 @@ suspend fun HttpClient.createWalletFlowCredentialOffer(
     } else {
         null
     },
+    runtimeOverrides: CredentialOfferRuntimeOverrides? = null,
 ): CredentialOfferCreateResponse =
     createCredentialOffer(
         CredentialOfferCreateRequest(
@@ -78,6 +80,7 @@ suspend fun HttpClient.createWalletFlowCredentialOffer(
             issuerStateMode = issuerStateMode,
             txCode = txCodeMode?.txCode(),
             txCodeValue = txCodeMode?.txCodeValue(),
+            runtimeOverrides = runtimeOverrides,
         )
     )
 


### PR DESCRIPTION
## Summary

Community Issuer2 now accepts `runtimeOverrides.authorizedTransactionDataTypes` on `POST /issuer2/credential-offers` and applies it to that offer's issuance session. Previously the request failed with `400 Failed to convert request body to CredentialOfferCreateRequest` because the Community DTO omitted the field, while Enterprise already supported the same override.

Fixes [WAL-1299](https://linear.app/walt-new/issue/WAL-1299/issuer2-community-authorizedtransactiondatatypes-cant-be-overridden).

## What Changed

### Request model
- Added `authorizedTransactionDataTypes` to Community `CredentialOfferRuntimeOverrides`.
- Documented the field in the credential-offer OpenAPI description and added a pre-authorized mDoc example.

### Offer session
- Copy the override onto the issuance session, falling back to the profile value when it is omitted, matching Enterprise.

### Tests
- Offer creation stores the override on `euAgeVerificationMdoc` without changing the configured profile.
- Issuing that offer embeds `urn:eudi:sca:payment:1` in the mDoc MSO `KeyAuthorizations`.

## Architecture Notes

- This is the same per-offer fallback used for other runtime override fields (`mapping`, `x5Chain`, `credentialStatus`, and so on).
- The session value is already the grant consumed at credential issuance, so no protocol-path change was required beyond persisting the override.

## Caveats and Follow-Ups

- Community docs already listed this override; no docs change.
- Passing an empty list replaces the profile grant, same `?:` semantics as Enterprise.

## Breaking

- None. Additive request field; the previous unknown-key `400` is the behavior being removed.


Made with [Cursor](https://cursor.com)