### PR TITLE
[WAL-820] fix(test) Make the DC API issuance E2E actually verify issuance

### DIFF
--- a/.github/scripts/mobile-ci/configure-android-device-phase.sh
+++ b/.github/scripts/mobile-ci/configure-android-device-phase.sh
@@ -19,7 +19,7 @@ case "$phase" in
     # The default image has no Google Play services. Keep GMS-only classes out of
     # instrumentation discovery; their class-level assumption would otherwise
     # collapse the reported test count and make Gradle fail the phase.
-    compose_demo_excluded_classes="id.walt.walletdemo.compose.android.DigitalCredentialSharingE2ETest"
+    compose_demo_excluded_classes="id.walt.walletdemo.compose.android.DigitalCredentialSharingE2ETest,id.walt.walletdemo.compose.android.DigitalCredentialIssuanceE2ETest"
     script="ANDROID_TEST_NOT_CLASS=$compose_demo_excluded_classes ./waltid-identity/.github/scripts/mobile-ci/run-android-compose-demo-tests.sh"
     emulator_options="-no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim"
     report_paths="waltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/outputs/androidTest-results/**/*.xml"
@@ -27,8 +27,8 @@ case "$phase" in
     emulator_target="default"
     ;;
   dc-api-compose)
-    # Dedicated Play Store lane for the class-level GMS-gated sharing E2Es.
-    dc_api_test_classes="id.walt.walletdemo.compose.android.DigitalCredentialSharingE2ETest"
+    # Dedicated Play Store lane for the GMS-gated Digital Credentials E2Es.
+    dc_api_test_classes="id.walt.walletdemo.compose.android.DigitalCredentialSharingE2ETest,id.walt.walletdemo.compose.android.DigitalCredentialIssuanceE2ETest"
     script="ANDROID_TEST_CLASS=$dc_api_test_classes ./waltid-identity/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh"
     # The cached artifact is the configured userdata disk, not a Quick Boot state. Always cold-boot
     # it so the first process/ADB/GMS state is recreated for every job and never restored from a

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialIssuanceE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialIssuanceE2ETest.kt
@@ -2,29 +2,28 @@ package id.walt.walletdemo.compose.android
 
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
-import androidx.credentials.CreateDigitalCredentialResponse
 import androidx.credentials.ExperimentalDigitalCredentialApi
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
 import id.walt.mobile.test.backend.DemoTestBackend
-import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.CREDENTIAL_OPERATION_TIMEOUT
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.UI_ELEMENT_TIMEOUT
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.assertClaimValueVisibleAfterScrolling
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.clickByTag
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.launchAndUnlock
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.relaunchAndUnlock
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.scrollDown
+import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.scrollUp
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.setTextByTag
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.waitForResource
+import java.util.regex.Pattern
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.fail
 import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +32,15 @@ import org.junit.runner.RunWith
  * OS-mediated Digital Credentials create E2E for OpenID4VCI pre-authorized offers.
  *
  * Requires Google Play services, so only the dedicated Play Store lane should run it.
