### PR TITLE
allow a list of deprecated flag with WARN

### DIFF
--- a/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/featureflag/FeatureManager.kt
+++ b/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/featureflag/FeatureManager.kt
@@ -13,6 +13,7 @@ object FeatureManager {
     val enabledFeatures = HashSet<String>()
     val disabledFeatures = HashSet<String>()
     val registeredFeatures = HashMap<String, AbstractFeature>()
+    val deprecatedFeatures = HashSet<String>()
 
     private val failed = ArrayList<Pair<AbstractFeature, Throwable>>()
 
@@ -22,6 +23,7 @@ object FeatureManager {
         enabledFeatures.clear()
         disabledFeatures.clear()
         registeredFeatures.clear()
+        deprecatedFeatures.clear()
         failed.clear()
         featureAmendments.clear()
     }
@@ -133,6 +135,7 @@ object FeatureManager {
     suspend fun registerCatalog(catalog: ServiceFeatureCatalog) {
         registerBaseFeatures(catalog.baseFeatures)
         registerOptionalFeatures(catalog.optionalFeatures)
+        registerDeprecatedFeatures(catalog.deprecatedFeatures)
     }
 
     suspend fun registerCatalogs(catalogs: List<ServiceFeatureCatalog>) {
@@ -142,10 +145,25 @@ object FeatureManager {
         catalogs.forEach { catalog ->
             registerOptionalFeatures(catalog.optionalFeatures)
         }
+        catalogs.forEach { catalog ->
+            registerDeprecatedFeatures(catalog.deprecatedFeatures)
+        }
     }
 
     fun registerFeature(feature: AbstractFeature) {
         registeredFeatures[feature.name] = feature
+    }
+
+    fun registerDeprecatedFeatures(names: Collection<String>) {
+        deprecatedFeatures.addAll(names)
+    }
+
+    fun configuredFeature(name: String, action: String): AbstractFeature? {
+        registeredFeatures[name]?.let { return it }
+        check(name in deprecatedFeatures) {
+            "Could not $action feature \"$name\" as it's not loaded/registered by any catalog. Registered features are: ${registeredFeatures.keys}"
+        }
+        return null
     }
 
     fun getDefaultedFeatures() =
@@ -175,8 +193,12 @@ object FeatureManager {
         val config = ConfigManager.getConfig<FeatureConfig>()
 
         config.disabledFeatures.forEach { name ->
-            registeredFeatures[name]?.let { disableFeature(it) }
-                ?: error("Could not disable feature \"$name\" as it's not loaded/registered by any catalog. Registered features are: ${registeredFeatures.keys}")
+            val feature = configuredFeature(name, "disable")
+            if (feature == null) {
+                log.warn { "Ignoring deprecated feature flag \"$name\" listed in disabledFeatures. This flag no longer has any effect and can be removed from the configuration." }
+            } else {
+                disableFeature(feature)
+            }
         }
         log.info { "Disabled features (${disabledFeatures.size}): ${disabledFeatures.joinToString()}" }
 
@@ -190,11 +212,13 @@ object FeatureManager {
         }
 
         config.enabledFeatures.forEach { name ->
-            registeredFeatures[name]?.let { feature ->
+            val feature = configuredFeature(name, "enable")
+            if (feature == null) {
+                log.warn { "Ignoring deprecated feature flag \"$name\" listed in enabledFeatures. This flag no longer has any effect and can be removed from the configuration." }
+            } else {
                 log.info { "Enabling feature \"${feature.name}\"..." }
                 enableFeatureAndIfNotSucceededRun(feature) { _, ex -> failed += feature to ex }
             }
-                ?: error("Could not enable feature \"$name\" as it's not loaded/registered by any catalog. Registered features are: ${registeredFeatures.keys}")
         }
         log.info { "Enabled features (${enabledFeatures.size}): ${enabledFeatures.joinToString()}" }
 

--- a/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/featureflag/ServiceFeatureCatalog.kt
+++ b/waltid-services/waltid-service-commons/src/main/kotlin/id/walt/commons/featureflag/ServiceFeatureCatalog.kt
@@ -7,5 +7,7 @@ interface ServiceFeatureCatalog {
 
     val baseFeatures: List<BaseFeature>
     val optionalFeatures: List<OptionalFeature>
+    val deprecatedFeatures: List<String>
+        get() = emptyList()
 
 }

--- a/waltid-services/waltid-service-commons/src/test/kotlin/id/walt/commons/featureflag/FeatureManagerDeprecatedFlagsTest.kt
+++ b/waltid-services/waltid-service-commons/src/test/kotlin/id/walt/commons/featureflag/FeatureManagerDeprecatedFlagsTest.kt
@@ -1,0 +1,46 @@
+package id.walt.commons.featureflag
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class FeatureManagerDeprecatedFlagsTest {
+
+    @BeforeTest
+    fun setUp() = FeatureManager.preclear()
+
+    @AfterTest
+    fun tearDown() = FeatureManager.preclear()
+
+    @Test
+    fun `deprecated flags are ignored instead of throwing`() {
+        FeatureManager.registerDeprecatedFeatures(listOf("issuer2"))
+
+        assertNull(FeatureManager.configuredFeature("issuer2", "enable"))
+        assertNull(FeatureManager.configuredFeature("issuer2", "disable"))
+    }
+
+    @Test
+    fun `unknown flags that are not deprecated still throw`() {
+        val exception = assertFailsWith<IllegalStateException> {
+            FeatureManager.configuredFeature("not-a-real-flag", "enable")
+        }
+
+        assertEquals(
+            "Could not enable feature \"not-a-real-flag\" as it's not loaded/registered by any catalog. Registered features are: []",
+            exception.message
+        )
+    }
+
+    @Test
+    fun `registered features are resolved even when also marked deprecated`() {
+        val feature = OptionalFeature(name = "issuer2", description = "test", default = true)
+        FeatureManager.registerFeature(feature)
+        FeatureManager.registerDeprecatedFeatures(listOf("issuer2"))
+
+        assertEquals(feature, FeatureManager.configuredFeature("issuer2", "enable"))
+    }
+}


### PR DESCRIPTION
Allows old flags to be put into a deprecated list, which emits WARN logs rather than halting the application startup
ES:https://github.com/walt-id/waltid-identity-enterprise/pull/605