### PR TITLE
[WAL-1294] fix(mobile): align public demo flows with 1.0.0-PRE contracts

### DIFF
--- a/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
+++ b/waltid-applications/mobile-e2e-fixtures/ios/TestHelpers/DemoBackend.swift
@@ -24,7 +24,7 @@ public final class DemoBackend {
     private static let eudiPidSdJwtVct = "https://issuer2.demo.walt.id/openid4vci/urn:eudi:pid:1"
     public static let transactionDataProfilesURL = URL(string: "https://wallet.demo.walt.id/wallet-api/transaction-data-profiles")!
     private static let paymentAuthorizationType = "org.waltid.transaction-data.payment-authorization"
-    private static let requiredPaymentAuthorizationFields: Set<String> = ["amount", "currency", "payee"]
+    private static let requiredPaymentAuthorizationFields: Set<String> = ["merchant_name", "amount", "currency"]
 
     public static let scenarios: [DemoCredentialScenario] = [
         DemoCredentialScenario(
@@ -358,9 +358,9 @@ public final class DemoBackend {
             "require_cryptographic_holder_binding": true,
             "transaction_data_hashes_alg": ["sha-256"],
         ]
+        payload.putProfileField(fields: fields, key: "merchant_name", value: "ACME Corp")
         payload.putProfileField(fields: fields, key: "amount", value: "42.00")
         payload.putProfileField(fields: fields, key: "currency", value: "EUR")
-        payload.putProfileField(fields: fields, key: "payee", value: "ACME Corp")
         return payload
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialSharingE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialSharingE2ETest.kt
@@ -63,7 +63,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.security.MessageDigest
@@ -211,11 +210,6 @@ class DigitalCredentialSharingE2ETest {
      *    prompt still renders, and the transaction data binds to the payment card alone.
      */
     @Test
-    @Ignore(
-        "Enable once the urn:eudi:sca:payment:1 transaction data profile, the scaPaymentCardMdoc " +
-            "issuance profile from this branch and euAgeVerificationMdoc are deployed together to " +
-            "verifier2.demo.walt.id and issuer2.demo.walt.id.",
-    )
     fun sharesMdocWithScaPaymentTransactionDataAndSecondCredential() = runBlocking {
         val fixture = start() ?: return@runBlocking
         val scaScenario = DemoTestBackend.presentationScenarios.first { it.id == "sca-payment-card" }

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PublicDemoBackendE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/PublicDemoBackendE2ETest.kt
@@ -249,10 +249,10 @@ class PublicDemoBackendE2ETest {
         )
         assertClaimValueVisibleAfterScrolling(
             device = device,
-            path = "transactionData[0].details.payee",
-            label = "Payee",
+            path = "transactionData[0].details.merchant_name",
+            label = "Merchant name",
             expectedValues = listOf("ACME Corp"),
-            message = "Payment payee missing",
+            message = "Payment merchant name missing",
         )
     }
 

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidHostTest/kotlin/id/walt/walletdemo/compose/logic/MobileDigitalCredentialSharingReviewTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidHostTest/kotlin/id/walt/walletdemo/compose/logic/MobileDigitalCredentialSharingReviewTest.kt
@@ -33,16 +33,16 @@ class MobileDigitalCredentialSharingReviewTest {
             transactionData = listOf(
                 transactionDataItem(
                     displayName = "Payment Authorization",
-                    detailsJson = """{"amount":"42.00","currency":"EUR","payee":"ACME Corp"}""",
+                    detailsJson = """{"merchant_name":"ACME Corp","amount":"42.00","currency":"EUR"}""",
                 ),
             ),
         ).toSharingReview()
 
         val payment = review.request.transactionData.single()
         assertEquals("Payment Authorization", payment.title)
+        assertEquals("ACME Corp", payment.textValue("Merchant name"))
         assertEquals("42.00", payment.textValue("Amount"))
         assertEquals("EUR", payment.textValue("Currency"))
-        assertEquals("ACME Corp", payment.textValue("Payee"))
     }
 
     /** Each item must survive the mapping: showing only the first authorizes the rest unseen. */

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayNormalizerTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/commonTest/kotlin/id/walt/walletdemo/compose/logic/CredentialDisplayNormalizerTest.kt
@@ -922,21 +922,21 @@ class CredentialDisplayNormalizerTest {
                     type = "org.waltid.transaction-data.payment-authorization",
                     displayName = "Payment Authorization",
                     credentialQueryIds = listOf("pid", "payment"),
-                    supportedFields = listOf("amount", "currency", "payee"),
+                    supportedFields = listOf("merchant_name", "amount", "currency"),
                     detailsJson = """
                         {
+                          "merchant_name": "ACME Corp",
                           "amount": "42.00",
-                          "currency": "EUR",
-                          "payee": "ACME Corp"
+                          "currency": "EUR"
                         }
                     """.trimIndent(),
                     rawJson = """
                         {
                           "type": "org.waltid.transaction-data.payment-authorization",
                           "credential_ids": ["pid", "payment"],
+                          "merchant_name": "ACME Corp",
                           "amount": "42.00",
-                          "currency": "EUR",
-                          "payee": "ACME Corp"
+                          "currency": "EUR"
                         }
                     """.trimIndent(),
                 )
@@ -953,14 +953,14 @@ class CredentialDisplayNormalizerTest {
 
         assertEquals("Payment Authorization", payment.title)
         assertEquals(
-            listOf("Amount", "Currency", "Payee"),
+            listOf("Merchant name", "Amount", "Currency"),
             payment.items.take(3).map { it.label },
         )
         assertEquals("org.waltid.transaction-data.payment-authorization", labelsToValues["Type"])
         assertEquals("pid, payment", labelsToValues["Credential queries"])
+        assertEquals("ACME Corp", labelsToValues["Merchant name"])
         assertEquals("42.00", labelsToValues["Amount"])
         assertEquals("EUR", labelsToValues["Currency"])
-        assertEquals("ACME Corp", labelsToValues["Payee"])
     }
 
     @Test

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
@@ -812,21 +812,21 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
                     type: "org.waltid.transaction-data.payment-authorization",
                     displayName: "Payment Authorization",
                     credentialQueryIDs: ["pid", "payment"],
-                    supportedFields: ["amount", "currency", "payee"],
+                    supportedFields: ["merchant_name", "amount", "currency"],
                     rawJSON: """
                     {
                       "type": "org.waltid.transaction-data.payment-authorization",
                       "credential_ids": ["pid", "payment"],
+                      "merchant_name": "ACME Corp",
                       "amount": "42.00",
-                      "currency": "EUR",
-                      "payee": "ACME Corp"
+                      "currency": "EUR"
                     }
                     """,
                     detailsJSON: """
                     {
+                      "merchant_name": "ACME Corp",
                       "amount": "42.00",
-                      "currency": "EUR",
-                      "payee": "ACME Corp"
+                      "currency": "EUR"
                     }
                     """
                 )
@@ -839,12 +839,12 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
         })
 
         XCTAssertEqual(payment.title, "Payment Authorization")