+ *
+ * Success is asserted from the issuer session and the wallet's own storage, not from the
+ * `CreateDigitalCredentialResponse`. The provider acknowledgment is a fixed `{"data":{}}` payload
+ * built from constants in `AndroidDigitalCredentialCreateProvider`, so it is byte-identical whether
+ * or not a credential was issued. It is also not reliably delivered: GMS reports the create result
+ * through `reportDummyResult()`, which omits `ACTIVITY_REQUEST_CODE_TAG`, and
+ * `CreateDigitalCredentialController` drops any result whose request code does not match, so the
+ * `CredentialManager.createCredential` continuation is never resumed. The Get controller has a
+ * branch for that case; the Create controller does not, up to and including 1.7.0-alpha03.
  */
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalDigitalCredentialApi::class)
@@ -42,7 +50,7 @@ class DigitalCredentialIssuanceE2ETest {
     fun acceptsPreAuthorizedOfferThroughCreateCredential() = runBlocking {
         val fixture = start() ?: return@runBlocking
         val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
-        val offer = DemoTestBackend.createOffer(scenario)
+        val offer = DemoTestBackend.createOffer(scenario, inlineOffer = true)
         val offerJson = requireNotNull(Uri.parse(offer.offerUrl).getQueryParameter("credential_offer")) {
             "Demo offer URL did not carry an inline credential_offer"
         }
@@ -58,19 +66,8 @@ class DigitalCredentialIssuanceE2ETest {
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
         )
 
-        val candidate = fixture.device.wait(
-            Until.findObject(By.textContains("walt.id")),
-            UI_ELEMENT_TIMEOUT,
-        ) ?: fixture.device.wait(
-            Until.findObject(By.textContains("Wallet")),
-            UI_ELEMENT_TIMEOUT,
-        )
-        assertNotNull("Credential Manager did not surface the wallet create option", candidate)
-        candidate.click()
-
-        val continueButton = fixture.device.wait(Until.findObject(By.res("continue_button")), UI_ELEMENT_TIMEOUT)
-            ?: fixture.device.wait(Until.findObject(By.text("Continue")), UI_ELEMENT_TIMEOUT)
-        continueButton?.click()
+        fixture.device.selectWalletCreateCandidate()
+        fixture.device.confirmSelectorIfAsked()
 
         assertNotNull(
             "Wallet create offer review did not open",
@@ -78,17 +75,19 @@ class DigitalCredentialIssuanceE2ETest {
         )
         clickByTag(fixture.device, "wallet.offerAcceptButton")
 
-        val response = withTimeout(CREDENTIAL_OPERATION_TIMEOUT) {
-            DigitalCredentialTestIssuer.await().getOrThrow()
-        }
-        assertIsCreateAck(response)
+        DemoTestBackend.waitForIssuerIssuanceSuccess(offer.offerId)
+        fixture.assertStoredCredentialIs(scenario)
     }
 
     @Test
     fun acceptsPreAuthorizedOfferWithTransactionCodeThroughCreateCredential() = runBlocking {
         val fixture = start() ?: return@runBlocking
         val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
-        val offer = DemoTestBackend.createOffer(scenario, withGeneratedTransactionCode = true)
+        val offer = DemoTestBackend.createOffer(
+            scenario,
+            withGeneratedTransactionCode = true,
+            inlineOffer = true,
+        )
         val txCode = requireNotNull(offer.txCode) { "Issuer did not return a transaction code" }
         val offerJson = requireNotNull(Uri.parse(offer.offerUrl).getQueryParameter("credential_offer")) {
             "Demo offer URL did not carry an inline credential_offer"
@@ -105,19 +104,8 @@ class DigitalCredentialIssuanceE2ETest {
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
         )
 
-        val candidate = fixture.device.wait(
-            Until.findObject(By.textContains("walt.id")),
-            UI_ELEMENT_TIMEOUT,
-        ) ?: fixture.device.wait(
-            Until.findObject(By.textContains("Wallet")),
-            UI_ELEMENT_TIMEOUT,
-        )
-        assertNotNull("Credential Manager did not surface the wallet create option", candidate)
-        candidate.click()
-
-        val continueButton = fixture.device.wait(Until.findObject(By.res("continue_button")), UI_ELEMENT_TIMEOUT)
-            ?: fixture.device.wait(Until.findObject(By.text("Continue")), UI_ELEMENT_TIMEOUT)
-        continueButton?.click()
+        fixture.device.selectWalletCreateCandidate()
+        fixture.device.confirmSelectorIfAsked()
 
         assertNotNull(
             "Wallet create offer review did not open",
@@ -130,19 +118,136 @@ class DigitalCredentialIssuanceE2ETest {
         setTextByTag(fixture.device, "wallet.txCodeInput", txCode)
         clickByTag(fixture.device, "wallet.offerAcceptButton")
 
-        val response = withTimeout(CREDENTIAL_OPERATION_TIMEOUT) {
-            DigitalCredentialTestIssuer.await().getOrThrow()
+        DemoTestBackend.waitForIssuerIssuanceSuccess(offer.offerId)
+        fixture.assertStoredCredentialIs(scenario)
+    }
+
+    /**
+     * Picks the wallet entry in the Credential Manager create picker.
+     *
+     * Scoped to [CREDENTIAL_SELECTOR_PACKAGE] because the wallet Activity is itself in the
+     * foreground when the picker is requested, and its own header reads "walt.id Wallet": an
+     * unscoped text match resolves that non-clickable TextView before the picker window is even
+     * added, so the click lands nowhere and the flow never starts.
+     */
+    private fun UiDevice.selectWalletCreateCandidate() {
+        val picker = By.pkg(CREDENTIAL_SELECTOR_PACKAGE)
+        val candidate = wait(Until.findObject(By.copy(picker).textContains("walt.id")), UI_ELEMENT_TIMEOUT)
+            ?: wait(Until.findObject(By.copy(picker).textContains("Wallet")), UI_ELEMENT_TIMEOUT)
+        assertNotNull("Credential Manager did not surface the wallet create option", candidate)
+        // The row's clickable node is an ancestor of the label when the picker lists candidates. On
+        // builds that pre-select the only candidate the label has no clickable ancestor at all, and
+        // the flow advances through the confirmation step instead, so this must not be fatal.
+        val target = requireNotNull(candidate)
+        (target.clickableAncestorOrSelf() ?: target).click()
+        waitForIdle()
+    }
+
+    /** Some builds add a confirmation step between candidate selection and the provider. */
+    private fun UiDevice.confirmSelectorIfAsked() {
+        val picker = By.pkg(CREDENTIAL_SELECTOR_PACKAGE)
+        val confirm = wait(Until.findObject(By.copy(picker).res("continue_button")), CONFIRM_STEP_TIMEOUT)
+            ?: wait(Until.findObject(By.copy(picker).text("Continue")), CONFIRM_STEP_TIMEOUT)
+        confirm?.clickableAncestorOrSelf()?.click()
+        waitForIdle()
+    }
+
+    private fun UiObject2.clickableAncestorOrSelf(): UiObject2? {
+        var node: UiObject2? = this
+        while (node != null) {
+            if (node.isClickable) return node
+            node = node.parent
         }
-        assertIsCreateAck(response)
+        return null
     }
 
-    private fun assertIsCreateAck(response: CreateDigitalCredentialResponse) {
-        val body = Json.parseToJsonElement(response.responseJson).jsonObject
-        assertEquals("openid4vci-v1", body["protocol"]?.jsonPrimitive?.content)
-        assertEquals("{}", body["data"]?.toString())
+    /**
+     * Asserts the wallet actually stored the credential [scenario] describes.
+     *
+     * The create flow runs in `DigitalCredentialCreateActivity`, which builds its own wallet instance
+     * and never reports into the main UI's status line, so the only wallet-side proof is the stored
+     * credential itself. Its card test tag is keyed by a wallet-local id, hence the tag pattern plus
+     * an assertion on the rendered doctype, which is the scenario's credential configuration id.
+     */
+    private fun Fixture.assertStoredCredentialIs(scenario: DemoTestBackend.CredentialScenario) {
+        relaunchAndUnlock(context, device)
+        clickByTag(device, "wallet.tab.credentials")
+
+        // Both methods issue the same doctype, and another test may already have stored one, so
+        // existence of that doctype alone cannot prove this issuance succeeded.
+        val card = device.waitForNewCredentialCard(preexistingCardTags)
+        if (card == null) {
+            fail(
+                "Wallet stored no new credential after the create flow " +
+                    "(cards before: $preexistingCardTags, after: ${device.credentialCardTags()})"
+            )
+            return
+        }
+        val cardTag = requireNotNull(card.resourceName) { "Credential card is missing its test tag" }
+        // Via clickByTag rather than card.click(): the scroll sweep above may have left the node
+        // stale or off screen, and clickByTag re-resolves and scrolls the tag into view.
+        clickByTag(device, cardTag)
+
+        val detailsTag = cardTag.replace("wallet.credentialCard.", "wallet.credentialDetails.")
+        assertNotNull(
+            "Credential details did not open for $cardTag",
+            waitForResource(device, detailsTag, UI_ELEMENT_TIMEOUT),
+        )
+        assertClaimValueVisibleAfterScrolling(
+            device = device,
+            path = "docType",
+            label = "Doc type",
+            expectedValues = listOf(scenario.credentialConfigurationId),
+            message = "Stored credential is not the ${scenario.displayName} this test issued",
+        )
     }
 
-    private class Fixture(val context: Context, val device: UiDevice)
+    /**
+     * The card only composes once the store reload lands, which is asynchronous after relaunch.
+     *
+     * The Credentials tab is a plain scrolling Column, so cards past the fold are not in the
+     * accessibility tree at all. When the sharing tests have already run on the same device the
+     * wallet holds several credentials and the new one is off screen, hence the scroll sweep.
+     */
+    private fun UiDevice.waitForNewCredentialCard(known: Set<String>): UiObject2? {
+        val deadline = System.currentTimeMillis() + UI_ELEMENT_TIMEOUT
+        while (System.currentTimeMillis() < deadline) {
+            newCredentialCard(known)?.let { return it }
+            repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) {
+                scrollDown()
+                newCredentialCard(known)?.let { return it }
+            }
+            repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) { scrollUp() }
+            Thread.sleep(500)
+        }
+        return null
+    }
+
+    private fun UiDevice.newCredentialCard(known: Set<String>): UiObject2? =
+        findObjects(By.res(CREDENTIAL_CARD_TAG))
+            .firstOrNull { runCatching { it.resourceName !in known }.getOrDefault(false) }
+
+    /** Every card tag currently in the tree, sweeping the list so off-screen cards are included. */
+    private fun UiDevice.credentialCardTags(): Set<String> {
+        val tags = mutableSetOf<String>()
+        fun collect() {
+            findObjects(By.res(CREDENTIAL_CARD_TAG))
+                .mapNotNullTo(tags) { runCatching { it.resourceName }.getOrNull() }
+        }
+        collect()
+        repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) {
+            scrollDown()
+            collect()
+        }
+        repeat(CREDENTIAL_LIST_SCROLL_ATTEMPTS) { scrollUp() }
+        return tags
+    }
+
+    private class Fixture(
+        val context: Context,
+        val device: UiDevice,
+        val preexistingCardTags: Set<String>,
+    )
 
     private fun start(): Fixture? {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
@@ -151,9 +256,12 @@ class DigitalCredentialIssuanceE2ETest {
             "Digital Credentials E2E requires an Android emulator with Google Play services",
             hasGooglePlayServices(context),
         )
-        val fixture = Fixture(context, UiDevice.getInstance(instrumentation))
-        launchAndUnlock(fixture.context, fixture.device)
-        return fixture
+        val device = UiDevice.getInstance(instrumentation)
+        launchAndUnlock(context, device)
+        // Recorded before issuance so the post-flow assertion can tell this run's credential apart
+        // from one an earlier test method in the same class already stored.
+        clickByTag(device, "wallet.tab.credentials")
+        return Fixture(context, device, device.credentialCardTags())
     }
 
     private fun hasGooglePlayServices(context: Context): Boolean =
@@ -163,6 +271,16 @@ class DigitalCredentialIssuanceE2ETest {
         }.getOrDefault(false)
 
     private companion object {
+        /** Owns `CredentialSelectorActivity`, i.e. the picker window these tests drive. */
         private const val CREDENTIAL_SELECTOR_PACKAGE = "com.google.android.gms"
+
+        /** Short: the confirmation step is optional, so its absence must not cost a full timeout. */
+        private const val CONFIRM_STEP_TIMEOUT = 5_000L
+
+        /** Card tags carry a wallet-local credential id, so they can only be matched by pattern. */
+        private val CREDENTIAL_CARD_TAG: Pattern = Pattern.compile("wallet\\.credentialCard\\..*")
+
+        /** Enough to walk a Credentials list holding every credential the DC API lane issues. */
+        private const val CREDENTIAL_LIST_SCROLL_ATTEMPTS = 6
     }
 }

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/WalletComposeE2EHelper.kt
@@ -337,7 +337,7 @@ internal object WalletComposeE2EHelper {
     private fun claimTag(path: String): String =
         "wallet.claim.${path.map { if (it.isLetterOrDigit()) it else '_' }.joinToString("")}"
 
-    private fun UiDevice.scrollDown() {
+    internal fun UiDevice.scrollDown() {
         swipe(
             displayWidth / 2,
             (displayHeight * 0.72).toInt(),
@@ -348,7 +348,7 @@ internal object WalletComposeE2EHelper {
         waitForIdle()
     }
 
-    private fun UiDevice.scrollUp() {
+    internal fun UiDevice.scrollUp() {
         swipe(
             displayWidth / 2,
             (displayHeight * 0.36).toInt(),

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/debug/java/id/walt/walletdemo/compose/android/DigitalCredentialTestIssuerActivity.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/debug/java/id/walt/walletdemo/compose/android/DigitalCredentialTestIssuerActivity.kt
@@ -6,33 +6,30 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.credentials.CreateDigitalCredentialRequest
-import androidx.credentials.CreateDigitalCredentialResponse
 import androidx.credentials.CredentialManager
 import androidx.credentials.ExperimentalDigitalCredentialApi
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 /** Debug-only native issuer used by the Digital Credentials create instrumentation E2E. */
 class DigitalCredentialTestIssuerActivity : ComponentActivity() {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        scope.launch {
-            val result = runCatching {
+        lifecycleScope.launch {
+            try {
                 CredentialManager.create(this@DigitalCredentialTestIssuerActivity).createCredential(
                     context = this@DigitalCredentialTestIssuerActivity,
                     request = CreateDigitalCredentialRequest(
                         requestJson = DigitalCredentialTestIssuer.requestJson,
                         origin = null,
                     ),
-                ) as CreateDigitalCredentialResponse
+                )
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (exception: Throwable) {
+                Log.e("DigitalCredentialE2E", "Credential Manager create failed", exception)
             }
-            result.exceptionOrNull()?.let { Log.e("DigitalCredentialE2E", "Credential Manager create failed", it) }
-            DigitalCredentialTestIssuer.complete(result)
             finish()
         }
     }
@@ -44,21 +41,10 @@ class DigitalCredentialTestIssuerActivity : ComponentActivity() {
  * The request JSON is injected so the E2E can pass a real issuer2 credential offer.
  */
 internal object DigitalCredentialTestIssuer {
-    private var result = CompletableDeferred<Result<CreateDigitalCredentialResponse>>()
-
     lateinit var requestJson: String
         private set
 
     fun reset(requestJson: String) {
-        result = CompletableDeferred()
         this.requestJson = requestJson
     }
-
-    fun complete(value: Result<CreateDigitalCredentialResponse>) {
-        result.complete(value)
-    }
-
-    suspend fun await(): Result<CreateDigitalCredentialResponse> = result.await()
-
-    fun isComplete(): Boolean = result.isCompleted
 }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoOfferReviewScreen.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoOfferReviewScreen.kt
@@ -100,19 +100,25 @@ fun WalletDemoOfferCreateSheet(
                 },
                 sheetState = sheetState,
             ) {
-                when (state) {
-                    WalletDemoOfferCreateUiState.Loading -> OfferCreateLoadingContent()
-                    is WalletDemoOfferCreateUiState.Review -> OfferCreateReviewContent(
-                        preview = state.preview,
-                        title = state.title,
-                        enabled = !state.submitting,
-                        onAccept = onAccept,
-                        onDecline = onDecline,
-                    )
-                    is WalletDemoOfferCreateUiState.WaitingForAuthorization -> OfferCreateWaitingForAuthorizationContent(
-                        completing = state.completing,
-                        onCancel = onCancelAuthorization,
-                    )
+                // ModalBottomSheet hosts its content in its own window, which the enclosing Box's
+                // semantics do not reach, so the export has to be repeated here or none of the
+                // sheet's test tags become resource IDs for platform UI automation.
+                Box(modifier = Modifier.exportTestTagsForPlatformAutomation()) {
+                    when (state) {
+                        WalletDemoOfferCreateUiState.Loading -> OfferCreateLoadingContent()
+                        is WalletDemoOfferCreateUiState.Review -> OfferCreateReviewContent(
+                            preview = state.preview,
+                            title = state.title,
+                            enabled = !state.submitting,
+                            onAccept = onAccept,
+                            onDecline = onDecline,
+                        )
+                        is WalletDemoOfferCreateUiState.WaitingForAuthorization ->
+                            OfferCreateWaitingForAuthorizationContent(
+                                completing = state.completing,
+                                onCancel = onCancelAuthorization,
+                            )
+                    }
                 }
             }
         }

--- a/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
+++ b/waltid-libraries/protocols/waltid-mobile-test-utils/src/commonMain/kotlin/id/walt/mobile/test/backend/DemoTestBackend.kt
@@ -142,7 +142,11 @@ object DemoTestBackend {
         val verifierCredentialQuery: JsonObject,
     )
 
-    data class GeneratedOffer(val offerUrl: String, val txCode: String?)
+    /**
+     * @property offerId The issuer-side session id, so callers can poll `/issuer2/sessions/{id}`
+     *   to confirm the issuer actually completed issuance rather than trusting a wallet-side ack.
+     */
+    data class GeneratedOffer(val offerUrl: String, val txCode: String?, val offerId: String)
 
     data class VerifierSession(val sessionId: String, val authorizationRequestUri: String)
 
@@ -152,13 +156,23 @@ object DemoTestBackend {
      */
     data class DcApiVerifierSession(val sessionId: String, val requestJson: String)
 
+    /**
+     * Creates a pre-authorized credential offer on the public demo issuer2.
+     *
+     * [inlineOffer] requests `valueMode=BY_VALUE`, so the returned URL carries a `credential_offer`
+     * query parameter instead of a `credential_offer_uri`. The issuer defaults to `BY_REFERENCE`,
+     * which is what the QR and deep link flows consume; DC API issuance needs the offer object itself
+     * because it is passed to `navigator.credentials.create` / Credential Manager verbatim.
+     */
     suspend fun createOffer(
         scenario: CredentialScenario,
         withGeneratedTransactionCode: Boolean = false,
+        inlineOffer: Boolean = false,
     ): GeneratedOffer {
         val payload = buildJsonObject {
             put("profileId", scenario.profileId)
             put("authMethod", "PRE_AUTHORIZED")
+            if (inlineOffer) put("valueMode", "BY_VALUE")
             if (withGeneratedTransactionCode) {
                 putJsonObject("txCode") {
                     put("input_mode", "numeric")
@@ -179,8 +193,55 @@ object DemoTestBackend {
         check(!withGeneratedTransactionCode || txCode != null) {
             "Public demo issuer2 did not return the requested transaction code: $response"
         }
+        val offerId = response["offerId"]?.jsonPrimitive?.contentOrNull
+            ?: error("Missing offerId in public demo issuer2 response: $response")
 
-        return GeneratedOffer(offerUrl = offerUrl, txCode = txCode)
+        return GeneratedOffer(
+            offerUrl = offerUrl,
+            txCode = txCode,
+            offerId = offerId,
+        )
+    }
+
+    /**
+     * Lifecycle status of an offer session, e.g. `ACTIVE` or `SUCCESSFUL`.
+     *
+     * Deliberately narrow: this endpoint also returns the issuer signing key and the full credential
+     * payload, so nothing but the status is lifted out of the response and it is never logged whole.
+     */
+    suspend fun issuerSessionStatus(offerId: String): String? {
+        val response = client.get("$ISSUER_BASE_URL/issuer2/sessions/$offerId")
+        check(response.status.isSuccess()) {
+            "Public demo issuer2 session lookup failed: ${response.status}"
+        }
+        return json.parseToJsonElement(response.bodyAsText())
+            .jsonObject["status"]?.jsonPrimitive?.contentOrNull
+    }
+
+    /**
+     * Waits until issuer2 closes the offer session, i.e. the credential was actually issued.
+     *
+     * The DC API create flow gives the caller no trustworthy completion signal of its own: the
+     * provider acknowledgment is built from constants, so asserting on it proves nothing about
+     * issuance. This is the authoritative signal that the protocol ran to completion.
+     */
+    suspend fun waitForIssuerIssuanceSuccess(offerId: String, timeoutMs: Long = 60_000) {
+        val mark = TimeSource.Monotonic.markNow()
+        while (true) {
+            val status = runCatching { issuerSessionStatus(offerId) }.getOrNull()
+            when (status?.uppercase()) {
+                "SUCCESSFUL" -> return
+                "UNSUCCESSFUL", "REJECTED_BY_USER", "EXPIRED" ->
+                    error("public demo issuer2 reported $status for offer session $offerId")
+            }
+            if (mark.elapsedNow() > timeoutMs.milliseconds) {
+                error(
+                    "public demo issuer2 did not complete issuance within ${timeoutMs}ms for offer " +
+                        "session $offerId (last status ${status ?: "<unavailable>"})"
+                )
+            }
+            delay(2_000.milliseconds)
+        }
     }
 
     suspend fun createVerifierSession(scenario: CredentialScenario): VerifierSession {


### PR DESCRIPTION
Follow-up to [#2077](https://github.com/walt-id/waltid-identity/pull/2077) and stacked on [#2086](https://github.com/walt-id/waltid-identity/pull/2086).

## What was wrong

- The offer was created by reference, but the DC API create flow needs an inline `valueMode=BY_VALUE` offer.
- Compose sheet test tags did not cross the bottom-sheet window boundary into UI automation resources.
- The wallet candidate lookup could match the foreground wallet header instead of the Credential Manager picker.
- The create acknowledgment is not a trustworthy completion signal on the affected AndroidX Credential Manager path.

## What it asserts now

- The issuer2 offer session reaches `SUCCESSFUL`, proving server-side issuance completed.
- The wallet contains a new credential card whose rendered document type matches the requested credential configuration.

The test remains in the existing dedicated Play Store `dc-api-compose` lane and shares its validated emulator with the Digital Credentials sharing suite.