### PR TITLE
Fix did:jwk issuer kid qualification and key resolution

### DIFF
--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolver.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolver.kt
@@ -125,7 +125,11 @@ class Crypto2JwtKeyResolver(
         val kidCandidates = idCandidates(kid)
         val matches = keys.filter { key -> idCandidates(key.id.value).any(kidCandidates::contains) }
         require(matches.size <= 1) { "Multiple DID verification keys match kid: $kid" }
-        return matches.singleOrNull() ?: throw NoSuchElementException("No DID verification key matches kid: $kid")
+        matches.singleOrNull()?.let { return it }
+        if (keys.size == 1 && did.startsWith("did:jwk:")) {
+            return keys.single()
+        }
+        throw NoSuchElementException("No DID verification key matches kid: $kid")
     }
 
     private fun idCandidates(id: String): Set<String> =

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolver.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolver.kt
@@ -119,17 +119,19 @@ class Crypto2JwtKeyResolver(
             require(keys.size == 1) { "JWT with multiple DID verification keys must include kid" }
             return keys.single()
         }
-        if (keys.size == 1 && kid == did && (did.startsWith("did:key:") || did.startsWith("did:jwk:"))) {
+        if (did.startsWith("did:jwk:")) {
+            require(keys.size == 1) { "did:jwk must resolve to exactly one verification key" }
+            require(kid == "$did#0") { "did:jwk kid must be '$did#0', but was '$kid'" }
+            return keys.single()
+        }
+        if (keys.size == 1 && kid == did && did.startsWith("did:key:")) {
             return keys.single()
         }
         val kidCandidates = idCandidates(kid)
         val matches = keys.filter { key -> idCandidates(key.id.value).any(kidCandidates::contains) }
         require(matches.size <= 1) { "Multiple DID verification keys match kid: $kid" }
-        matches.singleOrNull()?.let { return it }
-        if (keys.size == 1 && did.startsWith("did:jwk:")) {
-            return keys.single()
-        }
-        throw NoSuchElementException("No DID verification key matches kid: $kid")
+        return matches.singleOrNull()
+            ?: throw NoSuchElementException("No DID verification key matches kid: $kid")
     }
 
     private fun idCandidates(id: String): Set<String> =

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
@@ -31,6 +31,10 @@ object DidKeyResolver : BaseKeyResolver {
                 log.debug { "Matched key by kid '$kid' in DID document for $issuerId" }
                 return matched
             }