-        XCTAssertEqual(Array(payment.items.prefix(3).map(\.label)), ["Amount", "Currency", "Payee"])
+        XCTAssertEqual(Array(payment.items.prefix(3).map(\.label)), ["Merchant name", "Amount", "Currency"])
         XCTAssertEqual(valuesByLabel["Type"], "org.waltid.transaction-data.payment-authorization")
         XCTAssertEqual(valuesByLabel["Credential queries"], "pid, payment")
+        XCTAssertEqual(valuesByLabel["Merchant name"], "ACME Corp")
         XCTAssertEqual(valuesByLabel["Amount"], "42.00")
         XCTAssertEqual(valuesByLabel["Currency"], "EUR")
-        XCTAssertEqual(valuesByLabel["Payee"], "ACME Corp")
     }
 
     func testParsesStoredIssuerDisplayFromMetadataJSON() {

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -10,7 +10,6 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -42,8 +41,7 @@ object DemoTestBackend {
     const val SCA_PAYMENT_CURRENCY = "EUR"
     const val SCA_PAYMENT_AMOUNT = 11.56
     const val SCA_PAYMENT_TRANSACTION_ID = "8D8AC610-566D-4EF0-9C22-186B2A5ED793"
-    // The fields the currently deployed profile declares, not the ones #2062 configures.
-    private val requiredPaymentAuthorizationFields = setOf("amount", "currency", "payee")
+    private val requiredPaymentAuthorizationFields = setOf("merchant_name", "amount", "currency")
 
     val scenarios = listOf(
         CredentialScenario(
@@ -211,22 +209,28 @@ object DemoTestBackend {
         transactionData = listOf(paymentAuthorizationTransactionData("pid")),
     )
 
-    /**
-     * One `payment-authorization` transaction data item bound to [credentialId], with the fields the
-     * deployed profile declares.
-     *
-     * The profile is fetched rather than assumed, so a deployment that stops declaring `amount`,
-     * `currency` or `payee` fails here instead of producing an item whose fields a test cannot find on
-     * screen for a reason it would misattribute to the wallet. `payee` is required only for as long as
-     * the deployed profile is the pre-#2062 one.
-     */
+    /** One generic payment-authorization item using the current public-demo profile contract. */
     suspend fun paymentAuthorizationTransactionData(credentialId: String): JsonObject {
         val fields = transactionDataProfileFields(PAYMENT_AUTHORIZATION_TYPE)
         check(fields.containsAll(requiredPaymentAuthorizationFields)) {
             "Public demo transaction data profile '$PAYMENT_AUTHORIZATION_TYPE' is missing required fields: " +
                 (requiredPaymentAuthorizationFields - fields).joinToString()
         }
-        return paymentAuthorizationTransactionData(credentialId, fields)
+        return buildPaymentAuthorizationTransactionData(credentialId)
+    }
+
+    internal fun buildPaymentAuthorizationTransactionData(credentialId: String): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive(PAYMENT_AUTHORIZATION_TYPE))
+        putJsonArray("credential_ids") {
+            add(JsonPrimitive(credentialId))
+        }
+        put("require_cryptographic_holder_binding", JsonPrimitive(true))
+        putJsonArray("transaction_data_hashes_alg") {
+            add(JsonPrimitive("sha-256"))
+        }
+        put("merchant_name", JsonPrimitive("ACME Corp"))
+        put("amount", JsonPrimitive("42.00"))
+        put("currency", JsonPrimitive("EUR"))
     }
 
     /**
@@ -368,38 +372,12 @@ object DemoTestBackend {
         require(expectedOrigins.isNotEmpty()) { "DC API sessions require at least one expected origin" }
         require(credentialQueries.isNotEmpty()) { "DC API sessions require at least one DCQL credential query" }
 
-        val payload = buildJsonObject {
-            // Deliberately the *old* wire names. `20e20a539` renamed this flow's discriminator to
-            // "dc_api_openid4vp" and its core config to "core_flow", but verifier2.demo.walt.id -
-            // which these tests run against - is still serving a pre-rename build and answers the new
-            // names with HTTP 400 "Serializer for subclass 'dc_api_openid4vp' is not found". The two
-            // names move together: "dc_api" + "core_flow" is also a 400.
-            //
-            // Switch both to "dc_api_openid4vp" / "core_flow" once the demo verifier is redeployed
-            // from main; until then the new names would fail the whole DC API suite on the deployment
-            // rather than on anything this test exercises.
-            put("flow_type", "dc_api")
-            putJsonObject("core") {
-                putJsonObject("dcql_query") {
-                    putJsonArray("credentials") {
-                        credentialQueries.forEach { add(it) }
-                    }
-                }
-                if (encryptedResponse) put("encrypted_response", JsonPrimitive(true))
-            }
-            if (transactionData.isNotEmpty()) {
-                putJsonObject("openid") {
-                    putJsonArray("transactionData") {
-                        transactionData.forEach { add(it) }
-                    }
-                }
-            }
-            // No vp_policies override: the verifier applies its full default mdoc policy set, so a policy
-            // regression is visible here instead of silently skipped.
-            putJsonArray("expectedOrigins") {
-                expectedOrigins.forEach { add(JsonPrimitive(it)) }
-            }
-        }
+        val payload = buildDcApiVerifierSessionPayload(
+            credentialQueries = credentialQueries,
+            expectedOrigins = expectedOrigins,
+            encryptedResponse = encryptedResponse,
+            transactionData = transactionData,
+        )
 
         val response = requestJson(
             url = "$VERIFIER_BASE_URL/verification-session/create",
@@ -412,6 +390,35 @@ object DemoTestBackend {
             sessionId = sessionId,
             requestJson = dcApiRequestJson(sessionId),
         )
+    }
+
+    internal fun buildDcApiVerifierSessionPayload(
+        credentialQueries: List<JsonObject>,
+        expectedOrigins: List<String>,
+        encryptedResponse: Boolean = false,
+        transactionData: List<JsonObject> = emptyList(),
+    ): JsonObject = buildJsonObject {
+        put("flow_type", "dc_api_openid4vp")
+        putJsonObject("core_flow") {
+            putJsonObject("dcql_query") {
+                putJsonArray("credentials") {
+                    credentialQueries.forEach { add(it) }
+                }
+            }
+            if (encryptedResponse) put("encrypted_response", JsonPrimitive(true))
+        }
+        if (transactionData.isNotEmpty()) {
+            putJsonObject("openid") {
+                putJsonArray("transactionData") {
+                    transactionData.forEach { add(it) }
+                }
+            }
+        }
+        // No vp_policies override: the verifier applies its full default mdoc policy set, so a policy
+        // regression is visible here instead of silently skipped.
+        putJsonArray("expectedOrigins") {
+            expectedOrigins.forEach { add(JsonPrimitive(it)) }
+        }
     }
 
     /**
@@ -444,30 +451,6 @@ object DemoTestBackend {
             error("HTTP ${response.status.value} from verifier2 DC API response for $sessionId: $body")
         }
         return body
-    }
-
-    private fun paymentAuthorizationTransactionData(
-        credentialId: String,
-        fields: Set<String>,
-    ): JsonObject = buildJsonObject {
-        put("type", JsonPrimitive(PAYMENT_AUTHORIZATION_TYPE))
-        putJsonArray("credential_ids") {
-            add(JsonPrimitive(credentialId))
-        }
-        put("require_cryptographic_holder_binding", JsonPrimitive(true))
-        putJsonArray("transaction_data_hashes_alg") {
-            add(JsonPrimitive("sha-256"))
-        }
-        // Credential Manager consumes merchant_name/amount, so merchant_name is sent whether or not the
-        // deployed profile declares it yet.
-        put("merchant_name", JsonPrimitive("ACME Corp"))
-        putProfileField(fields, "amount", "42.00")
-        putProfileField(fields, "currency", "EUR")
-        // TODO: Remove `payee` once the transaction-data profile from #2062 is deployed to
-        //  wallet.demo.walt.id and verifier2.demo.walt.id. The repository config already declares
-        //  merchant_name/amount/currency; the deployed one still declares payee, and the fields are
-        //  resolved from it at run time.
-        putProfileField(fields, "payee", "ACME Corp")
     }
 
     suspend fun verifierSessionInfo(sessionId: String): JsonObject {
@@ -640,12 +623,6 @@ object DemoTestBackend {
 
     private fun claimSet(vararg claimIds: String) = kotlinx.serialization.json.buildJsonArray {
         claimIds.forEach { add(JsonPrimitive(it)) }
-    }
-
-    private fun JsonObjectBuilder.putProfileField(fields: Set<String>, key: String, value: String) {
-        if (key in fields) {
-            put(key, JsonPrimitive(value))
-        }
     }
 
     private val json = kotlinx.serialization.json.Json {

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/DemoTestBackendContractTest.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonTest/kotlin/id/walt/mobile/test/backend/DemoTestBackendContractTest.kt
@@ -1,0 +1,43 @@
+package id.walt.mobile.test.backend
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DemoTestBackendContractTest {
+
+    @Test
+    fun dcApiVerifierSessionUsesCurrentAnnexDWireShape() {
+        val payload = DemoTestBackend.buildDcApiVerifierSessionPayload(
+            credentialQueries = listOf(buildJsonObject { put("id", JsonPrimitive("query")) }),
+            expectedOrigins = listOf("android:apk-key-hash:test"),
+            encryptedResponse = true,
+        )
+
+        assertEquals("dc_api_openid4vp", payload["flow_type"]?.jsonPrimitive?.content)
+        assertTrue("core_flow" in payload)
+        assertFalse("core" in payload)
+        assertTrue("encrypted_response" in payload["core_flow"]!!.jsonObject)
+        assertEquals(
+            "android:apk-key-hash:test",
+            payload["expectedOrigins"]!!.jsonArray.single().jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun genericPaymentTransactionDataUsesCurrentFlatProfile() {
+        val transactionData = DemoTestBackend.buildPaymentAuthorizationTransactionData("pid")
+
+        assertEquals("ACME Corp", transactionData["merchant_name"]?.jsonPrimitive?.content)
+        assertEquals("42.00", transactionData["amount"]?.jsonPrimitive?.content)
+        assertEquals("EUR", transactionData["currency"]?.jsonPrimitive?.content)
+        assertFalse("payee" in transactionData)
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidDeviceTest/kotlin/id/walt/wallet2/mobile/test/MobileWalletIntegrationTest.kt
@@ -70,7 +70,7 @@ class MobileWalletIntegrationTest {
         private const val EUDI_EHIC_SD_JWT_CREDENTIAL_ID = "eu.europa.ec.eudi.ehic_sd_jwt_vc"
 
         private val DEMO_TRANSACTION_DATA_PROFILES = demoTransactionDataProfiles(
-            paymentAuthorizationFields = listOf("amount", "currency", "payee"),
+            paymentAuthorizationFields = listOf("merchant_name", "amount", "currency"),
         )
 
         private fun demoTransactionDataProfiles(
@@ -205,7 +205,7 @@ class MobileWalletIntegrationTest {
         assertTrue(
             transactionData.detailsJson.contains("\"amount\":\"42.00\"") &&
                 transactionData.detailsJson.contains("\"currency\":\"EUR\"") &&
-                transactionData.detailsJson.contains("\"payee\":\"ACME Corp\""),
+                transactionData.detailsJson.contains("\"merchant_name\":\"ACME Corp\""),
             "Preview should expose readable payment details: ${transactionData.detailsJson}",
         )
         val result = client.submitPresentation(


### PR DESCRIPTION
Fixes WAL-1294.

- Aligns the public wallet/verifier helpers with the v1.0.0-PRE demo contract.
- Uses `dc_api_openid4vp` with `core_flow` for DC API verifier sessions.
- Uses the current flat payment transaction-data profile and keeps SCA-specific nested payee data intact.
- Enables the combined SCA + EU age Android sharing path now that the public prerequisites are live.