### PR TITLE
fix(oid4vp): align mobile EUDI verifier integration

### DIFF
--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
@@ -61,12 +61,14 @@ actor EudiTestBackend {
     }
 
     func createVerifierTransaction(credentialId: String = "eu.europa.ec.eudi.pid_vc_sd_jwt") async throws -> VerifierTransaction {
+        let intendedUseID = try await resolveVerifierIntendedUseID()
         let payload: [String: Any] = [
             "dcql_query": TestHelpers.buildDcqlQuery(credentialID: credentialId),
             "nonce": UUID().uuidString,
             "request_uri_method": "post",
             "profile": "openid4vp",
-            "authorization_request_uri": "openid4vp://"
+            "authorization_request_uri": "openid4vp://",
+            "intended_use_id": intendedUseID,
         ]
 
         let response = try await client.jsonRequest(
@@ -82,6 +84,32 @@ actor EudiTestBackend {
         }
 
         return VerifierTransaction(transactionId: transactionId, authorizationRequestUri: authRequestUri)
+    }
+
+    private func resolveVerifierIntendedUseID() async throws -> String {
+        let response = try await client.jsonRequest(
+            url: URL(string: "https://verifier-backend.eudiw.dev/ui/intended-uses")!
+        )
+
+        guard let intendedUses = response["intended_uses"] as? [[String: Any]] else {
+            throw NSError(
+                domain: "EudiTestBackend",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Verifier response did not contain an intended_uses array"]
+            )
+        }
+
+        if let intendedUseID = intendedUses
+            .compactMap({ $0["intended_use_id"] as? String })
+            .first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+            return intendedUseID
+        }
+
+        throw NSError(
+            domain: "EudiTestBackend",
+            code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "Verifier exposes no configured intended use"]
+        )
     }
 
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/EudiTestBackend.swift
@@ -33,6 +33,7 @@ actor EudiTestBackend {
 
     private let client = WalletE2EClient()
     private let offerFlow: EudiOfferFlow
+    private static let verifierBackendURL = URL(string: "https://verifier-backend.eudiw.dev")!
 
     private init() {
         self.offerFlow = EudiOfferFlow(client: client)
@@ -72,7 +73,7 @@ actor EudiTestBackend {
         ]
 
         let response = try await client.jsonRequest(
-            url: URL(string: "https://verifier-backend.eudiw.dev/ui/presentations/v2")!,
+            url: Self.verifierBackendURL.appendingPathComponent("ui/presentations/v2"),
             method: "POST",
             headers: ["Content-Type": "application/json"],
             body: Data(try jsonString(payload).utf8)
@@ -88,7 +89,7 @@ actor EudiTestBackend {
 
     private func resolveVerifierIntendedUseID() async throws -> String {
         let response = try await client.jsonRequest(
-            url: URL(string: "https://verifier-backend.eudiw.dev/ui/intended-uses")!
+            url: Self.verifierBackendURL.appendingPathComponent("ui/intended-uses")
         )
 
         guard let intendedUses = response["intended_uses"] as? [[String: Any]] else {

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/MobileWalletIntegrationTests.swift
@@ -319,18 +319,10 @@ final class MobileWalletIntegrationTests: XCTestCase {
     }
 
     func testReceiveAndPresentEudiPidSdJwtAgainstEudi() async throws {
-        try XCTSkipIf(
-            true,
-            "Upstream issue: https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/172"
-        )
         try await receiveAndPresentEudiCredential(credentialID: Self.eudiPidSdJwtCredentialID)
     }
 
     func testPreviewAndSubmitEudiPidSdJwtAgainstEudi() async throws {
-        try XCTSkipIf(
-            true,
-            "Upstream issue: https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/172"
-        )
         try await previewAndSubmitEudiCredential(credentialID: Self.eudiPidSdJwtCredentialID)
     }
 

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/EudiTestBackend.kt
@@ -167,14 +167,8 @@ object EudiTestBackend {
     }
 
     suspend fun createVerifierTransaction(credentialId: String = "eu.europa.ec.eudi.pid_vc_sd_jwt"): VerifierTransaction {
-        val dcqlQuery = buildDcqlQuery(credentialId)
-        val payload = buildJsonObject {
-            put("dcql_query", dcqlQuery)
-            put("nonce", JsonPrimitive(Uuid.random().toString()))
-            put("request_uri_method", JsonPrimitive("post"))
-            put("profile", JsonPrimitive("openid4vp"))
-            put("authorization_request_uri", JsonPrimitive("openid4vp://"))
-        }
+        val intendedUseId = resolveVerifierIntendedUseId()
+        val payload = buildVerifierTransactionPayload(credentialId, intendedUseId)
 
         val response = requestText(
             url = "$VERIFIER_BACKEND/ui/presentations/v2",
@@ -190,6 +184,38 @@ object EudiTestBackend {
 
         return VerifierTransaction(transactionId, authRequestUri)
     }
+
+    private suspend fun resolveVerifierIntendedUseId(): String {
+        val response = requestText("$VERIFIER_BACKEND/ui/intended-uses")
+        val responseJson = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        return intendedUseIdFromResponse(responseJson)
+    }
+
+    internal fun intendedUseIdFromResponse(response: JsonObject): String {
+        val intendedUses = response["intended_uses"] as? JsonArray
+            ?: error("EUDI verifier response did not contain an intended_uses array")
+
+        return intendedUses.asSequence()
+            .mapNotNull { intendedUse ->
+                (intendedUse as? JsonObject)
+                    ?.get("intended_use_id")
+                    ?.let { it as? JsonPrimitive }
+                    ?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+            }
+            .firstOrNull()
+            ?: error("EUDI verifier exposes no configured intended use")
+    }
+
+    internal fun buildVerifierTransactionPayload(credentialId: String, intendedUseId: String): JsonObject =
+        buildJsonObject {
+            put("dcql_query", buildDcqlQuery(credentialId))
+            put("nonce", JsonPrimitive(Uuid.random().toString()))
+            put("request_uri_method", JsonPrimitive("post"))
+            put("profile", JsonPrimitive("openid4vp"))
+            put("authorization_request_uri", JsonPrimitive("openid4vp://"))
+            put("intended_use_id", JsonPrimitive(intendedUseId))
+        }
 
     suspend fun waitForVerifierSuccess(transactionId: String, timeoutMs: Long = 90_000) {
         val mark = TimeSource.Monotonic.markNow()

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/EudiTestBackendTest.kt
@@ -2,16 +2,64 @@ package id.walt.mobile.test.backend
 
 import io.ktor.http.encodeURLParameter
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class EudiTestBackendTest {
+    @Test
+    fun selectsFirstNonBlankConfiguredIntendedUse() {
+        val response = buildJsonObject {
+            putJsonArray("intended_uses") {
+                addJsonObject {
+                    put("intended_use_id", JsonPrimitive("  "))
+                }
+                addJsonObject {
+                    put("intended_use_id", JsonPrimitive("configured-use"))
+                }
+                addJsonObject {
+                    put("intended_use_id", JsonPrimitive("later-use"))
+                }
+            }
+        }
+
+        assertEquals("configured-use", EudiTestBackend.intendedUseIdFromResponse(response))
+    }
+
+    @Test
+    fun rejectsVerifierResponseWithoutConfiguredIntendedUse() {
+        val response = buildJsonObject {
+            putJsonArray("intended_uses") {
+                addJsonObject {
+                    put("description", JsonPrimitive("missing id"))
+                }
+            }
+        }
+
+        assertFailsWith<IllegalStateException> {
+            EudiTestBackend.intendedUseIdFromResponse(response)
+        }
+    }
+
+    @Test
+    fun addsIntendedUseIdWithoutSendingRegistrationCertificate() {
+        val payload = EudiTestBackend.buildVerifierTransactionPayload(
+            credentialId = "eu.europa.ec.eudi.ehic_sd_jwt_vc",
+            intendedUseId = "configured-use",
+        )
+
+        assertEquals("configured-use", payload["intended_use_id"]?.jsonPrimitive?.content)
+        assertFalse(payload.containsKey("registration_certificate"))
+    }
+
     @Test
     fun buildsEhicSdJwtVerifierQuery() {
         val query = EudiTestBackend.buildDcqlQuery("eu.europa.ec.eudi.ehic_sd_jwt_vc").jsonObject

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -41,7 +41,6 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import org.junit.Ignore
 import org.junit.Test
 import java.util.Base64
 import java.util.UUID
@@ -145,13 +144,11 @@ class MobileWalletIntegrationTest {
         previewAndSubmitEudiCredential(EUDI_EHIC_SD_JWT_CREDENTIAL_ID)
     }
 
-    @Ignore("Upstream issue: https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/172")
     @Test
     fun receiveAndPresentEudiPidSdJwtAgainstEudi() = runBlocking {
         receiveAndPresentEudiCredential(EUDI_PID_SD_JWT_CREDENTIAL_ID)
     }
 
-    @Ignore("Upstream issue: https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/172")
     @Test
     fun previewAndSubmitEudiPidSdJwtAgainstEudi() = runBlocking {
         previewAndSubmitEudiCredential(EUDI_PID_SD_JWT_CREDENTIAL_ID)

--- a/waltid-libraries/protocols/waltid-openid4vp/src/commonMain/kotlin/id/walt/verifier/openid/models/credentials/AttestationFormat.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp/src/commonMain/kotlin/id/walt/verifier/openid/models/credentials/AttestationFormat.kt
@@ -13,5 +13,7 @@ import kotlinx.serialization.Serializable
 enum class AttestationFormat {
     @SerialName("jwt")
     JWT,
-    // Other attestation formats can be added here
+
+    @SerialName("registration_cert")
+    REGISTRATION_CERT,
 }

--- a/waltid-libraries/protocols/waltid-openid4vp/src/commonTest/kotlin/id/walt/verifier/openid/models/authorization/VerifierInfoItemTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp/src/commonTest/kotlin/id/walt/verifier/openid/models/authorization/VerifierInfoItemTest.kt
@@ -1,0 +1,28 @@
+package id.walt.verifier.openid.models.authorization
+
+import id.walt.verifier.openid.models.credentials.AttestationFormat
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VerifierInfoItemTest {
+    @Test
+    fun decodesRegistrationCertificateVerifierInfo() {
+        val request = Json.decodeFromString<AuthorizationRequest>(
+            """
+            {
+              "verifier_info": [
+                {
+                  "format": "registration_cert",
+                  "data": "signed-registration-certificate"
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        val verifierInfo = requireNotNull(request.verifierInfo).single()
+        assertEquals(AttestationFormat.REGISTRATION_CERT, verifierInfo.format)
+        assertEquals("signed-registration-certificate", verifierInfo.data)
+    }
+}


### PR DESCRIPTION
## Summary

Update the mobile EUDI test adapters to follow the verifier's current transaction initialization contract and accept the registration certificate verifier-info format emitted by the live service.

The current EUDI PID SD-JWT mobile integration flows are enabled again after the shared path was verified on Android and iOS.

## What Changed

### EUDI verifier transaction setup

- Discover the first usable `intended_use_id` from `/ui/intended-uses` in the Kotlin and native iOS adapters.
- Include only `intended_use_id` in `/ui/presentations/v2`; do not copy or transmit registration certificate material.
- Add focused Kotlin coverage for discovery selection, empty-response failure, and payload shape.
- Re-enable the Android and iOS EUDI PID SD-JWT receive/present and preview/submit integration tests.

### OpenID4VP model compatibility

- Add `registration_cert` as a serialized `AttestationFormat` value so current EUDI Authorization Requests decode on Android and iOS.
- Add regression coverage for `verifier_info` decoding.

## Architecture Notes

- The verifier owns its configured WRPRC and certificate lifecycle; clients discover its ID rather than hardcoding a deployment-specific ID or embedding a JWS.
- The existing verifier trust anchor remains separate from WRPRC data.
- No production wallet presentation behavior or retry logic changes.

## Caveats and Follow-Ups

- The live EUDI endpoint is external; the Android and iOS PID and EHIC E2E cases remain acceptance coverage.
- Upstream [issue #172](https://github.com/eu-digital-identity-wallet/eudi-srv-web-issuing-eudiw-py/issues/172) remains open for a direct PID trust-validator configuration problem. The current mobile E2E flows pass and are no longer skipped for that issue.
- No breaking public API change is intended; `registration_cert` only extends the accepted serialized enum values.

## Breaking

None.
