### PR TITLE
[WAL-1309] fix(mobile): localize issuance metadata

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidHostTest/kotlin/id/walt/walletdemo/compose/logic/MobileWalletIssuanceMappingTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidHostTest/kotlin/id/walt/walletdemo/compose/logic/MobileWalletIssuanceMappingTest.kt
@@ -3,6 +3,7 @@ package id.walt.walletdemo.compose.logic
 import id.walt.wallet2.handlers.WalletIssuanceCredentialPreview
 import id.walt.wallet2.handlers.WalletIssuanceGrant
 import id.walt.wallet2.handlers.WalletIssuanceIssuerPreview
+import id.walt.wallet2.handlers.WalletIssuanceMetadataProvenance
 import id.walt.wallet2.handlers.WalletIssuanceOfferPreview
 import id.walt.wallet2.handlers.WalletIssuanceSession
 import kotlin.test.Test
@@ -21,6 +22,7 @@ class MobileWalletIssuanceMappingTest {
                     locale = "en",
                     logoUri = null,
                     logoAltText = null,
+                    metadataProvenance = WalletIssuanceMetadataProvenance.Unsigned,
                 ),
                 credentials = listOf(
                     WalletIssuanceCredentialPreview(

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidHostTest/kotlin/id/walt/walletdemo/compose/logic/MobileWalletIssuanceMappingTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidHostTest/kotlin/id/walt/walletdemo/compose/logic/MobileWalletIssuanceMappingTest.kt
@@ -1,0 +1,44 @@
+package id.walt.walletdemo.compose.logic
+
+import id.walt.wallet2.handlers.WalletIssuanceCredentialPreview
+import id.walt.wallet2.handlers.WalletIssuanceGrant
+import id.walt.wallet2.handlers.WalletIssuanceIssuerPreview
+import id.walt.wallet2.handlers.WalletIssuanceOfferPreview
+import id.walt.wallet2.handlers.WalletIssuanceSession
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MobileWalletIssuanceMappingTest {
+    @Test
+    fun credentialLogoAccessibilityTextReachesTheOfferReviewModel() {
+        val session = WalletIssuanceSession(
+            id = "issuance-1",
+            offer = WalletIssuanceOfferPreview(
+                grant = WalletIssuanceGrant.PRE_AUTHORIZED_CODE,
+                issuer = WalletIssuanceIssuerPreview(
+                    identifier = "https://issuer.example",
+                    name = "Example issuer",
+                    locale = "en",
+                    logoUri = null,
+                    logoAltText = null,
+                ),
+                credentials = listOf(
+                    WalletIssuanceCredentialPreview(
+                        configurationId = "mdl",
+                        format = "mso_mdoc",
+                        name = "Mobile Driving Licence",
+                        descriptionText = null,
+                        logoUri = "https://issuer.example/mdl.png",
+                        logoAltText = "Driving licence logo",
+                    ),
+                ),
+                transactionCode = null,
+            ),
+        )
+
+        assertEquals(
+            "Driving licence logo",
+            session.toDemoIssuanceSession().preview.offeredCredentials.single().display?.logoAltText,
+        )
+    }
+}

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileWalletIssuanceMapping.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/mobileMain/kotlin/id/walt/walletdemo/compose/logic/MobileWalletIssuanceMapping.kt
@@ -32,7 +32,7 @@ fun WalletIssuanceSession.toDemoIssuanceSession(): WalletDemoIssuanceSession =
                     display = WalletDemoMetadataDisplay(
                         name = credential.name,
                         logoUri = credential.logoUri,
-                        logoAltText = null,
+                        logoAltText = credential.logoAltText,
                         description = credential.descriptionText,
                     ),
                     claims = emptyList(),

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/OfferReviewView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Components/OfferReviewView.swift
@@ -149,7 +149,7 @@ private struct OfferedCredentialView: View {
                     name: credential.name,
                     locale: nil,
                     logoURI: credential.logoURI?.absoluteString,
-                    logoAltText: nil
+                    logoAltText: credential.logoAltText
                 ),
                 fallbackName: title,
                 supportingText: credential.descriptionText

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -349,13 +349,14 @@ public class MobileWallet internal constructor(
     public suspend fun startIssuance(
         request: MobileWalletIssuanceRequest,
     ): WalletIssuanceSession = issuanceSessions.start(
-        newIssuanceRequest(
+        request = newIssuanceRequest(
             offer = request.offer,
             keyId = request.keyId,
             did = request.did,
             clientId = request.clientId,
             redirectUri = request.redirectUri.trim(),
-        )
+        ),
+        preferredLocales = preferredLocales,
     )
 
     /**

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/commonMain/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionService.kt
@@ -39,6 +39,7 @@ import id.waltid.openid4vci.wallet.dpop.DPOP_NONCE_HEADER
 import id.waltid.openid4vci.wallet.dpop.USE_DPOP_NONCE
 import id.waltid.openid4vci.wallet.metadata.IssuerMetadataResolver
 import id.waltid.openid4vci.wallet.metadata.CredentialIssuerMetadataTrustResolver
+import id.waltid.openid4vci.wallet.metadata.LocalizedMetadata
 import id.waltid.openid4vci.wallet.metadata.MetadataSignerTrustType
 import id.waltid.openid4vci.wallet.metadata.OfferedCredentialResolver
 import id.waltid.openid4vci.wallet.metadata.ResolvedCredentialIssuerMetadata
@@ -132,6 +133,7 @@ data class WalletIssuanceCredentialPreview(
     val name: String?,
     val descriptionText: String?,
     val logoUri: String?,
+    val logoAltText: String? = null,
 )
 
 /** Typed offer preview retained by the issuance session. */
@@ -286,16 +288,24 @@ class WalletIssuanceSessionService(
     private val sessions = LinkedHashMap<String, ActiveSession>()
     private val deferred = LinkedHashMap<String, DeferredRecord>()
 
-    /** Resolves and binds an offer without initiating any authorization-server side effects. */
-    suspend fun start(request: WalletIssuanceSessionRequest): WalletIssuanceSession {
+    /**
+     * Resolves and binds an offer using the wallet's current language preferences.
+     *
+     * The selected review preview, rather than the locale configuration, is retained with the
+     * session so restored continuations preserve exactly what the user accepted.
+     */
+    suspend fun start(
+        request: WalletIssuanceSessionRequest,
+        preferredLocales: List<String> = emptyList(),
+    ): WalletIssuanceSession {
         val keyMaterial = resolveIssuanceKeyMaterial(request.key, request.keyId)
-        val resolved = resolve(request)
+        val resolved = resolve(request, preferredLocales)
         val grant = resolved.offer.getGrantType()
             ?: error("Credential offer does not contain a supported grant")
         val sessionId = Uuid.random().toString()
         val publicSession = WalletIssuanceSession(
             id = sessionId,
-            offer = resolved.toPreview(grant),
+            offer = resolved.toPreview(grant, preferredLocales),
         )
         val selectedKeyId = request.keyId ?: if (request.key == null) {
             keyMaterial.keyId.takeIf { it.isNotBlank() }
@@ -683,7 +693,7 @@ class WalletIssuanceSessionService(
                     val credentials = response.credentials
                         ?: throw IssuanceStageException(WalletIssuanceErrorCode.PROTOCOL)
                     emitEvent(WalletSessionEvent.issuance_credential_received)
-                    val label = offered.configuration.credentialMetadata?.display?.firstOrNull()?.name
+                    val label = active.public.offer.credentialName(offered.credentialConfigurationId)
                     credentials.forEach { issued ->
                         val stored = try {
                             wallet.parseAndStore(issued, label)
@@ -717,7 +727,7 @@ class WalletIssuanceSessionService(
                         credentialConfigurationId = offered.credentialConfigurationId,
                         intervalSeconds = response.interval,
                     )
-                    val label = offered.configuration.credentialMetadata?.display?.firstOrNull()?.name
+                    val label = active.public.offer.credentialName(offered.credentialConfigurationId)
                     pending += PendingDeferred(
                         public = public,
                         record = DeferredRecord(
@@ -944,7 +954,10 @@ class WalletIssuanceSessionService(
         return algorithms
     }
 
-    private suspend fun resolve(request: WalletIssuanceSessionRequest): ResolvedOffer {
+    private suspend fun resolve(
+        request: WalletIssuanceSessionRequest,
+        preferredLocales: List<String>,
+    ): ResolvedOffer {
         val offer = if (request.offerJson != null) {
             val inline = json.decodeFromString<CredentialOffer>(request.offerJson.toString())
             CredentialOfferResolver(httpClient).resolveCredentialOffer(inline, null)
@@ -956,7 +969,10 @@ class WalletIssuanceSessionService(
         // Operational metadata is always resolved from issuer-derived well-known endpoints.
         // Unrecognized offer parameters are caller-controlled and must not select network
         // endpoints for issuance.
-        val issuerMetadata = resolver.resolveCredentialIssuerMetadata(offer.credentialIssuer)
+        val issuerMetadata = resolver.resolveCredentialIssuerMetadata(
+            credentialIssuerUrl = offer.credentialIssuer,
+            preferredLocales = preferredLocales,
+        )
         require(issuerMetadata.metadata.credentialIssuer == offer.credentialIssuer) {
             "Credential issuer metadata identifier does not match the offer"
         }
@@ -990,8 +1006,11 @@ class WalletIssuanceSessionService(
         return grantAuthorizationServer
     }
 
-    private fun ResolvedOffer.toPreview(grant: GrantType): WalletIssuanceOfferPreview {
-        val issuerDisplay = issuerMetadata.metadata.display?.firstOrNull()
+    private fun ResolvedOffer.toPreview(
+        grant: GrantType,
+        preferredLocales: List<String>,
+    ): WalletIssuanceOfferPreview {
+        val issuerDisplay = LocalizedMetadata.select(issuerMetadata.metadata.display, preferredLocales) { it.locale }
         val txCode = offer.grants?.preAuthorizedCode?.txCode
         return WalletIssuanceOfferPreview(
             grant = when (grant) {
@@ -1008,13 +1027,17 @@ class WalletIssuanceSessionService(
                 metadataProvenance = issuerMetadata.toPreviewProvenance(),
             ),
             credentials = offeredCredentials.map { offered ->
-                val display = offered.configuration.credentialMetadata?.display?.firstOrNull()
+                val display = LocalizedMetadata.select(
+                    offered.configuration.credentialMetadata?.display,
+                    preferredLocales,
+                ) { it.locale }
                 WalletIssuanceCredentialPreview(
                     configurationId = offered.credentialConfigurationId,
                     format = offered.configuration.format.value,
                     name = display?.name,
                     descriptionText = display?.description,
                     logoUri = display?.logo?.uri,
+                    logoAltText = display?.logo?.altText,
                 )
             },
             transactionCode = txCode?.let {
@@ -1032,6 +1055,9 @@ class WalletIssuanceSessionService(
             trustType = signer.trustType,
         )
     }
+
+    private fun WalletIssuanceOfferPreview.credentialName(configurationId: String): String? =
+        credentials.firstOrNull { it.configurationId == configurationId }?.name
 
     private data class CredentialProofRequirement(val algorithm: JwsAlgorithm?) {
         val required: Boolean

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionServiceTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet/src/jvmTest/kotlin/id/walt/wallet2/handlers/WalletIssuanceSessionServiceTest.kt
@@ -48,6 +48,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -862,6 +863,104 @@ class WalletIssuanceSessionServiceTest {
         )
 
         assertEquals(stored.credentialIds, credentialStore.credentials.map { it.id })
+    }
+
+    @Test
+    fun localizedIssuancePreviewAndDeferredLabelStayConsistentAfterServiceRecreation() = runTest {
+        val key = JWKKey.generate(KeyType.secp256r1)
+        val credential = key.signJws(
+            """{"iss":"https://issuer.example","sub":"did:key:holder","vc":{"@context":["https://www.w3.org/2018/credentials/v1"],"type":["VerifiableCredential","TestCredential"],"credentialSubject":{"id":"did:key:holder"}}}"""
+                .encodeToByteArray()
+        )
+        val records = RecordingSessionStore()
+        val credentialStore = RecordingCredentialStore()
+        val localizedMetadata = issuerMetadata(proofRequired = false)
+            .replace(
+                "\"credential_endpoint\":\"$CREDENTIAL_ENDPOINT\",",
+                "\"display\":[{\"name\":\"English Issuer\",\"locale\":\"en\"},{\"name\":\"Deutscher Aussteller\",\"locale\":\"de\",\"logo\":{\"uri\":\"https://issuer.example/de.png\",\"alt_text\":\"Aussteller-Logo\"}}],\"credential_endpoint\":\"$CREDENTIAL_ENDPOINT\",",
+            )
+            .replace(
+                "\"credential_definition\":{\"type\":[\"VerifiableCredential\",\"TestCredential\"]}",
+                "\"credential_metadata\":{\"display\":[{\"name\":\"English Credential\",\"locale\":\"en\",\"description\":\"English description\"},{\"name\":\"Deutscher Nachweis\",\"locale\":\"de\",\"description\":\"Deutsche Beschreibung\",\"logo\":{\"uri\":\"https://issuer.example/credential-de.png\",\"alt_text\":\"Nachweis-Logo\"}}]},\"credential_definition\":{\"type\":[\"VerifiableCredential\",\"TestCredential\"]}",
+            )
+        val client = client { request ->
+            when (request.url.toString()) {
+                ISSUER_METADATA -> {
+                    assertEquals("de-AT", request.headers[HttpHeaders.AcceptLanguage])
+                    jsonResponse(localizedMetadata)
+                }
+                AS_METADATA -> jsonResponse(authorizationServerMetadata(authorizationCode = false))
+                TOKEN_ENDPOINT -> jsonResponse("""{"access_token":"access","token_type":"Bearer"}""")
+                CREDENTIAL_ENDPOINT -> jsonResponse(
+                    """{"transaction_id":"transaction-1","interval":1}""",
+                    HttpStatusCode.Accepted,
+                )
+                DEFERRED_ENDPOINT -> jsonResponse(
+                    """{"credentials":[{"credential":${Json.encodeToString(credential)}}]}""",
+                )
+                else -> respondError(HttpStatusCode.NotFound)
+            }
+        }
+        val wallet = Wallet("localized", staticKey = key, credentialStores = listOf(credentialStore))
+        val startedBy = WalletIssuanceSessionService(wallet, sessionStore = records, httpClient = client)
+
+        val session = startedBy.start(preAuthorizedRequest(), preferredLocales = listOf("de-AT"))
+        assertEquals("Deutscher Aussteller", session.offer.issuer.name)
+        assertEquals("https://issuer.example/de.png", session.offer.issuer.logoUri)
+        assertEquals("Deutscher Nachweis", session.offer.credentials.single().name)
+        assertEquals("Deutsche Beschreibung", session.offer.credentials.single().descriptionText)
+        assertEquals("Nachweis-Logo", session.offer.credentials.single().logoAltText)
+        assertFalse(records.records.values.single().payload.contains("preferredLocales"))
+
+        val resumedBy = WalletIssuanceSessionService(wallet, sessionStore = records, httpClient = client)
+        val deferred = assertIs<WalletIssuanceOutcome.Deferred>(resumedBy.continuePreAuthorized(session.id))
+        assertIs<WalletIssuanceOutcome.Stored>(resumedBy.resumeDeferred(deferred.credentials.single().id))
+
+        assertEquals("Deutscher Nachweis", credentialStore.credentials.single().label)
+    }
+
+    @Test
+    fun mdocPreviewSelectsLocalizedNameLogoAltTextAndDescription() = runTest {
+        val client = client { request ->
+            when (request.url.toString()) {
+                ISSUER_METADATA -> {
+                    assertEquals("de-AT", request.headers[HttpHeaders.AcceptLanguage])
+                    jsonResponse(
+                        """
+                        {
+                          "credential_issuer":"$ISSUER",
+                          "credential_endpoint":"$CREDENTIAL_ENDPOINT",
+                          "credential_configurations_supported":{
+                            "mdl":{
+                              "format":"mso_mdoc",
+                              "doctype":"org.iso.18013.5.1.mDL",
+                              "credential_metadata":{"display":[
+                                {"name":"Mobile Driving Licence","locale":"en","description":"English description","logo":{"uri":"https://issuer.example/mdl-en.png","alt_text":"English licence logo"}},
+                                {"name":"Mobiler Fuehrerschein","locale":"de","description":"Deutsche Beschreibung","logo":{"uri":"https://issuer.example/mdl-de.png","alt_text":"Fuehrerschein-Logo"}}
+                              ]}
+                            }
+                          }
+                        }
+                        """.trimIndent(),
+                    )
+                }
+                AS_METADATA -> jsonResponse(authorizationServerMetadata(authorizationCode = false))
+                else -> respondError(HttpStatusCode.NotFound)
+            }
+        }
+        val service = WalletIssuanceSessionService(
+            Wallet("localized-mdoc", staticKey = JWKKey.generate(KeyType.secp256r1)),
+            httpClient = client,
+        )
+
+        val preview = service.start(preAuthorizedRequest(configurationIds = listOf("mdl")), listOf("de-AT"))
+        val credential = preview.offer.credentials.single()
+
+        assertEquals("mso_mdoc", credential.format)
+        assertEquals("Mobiler Fuehrerschein", credential.name)
+        assertEquals("Deutsche Beschreibung", credential.descriptionText)
+        assertEquals("https://issuer.example/mdl-de.png", credential.logoUri)
+        assertEquals("Fuehrerschein-Logo", credential.logoAltText)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolver.kt
@@ -49,11 +49,16 @@ class IssuerMetadataResolver(
     /**
      * Resolves credential issuer metadata and retains its signed/unsigned provenance.
      *
+     * Language preferences are sent as `Accept-Language`. Callers must still select a display
+     * locally because issuers can return multiple localized alternatives.
+     *
      * @param credentialIssuerUrl Credential issuer identifier URL.
+     * @param preferredLocales Ordered BCP 47 locale preferences for the metadata request.
      * @return Parsed metadata with explicit unsigned or verified signed provenance.
      */
     suspend fun resolveCredentialIssuerMetadata(
         credentialIssuerUrl: String,
+        preferredLocales: List<String> = emptyList(),
     ): ResolvedCredentialIssuerMetadata {
         require(credentialIssuerUrl.isNotBlank()) { "Credential issuer URL cannot be blank" }
 
@@ -69,6 +74,7 @@ class IssuerMetadataResolver(
         log.debug { "Attempting to fetch metadata from ${urlsToTry.size} well-known endpoints" }
         log.trace { "Metadata URLs to try: ${urlsToTry.joinToString()}" }
 
+        val acceptLanguage = LocalizedMetadata.acceptLanguageValue(preferredLocales)
         val failures = mutableListOf<ResolveFailure>()
         for ((index, metadataUrl) in urlsToTry.withIndex()) {
             log.debug { "Attempt ${index + 1}/${urlsToTry.size}: Fetching from $metadataUrl" }
@@ -81,6 +87,7 @@ class IssuerMetadataResolver(
                             "${CredentialIssuerMetadataJwt.MEDIA_TYPE}, ${ContentType.Application.Json}"
                         } ?: ContentType.Application.Json.toString(),
                     )
+                    acceptLanguage?.let { header(HttpHeaders.AcceptLanguage, it) }
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadata.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadata.kt
@@ -45,15 +45,19 @@ public object LocalizedMetadata {
         val available = entries.orEmpty()
         if (available.isEmpty()) return null
 
-        val normalizedEntries = available.map { entry ->
-            entry to localeOf(entry)?.trim()?.takeIf(::isLanguageTag)?.lowercase()
+        val normalizedEntries = available.mapNotNull { entry ->
+            localeOf(entry)
+                ?.trim()
+                ?.takeIf(::isLanguageTag)
+                ?.lowercase()
+                ?.let { locale -> entry to locale }
         }
         normalizedPreferences(preferredLocales).forEach { preference ->
             progressiveTags(preference.lowercase()).forEach { candidate ->
                 normalizedEntries.firstOrNull { (_, locale) -> locale == candidate }?.let { return it.first }
             }
         }
-        return normalizedEntries.firstOrNull { (_, locale) -> locale == null }?.first ?: available.first()
+        return available.firstOrNull { localeOf(it) == null } ?: available.first()
     }
 
     private fun progressiveTags(tag: String): Sequence<String> = sequence {

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadata.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonMain/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadata.kt
@@ -1,0 +1,86 @@
+package id.waltid.openid4vci.wallet.metadata
+
+/**
+ * Selects localized protocol metadata using the wallet's ordered BCP 47 preferences.
+ *
+ * The protocol may return all display alternatives even when it receives `Accept-Language`, so
+ * callers must still select locally. Selection is deterministic: exact tag, progressively less
+ * specific tag, an unlocalized entry, then the first advertised entry.
+ */
+public object LocalizedMetadata {
+    /**
+     * Returns usable, de-duplicated BCP 47 language tags in the order the wallet supplied them.
+     *
+     * This deliberately accepts the compact, well-formed tag subset needed for HTTP
+     * `Accept-Language` and display matching. Invalid application configuration is omitted rather
+     * than being sent verbatim to an issuer.
+     */
+    public fun normalizedPreferences(preferredLocales: List<String>): List<String> =
+        preferredLocales
+            .map(String::trim)
+            .filter(::isLanguageTag)
+            .distinctBy(String::lowercase)
+
+    /** Returns the HTTP `Accept-Language` value, or null when no usable preference exists. */
+    public fun acceptLanguageValue(preferredLocales: List<String>): String? {
+        val preferences = normalizedPreferences(preferredLocales)
+            .take(MAX_ACCEPT_LANGUAGE_PREFERENCES)
+        if (preferences.isEmpty()) return null
+
+        return preferences.mapIndexed { index, languageTag ->
+            if (index == 0) languageTag else "$languageTag;q=${qualityValue(index, preferences.size)}"
+        }.joinToString(", ")
+    }
+
+    /**
+     * Selects a localized entry using the normalized wallet preferences.
+     *
+     * [localeOf] returns the entry's language tag, or null for an unlocalized entry.
+     */
+    public fun <T> select(
+        entries: List<T>?,
+        preferredLocales: List<String>,
+        localeOf: (T) -> String?,
+    ): T? {
+        val available = entries.orEmpty()
+        if (available.isEmpty()) return null
+
+        val normalizedEntries = available.map { entry ->
+            entry to localeOf(entry)?.trim()?.takeIf(::isLanguageTag)?.lowercase()
+        }
+        normalizedPreferences(preferredLocales).forEach { preference ->
+            progressiveTags(preference.lowercase()).forEach { candidate ->
+                normalizedEntries.firstOrNull { (_, locale) -> locale == candidate }?.let { return it.first }
+            }
+        }
+        return normalizedEntries.firstOrNull { (_, locale) -> locale == null }?.first ?: available.first()
+    }
+
+    private fun progressiveTags(tag: String): Sequence<String> = sequence {
+        var candidate = tag
+        while (true) {
+            yield(candidate)
+            val separator = candidate.lastIndexOf('-')
+            if (separator < 0) return@sequence
+            candidate = candidate.substring(0, separator)
+            // RFC 4647 lookup removes a singleton extension/private-use subtag together with
+            // the preceding separator instead of considering an incomplete extension as a range.
+            if (candidate.substringAfterLast('-', candidate).length == 1) {
+                val singletonSeparator = candidate.lastIndexOf('-')
+                candidate = if (singletonSeparator < 0) return@sequence else candidate.substring(0, singletonSeparator)
+            }
+        }
+    }
+
+    private fun isLanguageTag(value: String): Boolean =
+        LANGUAGE_TAG.matches(value)
+
+    private fun qualityValue(index: Int, preferenceCount: Int): String {
+        val decrement = if (preferenceCount <= 10) 100 else maxOf(1, 999 / preferenceCount)
+        val thousandths = (1000 - index * decrement).coerceAtLeast(1)
+        return "0.${thousandths.toString().padStart(3, '0').trimEnd('0')}"
+    }
+
+    private val LANGUAGE_TAG = Regex("[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*")
+    private const val MAX_ACCEPT_LANGUAGE_PREFERENCES = 1000
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
@@ -65,6 +65,54 @@ class IssuerMetadataResolverTest {
     }
 
     @Test
+    fun `credential issuer metadata request sends normalized Accept-Language only when configured`() = runTest {
+        val issuerUrl = "https://example.com"
+        val client = createMockClient { request ->
+            assertEquals("de-AT, en;q=0.9", request.headers[HttpHeaders.AcceptLanguage])
+            respond(
+                content = """
+                    {"credential_issuer":"$issuerUrl","credential_endpoint":"$issuerUrl/credential",
+                    "credential_configurations_supported":{"mdl":{"format":"mso_mdoc",
+                    "doctype":"org.iso.18013.5.1.mDL","credential_metadata":{"display":[
+                    {"name":"Mobile Driving Licence","locale":"en"},
+                    {"name":"Mobiler Fuehrerschein","locale":"de"}]}}}}
+                """.trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        val metadata = IssuerMetadataResolver(client).resolveCredentialIssuerMetadata(
+            credentialIssuerUrl = issuerUrl,
+            preferredLocales = listOf(" de-AT ", "DE-at", "invalid tag", "en"),
+        )
+
+        assertEquals(1, metadata.credentialConfigurationsSupported?.size)
+    }
+
+    @Test
+    fun `credential issuer metadata request omits Accept-Language for unusable preferences`() = runTest {
+        val issuerUrl = "https://example.com"
+        val client = createMockClient { request ->
+            assertEquals(null, request.headers[HttpHeaders.AcceptLanguage])
+            respond(
+                content = """
+                    {"credential_issuer":"$issuerUrl","credential_endpoint":"$issuerUrl/credential",
+                    "credential_configurations_supported":{"test":{"format":"jwt_vc_json",
+                    "credential_definition":{"type":["VerifiableCredential","TestCredential"]}}}}
+                """.trimIndent(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        IssuerMetadataResolver(client).resolveCredentialIssuerMetadata(
+            credentialIssuerUrl = issuerUrl,
+            preferredLocales = listOf(" ", "invalid tag", "en_US"),
+        )
+    }
+
+    @Test
     fun testResolveCredentialIssuerMetadataWithIssuerPath() = runTest {
         val issuerUrl = "https://example.com/openid4vci"
         val mockResponse = """

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/IssuerMetadataResolverTest.kt
@@ -87,7 +87,7 @@ class IssuerMetadataResolverTest {
             preferredLocales = listOf(" de-AT ", "DE-at", "invalid tag", "en"),
         )
 
-        assertEquals(1, metadata.credentialConfigurationsSupported?.size)
+        assertEquals(1, metadata.metadata.credentialConfigurationsSupported.size)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadataTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadataTest.kt
@@ -1,0 +1,73 @@
+package id.waltid.openid4vci.wallet.metadata
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LocalizedMetadataTest {
+    private data class Display(val locale: String?, val name: String)
+
+    @Test
+    fun `selects exact then progressively less specific language tags`() {
+        val displays = listOf(
+            Display("de", "German"),
+            Display("de-AT", "Austrian German"),
+            Display(null, "Unlocalized"),
+        )
+
+        assertEquals("Austrian German", select(displays, listOf("de-AT"))?.name)
+        assertEquals("German", select(displays, listOf("de-CH"))?.name)
+    }
+
+    @Test
+    fun `lookup removes extension and private-use singleton subtags together`() {
+        assertEquals(
+            "Swiss German",
+            select(
+                listOf(
+                    Display("de-CH-u", "Incomplete extension"),
+                    Display("de-CH", "Swiss German"),
+                ),
+                listOf("de-CH-u-co-phonebk"),
+            )?.name,
+        )
+        assertEquals(
+            "English",
+            select(
+                listOf(Display("en-x", "Incomplete private use"), Display("en", "English")),
+                listOf("en-x-wallet"),
+            )?.name,
+        )
+    }
+
+    @Test
+    fun `falls back to unlocalized then first advertised display deterministically`() {
+        assertEquals(
+            "Unlocalized",
+            select(
+                listOf(Display("en", "English"), Display(null, "Unlocalized")),
+                listOf("de"),
+            )?.name,
+        )
+        assertEquals(
+            "English",
+            select(listOf(Display("en", "English"), Display("fr", "French")), listOf("de"))?.name,
+        )
+    }
+
+    @Test
+    fun `normalizes preferences before constructing Accept-Language`() {
+        assertEquals(
+            "de-AT, en;q=0.9",
+            LocalizedMetadata.acceptLanguageValue(listOf(" de-AT ", "", "DE-at", "invalid tag", "en")),
+        )
+    }
+
+    @Test
+    fun `does not construct Accept-Language from empty or invalid preferences`() {
+        assertNull(LocalizedMetadata.acceptLanguageValue(listOf(" ", "invalid tag", "en_US")))
+    }
+
+    private fun select(displays: List<Display>, preferredLocales: List<String>): Display? =
+        LocalizedMetadata.select(displays, preferredLocales) { it.locale }
+}

--- a/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadataTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vci-wallet/src/commonTest/kotlin/id/waltid/openid4vci/wallet/metadata/LocalizedMetadataTest.kt
@@ -56,6 +56,21 @@ class LocalizedMetadataTest {
     }
 
     @Test
+    fun `malformed locales do not become the unlocalized fallback`() {
+        assertEquals(
+            "Unlocalized",
+            select(
+                listOf(
+                    Display("en_US", "Malformed locale"),
+                    Display(" ", "Blank locale"),
+                    Display(null, "Unlocalized"),
+                ),
+                listOf("de"),
+            )?.name,
+        )
+    }
+
+    @Test
     fun `normalizes preferences before constructing Accept-Language`() {
         assertEquals(
             "de-AT, en;q=0.9",

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -423,7 +423,8 @@ private extension Waltid_openid4vc_walletWalletIssuanceCredentialPreview {
             format: format,
             name: name,
             descriptionText: descriptionText,
-            logoURI: logoUri.flatMap(URL.init(string:))
+            logoURI: logoUri.flatMap(URL.init(string:)),
+            logoAltText: logoAltText
         )
     }
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -894,6 +894,9 @@ public struct IssuanceCredentialPreview: Equatable, Sendable {
     /// Credential logo URL when advertised.
     public let logoURI: URL?
 
+    /// Accessibility text for the credential logo when advertised.
+    public let logoAltText: String?
+
     /// Creates a credential preview.
     ///
     /// - Parameters:
@@ -902,12 +905,21 @@ public struct IssuanceCredentialPreview: Equatable, Sendable {
     ///   - name: Localized credential name.
     ///   - descriptionText: Localized credential description.
     ///   - logoURI: Credential logo URL.
-    public init(configurationID: String, format: String, name: String?, descriptionText: String?, logoURI: URL?) {
+    ///   - logoAltText: Accessibility text for the credential logo.
+    public init(
+        configurationID: String,
+        format: String,
+        name: String?,
+        descriptionText: String?,
+        logoURI: URL?,
+        logoAltText: String? = nil
+    ) {
         self.configurationID = configurationID
         self.format = format
         self.name = name
         self.descriptionText = descriptionText
         self.logoURI = logoURI
+        self.logoAltText = logoAltText
     }
 }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -27,6 +27,19 @@ final class WalletAPITests: XCTestCase {
         XCTAssertEqual(configuration.preferredLocales, Locale.preferredLanguages)
     }
 
+    func testIssuanceCredentialPreviewRetainsLogoAccessibilityText() {
+        let preview = IssuanceCredentialPreview(
+            configurationID: "mdl",
+            format: "mso_mdoc",
+            name: "Mobile Driving Licence",
+            descriptionText: nil,
+            logoURI: URL(string: "https://issuer.example/mdl.png"),
+            logoAltText: "Driving licence logo"
+        )
+
+        XCTAssertEqual(preview.logoAltText, "Driving licence logo")
+    }
+
     func testPublicPersistenceConfigurationUsesEncryptedDefault() {
         let configuration = WalletConfiguration(persistence: WalletPersistence(databaseKey: .managed))
 


### PR DESCRIPTION
## Summary

[WAL-1309](https://linear.app/walt-new/issue/WAL-1309/display-issuer-and-verifier-metadata-consistently-in-mobile-wallet) makes OpenID4VCI issuer and credential metadata follow the mobile wallet's locale preferences throughout issuance review and storage.

The wallet now requests localized Credential Issuer metadata, selects display entries deterministically, and retains the reviewed credential label across immediate and deferred issuance. Compose and native iOS also receive credential-logo accessibility text.

## What Changed

### Localized issuer metadata

- Send normalized `Accept-Language` preferences when resolving Credential Issuer metadata.
- Select issuer and credential display entries using exact and progressively less-specific BCP 47 lookup, followed by unlocalized and first-entry fallbacks.

### Issuance continuity

- Retain the selected issuer and credential preview in the issuance session.
- Reuse the reviewed credential name when storing immediate or deferred credentials.

### Mobile parity

- Carry credential logo `alt_text` through the KMP, Compose, and Swift Wallet SDK models.
- Render that accessibility text in the Compose and native iOS issuance-review surfaces.

## Scope

- Keep the change limited to OpenID4VCI issuance metadata and mobile review models.
- Leave OpenID4VP verifier trust, pre-registration, response destinations, and enterprise fixtures unchanged.
- Keep presentation hierarchy and technical request details provided by [#2125](https://github.com/walt-id/waltid-identity/pull/2125).

## Architecture Notes

Locale selection stays in shared protocol and wallet code; platform UIs render the normalized preview. The selected preview, rather than mutable locale settings, is retained with the issuance session so restored continuations preserve what the user reviewed.