+            if (keys.size == 1 && issuerId.startsWith("did:jwk:")) {
+                log.debug { "Using the single did:jwk key for unmatched kid '$kid'" }
+                return keys.first()
+            }
             throw NoSuchElementException("No key with kid '$kid' found in DID document for $issuerId")
         }
 

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
@@ -22,7 +22,7 @@ object DidKeyResolver : BaseKeyResolver {
 
         if (!kid.isNullOrBlank()) {
             val selfIdentifyingKid = kid == selfIdentifyingVerificationMethod(issuerId) ||
-                kid == issuerId && (issuerId.startsWith("did:key:") || issuerId.startsWith("did:jwk:"))
+                kid == issuerId && issuerId.startsWith("did:key:")
             if (keys.size == 1 && selfIdentifyingKid) {
                 return keys.first()
             }
@@ -30,10 +30,6 @@ object DidKeyResolver : BaseKeyResolver {
             if (matched != null) {
                 log.debug { "Matched key by kid '$kid' in DID document for $issuerId" }
                 return matched
-            }
-            if (keys.size == 1 && issuerId.startsWith("did:jwk:")) {
-                log.debug { "Using the single did:jwk key for unmatched kid '$kid'" }
-                return keys.first()
             }
             throw NoSuchElementException("No key with kid '$kid' found in DID document for $issuerId")
         }

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonTest/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolverTest.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonTest/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolverTest.kt
@@ -83,23 +83,23 @@ class Crypto2JwtKeyResolverTest {
     }
 
     @Test
-    fun `did jwk key is selected when kid is the DID`() = runTest {
-        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
-            jwtHeader = buildJsonObject { put("kid", DID_JWK) },
-            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+    fun `did jwk resolution rejects kid that is the DID without fragment`() = runTest {
+        assertNull(
+            resolver("$DID_JWK#0").resolveFromJwt(
+                jwtHeader = buildJsonObject { put("kid", DID_JWK) },
+                jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+            )
         )
-
-        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
     }
 
     @Test
-    fun `did jwk single key is used when kid is a kms resource path`() = runTest {
-        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
-            jwtHeader = buildJsonObject { put("kid", "$DID_JWK#org.tenant.kms.key_issuer") },
-            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+    fun `did jwk resolution rejects kid that is not the method verification fragment`() = runTest {
+        assertNull(
+            resolver("$DID_JWK#0").resolveFromJwt(
+                jwtHeader = buildJsonObject { put("kid", "$DID_JWK#org.tenant.kms.key_issuer") },
+                jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+            )
         )
-
-        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
     }
 
     @Test

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonTest/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolverTest.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonTest/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolverTest.kt
@@ -71,6 +71,47 @@ class Crypto2JwtKeyResolverTest {
         assertFailsWith<IllegalArgumentException> { resolver.resolveFromDid(DID, "shared") }
     }
 
+    @Test
+    fun `did jwk key is selected by method verification fragment`() = runTest {
+        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
+            jwtHeader = buildJsonObject { put("kid", "$DID_JWK#0") },
+            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+        )
+
+        assertEquals(JwtKeyResolutionSource.DID, resolved?.source)
+        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
+    }
+
+    @Test
+    fun `did jwk key is selected when kid is the DID`() = runTest {
+        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
+            jwtHeader = buildJsonObject { put("kid", DID_JWK) },
+            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+        )
+
+        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
+    }
+
+    @Test
+    fun `did jwk single key is used when kid is a kms resource path`() = runTest {
+        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
+            jwtHeader = buildJsonObject { put("kid", "$DID_JWK#org.tenant.kms.key_issuer") },
+            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+        )
+
+        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
+    }
+
+    @Test
+    fun `did jwk single key is used when kid is omitted`() = runTest {
+        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
+            jwtHeader = null,
+            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
+        )
+
+        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
+    }
+
     private suspend fun resolver(vararg keyIds: String): Crypto2JwtKeyResolver {
         val runtime = CryptoRuntime(defaultSoftwareKeyProviders())
         val keys = keyIds.map { keyId ->
@@ -87,5 +128,7 @@ class Crypto2JwtKeyResolverTest {
 
     private companion object {
         const val DID = "did:example:issuer"
+        const val DID_JWK =
+            "did:jwk:eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6ImVCVkJMaC16eVQ0NWZTbklWUTBtbmVvTUc0dTU4eHFhSHk1aE5SOVZPdGciLCJ5IjoiRTl0ZTdyX3A5dWIyaS1ER01SUzVwSVQ2ZWpzdDd4OTRkLTBFTWoteVEzbyJ9"
     }
 }

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
@@ -330,7 +330,9 @@ object Issuer {
         val rawId = issuerKey.id.value
         val keyId = when {
             DidUtils.isDidUrl(rawId) -> rawId
-            issuerDid != null && DidUtils.isDidUrl(issuerDid) && !issuerDid.startsWith("did:key:") ->
+            issuerDid != null && DidUtils.isDidUrl(issuerDid) &&
+                !issuerDid.startsWith("did:key:") &&
+                !issuerDid.startsWith("did:jwk:") ->
                 publicJwkThumbprint(issuerKey)
             else -> rawId
         }
@@ -349,6 +351,7 @@ object Issuer {
         DidUtils.isDidUrl(keyId) -> keyId
         keyId.startsWith("#") -> issuerDid + keyId
         issuerDid.startsWith("did:key:") -> "$issuerDid#${issuerDid.removePrefix("did:key:")}"
+        issuerDid.startsWith("did:jwk:") -> "$issuerDid#0"
         else -> "$issuerDid#$keyId"
     }
 }

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonMain/kotlin/id/walt/w3c/issuance/Issuer.kt
@@ -348,10 +348,10 @@ object Issuer {
 
     private fun qualifyDidKeyId(keyId: String, issuerDid: String?): String = when {
         issuerDid.isNullOrEmpty() -> keyId
+        issuerDid.startsWith("did:jwk:") -> "$issuerDid#0"
         DidUtils.isDidUrl(keyId) -> keyId
         keyId.startsWith("#") -> issuerDid + keyId
         issuerDid.startsWith("did:key:") -> "$issuerDid#${issuerDid.removePrefix("did:key:")}"
-        issuerDid.startsWith("did:jwk:") -> "$issuerDid#0"
         else -> "$issuerDid#$keyId"
     }
 }

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonTest/kotlin/Crypto2W3cCredentialTest.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonTest/kotlin/Crypto2W3cCredentialTest.kt
@@ -172,11 +172,12 @@ class Crypto2W3cCredentialTest {
 
         assertEquals("$didJwk#0", Issuer.getKidHeader(kmsStyleKey, didJwk))
         assertEquals("$didJwk#0", Issuer.getKidHeader(key("$didJwk#0"), didJwk))
+        assertEquals("$didJwk#0", Issuer.getKidHeader(key("$didJwk#org.tenant.kms.key_issuer"), didJwk))
         assertEquals("$didJwk#0", Issuer.getKidHeader(key("#0"), didJwk))
     }
 
     @Test
-    fun `did jwk credential signature resolves for method kid and kms-style kid`() = runTest {
+    fun `did jwk credential signature resolves for method kid and rejects non-method kid`() = runTest {
         DidService.minimalInit()
         val key = key("org.tenant.kms.key_issuer")
         val didJwk = Crypto2DidJwkRegistrar().createByKey(key, DidJwkCreateOptions()).did
@@ -199,7 +200,7 @@ class Crypto2W3cCredentialTest {
         )
         assertTrue(scheme.verifyCrypto2(issued, setOf(JwsAlgorithm.ES256)).isSuccess)
 
-        val alreadyIssued = CompactJws.sign(
+        val nonMethodKid = CompactJws.sign(
             payload = payload,
             key = key,
             algorithm = JwsAlgorithm.ES256,
@@ -208,7 +209,7 @@ class Crypto2W3cCredentialTest {
                 put("typ", "dc+sd-jwt")
             },
         )
-        assertTrue(scheme.verifyCrypto2(alreadyIssued, setOf(JwsAlgorithm.ES256)).isSuccess)
+        assertFalse(scheme.verifyCrypto2(nonMethodKid, setOf(JwsAlgorithm.ES256)).isSuccess)
     }
 
     private suspend fun publicJwkThumbprint(key: Key) =

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonTest/kotlin/Crypto2W3cCredentialTest.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonTest/kotlin/Crypto2W3cCredentialTest.kt
@@ -6,6 +6,9 @@ import id.walt.crypto2.jose.JwsAlgorithm
 import id.walt.crypto2.keys.*
 import id.walt.crypto2.providers.GenerateSoftwareKeyRequest
 import id.walt.crypto2.providers.cryptography.defaultSoftwareKeyProviders
+import id.walt.did.dids.DidService
+import id.walt.did.dids.registrar.dids.DidJwkCreateOptions
+import id.walt.did.dids.registrar.local.jwk.Crypto2DidJwkRegistrar
 import id.walt.sdjwt.SDMap
 import id.walt.w3c.PresentationBuilder
 import id.walt.w3c.issuance.Issuer
@@ -160,6 +163,52 @@ class Crypto2W3cCredentialTest {
             Issuer.getKidHeader(key("ignored-for-self-identifying-did"), didKey),
         )
         assertEquals(didKeyVerificationMethod, Issuer.getKidHeader(key(didKeyVerificationMethod), didKey))
+    }
+
+    @Test
+    fun `did jwk issuer kid uses the method verification fragment`() = runTest {
+        val kmsStyleKey = key("org.tenant.kms.key_issuer")
+        val didJwk = Crypto2DidJwkRegistrar().createByKey(kmsStyleKey, DidJwkCreateOptions()).did
+
+        assertEquals("$didJwk#0", Issuer.getKidHeader(kmsStyleKey, didJwk))
+        assertEquals("$didJwk#0", Issuer.getKidHeader(key("$didJwk#0"), didJwk))
+        assertEquals("$didJwk#0", Issuer.getKidHeader(key("#0"), didJwk))
+    }
+
+    @Test
+    fun `did jwk credential signature resolves for method kid and kms-style kid`() = runTest {
+        DidService.minimalInit()
+        val key = key("org.tenant.kms.key_issuer")
+        val didJwk = Crypto2DidJwkRegistrar().createByKey(key, DidJwkCreateOptions()).did
+        val payload = buildJsonObject {
+            put("iss", didJwk)
+            put("vct", "urn:example:pid")
+        }.toString().encodeToByteArray()
+
+        val methodKid = Issuer.getKidHeader(key, didJwk)
+        assertEquals("$didJwk#0", methodKid)
+        val scheme = JwsSignatureScheme()
+        val issued = CompactJws.sign(
+            payload = payload,
+            key = key,
+            algorithm = JwsAlgorithm.ES256,
+            protectedHeader = buildJsonObject {
+                put("kid", methodKid)
+                put("typ", "dc+sd-jwt")
+            },
+        )
+        assertTrue(scheme.verifyCrypto2(issued, setOf(JwsAlgorithm.ES256)).isSuccess)
+
+        val alreadyIssued = CompactJws.sign(
+            payload = payload,
+            key = key,
+            algorithm = JwsAlgorithm.ES256,
+            protectedHeader = buildJsonObject {
+                put("kid", "$didJwk#org.tenant.kms.key_issuer")
+                put("typ", "dc+sd-jwt")
+            },
+        )
+        assertTrue(scheme.verifyCrypto2(alreadyIssued, setOf(JwsAlgorithm.ES256)).isSuccess)
     }
 
     private suspend fun publicJwkThumbprint(key: Key) =


### PR DESCRIPTION
## Summary

Issuer2 and other `getKidHeader` callers now emit the `did:jwk` verification-method id (`{did}#0`) instead of a stored key id or JWK thumbprint fragment. Verifier signature checks were failing with `Could not resolve issuer key` because `did:jwk` documents only publish `#0`, so a non-method `kid` never matched the resolved key.

This unblocks SD-JWT VC (and other JWT) verification for credentials whose issuer DID is `did:jwk`. `did:key` was already rewritten to its method verification-method id and is unchanged. Tracked as WAL-1307.

Related PRs:
- [walt-id/waltid-identity-enterprise#612](https://github.com/walt-id/waltid-identity-enterprise/pull/612) (WAL-1307-related, independent of these changes)
- [walt-id/waltid-identity-enterprise-license#4](https://github.com/walt-id/waltid-identity-enterprise-license/pull/4)

## What Changed

### Issuer kid construction
- `did:jwk` is treated as a self-identifying DID method: `kid` is always `{did}#0`, including when the signing key id is already a DID URL or starts with `#`.
- Thumbprint substitution is skipped for `did:jwk`, matching the existing `did:key` exception. `did:web` still uses a thumbprint or explicit verification-method id.

### Key resolution
- `did:jwk` resolution requires exactly one verification key and `kid` `{did}#0`.
- A KMS-path, thumbprint, or DID-without-fragment `kid` does not resolve. Omitted `kid` still selects the single key.
- Multi-key methods such as `did:web` still require a matching verification-method id.

### Tests
- Kid qualification covers KMS-style key ids, DID-URL key ids, `{did}#0`, and `#0`.
- Round-trip signature verification succeeds for `{did}#0` and fails for a non-method fragment.
- Resolver tests cover `#0` success, omitted `kid` success, and rejection of DID-as-kid and KMS-path fragments.

## Architecture Notes

- `did:jwk` encodes exactly one public key in the DID and always exposes verification method `#0`. A non-`#0` fragment cannot select a different key.
- Issuance always writes `{did}#0`. Resolution is strict; there is no unmatched-kid fallback.
- OpenID4VCI SD-JWT signing already goes through `Issuer.getKidHeader`, so Issuer2 inherits this without an enterprise-only change.

## Caveats and Follow-Ups

- Credentials already issued with a non-`#0` `did:jwk` kid will fail signature-key resolution after this change and need re-issuance.
- No Verifier2 trust-list, JWKS, or DID-store configuration is required for `did:jwk`.

## Breaking

- Newly issued `did:jwk` JWTs use `kid` `{did}#0` instead of `{did}#{keyId}` or `{did}#{thumbprint}`. Relying parties that required a non-`#0` fragment for `did:jwk` will need to accept `#0`.
- Verification now rejects `did:jwk` JWTs whose `kid` is not `{did}#0` (except when `kid` is omitted and the document has a single key).
