### PR TITLE
[WAL-1209] feat(wallet): specify timed biometric key-use reuse

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidMain/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/androidMain/kotlin/id/walt/walletdemo/compose/logic/AndroidDemoWallet.kt
@@ -46,7 +46,7 @@ suspend fun createAndroidDemoMobileWallet(
                     List(locales.size()) { index -> locales[index].toLanguageTag() }
                 },
                 defaultKeyUseAuthorizationPolicy = if (config.biometricEnabled) {
-                    KeyUseAuthorizationPolicy.BiometricCurrentSet
+                    KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds = 10)
                 } else {
                     KeyUseAuthorizationPolicy.None
                 },

--- a/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/iosMain/kotlin/id/walt/walletdemo/compose/logic/IosDemoWallet.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedLogic/src/iosMain/kotlin/id/walt/walletdemo/compose/logic/IosDemoWallet.kt
@@ -37,7 +37,7 @@ fun createIosDemoWallet(
                     crossProcessAccess = crossProcessAccess,
                     onDigitalCredentialRegistryChanged = onDigitalCredentialRegistryChanged,
                     defaultKeyUseAuthorizationPolicy = if (config.biometricEnabled) {
-                        KeyUseAuthorizationPolicy.BiometricCurrentSet
+                        KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds = 10)
                     } else {
                         KeyUseAuthorizationPolicy.None
                     },

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletViewModel.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/ViewModels/WalletViewModel.swift
@@ -215,7 +215,7 @@ class WalletViewModel: ObservableObject {
             ),
             transactionDataProfiles: transactionDataProfiles.profiles,
             crossProcessAccess: Self.crossProcessAccessConfiguration(),
-            defaultKeyUseAuthorizationPolicy: biometricEnabled ? .biometricCurrentSet : .none,
+            defaultKeyUseAuthorizationPolicy: biometricEnabled ? .biometricTimedReuse(timeoutSeconds: 10) : .none,
             keyUseAuthorizationPrompt: WalletKeyUseAuthorizationPrompt(
                 message: "Authorize wallet signing",
                 cancelText: "Cancel"

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/androidHostTest/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackendPolicyTest.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/androidHostTest/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackendPolicyTest.kt
@@ -184,6 +184,50 @@ class AndroidSignumKeyBackendPolicyTest {
     }
 
     @Test
+    fun `timed biometric reuse requires the exact Keystore policy`() {
+        val policy = SignumKeyPolicy(
+            hardware = SignumHardwarePolicy.REQUIRED,
+            authentication = SignumAuthenticationPolicy.UserPresence(
+                biometric = true,
+                allowNewBiometrics = true,
+                deviceCredential = false,
+                timeoutSeconds = 10,
+            ),
+        )
+
+        validateAndroidNativePolicy(
+            alias = "timed-biometric",
+            policy = policy,
+            isInsideSecureHardware = true,
+            securityLevel = KeyProperties.SECURITY_LEVEL_TRUSTED_ENVIRONMENT,
+            isUserAuthenticationRequired = true,
+            userAuthenticationValidityDurationSeconds = 10,
+            isInvalidatedByBiometricEnrollment = false,
+            userAuthenticationType = KeyProperties.AUTH_BIOMETRIC_STRONG,
+        )
+
+        listOf(
+            Triple(0, false, KeyProperties.AUTH_BIOMETRIC_STRONG),
+            Triple(11, false, KeyProperties.AUTH_BIOMETRIC_STRONG),
+            Triple(10, true, KeyProperties.AUTH_BIOMETRIC_STRONG),
+            Triple(10, false, KeyProperties.AUTH_DEVICE_CREDENTIAL),
+        ).forEach { (duration, invalidatedByEnrollment, authenticationType) ->
+            assertFailsWith<SignumKeyPolicyMismatchException> {
+                validateAndroidNativePolicy(
+                    alias = "timed-biometric",
+                    policy = policy,
+                    isInsideSecureHardware = true,
+                    securityLevel = KeyProperties.SECURITY_LEVEL_TRUSTED_ENVIRONMENT,
+                    isUserAuthenticationRequired = true,
+                    userAuthenticationValidityDurationSeconds = duration,
+                    isInvalidatedByBiometricEnrollment = invalidatedByEnrollment,
+                    userAuthenticationType = authenticationType,
+                )
+            }
+        }
+    }
+
+    @Test
     fun `verification uses the cached public key without requesting interaction`() = runTest {
         val provider = CryptographySoftwareKeyProvider()
         val spec = KeySpec.Ec(EcCurve.P256)

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/androidHostTest/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackendPolicyTest.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/androidHostTest/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackendPolicyTest.kt
@@ -14,6 +14,8 @@ import id.walt.crypto2.providers.cryptography.CryptographySoftwareKeyProvider
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class AndroidSignumKeyBackendPolicyTest {
@@ -51,7 +53,7 @@ class AndroidSignumKeyBackendPolicyTest {
             isUserAuthenticationRequired = false,
             userAuthenticationValidityDurationSeconds = -1,
             isInvalidatedByBiometricEnrollment = false,
-            userAuthenticationType = null,
+            userAuthenticationType = KeyProperties.AUTH_BIOMETRIC_STRONG,
         )
     }
 
@@ -65,7 +67,7 @@ class AndroidSignumKeyBackendPolicyTest {
             isUserAuthenticationRequired = false,
             userAuthenticationValidityDurationSeconds = -1,
             isInvalidatedByBiometricEnrollment = false,
-            userAuthenticationType = null,
+            userAuthenticationType = KeyProperties.AUTH_BIOMETRIC_STRONG,
         )
     }
 
@@ -80,7 +82,7 @@ class AndroidSignumKeyBackendPolicyTest {
                 isUserAuthenticationRequired = false,
                 userAuthenticationValidityDurationSeconds = -1,
                 isInvalidatedByBiometricEnrollment = false,
-                userAuthenticationType = null,
+                userAuthenticationType = KeyProperties.AUTH_BIOMETRIC_STRONG,
             )
         }
     }
@@ -225,6 +227,32 @@ class AndroidSignumKeyBackendPolicyTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `expired timed reuse without interaction context maps to stable boundary failure`() {
+        val cause = UnsupportedOperationException("A prompt host is unavailable")
+
+        val mapped = cause.mapTimedReuseInteractionContextFailure(
+            alias = "timed-biometric",
+            hasInteractionContext = false,
+        )
+
+        assertIs<SignumInteractionContextUnavailableException>(mapped)
+        assertSame(cause, mapped.cause)
+    }
+
+    @Test
+    fun `timed reuse preserves provider failure when an interaction context can prompt`() {
+        val cause = UnsupportedOperationException("Timed authorization expired")
+
+        assertSame(
+            cause,
+            cause.mapTimedReuseInteractionContextFailure(
+                alias = "timed-biometric",
+                hasInteractionContext = true,
+            ),
+        )
     }
 
     @Test

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/androidMain/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackend.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/androidMain/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackend.kt
@@ -2,6 +2,7 @@ package id.walt.crypto2.signum
 
 import android.os.Build
 import android.security.keystore.KeyProperties
+import android.security.keystore.UserNotAuthenticatedException
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
@@ -31,8 +32,7 @@ public class AndroidSignumKeyBackend(
         spec.isSupportedSignumSpec() &&
             usages.all { it == KeyUsage.SIGN || it == KeyUsage.VERIFY || it == KeyUsage.KEY_AGREEMENT } &&
             (KeyUsage.KEY_AGREEMENT !in usages || spec is KeySpec.Ec) &&
-            (KeyUsage.KEY_AGREEMENT in usages) == policy.keyAgreement &&
-            (!policy.authentication.isBiometricTimedReuse() || Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+            (KeyUsage.KEY_AGREEMENT in usages) == policy.keyAgreement
 
     override suspend fun create(
         alias: String,
@@ -118,6 +118,13 @@ public class AndroidSignumKeyBackend(
                     throw failure.mapSignumFailure(alias)
                 }
             },
+            operationFailureMapper = { failure ->
+                if (policy.authentication.isBiometricTimedReuse()) {
+                    failure.mapTimedReuseInteractionContextFailure(alias, availableInteractionContext() != null)
+                } else {
+                    failure
+                }
+            },
             nativePublicKey = signer.publicKey,
             keyAgreementEnabled = KeyUsage.KEY_AGREEMENT in usages && policy.keyAgreement,
         )
@@ -144,9 +151,7 @@ public class AndroidSignumKeyBackend(
             isUserAuthenticationRequired = info.isUserAuthenticationRequired,
             userAuthenticationValidityDurationSeconds = info.userAuthenticationValidityDurationSeconds,
             isInvalidatedByBiometricEnrollment = info.isInvalidatedByBiometricEnrollment,
-            userAuthenticationType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                info.userAuthenticationType
-            } else null,
+            userAuthenticationType = info.userAuthenticationType,
         )
     }
 
@@ -176,7 +181,7 @@ internal fun validateAndroidNativePolicy(
     isUserAuthenticationRequired: Boolean,
     userAuthenticationValidityDurationSeconds: Int,
     isInvalidatedByBiometricEnrollment: Boolean,
-    userAuthenticationType: Int?,
+    userAuthenticationType: Int,
 ) {
     if (policy.hardware == SignumHardwarePolicy.REQUIRED) {
         if (!isInsideSecureHardware) {
@@ -201,7 +206,7 @@ internal fun validateAndroidNativePolicy(
                 "the native key does not require biometric authentication for every use",
             )
         }
-        if (userAuthenticationType != null && userAuthenticationType != KeyProperties.AUTH_BIOMETRIC_STRONG) {
+        if (userAuthenticationType != KeyProperties.AUTH_BIOMETRIC_STRONG) {
             throw SignumKeyPolicyMismatchException(alias, "the native key does not require BIOMETRIC_STRONG")
         }
     }
@@ -216,9 +221,26 @@ internal fun validateAndroidNativePolicy(
                 "the native key does not enforce the requested biometric authorization reuse interval",
             )
         }
-        if (userAuthenticationType != null && userAuthenticationType != KeyProperties.AUTH_BIOMETRIC_STRONG) {
+        if (userAuthenticationType != KeyProperties.AUTH_BIOMETRIC_STRONG) {
             throw SignumKeyPolicyMismatchException(alias, "the native key does not require BIOMETRIC_STRONG")
         }
+    }
+}
+
+/**
+ * Converts an expired timed-reuse operation with no viable AndroidX prompt host into the stable
+ * wallet boundary failure before a provider-specific exception can escape.
+ */
+internal fun Throwable.mapTimedReuseInteractionContextFailure(alias: String, hasInteractionContext: Boolean): Throwable {
+    if (hasInteractionContext) return this
+    val causes = generateSequence(this) { it.cause }.toList()
+    return if (causes.any { it is UserNotAuthenticatedException || it is UnsupportedOperationException }) {
+        SignumInteractionContextUnavailableException(
+            "A resumed FragmentActivity is required to reauthorize timed Signum key $alias",
+            this,
+        )
+    } else {
+        this
     }
 }
 

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/androidMain/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackend.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/androidMain/kotlin/id/walt/crypto2/signum/AndroidSignumKeyBackend.kt
@@ -17,9 +17,10 @@ import id.walt.crypto2.keys.ProviderId
 /**
  * Android-only Signum backend backed by Android KeyStore.
  *
- * Android [SignumAuthenticationPolicy.UserPresence] operations resolve a current resumed
+ * Per-use Android [SignumAuthenticationPolicy.UserPresence] operations resolve a current resumed
  * [FragmentActivity] at operation time so AndroidX BiometricPrompt can perform interactive
- * authorization. iOS Signum backends do not require this Android interaction host.
+ * authorization. Timed operations only use an available activity if Keystore reports that
+ * reusable authorization has expired; an already authorized signing operation remains headless.
  */
 public class AndroidSignumKeyBackend(
     private val interactionContextProvider: () -> FragmentActivity? = { null },
@@ -30,7 +31,8 @@ public class AndroidSignumKeyBackend(
         spec.isSupportedSignumSpec() &&
             usages.all { it == KeyUsage.SIGN || it == KeyUsage.VERIFY || it == KeyUsage.KEY_AGREEMENT } &&
             (KeyUsage.KEY_AGREEMENT !in usages || spec is KeySpec.Ec) &&
-            (KeyUsage.KEY_AGREEMENT in usages) == policy.keyAgreement
+            (KeyUsage.KEY_AGREEMENT in usages) == policy.keyAgreement &&
+            (!policy.authentication.isBiometricTimedReuse() || Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
 
     override suspend fun create(
         alias: String,
@@ -95,15 +97,18 @@ public class AndroidSignumKeyBackend(
             attestation = attestation,
             authentication = policy.authentication,
             signerFor = { algorithm: SignatureAlgorithm ->
-                val interactionContext = policy.authentication.takeIf {
-                    it is SignumAuthenticationPolicy.UserPresence
+                val interactionContext = when {
+                    policy.authentication.isBiometricCurrentSetEveryUse() -> requireInteractionContext(alias)
+                    policy.authentication.isBiometricTimedReuse() -> availableInteractionContext()
+                    else -> null
                 }
-                    ?.let { requireInteractionContext(alias) }
                 AndroidKeyStoreProvider.getSignerForKey(alias) {
                     configureSignumOperation(algorithm, policy.authentication)
                     if (interactionContext != null) {
                         unlockPrompt {
-                            if (policy.authentication.isBiometricCurrentSetEveryUse()) {
+                            if (policy.authentication.isBiometricCurrentSetEveryUse() ||
+                                policy.authentication.isBiometricTimedReuse()
+                            ) {
                                 allowedAuthenticators = BIOMETRIC_STRONG
                             }
                             activity = interactionContext
@@ -125,7 +130,8 @@ public class AndroidSignumKeyBackend(
         alias: String,
     ) {
         if (policy.hardware != SignumHardwarePolicy.REQUIRED &&
-            !policy.authentication.isBiometricCurrentSetEveryUse()
+            !policy.authentication.isBiometricCurrentSetEveryUse() &&
+            !policy.authentication.isBiometricTimedReuse()
         ) return
         val androidSigner = signer as? AndroidKeystoreSigner
             ?: throw SignumKeyPolicyMismatchException(alias, "the native signer is not Android Keystore-backed")
@@ -145,13 +151,18 @@ public class AndroidSignumKeyBackend(
     }
 
     private fun requireInteractionContext(alias: String): FragmentActivity {
+        return availableInteractionContext()
+            ?: throw SignumInteractionContextUnavailableException(
+                "A resumed FragmentActivity is required to use protected Signum key $alias",
+            )
+    }
+
+    private fun availableInteractionContext(): FragmentActivity? {
         val activity = interactionContextProvider()
         if (activity == null || activity.isFinishing || activity.isDestroyed || activity.isChangingConfigurations ||
             !activity.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
         ) {
-            throw SignumInteractionContextUnavailableException(
-                "A resumed FragmentActivity is required to use protected Signum key $alias",
-            )
+            return null
         }
         return activity
     }
@@ -188,6 +199,21 @@ internal fun validateAndroidNativePolicy(
             throw SignumKeyPolicyMismatchException(
                 alias,
                 "the native key does not require biometric authentication for every use",
+            )
+        }
+        if (userAuthenticationType != null && userAuthenticationType != KeyProperties.AUTH_BIOMETRIC_STRONG) {
+            throw SignumKeyPolicyMismatchException(alias, "the native key does not require BIOMETRIC_STRONG")
+        }
+    }
+    if (policy.authentication.isBiometricTimedReuse()) {
+        val timeoutSeconds = (policy.authentication as SignumAuthenticationPolicy.UserPresence).timeoutSeconds
+        if (!isUserAuthenticationRequired ||
+            userAuthenticationValidityDurationSeconds != timeoutSeconds ||
+            isInvalidatedByBiometricEnrollment
+        ) {
+            throw SignumKeyPolicyMismatchException(
+                alias,
+                "the native key does not enforce the requested biometric authorization reuse interval",
             )
         }
         if (userAuthenticationType != null && userAuthenticationType != KeyProperties.AUTH_BIOMETRIC_STRONG) {

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/commonMain/kotlin/id/walt/crypto2/signum/SignumKeyPolicy.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/commonMain/kotlin/id/walt/crypto2/signum/SignumKeyPolicy.kt
@@ -65,6 +65,13 @@ internal fun SignumAuthenticationPolicy.isBiometricCurrentSetEveryUse(): Boolean
         !deviceCredential &&
         timeoutSeconds == 0
 
+internal fun SignumAuthenticationPolicy.isBiometricTimedReuse(): Boolean =
+    this is SignumAuthenticationPolicy.UserPresence &&
+        biometric &&
+        allowNewBiometrics &&
+        !deviceCredential &&
+        timeoutSeconds > 0
+
 @Serializable
 enum class SignumProtectionLevel {
     HARDWARE,

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/iosMain/kotlin/id/walt/crypto2/signum/IosSignumKeyBackend.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/iosMain/kotlin/id/walt/crypto2/signum/IosSignumKeyBackend.kt
@@ -173,10 +173,12 @@ class IosSignumKeyBackend : SignumPlatformBackend {
         alias: String,
     ) {
         if (policy.hardware != SignumHardwarePolicy.REQUIRED &&
-            !policy.authentication.isBiometricCurrentSetEveryUse()
+            !policy.authentication.isBiometricCurrentSetEveryUse() &&
+            !policy.authentication.isBiometricTimedReuse()
         ) return
-        val exactAuthentication = policy.authentication.isBiometricCurrentSetEveryUse()
-        val iosSigner = if (exactAuthentication) {
+        val requiresAuthentication = policy.authentication.isBiometricCurrentSetEveryUse() ||
+            policy.authentication.isBiometricTimedReuse()
+        val iosSigner = if (requiresAuthentication) {
             signer as? IosSigner
                 ?: throw SignumKeyPolicyMismatchException(alias, "the native signer is not Keychain-backed")
         } else {
@@ -185,6 +187,7 @@ class IosSignumKeyBackend : SignumPlatformBackend {
         validateIosNativePolicy(
             alias = alias,
             policy = policy,
+            needsAuthentication = iosSigner?.needsAuthentication ?: false,
             needsAuthenticationForEveryUse = iosSigner?.needsAuthenticationForEveryUse ?: false,
             isSecureEnclave = if (policy.hardware == SignumHardwarePolicy.REQUIRED) {
                 isSecureEnclaveKey(alias)
@@ -198,6 +201,7 @@ class IosSignumKeyBackend : SignumPlatformBackend {
         alias: String,
         policy: SignumKeyPolicy,
         needsAuthenticationForEveryUse: Boolean,
+        needsAuthentication: Boolean = needsAuthenticationForEveryUse,
         isSecureEnclave: Boolean,
     ) {
         if (policy.hardware == SignumHardwarePolicy.REQUIRED && !isSecureEnclave) {
@@ -205,11 +209,20 @@ class IosSignumKeyBackend : SignumPlatformBackend {
         }
         if (
             policy.authentication.isBiometricCurrentSetEveryUse() &&
-            !needsAuthenticationForEveryUse
+            (!needsAuthentication || !needsAuthenticationForEveryUse)
         ) {
             throw SignumKeyPolicyMismatchException(
                 alias,
                 "the native key does not enforce biometric authentication for every use",
+            )
+        }
+        if (
+            policy.authentication.isBiometricTimedReuse() &&
+            (needsAuthenticationForEveryUse || !needsAuthentication)
+        ) {
+            throw SignumKeyPolicyMismatchException(
+                alias,
+                "the native key does not enforce reusable biometric authentication",
             )
         }
     }

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/iosMain/kotlin/id/walt/crypto2/signum/IosSignumKeyBackend.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/iosMain/kotlin/id/walt/crypto2/signum/IosSignumKeyBackend.kt
@@ -207,6 +207,8 @@ class IosSignumKeyBackend : SignumPlatformBackend {
         if (policy.hardware == SignumHardwarePolicy.REQUIRED && !isSecureEnclave) {
             throw SignumKeyPolicyMismatchException(alias, "the native key is not Secure Enclave-backed")
         }
+        // Signum exposes only whether authentication is required and reusable. Its pinned public
+        // API does not expose the effective positive timeout after restoration to compare it.
         if (
             policy.authentication.isBiometricCurrentSetEveryUse() &&
             (!needsAuthentication || !needsAuthenticationForEveryUse)

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/iosTest/kotlin/id/walt/crypto2/signum/IosSignumKeyBackendPolicyTest.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/iosTest/kotlin/id/walt/crypto2/signum/IosSignumKeyBackendPolicyTest.kt
@@ -86,6 +86,42 @@ class IosSignumKeyBackendPolicyTest {
     }
 
     @Test
+    fun `timed biometric reuse requires reusable authenticated Secure Enclave access`() {
+        val policy = SignumKeyPolicy(
+            hardware = SignumHardwarePolicy.REQUIRED,
+            authentication = SignumAuthenticationPolicy.UserPresence(
+                biometric = true,
+                allowNewBiometrics = true,
+                deviceCredential = false,
+                timeoutSeconds = 10,
+            ),
+        )
+
+        backend.validateIosNativePolicy(
+            alias = "timed-biometric",
+            policy = policy,
+            needsAuthentication = true,
+            needsAuthenticationForEveryUse = false,
+            isSecureEnclave = true,
+        )
+
+        listOf(
+            false to false,
+            true to true,
+        ).forEach { (needsAuthentication, needsAuthenticationForEveryUse) ->
+            assertFailsWith<SignumKeyPolicyMismatchException> {
+                backend.validateIosNativePolicy(
+                    alias = "timed-biometric",
+                    policy = policy,
+                    needsAuthentication = needsAuthentication,
+                    needsAuthenticationForEveryUse = needsAuthenticationForEveryUse,
+                    isSecureEnclave = true,
+                )
+            }
+        }
+    }
+
+    @Test
     fun `keychain item not found maps to a typed Signum missing-key failure`() {
         val mapped = CFCryptoOperationFailed(
             thing = "load Signum key",

--- a/waltid-libraries/crypto/waltid-crypto2-signum/src/mobileMain/kotlin/id/walt/crypto2/signum/SignumPlatformSupport.kt
+++ b/waltid-libraries/crypto/waltid-crypto2-signum/src/mobileMain/kotlin/id/walt/crypto2/signum/SignumPlatformSupport.kt
@@ -113,6 +113,7 @@ internal class SignumPlatformKeyHandle(
     override val attestation: SignumKeyAttestation?,
     private val authentication: SignumAuthenticationPolicy,
     private val signerFor: suspend (SignatureAlgorithm) -> PlatformSigningProviderSigner<*, *>,
+    private val operationFailureMapper: (Throwable) -> Throwable = { it },
     private val nativePublicKey: CryptoPublicKey,
     keyAgreementEnabled: Boolean,
 ) : SignumPlatformKey {
@@ -122,10 +123,14 @@ internal class SignumPlatformKeyHandle(
 
     override suspend fun sign(data: ByteArray, algorithm: SignatureAlgorithm): ByteArray {
         require(algorithm in signatureAlgorithms) { "Unsupported Signum signature algorithm" }
-        return when (val result = signerFor(algorithm).sign(data)) {
-            is SignatureResult.Success -> result.signature.rawByteArray
-            is SignatureResult.Failure -> throw SignumUserCancelledException(result.problem)
-            is SignatureResult.Error -> throw result.exception
+        return try {
+            when (val result = signerFor(algorithm).sign(data)) {
+                is SignatureResult.Success -> result.signature.rawByteArray
+                is SignatureResult.Failure -> throw SignumUserCancelledException(result.problem)
+                is SignatureResult.Error -> throw result.exception
+            }
+        } catch (cause: Throwable) {
+            throw operationFailureMapper(cause)
         }
     }
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -46,6 +46,14 @@ Secure Enclave device and an `NSFaceIDUsageDescription` host-app entry.
 The policy is chosen only while creating a new key. Restored keys retain their
 persisted policy; changing the default never weakens or recreates an existing key.
 
+`BiometricTimedReuse(timeoutSeconds)` is available for a fixed 1–30 second,
+non-sliding reuse interval. It also requires P-256, strong biometrics, and no
+device-credential fallback, but intentionally permits new biometric enrollment
+without invalidating the key. Android requires API 30 or newer and reports `PlatformKeyStore` enforcement;
+iOS reports `ProviderProcess` enforcement, which may end reusable authorization
+earlier but never extends it past the configured interval. It has no action,
+session, or batch scope.
+
 ## Receiving credentials
 
 Start an issuance session to resolve the offer and retain the exact reviewed

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -49,10 +49,13 @@ persisted policy; changing the default never weakens or recreates an existing ke
 `BiometricTimedReuse(timeoutSeconds)` is available for a fixed 1–30 second,
 non-sliding reuse interval. It also requires P-256, strong biometrics, and no
 device-credential fallback, but intentionally permits new biometric enrollment
-without invalidating the key. Android requires API 30 or newer and reports `PlatformKeyStore` enforcement;
-iOS reports `ProviderProcess` enforcement, which may end reusable authorization
-earlier but never extends it past the configured interval. It has no action,
-session, or batch scope.
+without invalidating the key. Android reports `PlatformKeyStore` with
+`PlatformVerified`: native KeyStore metadata must exactly match the requested
+interval. iOS reports `ProviderProcess` with `ProviderConfigured`: Signum
+receives the requested interval, but its pinned public API cannot independently
+expose the effective positive timeout after restoration. Timed reuse is recent
+platform or provider authentication, not issuance, presentation, or other
+wallet-action consent, and is not guaranteed to be key-local.
 
 ## Receiving credentials
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -50,10 +50,11 @@ persisted policy; changing the default never weakens or recreates an existing ke
 non-sliding reuse interval. It also requires P-256, strong biometrics, and no
 device-credential fallback, but intentionally permits new biometric enrollment
 without invalidating the key. Android reports `PlatformKeyStore` with
-`PlatformVerified`: native KeyStore metadata must exactly match the requested
-interval. iOS reports `ProviderProcess` with `ProviderConfigured`: Signum
-receives the requested interval, but its pinned public API cannot independently
-expose the effective positive timeout after restoration. Timed reuse is recent
+`IndependentReadback`: native KeyStore metadata can be read back and compared
+with the requested interval after creation or restoration. iOS reports
+`ProviderProcess` with `ProviderConfigurationOnly`: Signum receives the
+requested interval, but its pinned public API cannot independently expose the
+effective positive timeout after restoration. Timed reuse is recent
 platform or provider authentication, not issuance, presentation, or other
 wallet-action consent, and is not guaranteed to be key-local.
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -74,19 +74,19 @@ final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthoriza
     }
 }
 
-final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification|null[0]
-    enum entry PlatformVerified // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.PlatformVerified|null[0]
-    enum entry ProviderConfigured // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured|null[0]
+final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation|null[0]
+    enum entry IndependentReadback // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.IndependentReadback|null[0]
+    enum entry ProviderConfigurationOnly // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly|null[0]
 
-    final val entries // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val entries // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.entries.<get-entries>|<get-entries>#static(){}[0]
 
-    final fun valueOf(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.values|values#static(){}[0]
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.values|values#static(){}[0]
 
-    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.Companion|null[0]
-        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(){}[0]
-        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     }
 }
 
@@ -688,13 +688,13 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight { // id
         final fun <get-reuseEnforcement>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.reuseEnforcement.<get-reuseEnforcement>|<get-reuseEnforcement>(){}[0]
     final val supported // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.supported|{}supported[0]
         final fun <get-supported>(): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.supported.<get-supported>|<get-supported>(){}[0]
-    final val timeoutVerification // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.timeoutVerification|{}timeoutVerification[0]
-        final fun <get-timeoutVerification>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.timeoutVerification.<get-timeoutVerification>|<get-timeoutVerification>(){}[0]
+    final val timeoutValidation // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.timeoutValidation|{}timeoutValidation[0]
+        final fun <get-timeoutValidation>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.timeoutValidation.<get-timeoutValidation>|<get-timeoutValidation>(){}[0]
 
     final fun component1(): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component1|component1(){}[0]
     final fun component2(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component2|component2(){}[0]
     final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component3|component3(){}[0]
-    final fun component4(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component4|component4(){}[0]
+    final fun component4(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutValidation? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component4|component4(){}[0]
     final fun component5(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component5|component5(){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.hashCode|hashCode(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -74,6 +74,22 @@ final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthoriza
     }
 }
 
+final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification|null[0]
+    enum entry PlatformVerified // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.PlatformVerified|null[0]
+    enum entry ProviderConfigured // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured|null[0]
+
+    final val entries // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
 final enum class id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus : kotlin/Enum<id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus> { // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus|null[0]
     enum entry AUTHORIZED // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.AUTHORIZED|null[0]
     enum entry NOT_AUTHORIZED // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.NOT_AUTHORIZED|null[0]
@@ -672,11 +688,14 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight { // id
         final fun <get-reuseEnforcement>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.reuseEnforcement.<get-reuseEnforcement>|<get-reuseEnforcement>(){}[0]
     final val supported // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.supported|{}supported[0]
         final fun <get-supported>(): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.supported.<get-supported>|<get-supported>(){}[0]
+    final val timeoutVerification // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.timeoutVerification|{}timeoutVerification[0]
+        final fun <get-timeoutVerification>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.timeoutVerification.<get-timeoutVerification>|<get-timeoutVerification>(){}[0]
 
     final fun component1(): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component1|component1(){}[0]
     final fun component2(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component2|component2(){}[0]
     final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component3|component3(){}[0]
-    final fun component4(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component4|component4(){}[0]
+    final fun component4(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component4|component4(){}[0]
+    final fun component5(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component5|component5(){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.toString|toString(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -41,6 +41,39 @@ final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeErrorCategory :
     }
 }
 
+final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType|null[0]
+    enum entry BiometricCurrentSet // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.BiometricCurrentSet|null[0]
+    enum entry BiometricTimedReuse // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse|null[0]
+    enum entry None // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.None|null[0]
+
+    final val entries // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
+final enum class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement : kotlin/Enum<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement|null[0]
+    enum entry PlatformKeyStore // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore|null[0]
+    enum entry ProviderProcess // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess|null[0]
+
+    final val entries // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
 final enum class id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus : kotlin/Enum<id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus> { // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus|null[0]
     enum entry AUTHORIZED // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.AUTHORIZED|null[0]
     enum entry NOT_AUTHORIZED // id.walt.wallet2.mobile/IosIdentityDocumentRegistrationStatus.NOT_AUTHORIZED|null[0]
@@ -549,7 +582,7 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfigu
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration|null[0]
-    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
+    constructor <init>(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.<init>|<init>(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
 
     final val appGroupIdentifier // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.appGroupIdentifier|{}appGroupIdentifier[0]
         final fun <get-appGroupIdentifier>(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.appGroupIdentifier.<get-appGroupIdentifier>|<get-appGroupIdentifier>(){}[0]
@@ -562,7 +595,7 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // i
     final val defaultKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyType|{}defaultKeyType[0]
         final fun <get-defaultKeyType>(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyType.<get-defaultKeyType>|<get-defaultKeyType>(){}[0]
     final val defaultKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyUseAuthorizationPolicy|{}defaultKeyUseAuthorizationPolicy[0]
-        final fun <get-defaultKeyUseAuthorizationPolicy>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyUseAuthorizationPolicy.<get-defaultKeyUseAuthorizationPolicy>|<get-defaultKeyUseAuthorizationPolicy>(){}[0]
+        final fun <get-defaultKeyUseAuthorizationPolicy>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.defaultKeyUseAuthorizationPolicy.<get-defaultKeyUseAuthorizationPolicy>|<get-defaultKeyUseAuthorizationPolicy>(){}[0]
     final val keyUseAuthorizationPrompt // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keyUseAuthorizationPrompt|{}keyUseAuthorizationPrompt[0]
         final fun <get-keyUseAuthorizationPrompt>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keyUseAuthorizationPrompt.<get-keyUseAuthorizationPrompt>|<get-keyUseAuthorizationPrompt>(){}[0]
     final val keychainAccessGroup // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.keychainAccessGroup|{}keychainAccessGroup[0]
@@ -578,7 +611,7 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // i
 
     final fun component1(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component1|component1(){}[0]
     final fun component10(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component10|component10(){}[0]
-    final fun component11(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component11|component11(){}[0]
+    final fun component11(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component11|component11(){}[0]
     final fun component12(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component12|component12(){}[0]
     final fun component2(): id.walt.wallet2.mobile/MobileWalletKeyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component2|component2(){}[0]
     final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component3|component3(){}[0]
@@ -588,7 +621,7 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration { // i
     final fun component7(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component7|component7(){}[0]
     final fun component8(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component8|component8(){}[0]
     final fun component9(): kotlin/String? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.component9|component9(){}[0]
-    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
+    final fun copy(kotlin/String = ..., id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgePersistence = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeDatabaseEncryptionKeyProvider? = ..., id.walt.wallet2.mobile/WalletAttestationConfig? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletTransactionDataProfile> = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeClientIdTrustConfiguration = ..., kotlin/String? = ..., kotlin/String? = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPrompt = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.copy|copy(kotlin.String;id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgePersistence;id.walt.wallet2.mobile.swiftinterop.WalletBridgeDatabaseEncryptionKeyProvider?;id.walt.wallet2.mobile.WalletAttestationConfig?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletTransactionDataProfile>;id.walt.wallet2.mobile.swiftinterop.WalletBridgeClientIdTrustConfiguration;kotlin.String?;kotlin.String?;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeConfiguration.toString|toString(){}[0]
@@ -631,13 +664,19 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeError { // id.walt.w
 }
 
 final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight|null[0]
+    final val effectivePolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.effectivePolicy|{}effectivePolicy[0]
+        final fun <get-effectivePolicy>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.effectivePolicy.<get-effectivePolicy>|<get-effectivePolicy>(){}[0]
     final val failure // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.failure|{}failure[0]
         final fun <get-failure>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.failure.<get-failure>|<get-failure>(){}[0]
+    final val reuseEnforcement // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.reuseEnforcement|{}reuseEnforcement[0]
+        final fun <get-reuseEnforcement>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.reuseEnforcement.<get-reuseEnforcement>|<get-reuseEnforcement>(){}[0]
     final val supported // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.supported|{}supported[0]
         final fun <get-supported>(): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.supported.<get-supported>|<get-supported>(){}[0]
 
     final fun component1(): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component1|component1(){}[0]
-    final fun component2(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component2|component2(){}[0]
+    final fun component2(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component2|component2(){}[0]
+    final fun component3(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component3|component3(){}[0]
+    final fun component4(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.component4|component4(){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.toString|toString(){}[0]
@@ -655,6 +694,41 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight { // id
         final val $childSerializers // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.Companion.$childSerializers|{}$childSerializers[0]
 
         final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy|null[0]
+    constructor <init>(id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType, kotlin/Int? = ...) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.<init>|<init>(id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicyType;kotlin.Int?){}[0]
+
+    final val timeoutSeconds // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.timeoutSeconds|{}timeoutSeconds[0]
+        final fun <get-timeoutSeconds>(): kotlin/Int? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.timeoutSeconds.<get-timeoutSeconds>|<get-timeoutSeconds>(){}[0]
+    final val type // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.type|{}type[0]
+        final fun <get-type>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.type.<get-type>|<get-type>(){}[0]
+
+    final fun component1(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.component1|component1(){}[0]
+    final fun component2(): kotlin/Int? // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.component2|component2(){}[0]
+    final fun copy(id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicyType = ..., kotlin/Int? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.copy|copy(id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicyType;kotlin.Int?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy> { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.$serializer|null[0]
+        final val descriptor // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy) // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy){}[0]
+    }
+
+    final object Companion { // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.Companion|null[0]
+        final val $childSerializers // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.Companion.$childSerializers|{}$childSerializers[0]
+        final val BiometricCurrentSet // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.Companion.BiometricCurrentSet|{}BiometricCurrentSet[0]
+            final fun <get-BiometricCurrentSet>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.Companion.BiometricCurrentSet.<get-BiometricCurrentSet>|<get-BiometricCurrentSet>(){}[0]
+        final val None // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.Companion.None|{}None[0]
+            final fun <get-None>(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.Companion.None.<get-None>|<get-None>(){}[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy> // id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy.Companion.serializer|serializer(){}[0]
     }
 }
 
@@ -729,14 +803,14 @@ final class id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge { // id.walt.wal
 
     final fun digitalCredentialCapabilities(): id.walt.wallet2.mobile/MobileWalletDigitalCredentialCapabilities // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.digitalCredentialCapabilities|digitalCredentialCapabilities(){}[0]
     final suspend fun beginAuthorizationIssuance(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.handlers/WalletIssuanceAuthorization> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.beginAuthorizationIssuance|beginAuthorizationIssuance(kotlin.String){}[0]
-    final suspend fun bootstrap(id.walt.wallet2.mobile/MobileWalletKeyType? = ..., kotlin/String = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletBootstrapResult> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.bootstrap|bootstrap(id.walt.wallet2.mobile.MobileWalletKeyType?;kotlin.String;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy?){}[0]
+    final suspend fun bootstrap(id.walt.wallet2.mobile/MobileWalletKeyType? = ..., kotlin/String = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletBootstrapResult> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.bootstrap|bootstrap(id.walt.wallet2.mobile.MobileWalletKeyType?;kotlin.String;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy?){}[0]
     final suspend fun cancelIssuance(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.handlers/WalletIssuanceOutcome> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.cancelIssuance|cancelIssuance(kotlin.String){}[0]
     final suspend fun continueAuthorizationIssuance(kotlin/String, kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.handlers/WalletIssuanceOutcome> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.continueAuthorizationIssuance|continueAuthorizationIssuance(kotlin.String;kotlin.String){}[0]
     final suspend fun continuePreAuthorizedIssuance(kotlin/String, kotlin/String? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.handlers/WalletIssuanceOutcome> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.continuePreAuthorizedIssuance|continuePreAuthorizedIssuance(kotlin.String;kotlin.String?){}[0]
     final suspend fun credentials(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletCredential>> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.credentials|credentials(){}[0]
     final suspend fun deleteWallet(): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<kotlin/Unit> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.deleteWallet|deleteWallet(){}[0]
     final suspend fun discardPresentationPreview(id.walt.wallet2.mobile/MobileWalletPresentationPreviewHandle): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<kotlin/Unit> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.discardPresentationPreview|discardPresentationPreview(id.walt.wallet2.mobile.MobileWalletPresentationPreviewHandle){}[0]
-    final suspend fun keyUseAuthorizationPreflight(id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.keyUseAuthorizationPreflight|keyUseAuthorizationPreflight(id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy){}[0]
+    final suspend fun keyUseAuthorizationPreflight(id.walt.wallet2.mobile/MobileWalletKeyType = ..., id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyUseAuthorizationPolicy = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile.swiftinterop/WalletBridgeKeyPreflight> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.keyUseAuthorizationPreflight|keyUseAuthorizationPreflight(id.walt.wallet2.mobile.MobileWalletKeyType;id.walt.wallet2.mobile.swiftinterop.WalletBridgeKeyUseAuthorizationPolicy){}[0]
     final suspend fun present(kotlin/String, kotlin/String? = ..., kotlin/Boolean? = ...): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletPresentationResult> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.present|present(kotlin.String;kotlin.String?;kotlin.Boolean?){}[0]
     final suspend fun previewAnnexCPresentation(id.walt.wallet2.mobile/MobileWalletAnnexCRequest): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletAnnexCPreview> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.previewAnnexCPresentation|previewAnnexCPresentation(id.walt.wallet2.mobile.MobileWalletAnnexCRequest){}[0]
     final suspend fun previewPresentation(kotlin/String): id.walt.wallet2.mobile.swiftinterop/WalletBridgeResult<id.walt.wallet2.mobile/MobileWalletPresentationPreviewResult> // id.walt.wallet2.mobile.swiftinterop/WalletSdkBridge.previewPresentation|previewPresentation(kotlin.String){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/MobileWalletFactoryTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/MobileWalletFactoryTest.kt
@@ -179,6 +179,11 @@ class MobileWalletFactoryTest {
                 requested = KeyUseAuthorizationPolicy.BiometricCurrentSet,
                 expected = KeyUseAuthorizationPolicy.BiometricCurrentSet,
             ),
+            PolicyCase(
+                configured = KeyUseAuthorizationPolicy.BiometricCurrentSet,
+                requested = KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds = 10),
+                expected = KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds = 10),
+            ),
         )
 
         cases.forEach { case ->
@@ -197,7 +202,7 @@ class MobileWalletFactoryTest {
                         keyUseAuthorizationPolicy = case.requested,
                     )
                 }
-                assertEquals(KeyUseAuthorizationSupport.Supported, preflight)
+                assertEquals(KeyUseAuthorizationSupport.Supported(case.expected), preflight)
                 assertEquals(listOf(case.expected), provider.preflightPolicies)
             }
 
@@ -345,13 +350,13 @@ class MobileWalletFactoryTest {
         var generateCount = 0
         var deleteCount = 0
         var generateFailure: Throwable? = null
-        var preflightResult: KeyUseAuthorizationSupport = KeyUseAuthorizationSupport.Supported
+        var preflightResult: KeyUseAuthorizationSupport? = null
         val preflightPolicies = mutableListOf<KeyUseAuthorizationPolicy>()
         val generatedPolicies = mutableListOf<KeyUseAuthorizationPolicy>()
 
         override suspend fun preflight(requirements: WalletKeyRequirements): KeyUseAuthorizationSupport {
             preflightPolicies += requirements.authorizationPolicy
-            return preflightResult
+            return preflightResult ?: KeyUseAuthorizationSupport.Supported(requirements.authorizationPolicy)
         }
 
         override suspend fun generateManagedKey(request: WalletKeyCreationRequest): ManagedKey {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/MobileWalletFactoryTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/MobileWalletFactoryTest.kt
@@ -29,6 +29,8 @@ import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationException
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutValidation
 import id.walt.wallet2.persistence.keys.WalletKeyCreationRequest
 import id.walt.wallet2.persistence.keys.WalletKeyRequirements
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
@@ -202,7 +204,7 @@ class MobileWalletFactoryTest {
                         keyUseAuthorizationPolicy = case.requested,
                     )
                 }
-                assertEquals(KeyUseAuthorizationSupport.Supported(case.expected), preflight)
+                assertEquals(case.expected.toSupportedPreflight(), preflight)
                 assertEquals(listOf(case.expected), provider.preflightPolicies)
             }
 
@@ -356,7 +358,7 @@ class MobileWalletFactoryTest {
 
         override suspend fun preflight(requirements: WalletKeyRequirements): KeyUseAuthorizationSupport {
             preflightPolicies += requirements.authorizationPolicy
-            return preflightResult ?: KeyUseAuthorizationSupport.Supported(requirements.authorizationPolicy)
+            return preflightResult ?: requirements.authorizationPolicy.toSupportedPreflight()
         }
 
         override suspend fun generateManagedKey(request: WalletKeyCreationRequest): ManagedKey {
@@ -425,4 +427,13 @@ class MobileWalletFactoryTest {
     private companion object {
         val PRIVATE_JWK_MEMBERS = setOf("d", "p", "q", "dp", "dq", "qi", "oth", "k")
     }
+}
+
+private fun KeyUseAuthorizationPolicy.toSupportedPreflight(): KeyUseAuthorizationSupport.Supported = when (this) {
+    is KeyUseAuthorizationPolicy.BiometricTimedReuse -> KeyUseAuthorizationSupport.Supported(
+        effectivePolicy = this,
+        reuseEnforcement = KeyUseAuthorizationReuseEnforcement.ProviderProcess,
+        timeoutValidation = KeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly,
+    )
+    else -> KeyUseAuthorizationSupport.Supported(this)
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWallet.kt
@@ -288,7 +288,7 @@ public class MobileWallet internal constructor(
             .also { syncDigitalCredentialRegistration() }
     }
 
-    /** Checks an exact key-use authorization request without creating or persisting a key. */
+    /** Checks whether a key-use authorization request is supported without creating or persisting a key. */
     public suspend fun keyUseAuthorizationPreflight(
         keyType: MobileWalletKeyType = defaultKeyType,
         keyUseAuthorizationPolicy: KeyUseAuthorizationPolicy = defaultKeyUseAuthorizationPolicy,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridge.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridge.kt
@@ -64,22 +64,22 @@ public class WalletSdkBridge private constructor(
     public suspend fun bootstrap(
         keyType: MobileWalletKeyType? = null,
         didMethod: String = "key",
-        keyUseAuthorizationPolicy: KeyUseAuthorizationPolicy? = null,
+        keyUseAuthorizationPolicy: WalletBridgeKeyUseAuthorizationPolicy? = null,
     ): WalletBridgeResult<MobileWalletBootstrapResult> =
         walletBridgeCall {
             operations.bootstrap(
                 keyType = keyType,
                 didMethod = didMethod,
-                keyUseAuthorizationPolicy = keyUseAuthorizationPolicy,
+                keyUseAuthorizationPolicy = keyUseAuthorizationPolicy?.toCorePolicy(),
             )
         }
 
     /** Checks whether an exact key-use authorization request can be enforced without creating a key. */
     public suspend fun keyUseAuthorizationPreflight(
         keyType: MobileWalletKeyType = MobileWalletKeyType.secp256r1,
-        policy: KeyUseAuthorizationPolicy = KeyUseAuthorizationPolicy.BiometricCurrentSet,
+        policy: WalletBridgeKeyUseAuthorizationPolicy = WalletBridgeKeyUseAuthorizationPolicy.BiometricCurrentSet,
     ): WalletBridgeResult<WalletBridgeKeyPreflight> =
-        walletBridgeCall { operations.keyUseAuthorizationPreflight(keyType, policy).toBridgeModel() }
+        walletBridgeCall { operations.keyUseAuthorizationPreflight(keyType, policy.toCorePolicy()).toBridgeModel() }
 
     /** Resolves an offer and starts its bound OpenID4VCI issuance session. */
     public suspend fun startIssuance(

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridge.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridge.kt
@@ -74,7 +74,7 @@ public class WalletSdkBridge private constructor(
             )
         }
 
-    /** Checks whether an exact key-use authorization request can be enforced without creating a key. */
+    /** Checks whether a key-use authorization request is supported without creating a key. */
     public suspend fun keyUseAuthorizationPreflight(
         keyType: MobileWalletKeyType = MobileWalletKeyType.secp256r1,
         policy: WalletBridgeKeyUseAuthorizationPolicy = WalletBridgeKeyUseAuthorizationPolicy.BiometricCurrentSet,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -27,6 +27,7 @@ import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason
 import id.walt.wallet2.persistence.encryption.WalletPersistenceException
@@ -73,7 +74,12 @@ public data class WalletBridgeConfiguration(
     public val keyUseAuthorizationPrompt: KeyUseAuthorizationPrompt = KeyUseAuthorizationPrompt(),
 )
 
-/** Swift-bridge representation of the authorization policy selected for a newly created key. */
+/**
+ * Swift-bridge representation of the authorization policy selected for a newly created key.
+ *
+ * @property type Selected authorization-policy variant.
+ * @property timeoutSeconds Fixed timed-reuse interval in seconds, only for [WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse].
+ */
 @Serializable
 public data class WalletBridgeKeyUseAuthorizationPolicy(
     public val type: WalletBridgeKeyUseAuthorizationPolicyType,
@@ -92,9 +98,12 @@ public data class WalletBridgeKeyUseAuthorizationPolicy(
         }
     }
 
+    /** Predefined bridge policies that do not require a timeout. */
     public companion object {
+        /** Ordinary non-interactive private-key operations. */
         public val None: WalletBridgeKeyUseAuthorizationPolicy =
             WalletBridgeKeyUseAuthorizationPolicy(WalletBridgeKeyUseAuthorizationPolicyType.None)
+        /** Strong biometric authentication for every private-key operation. */
         public val BiometricCurrentSet: WalletBridgeKeyUseAuthorizationPolicy =
             WalletBridgeKeyUseAuthorizationPolicy(WalletBridgeKeyUseAuthorizationPolicyType.BiometricCurrentSet)
     }
@@ -128,18 +137,34 @@ internal fun KeyUseAuthorizationPolicy.toBridgePolicy(): WalletBridgeKeyUseAutho
 @ConsistentCopyVisibility
 @Serializable
 public data class WalletBridgeKeyPreflight internal constructor(
-    /** Whether the requested authorization policy can be enforced exactly. */
+    /** Whether the requested authorization policy is supported with the reported metadata. */
     public val supported: Boolean,
     /** The authorization policy that will be effective when [supported] is true. */
     public val effectivePolicy: WalletBridgeKeyUseAuthorizationPolicy? = null,
     /** The enforcement boundary for timed reuse, when a timed policy is supported. */
     public val reuseEnforcement: WalletBridgeKeyUseAuthorizationReuseEnforcement? = null,
+    /** How the requested timed-reuse interval was validated, when a timed policy is supported. */
+    public val timeoutVerification: WalletBridgeKeyUseAuthorizationReuseTimeoutVerification? = null,
     /** Core preflight reason when the request is unsupported. */
     public val failure: KeyUseAuthorizationUnsupportedReason? = null,
 ) {
     init {
         require(supported == (failure == null) && supported == (effectivePolicy != null)) {
             "Wallet bridge preflight must include an effective policy exactly when supported"
+        }
+        val timed = effectivePolicy?.type == WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse
+        require((reuseEnforcement != null) == timed && (timeoutVerification != null) == timed) {
+            "Timed bridge preflight must include enforcement and timeout verification only for timed policy"
+        }
+        if (timed) {
+            require(
+                (reuseEnforcement == WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore &&
+                    timeoutVerification == WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.PlatformVerified) ||
+                    (reuseEnforcement == WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess &&
+                        timeoutVerification == WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured),
+            ) {
+                "Timed bridge preflight must report a matching enforcement and timeout verification"
+            }
         }
     }
 }
@@ -149,6 +174,7 @@ internal fun KeyUseAuthorizationSupport.toBridgeModel(): WalletBridgeKeyPrefligh
         supported = true,
         effectivePolicy = effectivePolicy.toBridgePolicy(),
         reuseEnforcement = reuseEnforcement?.toBridgeModel(),
+        timeoutVerification = timeoutVerification?.toBridgeModel(),
     )
     is KeyUseAuthorizationSupport.Unsupported -> WalletBridgeKeyPreflight(supported = false, failure = reason)
 }
@@ -160,11 +186,26 @@ public enum class WalletBridgeKeyUseAuthorizationReuseEnforcement {
     ProviderProcess,
 }
 
+/** Timeout-validation evidence reported for a supported timed-reuse key. */
+@Serializable
+public enum class WalletBridgeKeyUseAuthorizationReuseTimeoutVerification {
+    PlatformVerified,
+    ProviderConfigured,
+}
+
 internal fun KeyUseAuthorizationReuseEnforcement.toBridgeModel(): WalletBridgeKeyUseAuthorizationReuseEnforcement = when (this) {
     KeyUseAuthorizationReuseEnforcement.PlatformKeyStore ->
         WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore
     KeyUseAuthorizationReuseEnforcement.ProviderProcess ->
         WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess
+}
+
+internal fun KeyUseAuthorizationReuseTimeoutVerification.toBridgeModel():
+    WalletBridgeKeyUseAuthorizationReuseTimeoutVerification = when (this) {
+    KeyUseAuthorizationReuseTimeoutVerification.PlatformVerified ->
+        WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.PlatformVerified
+    KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured ->
+        WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured
 }
 
 /**

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -26,6 +26,7 @@ import id.walt.wallet2.persistence.keys.KeyUseAuthorizationException
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason
 import id.walt.wallet2.persistence.encryption.WalletPersistenceException
@@ -67,9 +68,61 @@ public data class WalletBridgeConfiguration(
     public val clientIdTrustConfiguration: WalletBridgeClientIdTrustConfiguration = WalletBridgeClientIdTrustConfiguration(),
     public val appGroupIdentifier: String? = null,
     public val keychainAccessGroup: String? = null,
-    public val defaultKeyUseAuthorizationPolicy: KeyUseAuthorizationPolicy = KeyUseAuthorizationPolicy.BiometricCurrentSet,
+    public val defaultKeyUseAuthorizationPolicy: WalletBridgeKeyUseAuthorizationPolicy =
+        WalletBridgeKeyUseAuthorizationPolicy.BiometricCurrentSet,
     public val keyUseAuthorizationPrompt: KeyUseAuthorizationPrompt = KeyUseAuthorizationPrompt(),
 )
+
+/** Swift-bridge representation of the authorization policy selected for a newly created key. */
+@Serializable
+public data class WalletBridgeKeyUseAuthorizationPolicy(
+    public val type: WalletBridgeKeyUseAuthorizationPolicyType,
+    public val timeoutSeconds: Int? = null,
+) {
+    init {
+        when (type) {
+            WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse ->
+                require(timeoutSeconds != null && timeoutSeconds in 1..30) {
+                    "Timed biometric reuse timeout must be between 1 and 30 seconds"
+                }
+
+            WalletBridgeKeyUseAuthorizationPolicyType.None,
+            WalletBridgeKeyUseAuthorizationPolicyType.BiometricCurrentSet ->
+                require(timeoutSeconds == null) { "Only timed biometric reuse accepts a timeout" }
+        }
+    }
+
+    public companion object {
+        public val None: WalletBridgeKeyUseAuthorizationPolicy =
+            WalletBridgeKeyUseAuthorizationPolicy(WalletBridgeKeyUseAuthorizationPolicyType.None)
+        public val BiometricCurrentSet: WalletBridgeKeyUseAuthorizationPolicy =
+            WalletBridgeKeyUseAuthorizationPolicy(WalletBridgeKeyUseAuthorizationPolicyType.BiometricCurrentSet)
+    }
+}
+
+/** Variants supported by [WalletBridgeKeyUseAuthorizationPolicy]. */
+@Serializable
+public enum class WalletBridgeKeyUseAuthorizationPolicyType {
+    None,
+    BiometricCurrentSet,
+    BiometricTimedReuse,
+}
+
+internal fun WalletBridgeKeyUseAuthorizationPolicy.toCorePolicy(): KeyUseAuthorizationPolicy = when (type) {
+    WalletBridgeKeyUseAuthorizationPolicyType.None -> KeyUseAuthorizationPolicy.None
+    WalletBridgeKeyUseAuthorizationPolicyType.BiometricCurrentSet -> KeyUseAuthorizationPolicy.BiometricCurrentSet
+    WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse ->
+        KeyUseAuthorizationPolicy.BiometricTimedReuse(requireNotNull(timeoutSeconds))
+}
+
+internal fun KeyUseAuthorizationPolicy.toBridgePolicy(): WalletBridgeKeyUseAuthorizationPolicy = when (this) {
+    KeyUseAuthorizationPolicy.None -> WalletBridgeKeyUseAuthorizationPolicy.None
+    KeyUseAuthorizationPolicy.BiometricCurrentSet -> WalletBridgeKeyUseAuthorizationPolicy.BiometricCurrentSet
+    is KeyUseAuthorizationPolicy.BiometricTimedReuse -> WalletBridgeKeyUseAuthorizationPolicy(
+        type = WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse,
+        timeoutSeconds = timeoutSeconds,
+    )
+}
 
 /** Swift-friendly result of a key-use authorization preflight. */
 @ConsistentCopyVisibility
@@ -77,19 +130,41 @@ public data class WalletBridgeConfiguration(
 public data class WalletBridgeKeyPreflight internal constructor(
     /** Whether the requested authorization policy can be enforced exactly. */
     public val supported: Boolean,
+    /** The authorization policy that will be effective when [supported] is true. */
+    public val effectivePolicy: WalletBridgeKeyUseAuthorizationPolicy? = null,
+    /** The enforcement boundary for timed reuse, when a timed policy is supported. */
+    public val reuseEnforcement: WalletBridgeKeyUseAuthorizationReuseEnforcement? = null,
     /** Core preflight reason when the request is unsupported. */
     public val failure: KeyUseAuthorizationUnsupportedReason? = null,
 ) {
     init {
-        require(supported == (failure == null)) {
-            "Wallet bridge preflight must include a failure exactly when unsupported"
+        require(supported == (failure == null) && supported == (effectivePolicy != null)) {
+            "Wallet bridge preflight must include an effective policy exactly when supported"
         }
     }
 }
 
 internal fun KeyUseAuthorizationSupport.toBridgeModel(): WalletBridgeKeyPreflight = when (this) {
-    KeyUseAuthorizationSupport.Supported -> WalletBridgeKeyPreflight(supported = true)
+    is KeyUseAuthorizationSupport.Supported -> WalletBridgeKeyPreflight(
+        supported = true,
+        effectivePolicy = effectivePolicy.toBridgePolicy(),
+        reuseEnforcement = reuseEnforcement?.toBridgeModel(),
+    )
     is KeyUseAuthorizationSupport.Unsupported -> WalletBridgeKeyPreflight(supported = false, failure = reason)
+}
+
+/** Enforcement boundary reported for a supported timed-reuse key. */
+@Serializable
+public enum class WalletBridgeKeyUseAuthorizationReuseEnforcement {
+    PlatformKeyStore,
+    ProviderProcess,
+}
+
+internal fun KeyUseAuthorizationReuseEnforcement.toBridgeModel(): WalletBridgeKeyUseAuthorizationReuseEnforcement = when (this) {
+    KeyUseAuthorizationReuseEnforcement.PlatformKeyStore ->
+        WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore
+    KeyUseAuthorizationReuseEnforcement.ProviderProcess ->
+        WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess
 }
 
 /**
@@ -117,7 +192,7 @@ internal fun WalletBridgeConfiguration.toMobileWalletConfig(): MobileWalletConfi
         persistence = persistence.toMobileWalletPersistence(databaseKeyProvider),
         preferredLocales = preferredLocales,
         transactionDataProfiles = transactionDataProfiles,
-        defaultKeyUseAuthorizationPolicy = defaultKeyUseAuthorizationPolicy,
+        defaultKeyUseAuthorizationPolicy = defaultKeyUseAuthorizationPolicy.toCorePolicy(),
         keyUseAuthorizationPrompt = keyUseAuthorizationPrompt,
         crossProcessAccess = appGroupIdentifier?.let { appGroup ->
             MobileWalletCrossProcessAccess(

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosMain/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModels.kt
@@ -27,7 +27,7 @@ import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPrompt
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
-import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutValidation
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason
 import id.walt.wallet2.persistence.encryption.WalletPersistenceException
@@ -143,8 +143,8 @@ public data class WalletBridgeKeyPreflight internal constructor(
     public val effectivePolicy: WalletBridgeKeyUseAuthorizationPolicy? = null,
     /** The enforcement boundary for timed reuse, when a timed policy is supported. */
     public val reuseEnforcement: WalletBridgeKeyUseAuthorizationReuseEnforcement? = null,
-    /** How the requested timed-reuse interval was validated, when a timed policy is supported. */
-    public val timeoutVerification: WalletBridgeKeyUseAuthorizationReuseTimeoutVerification? = null,
+    /** How a timed-reuse interval can be validated after key creation or restoration. */
+    public val timeoutValidation: WalletBridgeKeyUseAuthorizationReuseTimeoutValidation? = null,
     /** Core preflight reason when the request is unsupported. */
     public val failure: KeyUseAuthorizationUnsupportedReason? = null,
 ) {
@@ -153,18 +153,8 @@ public data class WalletBridgeKeyPreflight internal constructor(
             "Wallet bridge preflight must include an effective policy exactly when supported"
         }
         val timed = effectivePolicy?.type == WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse
-        require((reuseEnforcement != null) == timed && (timeoutVerification != null) == timed) {
-            "Timed bridge preflight must include enforcement and timeout verification only for timed policy"
-        }
-        if (timed) {
-            require(
-                (reuseEnforcement == WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore &&
-                    timeoutVerification == WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.PlatformVerified) ||
-                    (reuseEnforcement == WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess &&
-                        timeoutVerification == WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured),
-            ) {
-                "Timed bridge preflight must report a matching enforcement and timeout verification"
-            }
+        require((reuseEnforcement != null) == timed && (timeoutValidation != null) == timed) {
+            "Timed bridge preflight must include enforcement and timeout validation only for timed policy"
         }
     }
 }
@@ -174,7 +164,7 @@ internal fun KeyUseAuthorizationSupport.toBridgeModel(): WalletBridgeKeyPrefligh
         supported = true,
         effectivePolicy = effectivePolicy.toBridgePolicy(),
         reuseEnforcement = reuseEnforcement?.toBridgeModel(),
-        timeoutVerification = timeoutVerification?.toBridgeModel(),
+        timeoutValidation = timeoutValidation?.toBridgeModel(),
     )
     is KeyUseAuthorizationSupport.Unsupported -> WalletBridgeKeyPreflight(supported = false, failure = reason)
 }
@@ -186,11 +176,11 @@ public enum class WalletBridgeKeyUseAuthorizationReuseEnforcement {
     ProviderProcess,
 }
 
-/** Timeout-validation evidence reported for a supported timed-reuse key. */
+/** Timeout-validation capability reported for a supported timed-reuse key. */
 @Serializable
-public enum class WalletBridgeKeyUseAuthorizationReuseTimeoutVerification {
-    PlatformVerified,
-    ProviderConfigured,
+public enum class WalletBridgeKeyUseAuthorizationReuseTimeoutValidation {
+    IndependentReadback,
+    ProviderConfigurationOnly,
 }
 
 internal fun KeyUseAuthorizationReuseEnforcement.toBridgeModel(): WalletBridgeKeyUseAuthorizationReuseEnforcement = when (this) {
@@ -200,12 +190,12 @@ internal fun KeyUseAuthorizationReuseEnforcement.toBridgeModel(): WalletBridgeKe
         WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess
 }
 
-internal fun KeyUseAuthorizationReuseTimeoutVerification.toBridgeModel():
-    WalletBridgeKeyUseAuthorizationReuseTimeoutVerification = when (this) {
-    KeyUseAuthorizationReuseTimeoutVerification.PlatformVerified ->
-        WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.PlatformVerified
-    KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured ->
-        WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured
+internal fun KeyUseAuthorizationReuseTimeoutValidation.toBridgeModel():
+    WalletBridgeKeyUseAuthorizationReuseTimeoutValidation = when (this) {
+    KeyUseAuthorizationReuseTimeoutValidation.IndependentReadback ->
+        WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.IndependentReadback
+    KeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly ->
+        WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly
 }
 
 /**

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModelsTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModelsTest.kt
@@ -7,7 +7,7 @@ import id.walt.wallet2.persistence.keys.KeyUseAuthorizationException
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
-import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutValidation
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason
 import kotlinx.coroutines.CancellationException
@@ -89,7 +89,7 @@ class WalletSdkBridgeModelsTest {
     }
 
     @Test
-    fun bridgeTimedAuthorizationPolicyPreservesTimeoutAndProviderVerification() {
+    fun bridgeTimedAuthorizationPolicyPreservesTimeoutAndProviderValidation() {
         val timed = WalletBridgeKeyUseAuthorizationPolicy(
             type = WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse,
             timeoutSeconds = 10,
@@ -100,7 +100,7 @@ class WalletSdkBridgeModelsTest {
         val preflight = KeyUseAuthorizationSupport.Supported(
             effectivePolicy = KeyUseAuthorizationPolicy.BiometricTimedReuse(10),
             reuseEnforcement = KeyUseAuthorizationReuseEnforcement.ProviderProcess,
-            timeoutVerification = KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured,
+            timeoutValidation = KeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly,
         ).toBridgeModel()
 
         assertEquals(timed, preflight.effectivePolicy)
@@ -109,13 +109,13 @@ class WalletSdkBridgeModelsTest {
             preflight.reuseEnforcement,
         )
         assertEquals(
-            WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured,
-            preflight.timeoutVerification,
+            WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly,
+            preflight.timeoutValidation,
         )
     }
 
     @Test
-    fun bridgePreflightRejectsIncompleteOrMismatchedTimedMetadata() {
+    fun bridgePreflightRejectsIncompleteTimedMetadataButKeepsAxesOrthogonal() {
         val policy = WalletBridgeKeyUseAuthorizationPolicy(
             type = WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse,
             timeoutSeconds = 10,
@@ -124,14 +124,16 @@ class WalletSdkBridgeModelsTest {
         assertFailsWith<IllegalArgumentException> {
             WalletBridgeKeyPreflight(supported = true, effectivePolicy = policy)
         }
-        assertFailsWith<IllegalArgumentException> {
-            WalletBridgeKeyPreflight(
-                supported = true,
-                effectivePolicy = policy,
-                reuseEnforcement = WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore,
-                timeoutVerification = WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured,
-            )
-        }
+        val valid = WalletBridgeKeyPreflight(
+            supported = true,
+            effectivePolicy = policy,
+            reuseEnforcement = WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore,
+            timeoutValidation = WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly,
+        )
+        assertEquals(
+            WalletBridgeKeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly,
+            valid.timeoutValidation,
+        )
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModelsTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModelsTest.kt
@@ -5,6 +5,9 @@ import id.walt.wallet2.handlers.PreviewSessionFailureReason
 import id.walt.wallet2.persistence.encryption.WalletPersistenceException
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationException
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason
 import kotlinx.coroutines.CancellationException
 import kotlin.test.Test
@@ -82,6 +85,27 @@ class WalletSdkBridgeModelsTest {
         assertFailsWith<IllegalArgumentException> {
             WalletBridgeKeyPreflight(supported = false)
         }
+    }
+
+    @Test
+    fun bridgeTimedAuthorizationPolicyPreservesTimeoutAndProviderEnforcement() {
+        val timed = WalletBridgeKeyUseAuthorizationPolicy(
+            type = WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse,
+            timeoutSeconds = 10,
+        )
+
+        assertEquals(KeyUseAuthorizationPolicy.BiometricTimedReuse(10), timed.toCorePolicy())
+
+        val preflight = KeyUseAuthorizationSupport.Supported(
+            effectivePolicy = KeyUseAuthorizationPolicy.BiometricTimedReuse(10),
+            reuseEnforcement = KeyUseAuthorizationReuseEnforcement.ProviderProcess,
+        ).toBridgeModel()
+
+        assertEquals(timed, preflight.effectivePolicy)
+        assertEquals(
+            WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess,
+            preflight.reuseEnforcement,
+        )
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModelsTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/iosTest/kotlin/id/walt/wallet2/mobile/swiftinterop/WalletSdkBridgeModelsTest.kt
@@ -7,6 +7,7 @@ import id.walt.wallet2.persistence.keys.KeyUseAuthorizationException
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationSupport
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason
 import kotlinx.coroutines.CancellationException
@@ -88,7 +89,7 @@ class WalletSdkBridgeModelsTest {
     }
 
     @Test
-    fun bridgeTimedAuthorizationPolicyPreservesTimeoutAndProviderEnforcement() {
+    fun bridgeTimedAuthorizationPolicyPreservesTimeoutAndProviderVerification() {
         val timed = WalletBridgeKeyUseAuthorizationPolicy(
             type = WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse,
             timeoutSeconds = 10,
@@ -99,6 +100,7 @@ class WalletSdkBridgeModelsTest {
         val preflight = KeyUseAuthorizationSupport.Supported(
             effectivePolicy = KeyUseAuthorizationPolicy.BiometricTimedReuse(10),
             reuseEnforcement = KeyUseAuthorizationReuseEnforcement.ProviderProcess,
+            timeoutVerification = KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured,
         ).toBridgeModel()
 
         assertEquals(timed, preflight.effectivePolicy)
@@ -106,6 +108,30 @@ class WalletSdkBridgeModelsTest {
             WalletBridgeKeyUseAuthorizationReuseEnforcement.ProviderProcess,
             preflight.reuseEnforcement,
         )
+        assertEquals(
+            WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured,
+            preflight.timeoutVerification,
+        )
+    }
+
+    @Test
+    fun bridgePreflightRejectsIncompleteOrMismatchedTimedMetadata() {
+        val policy = WalletBridgeKeyUseAuthorizationPolicy(
+            type = WalletBridgeKeyUseAuthorizationPolicyType.BiometricTimedReuse,
+            timeoutSeconds = 10,
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            WalletBridgeKeyPreflight(supported = true, effectivePolicy = policy)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            WalletBridgeKeyPreflight(
+                supported = true,
+                effectivePolicy = policy,
+                reuseEnforcement = WalletBridgeKeyUseAuthorizationReuseEnforcement.PlatformKeyStore,
+                timeoutVerification = WalletBridgeKeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured,
+            )
+        }
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/api/waltid-openid4vc-wallet-persistence-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/api/waltid-openid4vc-wallet-persistence-mobile.klib.api
@@ -27,19 +27,19 @@ final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationFailure : k
     }
 }
 
-final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy : kotlin/Enum<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy> { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy|null[0]
-    enum entry BiometricCurrentSet // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet|null[0]
-    enum entry None // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None|null[0]
+final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement : kotlin/Enum<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement> { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement|null[0]
+    enum entry PlatformKeyStore // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.PlatformKeyStore|null[0]
+    enum entry ProviderProcess // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.ProviderProcess|null[0]
 
-    final val entries // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val entries // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.entries.<get-entries>|<get-entries>#static(){}[0]
 
-    final fun valueOf(kotlin/String): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.values|values#static(){}[0]
+    final fun valueOf(kotlin/String): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.values|values#static(){}[0]
 
-    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.Companion|null[0]
-        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.Companion.serializer|serializer(){}[0]
-        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     }
 }
 
@@ -79,7 +79,72 @@ abstract interface id.walt.wallet2.persistence.keys/PlatformManagedKeyProvider {
     abstract suspend fun restoreManagedKey(id.walt.crypto2.keys/StoredKey.Managed): id.walt.wallet2.persistence.keys/PlatformManagedKeyRestoration // id.walt.wallet2.persistence.keys/PlatformManagedKeyProvider.restoreManagedKey|restoreManagedKey(id.walt.crypto2.keys.StoredKey.Managed){}[0]
 }
 
+sealed interface id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy|null[0]
+    final class BiometricTimedReuse : id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse|null[0]
+        constructor <init>(kotlin/Int) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.<init>|<init>(kotlin.Int){}[0]
+
+        final val timeoutSeconds // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.timeoutSeconds|{}timeoutSeconds[0]
+            final fun <get-timeoutSeconds>(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.timeoutSeconds.<get-timeoutSeconds>|<get-timeoutSeconds>(){}[0]
+
+        final fun component1(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.component1|component1(){}[0]
+        final fun copy(kotlin/Int = ...): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.copy|copy(kotlin.Int){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.toString|toString(){}[0]
+
+        final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse> { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.$serializer|null[0]
+            final val descriptor // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.$serializer.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.$serializer.childSerializers|childSerializers(){}[0]
+            final fun deserialize(kotlinx.serialization.encoding/Decoder): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+            final fun serialize(kotlinx.serialization.encoding/Encoder, id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy.BiometricTimedReuse){}[0]
+        }
+
+        final object Companion { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricTimedReuse.Companion.serializer|serializer(){}[0]
+        }
+    }
+
+    final object BiometricCurrentSet : id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy, kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet.hashCode|hashCode(){}[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.BiometricCurrentSet.toString|toString(){}[0]
+    }
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+
+    final object None : id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy, kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None.hashCode|hashCode(){}[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy.None.toString|toString(){}[0]
+    }
+}
+
 sealed interface id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport|null[0]
+    final class Supported : id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported|null[0]
+        constructor <init>(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy, id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ...) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.<init>|<init>(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?){}[0]
+
+        final val effectivePolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.effectivePolicy|{}effectivePolicy[0]
+            final fun <get-effectivePolicy>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.effectivePolicy.<get-effectivePolicy>|<get-effectivePolicy>(){}[0]
+        final val reuseEnforcement // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.reuseEnforcement|{}reuseEnforcement[0]
+            final fun <get-reuseEnforcement>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.reuseEnforcement.<get-reuseEnforcement>|<get-reuseEnforcement>(){}[0]
+
+        final fun component1(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component1|component1(){}[0]
+        final fun component2(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component2|component2(){}[0]
+        final fun copy(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ...): id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.copy|copy(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.toString|toString(){}[0]
+    }
+
     final class Unsupported : id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Unsupported|null[0]
         constructor <init>(id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Unsupported.<init>|<init>(id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason){}[0]
 
@@ -91,12 +156,6 @@ sealed interface id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { /
         final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Unsupported.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Unsupported.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Unsupported.toString|toString(){}[0]
-    }
-
-    final object Supported : id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported|null[0]
-        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.equals|equals(kotlin.Any?){}[0]
-        final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.hashCode|hashCode(){}[0]
-        final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.toString|toString(){}[0]
     }
 }
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/api/waltid-openid4vc-wallet-persistence-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/api/waltid-openid4vc-wallet-persistence-mobile.klib.api
@@ -43,19 +43,19 @@ final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforc
     }
 }
 
-final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification : kotlin/Enum<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification|null[0]
-    enum entry PlatformVerified // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.PlatformVerified|null[0]
-    enum entry ProviderConfigured // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured|null[0]
+final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation : kotlin/Enum<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation> { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation|null[0]
+    enum entry IndependentReadback // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.IndependentReadback|null[0]
+    enum entry ProviderConfigurationOnly // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly|null[0]
 
-    final val entries // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.entries.<get-entries>|<get-entries>#static(){}[0]
+    final val entries // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.entries.<get-entries>|<get-entries>#static(){}[0]
 
-    final fun valueOf(kotlin/String): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.values|values#static(){}[0]
+    final fun valueOf(kotlin/String): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.values|values#static(){}[0]
 
-    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.Companion|null[0]
-        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(){}[0]
-        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
     }
 }
 
@@ -146,19 +146,19 @@ sealed interface id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy { //
 
 sealed interface id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport|null[0]
     final class Supported : id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported|null[0]
-        constructor <init>(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy, id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? = ...) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.<init>|<init>(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification?){}[0]
+        constructor <init>(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy, id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation? = ...) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.<init>|<init>(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutValidation?){}[0]
 
         final val effectivePolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.effectivePolicy|{}effectivePolicy[0]
             final fun <get-effectivePolicy>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.effectivePolicy.<get-effectivePolicy>|<get-effectivePolicy>(){}[0]
         final val reuseEnforcement // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.reuseEnforcement|{}reuseEnforcement[0]
             final fun <get-reuseEnforcement>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.reuseEnforcement.<get-reuseEnforcement>|<get-reuseEnforcement>(){}[0]
-        final val timeoutVerification // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.timeoutVerification|{}timeoutVerification[0]
-            final fun <get-timeoutVerification>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.timeoutVerification.<get-timeoutVerification>|<get-timeoutVerification>(){}[0]
+        final val timeoutValidation // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.timeoutValidation|{}timeoutValidation[0]
+            final fun <get-timeoutValidation>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.timeoutValidation.<get-timeoutValidation>|<get-timeoutValidation>(){}[0]
 
         final fun component1(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component1|component1(){}[0]
         final fun component2(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component2|component2(){}[0]
-        final fun component3(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component3|component3(){}[0]
-        final fun copy(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? = ...): id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.copy|copy(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification?){}[0]
+        final fun component3(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component3|component3(){}[0]
+        final fun copy(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutValidation? = ...): id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.copy|copy(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutValidation?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.toString|toString(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/api/waltid-openid4vc-wallet-persistence-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/api/waltid-openid4vc-wallet-persistence-mobile.klib.api
@@ -43,6 +43,22 @@ final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforc
     }
 }
 
+final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification : kotlin/Enum<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification|null[0]
+    enum entry PlatformVerified // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.PlatformVerified|null[0]
+    enum entry ProviderConfigured // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured|null[0]
+
+    final val entries // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.values|values#static(){}[0]
+
+    final object Companion : kotlinx.serialization.internal/SerializerFactory { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.Companion|null[0]
+        final fun serializer(): kotlinx.serialization/KSerializer<id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(){}[0]
+        final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+    }
+}
+
 final enum class id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason : kotlin/Enum<id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason> { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason|null[0]
     enum entry BiometricNotEnrolled // id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason.BiometricNotEnrolled|null[0]
     enum entry BiometricUnavailable // id.walt.wallet2.persistence.keys/KeyUseAuthorizationUnsupportedReason.BiometricUnavailable|null[0]
@@ -130,16 +146,19 @@ sealed interface id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy { //
 
 sealed interface id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport|null[0]
     final class Supported : id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport { // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported|null[0]
-        constructor <init>(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy, id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ...) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.<init>|<init>(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?){}[0]
+        constructor <init>(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy, id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? = ...) // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.<init>|<init>(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification?){}[0]
 
         final val effectivePolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.effectivePolicy|{}effectivePolicy[0]
             final fun <get-effectivePolicy>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.effectivePolicy.<get-effectivePolicy>|<get-effectivePolicy>(){}[0]
         final val reuseEnforcement // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.reuseEnforcement|{}reuseEnforcement[0]
             final fun <get-reuseEnforcement>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.reuseEnforcement.<get-reuseEnforcement>|<get-reuseEnforcement>(){}[0]
+        final val timeoutVerification // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.timeoutVerification|{}timeoutVerification[0]
+            final fun <get-timeoutVerification>(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.timeoutVerification.<get-timeoutVerification>|<get-timeoutVerification>(){}[0]
 
         final fun component1(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component1|component1(){}[0]
         final fun component2(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component2|component2(){}[0]
-        final fun copy(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ...): id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.copy|copy(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?){}[0]
+        final fun component3(): id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.component3|component3(){}[0]
+        final fun copy(id.walt.wallet2.persistence.keys/KeyUseAuthorizationPolicy = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseEnforcement? = ..., id.walt.wallet2.persistence.keys/KeyUseAuthorizationReuseTimeoutVerification? = ...): id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.copy|copy(id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement?;id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutVerification?){}[0]
         final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // id.walt.wallet2.persistence.keys/KeyUseAuthorizationSupport.Supported.toString|toString(){}[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidHostTest/kotlin/id/walt/wallet2/persistence/stores/SqlDelightKeyStoreRestartTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidHostTest/kotlin/id/walt/wallet2/persistence/stores/SqlDelightKeyStoreRestartTest.kt
@@ -144,7 +144,7 @@ class SqlDelightKeyStoreRestartTest {
             )
 
             assertEquals(
-                KeyUseAuthorizationSupport.Supported,
+                KeyUseAuthorizationSupport.Supported(KeyUseAuthorizationPolicy.None),
                 store.preflight(
                     WalletKeyRequirements(
                         spec = KeySpec.Rsa(2048),
@@ -246,6 +246,32 @@ class SqlDelightKeyStoreRestartTest {
                 store.getCrypto2Key(stored.id.value, KEY_USAGES)
             }
             assertEquals(KeyUseAuthorizationFailure.ProtectedKeyUnavailable, error.failure)
+        }
+    }
+
+    @Test
+    fun `timed authorization policy persists and restores through the same schema version`() = runTest {
+        database().use { database ->
+            val timed = KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds = 10)
+            val provider = FakePlatformManagedKeyProvider(authorizationPolicy = timed)
+            val store = SqlDelightKeyStore(provider, database.queries)
+            val key = store.generateKey(
+                WalletKeyCreationRequest(
+                    id = KeyId("timed-reuse"),
+                    requirements = WalletKeyRequirements(
+                        spec = KeySpec.Ec(EcCurve.P256),
+                        usages = KEY_USAGES,
+                        authorizationPolicy = timed,
+                    ),
+                ),
+            )
+
+            assertEquals(listOf<KeyUseAuthorizationPolicy>(timed), provider.generatedPolicies)
+            provider.restoredPolicies.clear()
+            assertNotNull(
+                SqlDelightKeyStore(provider, database.queries).getCrypto2Key(key.id.value, KEY_USAGES),
+            )
+            assertEquals(listOf<KeyUseAuthorizationPolicy>(timed), provider.restoredPolicies)
         }
     }
 
@@ -417,7 +443,7 @@ class SqlDelightKeyStoreRestartTest {
     private class FakePlatformManagedKeyProvider : PlatformManagedKeyProvider {
         constructor(
             authorizationPolicy: KeyUseAuthorizationPolicy = KeyUseAuthorizationPolicy.None,
-            preflightResult: KeyUseAuthorizationSupport = KeyUseAuthorizationSupport.Supported,
+            preflightResult: KeyUseAuthorizationSupport = KeyUseAuthorizationSupport.Supported(authorizationPolicy),
             restoreFailure: Throwable? = null,
             signFailure: Throwable? = null,
             metadataFailure: Throwable? = null,
@@ -440,6 +466,8 @@ class SqlDelightKeyStoreRestartTest {
         val managedIds = mutableSetOf<KeyId>()
         var generateCount = 0
         var deleteCount = 0
+        val generatedPolicies = mutableListOf<KeyUseAuthorizationPolicy>()
+        val restoredPolicies = mutableListOf<KeyUseAuthorizationPolicy>()
 
         override suspend fun preflight(requirements: WalletKeyRequirements): KeyUseAuthorizationSupport =
             preflightResult
@@ -447,6 +475,7 @@ class SqlDelightKeyStoreRestartTest {
         override suspend fun generateManagedKey(request: WalletKeyCreationRequest): ManagedKey {
             generateCount++
             managedIds += request.id
+            generatedPolicies += request.requirements.authorizationPolicy
             return managedKey(descriptor(request.id, request.requirements.spec, request.requirements.usages))
         }
 
@@ -456,6 +485,7 @@ class SqlDelightKeyStoreRestartTest {
             if (stored.id !in managedIds) {
                 return PlatformManagedKeyRestoration.Missing(authorizationPolicy)
             }
+            restoredPolicies += authorizationPolicy
             return PlatformManagedKeyRestoration.Restored(
                 key = managedKey(stored),
                 authorizationPolicy = authorizationPolicy,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidHostTest/kotlin/id/walt/wallet2/persistence/stores/SqlDelightKeyStoreRestartTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidHostTest/kotlin/id/walt/wallet2/persistence/stores/SqlDelightKeyStoreRestartTest.kt
@@ -18,6 +18,8 @@ import id.walt.crypto2.serialization.BinaryData
 import id.walt.crypto2.serialization.StoredKeyCodec
 import id.walt.wallet2.persistence.db.WalletPersistenceDatabase
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationPolicy
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseEnforcement
+import id.walt.wallet2.persistence.keys.KeyUseAuthorizationReuseTimeoutValidation
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationUnsupportedReason
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationException
 import id.walt.wallet2.persistence.keys.KeyUseAuthorizationFailure
@@ -443,7 +445,7 @@ class SqlDelightKeyStoreRestartTest {
     private class FakePlatformManagedKeyProvider : PlatformManagedKeyProvider {
         constructor(
             authorizationPolicy: KeyUseAuthorizationPolicy = KeyUseAuthorizationPolicy.None,
-            preflightResult: KeyUseAuthorizationSupport = KeyUseAuthorizationSupport.Supported(authorizationPolicy),
+            preflightResult: KeyUseAuthorizationSupport = authorizationPolicy.toSupportedPreflight(),
             restoreFailure: Throwable? = null,
             signFailure: Throwable? = null,
             metadataFailure: Throwable? = null,
@@ -532,4 +534,13 @@ class SqlDelightKeyStoreRestartTest {
             providerData = BinaryData(id.encodeToByteArray()),
         )
     }
+}
+
+private fun KeyUseAuthorizationPolicy.toSupportedPreflight(): KeyUseAuthorizationSupport.Supported = when (this) {
+    is KeyUseAuthorizationPolicy.BiometricTimedReuse -> KeyUseAuthorizationSupport.Supported(
+        effectivePolicy = this,
+        reuseEnforcement = KeyUseAuthorizationReuseEnforcement.ProviderProcess,
+        timeoutValidation = KeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly,
+    )
+    else -> KeyUseAuthorizationSupport.Supported(this)
 }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
@@ -113,8 +113,8 @@ private fun KeyUseAuthorizationPolicy.supportedOnAndroid(): KeyUseAuthorizationS
         } else {
             null
         },
-        timeoutVerification = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
-            KeyUseAuthorizationReuseTimeoutVerification.PlatformVerified
+        timeoutValidation = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
+            KeyUseAuthorizationReuseTimeoutValidation.IndependentReadback
         } else {
             null
         },

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
@@ -113,4 +113,9 @@ private fun KeyUseAuthorizationPolicy.supportedOnAndroid(): KeyUseAuthorizationS
         } else {
             null
         },
+        timeoutVerification = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
+            KeyUseAuthorizationReuseTimeoutVerification.PlatformVerified
+        } else {
+            null
+        },
     )

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/androidMain/kotlin/id/walt/wallet2/persistence/keys/AndroidPlatformKeyProvider.kt
@@ -11,8 +11,6 @@ import id.walt.crypto2.keys.ManagedKey
 import id.walt.crypto2.keys.StoredKey
 import id.walt.crypto2.providers.GenerateManagedKeyRequest
 import id.walt.crypto2.signum.AndroidSignumKeyBackend
-import id.walt.crypto2.signum.SignumAuthenticationPolicy
-import id.walt.crypto2.signum.SignumHardwarePolicy
 import id.walt.crypto2.signum.SignumKeyPolicy
 import id.walt.crypto2.signum.SignumKeyOptions
 import id.walt.crypto2.signum.SignumKeyNotFoundException
@@ -38,8 +36,8 @@ public class AndroidPlatformKeyProvider(
         if (!backend.supports(requirements.spec, requirements.usages, signumPolicy)) {
             return KeyUseAuthorizationSupport.Unsupported(KeyUseAuthorizationUnsupportedReason.UnsupportedCombination)
         }
-        if (requirements.authorizationPolicy == KeyUseAuthorizationPolicy.None) {
-            return KeyUseAuthorizationSupport.Supported
+        if (requirements.authorizationPolicy is KeyUseAuthorizationPolicy.None) {
+            return requirements.authorizationPolicy.supportedOnAndroid()
         }
         val failure = when {
             requirements.spec != KeySpec.Ec(EcCurve.P256) ||
@@ -52,7 +50,7 @@ public class AndroidPlatformKeyProvider(
             }
         }
         return failure?.let { KeyUseAuthorizationSupport.Unsupported(it) }
-            ?: KeyUseAuthorizationSupport.Supported
+            ?: requirements.authorizationPolicy.supportedOnAndroid()
     }
 
     override suspend fun generateManagedKey(request: WalletKeyCreationRequest): ManagedKey = try {
@@ -66,7 +64,7 @@ public class AndroidPlatformKeyProvider(
         ).withWalletAuthorizationMapping(request.requirements.authorizationPolicy)
     } catch (cause: Throwable) {
         if (
-            request.requirements.authorizationPolicy == KeyUseAuthorizationPolicy.None &&
+            request.requirements.authorizationPolicy is KeyUseAuthorizationPolicy.None &&
             cause is SignumKeyPolicyMismatchException
         ) {
             throw cause
@@ -105,21 +103,14 @@ public class AndroidPlatformKeyProvider(
 
     private fun WalletKeyCreationRequest.toSignumPolicy(): SignumKeyPolicy =
         requirements.authorizationPolicy.toSignumPolicy(prompt)
-
-    private fun KeyUseAuthorizationPolicy.toSignumPolicy(
-        prompt: KeyUseAuthorizationPrompt = KeyUseAuthorizationPrompt(),
-    ): SignumKeyPolicy = when (this) {
-        KeyUseAuthorizationPolicy.None -> SignumKeyPolicy()
-        KeyUseAuthorizationPolicy.BiometricCurrentSet -> SignumKeyPolicy(
-            hardware = SignumHardwarePolicy.REQUIRED,
-            authentication = SignumAuthenticationPolicy.UserPresence(
-                biometric = true,
-                allowNewBiometrics = false,
-                deviceCredential = false,
-                timeoutSeconds = 0,
-                prompt = prompt.reason,
-                cancelText = prompt.cancelText,
-            ),
-        )
-    }
 }
+
+private fun KeyUseAuthorizationPolicy.supportedOnAndroid(): KeyUseAuthorizationSupport.Supported =
+    KeyUseAuthorizationSupport.Supported(
+        effectivePolicy = this,
+        reuseEnforcement = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
+            KeyUseAuthorizationReuseEnforcement.PlatformKeyStore
+        } else {
+            null
+        },
+    )

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/KeyUseAuthorization.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/KeyUseAuthorization.kt
@@ -21,11 +21,16 @@ public sealed interface KeyUseAuthorizationPolicy {
      * Strong biometric authorization may be reused for private-key operations during the fixed
      * interval. The interval starts with successful authentication and never slides on signing.
      *
-     * New biometric enrollment does not invalidate this key. The platform or provider may end
-     * reusable authorization earlier, but never extends it beyond [timeoutSeconds].
+     * New biometric enrollment does not invalidate this key. Android verifies this interval from
+     * native KeyStore metadata. iOS configures it in Signum, but Signum's pinned public API does
+     * not expose an effective positive timeout after restoration for independent verification.
+     *
+     * Timed reuse is recent platform or provider authentication. It is not authorization or
+     * consent for issuance, presentation, or another wallet action, and is not key-local.
      */
     @Serializable
     public data class BiometricTimedReuse(
+        /** Fixed, non-sliding strong-biometric reuse interval in seconds, from 1 through 30. */
         public val timeoutSeconds: Int,
     ) : KeyUseAuthorizationPolicy {
         init {
@@ -111,11 +116,13 @@ public sealed interface KeyUseAuthorizationSupport {
         public val effectivePolicy: KeyUseAuthorizationPolicy,
         /** How a timed-reuse interval is enforced, when one is selected. */
         public val reuseEnforcement: KeyUseAuthorizationReuseEnforcement? = null,
+        /** How the requested timed-reuse interval was validated, when one is selected. */
+        public val timeoutVerification: KeyUseAuthorizationReuseTimeoutVerification? = null,
     ) : KeyUseAuthorizationSupport
 
     /** The wallet cannot satisfy the requested capability set. */
     public data class Unsupported(
-        /** Reason the exact requirements cannot currently be enforced. */
+        /** Reason the requested requirements cannot currently be satisfied. */
         public val reason: KeyUseAuthorizationUnsupportedReason,
     ) : KeyUseAuthorizationSupport
 }
@@ -130,7 +137,17 @@ public enum class KeyUseAuthorizationReuseEnforcement {
     ProviderProcess,
 }
 
-/** Reasons an exact key-creation requirement cannot currently be enforced. */
+/** How a requested timed-reuse interval was validated before key creation. */
+@Serializable
+public enum class KeyUseAuthorizationReuseTimeoutVerification {
+    /** Android native KeyStore metadata exactly matches the requested interval. */
+    PlatformVerified,
+
+    /** The provider received the requested interval but cannot expose it for independent verification. */
+    ProviderConfigured,
+}
+
+/** Reasons a requested key-creation requirement cannot currently be satisfied. */
 public enum class KeyUseAuthorizationUnsupportedReason {
     UnsupportedCombination,
     BiometricUnavailable,

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/KeyUseAuthorization.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/KeyUseAuthorization.kt
@@ -21,12 +21,14 @@ public sealed interface KeyUseAuthorizationPolicy {
      * Strong biometric authorization may be reused for private-key operations during the fixed
      * interval. The interval starts with successful authentication and never slides on signing.
      *
-     * New biometric enrollment does not invalidate this key. Android verifies this interval from
-     * native KeyStore metadata. iOS configures it in Signum, but Signum's pinned public API does
-     * not expose an effective positive timeout after restoration for independent verification.
+     * New biometric enrollment does not invalidate this key. Android can independently read back
+     * this interval from native KeyStore metadata after creation or restoration. iOS configures it
+     * in Signum, but Signum's pinned public API does not expose an effective positive timeout after
+     * restoration for independent readback.
      *
      * Timed reuse is recent platform or provider authentication. It is not authorization or
-     * consent for issuance, presentation, or another wallet action, and is not key-local.
+     * consent for issuance, presentation, or another wallet action, and is not guaranteed to be
+     * key-local.
      */
     @Serializable
     public data class BiometricTimedReuse(
@@ -116,9 +118,16 @@ public sealed interface KeyUseAuthorizationSupport {
         public val effectivePolicy: KeyUseAuthorizationPolicy,
         /** How a timed-reuse interval is enforced, when one is selected. */
         public val reuseEnforcement: KeyUseAuthorizationReuseEnforcement? = null,
-        /** How the requested timed-reuse interval was validated, when one is selected. */
-        public val timeoutVerification: KeyUseAuthorizationReuseTimeoutVerification? = null,
-    ) : KeyUseAuthorizationSupport
+        /** How a timed-reuse interval can be validated after key creation or restoration. */
+        public val timeoutValidation: KeyUseAuthorizationReuseTimeoutValidation? = null,
+    ) : KeyUseAuthorizationSupport {
+        init {
+            val timed = effectivePolicy is KeyUseAuthorizationPolicy.BiometricTimedReuse
+            require((reuseEnforcement != null) == timed && (timeoutValidation != null) == timed) {
+                "Timed support must include enforcement and timeout validation only for timed policy"
+            }
+        }
+    }
 
     /** The wallet cannot satisfy the requested capability set. */
     public data class Unsupported(
@@ -137,14 +146,14 @@ public enum class KeyUseAuthorizationReuseEnforcement {
     ProviderProcess,
 }
 
-/** How a requested timed-reuse interval was validated before key creation. */
+/** How a timed-reuse interval can be validated after key creation or restoration. */
 @Serializable
-public enum class KeyUseAuthorizationReuseTimeoutVerification {
-    /** Android native KeyStore metadata exactly matches the requested interval. */
-    PlatformVerified,
+public enum class KeyUseAuthorizationReuseTimeoutValidation {
+    /** Native metadata can be read back independently and compared to the requested interval. */
+    IndependentReadback,
 
-    /** The provider received the requested interval but cannot expose it for independent verification. */
-    ProviderConfigured,
+    /** The requested interval can be passed to the provider but cannot be independently read back. */
+    ProviderConfigurationOnly,
 }
 
 /** Reasons a requested key-creation requirement cannot currently be satisfied. */

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/KeyUseAuthorization.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/KeyUseAuthorization.kt
@@ -8,12 +8,32 @@ import kotlinx.serialization.Serializable
 
 /** Immutable authorization policy selected when a wallet key is created. */
 @Serializable
-public enum class KeyUseAuthorizationPolicy {
+public sealed interface KeyUseAuthorizationPolicy {
     /** Private-key operations retain their ordinary non-interactive behavior. */
-    None,
+    @Serializable
+    public data object None : KeyUseAuthorizationPolicy
 
     /** Every private-key operation requires a currently enrolled strong biometric. */
-    BiometricCurrentSet,
+    @Serializable
+    public data object BiometricCurrentSet : KeyUseAuthorizationPolicy
+
+    /**
+     * Strong biometric authorization may be reused for private-key operations during the fixed
+     * interval. The interval starts with successful authentication and never slides on signing.
+     *
+     * New biometric enrollment does not invalidate this key. The platform or provider may end
+     * reusable authorization earlier, but never extends it beyond [timeoutSeconds].
+     */
+    @Serializable
+    public data class BiometricTimedReuse(
+        public val timeoutSeconds: Int,
+    ) : KeyUseAuthorizationPolicy {
+        init {
+            require(timeoutSeconds in 1..30) {
+                "Biometric authorization reuse timeout must be between 1 and 30 seconds"
+            }
+        }
+    }
 }
 
 /**
@@ -86,13 +106,28 @@ public data class WalletKeyCreationRequest(
 /** Result of checking whether the wallet can satisfy the requested key and authorization requirements. */
 public sealed interface KeyUseAuthorizationSupport {
     /** The wallet can satisfy the requested key and authorization requirements. */
-    public data object Supported : KeyUseAuthorizationSupport
+    public data class Supported(
+        /** Authorization policy that will be effective for the created key. */
+        public val effectivePolicy: KeyUseAuthorizationPolicy,
+        /** How a timed-reuse interval is enforced, when one is selected. */
+        public val reuseEnforcement: KeyUseAuthorizationReuseEnforcement? = null,
+    ) : KeyUseAuthorizationSupport
 
     /** The wallet cannot satisfy the requested capability set. */
     public data class Unsupported(
         /** Reason the exact requirements cannot currently be enforced. */
         public val reason: KeyUseAuthorizationUnsupportedReason,
     ) : KeyUseAuthorizationSupport
+}
+
+/** Distinguishes platform-keystore and provider-process enforcement for timed authorization reuse. */
+@Serializable
+public enum class KeyUseAuthorizationReuseEnforcement {
+    /** The native key store enforces the authorization validity interval. */
+    PlatformKeyStore,
+
+    /** The platform crypto provider reuses authenticated process-local authorization state. */
+    ProviderProcess,
 }
 
 /** Reasons an exact key-creation requirement cannot currently be enforced. */

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/PlatformManagedKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/PlatformManagedKeyProvider.kt
@@ -12,7 +12,7 @@ import id.walt.crypto2.keys.StoredKey
  * exceptions.
  */
 public interface PlatformManagedKeyProvider {
-    /** Checks whether the exact requirements can be enforced without fallback. */
+    /** Checks whether the requested requirements are supported without fallback. */
     public suspend fun preflight(requirements: WalletKeyRequirements): KeyUseAuthorizationSupport
 
     /** Generates a managed key in the platform key store. */

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/SignumWalletKeyMapping.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/keys/SignumWalletKeyMapping.kt
@@ -73,7 +73,7 @@ internal fun Throwable.toKeyUseAuthorizationException(
 internal fun ManagedKey.withWalletAuthorizationMapping(
     authorizationPolicy: KeyUseAuthorizationPolicy,
 ): ManagedKey {
-    if (authorizationPolicy == KeyUseAuthorizationPolicy.None) {
+    if (authorizationPolicy is KeyUseAuthorizationPolicy.None) {
         return this
     }
 
@@ -96,23 +96,52 @@ internal fun ManagedKey.withWalletAuthorizationMapping(
 }
 
 /** Interprets persisted Signum policy only when the complete wallet protected-key shape matches. */
-internal fun SignumKeyPolicy.toWalletPolicy(stored: StoredKey.Managed): KeyUseAuthorizationPolicy =
-    when (val authentication = authentication) {
-        SignumAuthenticationPolicy.None -> KeyUseAuthorizationPolicy.None
-        else -> if (
-            stored.spec == KeySpec.Ec(EcCurve.P256) &&
-            stored.usages == setOf(KeyUsage.SIGN, KeyUsage.VERIFY) &&
-            hardware == SignumHardwarePolicy.REQUIRED &&
-            authentication.isWalletBiometricCurrentSet()
-        ) {
-            KeyUseAuthorizationPolicy.BiometricCurrentSet
-        } else {
-            throw KeyUseAuthorizationException(
-                KeyUseAuthorizationFailure.InvalidStoredKeyMetadata,
-                "Stored Signum key uses an unsupported wallet authorization policy",
-            )
-        }
-    }
+internal fun SignumKeyPolicy.toWalletPolicy(stored: StoredKey.Managed): KeyUseAuthorizationPolicy = when {
+    authentication == SignumAuthenticationPolicy.None -> KeyUseAuthorizationPolicy.None
+    stored.spec == KeySpec.Ec(EcCurve.P256) &&
+        stored.usages == setOf(KeyUsage.SIGN, KeyUsage.VERIFY) &&
+        hardware == SignumHardwarePolicy.REQUIRED &&
+        authentication.isWalletBiometricCurrentSet() -> KeyUseAuthorizationPolicy.BiometricCurrentSet
+    stored.spec == KeySpec.Ec(EcCurve.P256) &&
+        stored.usages == setOf(KeyUsage.SIGN, KeyUsage.VERIFY) &&
+        hardware == SignumHardwarePolicy.REQUIRED &&
+        authentication.isWalletBiometricTimedReuse() -> KeyUseAuthorizationPolicy.BiometricTimedReuse(
+        requireNotNull(authentication as? SignumAuthenticationPolicy.UserPresence).timeoutSeconds,
+    )
+    else -> throw KeyUseAuthorizationException(
+        KeyUseAuthorizationFailure.InvalidStoredKeyMetadata,
+        "Stored Signum key uses an unsupported wallet authorization policy",
+    )
+}
+
+/** Maps the complete immutable wallet policy to the protected Signum key policy. */
+internal fun KeyUseAuthorizationPolicy.toSignumPolicy(
+    prompt: KeyUseAuthorizationPrompt = KeyUseAuthorizationPrompt(),
+): SignumKeyPolicy = when (this) {
+    KeyUseAuthorizationPolicy.None -> SignumKeyPolicy()
+    KeyUseAuthorizationPolicy.BiometricCurrentSet -> SignumKeyPolicy(
+        hardware = SignumHardwarePolicy.REQUIRED,
+        authentication = SignumAuthenticationPolicy.UserPresence(
+            biometric = true,
+            allowNewBiometrics = false,
+            deviceCredential = false,
+            timeoutSeconds = 0,
+            prompt = prompt.reason,
+            cancelText = prompt.cancelText,
+        ),
+    )
+    is KeyUseAuthorizationPolicy.BiometricTimedReuse -> SignumKeyPolicy(
+        hardware = SignumHardwarePolicy.REQUIRED,
+        authentication = SignumAuthenticationPolicy.UserPresence(
+            biometric = true,
+            allowNewBiometrics = true,
+            deviceCredential = false,
+            timeoutSeconds = timeoutSeconds,
+            prompt = prompt.reason,
+            cancelText = prompt.cancelText,
+        ),
+    )
+}
 
 private fun SignumAuthenticationPolicy.isWalletBiometricCurrentSet(): Boolean =
     this is SignumAuthenticationPolicy.UserPresence &&
@@ -120,3 +149,10 @@ private fun SignumAuthenticationPolicy.isWalletBiometricCurrentSet(): Boolean =
         !allowNewBiometrics &&
         !deviceCredential &&
         timeoutSeconds == 0
+
+private fun SignumAuthenticationPolicy.isWalletBiometricTimedReuse(): Boolean =
+    this is SignumAuthenticationPolicy.UserPresence &&
+        biometric &&
+        allowNewBiometrics &&
+        !deviceCredential &&
+        timeoutSeconds in 1..30

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightKeyStore.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonMain/kotlin/id/walt/wallet2/persistence/stores/SqlDelightKeyStore.kt
@@ -79,12 +79,12 @@ public class SqlDelightKeyStore(
     /** Checks whether the wallet can satisfy the request using a managed key or an allowed software key. */
     public suspend fun preflight(requirements: WalletKeyRequirements): KeyUseAuthorizationSupport =
         managedKeyProvider.preflight(requirements).let { managedSupport ->
-            if (managedSupport == KeyUseAuthorizationSupport.Supported) {
+            if (managedSupport is KeyUseAuthorizationSupport.Supported) {
                 managedSupport
-            } else if (requirements.authorizationPolicy != KeyUseAuthorizationPolicy.None) {
+            } else if (requirements.authorizationPolicy !is KeyUseAuthorizationPolicy.None) {
                 managedSupport
             } else if (supportsSoftware(requirements)) {
-                KeyUseAuthorizationSupport.Supported
+                KeyUseAuthorizationSupport.Supported(requirements.authorizationPolicy)
             } else {
                 KeyUseAuthorizationSupport.Unsupported(
                     KeyUseAuthorizationUnsupportedReason.UnsupportedCombination,
@@ -99,11 +99,11 @@ public class SqlDelightKeyStore(
         }
         val managedSupport = managedKeyProvider.preflight(request.requirements)
         val key = when (managedSupport) {
-            KeyUseAuthorizationSupport.Supported ->
+            is KeyUseAuthorizationSupport.Supported ->
                 managedKeyProvider.generateManagedKey(request)
 
             is KeyUseAuthorizationSupport.Unsupported -> {
-                if (request.requirements.authorizationPolicy != KeyUseAuthorizationPolicy.None) {
+                if (request.requirements.authorizationPolicy !is KeyUseAuthorizationPolicy.None) {
                     throw KeyUseAuthorizationException(
                         failure = managedSupport.reason.toAuthorizationFailure(),
                         message = "The platform cannot enforce ${request.requirements.authorizationPolicy} for ${request.requirements.spec}",
@@ -198,7 +198,7 @@ public class SqlDelightKeyStore(
             val restoration = managedKeyProvider.restoreManagedKey(stored)
             when (restoration) {
                 is PlatformManagedKeyRestoration.Missing -> {
-                    if (restoration.authorizationPolicy != KeyUseAuthorizationPolicy.None) {
+                    if (restoration.authorizationPolicy !is KeyUseAuthorizationPolicy.None) {
                         throw KeyUseAuthorizationException(
                             KeyUseAuthorizationFailure.ProtectedKeyUnavailable,
                             "Protected mobile key '${stored.id.value}' is unavailable",

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonTest/kotlin/id/walt/wallet2/persistence/keys/SignumWalletKeyMappingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonTest/kotlin/id/walt/wallet2/persistence/keys/SignumWalletKeyMappingTest.kt
@@ -181,6 +181,29 @@ class SignumWalletKeyMappingTest {
         }
     }
 
+    @Test
+    fun `support metadata must match the effective policy shape without coupling its axes`() {
+        val timed = KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds = 10)
+
+        assertFailsWith<IllegalArgumentException> {
+            KeyUseAuthorizationSupport.Supported(effectivePolicy = timed)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            KeyUseAuthorizationSupport.Supported(
+                effectivePolicy = KeyUseAuthorizationPolicy.None,
+                reuseEnforcement = KeyUseAuthorizationReuseEnforcement.PlatformKeyStore,
+                timeoutValidation = KeyUseAuthorizationReuseTimeoutValidation.IndependentReadback,
+            )
+        }
+
+        val support = KeyUseAuthorizationSupport.Supported(
+            effectivePolicy = timed,
+            reuseEnforcement = KeyUseAuthorizationReuseEnforcement.ProviderProcess,
+            timeoutValidation = KeyUseAuthorizationReuseTimeoutValidation.IndependentReadback,
+        )
+        assertEquals(timed, support.effectivePolicy)
+    }
+
     private fun storedManagedKey(spec: KeySpec, usages: Set<KeyUsage>) = StoredKey.Managed(
         version = StoredKey.CURRENT_VERSION,
         id = KeyId("protected"),

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonTest/kotlin/id/walt/wallet2/persistence/keys/SignumWalletKeyMappingTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/commonTest/kotlin/id/walt/wallet2/persistence/keys/SignumWalletKeyMappingTest.kt
@@ -141,6 +141,46 @@ class SignumWalletKeyMappingTest {
         }
     }
 
+    @Test
+    fun `maps the complete timed biometric reuse policy`() {
+        val timed = KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds = 10)
+        val expected = SignumKeyPolicy(
+            hardware = SignumHardwarePolicy.REQUIRED,
+            authentication = SignumAuthenticationPolicy.UserPresence(
+                biometric = true,
+                allowNewBiometrics = true,
+                deviceCredential = false,
+                timeoutSeconds = 10,
+                prompt = "Please authorize cryptographic signature",
+            ),
+        )
+        val valid = storedManagedKey(KeySpec.Ec(EcCurve.P256), setOf(KeyUsage.SIGN, KeyUsage.VERIFY))
+
+        assertEquals(expected, timed.toSignumPolicy())
+        assertEquals(timed, expected.toWalletPolicy(valid))
+
+        listOf(
+            expected.copy(authentication = (expected.authentication as SignumAuthenticationPolicy.UserPresence).copy(timeoutSeconds = 0)),
+            expected.copy(authentication = (expected.authentication as SignumAuthenticationPolicy.UserPresence).copy(timeoutSeconds = 31)),
+            expected.copy(authentication = (expected.authentication as SignumAuthenticationPolicy.UserPresence).copy(allowNewBiometrics = false)),
+            expected.copy(authentication = (expected.authentication as SignumAuthenticationPolicy.UserPresence).copy(deviceCredential = true)),
+        ).forEach { malformed ->
+            val failure = assertFailsWith<KeyUseAuthorizationException> {
+                malformed.toWalletPolicy(valid)
+            }
+            assertEquals(KeyUseAuthorizationFailure.InvalidStoredKeyMetadata, failure.failure)
+        }
+    }
+
+    @Test
+    fun `rejects timed biometric reuse outside the supported interval`() {
+        listOf(0, 31).forEach { timeoutSeconds ->
+            assertFailsWith<IllegalArgumentException> {
+                KeyUseAuthorizationPolicy.BiometricTimedReuse(timeoutSeconds)
+            }
+        }
+    }
+
     private fun storedManagedKey(spec: KeySpec, usages: Set<KeyUsage>) = StoredKey.Managed(
         version = StoredKey.CURRENT_VERSION,
         id = KeyId("protected"),

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
@@ -126,6 +126,11 @@ private fun KeyUseAuthorizationPolicy.supportedOnIos(): KeyUseAuthorizationSuppo
         } else {
             null
         },
+        timeoutVerification = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
+            KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured
+        } else {
+            null
+        },
     )
 
 private val isSimulator: Boolean by lazy {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
@@ -126,8 +126,8 @@ private fun KeyUseAuthorizationPolicy.supportedOnIos(): KeyUseAuthorizationSuppo
         } else {
             null
         },
-        timeoutVerification = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
-            KeyUseAuthorizationReuseTimeoutVerification.ProviderConfigured
+        timeoutValidation = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
+            KeyUseAuthorizationReuseTimeoutValidation.ProviderConfigurationOnly
         } else {
             null
         },

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-persistence-mobile/src/iosMain/kotlin/id/walt/wallet2/persistence/keys/IosPlatformKeyProvider.kt
@@ -7,8 +7,6 @@ import id.walt.crypto2.keys.ManagedKey
 import id.walt.crypto2.keys.StoredKey
 import id.walt.crypto2.providers.GenerateManagedKeyRequest
 import id.walt.crypto2.signum.IosSignumKeyBackend
-import id.walt.crypto2.signum.SignumAuthenticationPolicy
-import id.walt.crypto2.signum.SignumHardwarePolicy
 import id.walt.crypto2.signum.SignumKeyNotFoundException
 import id.walt.crypto2.signum.SignumKeyOptions
 import id.walt.crypto2.signum.SignumKeyPolicy
@@ -38,8 +36,8 @@ public class IosPlatformKeyProvider : PlatformManagedKeyProvider {
         if (!backend.supports(requirements.spec, requirements.usages, signumPolicy)) {
             return KeyUseAuthorizationSupport.Unsupported(KeyUseAuthorizationUnsupportedReason.UnsupportedCombination)
         }
-        if (requirements.authorizationPolicy == KeyUseAuthorizationPolicy.None) {
-            return KeyUseAuthorizationSupport.Supported
+        if (requirements.authorizationPolicy is KeyUseAuthorizationPolicy.None) {
+            return requirements.authorizationPolicy.supportedOnIos()
         }
         val failure = when {
             requirements.spec != KeySpec.Ec(EcCurve.P256) ||
@@ -49,7 +47,7 @@ public class IosPlatformKeyProvider : PlatformManagedKeyProvider {
             else -> biometricAvailabilityFailure()
         }
         return failure?.let { KeyUseAuthorizationSupport.Unsupported(it) }
-            ?: KeyUseAuthorizationSupport.Supported
+            ?: requirements.authorizationPolicy.supportedOnIos()
     }
 
     override suspend fun generateManagedKey(request: WalletKeyCreationRequest): ManagedKey = try {
@@ -63,7 +61,7 @@ public class IosPlatformKeyProvider : PlatformManagedKeyProvider {
         ).withWalletAuthorizationMapping(request.requirements.authorizationPolicy)
     } catch (cause: Throwable) {
         if (
-            request.requirements.authorizationPolicy == KeyUseAuthorizationPolicy.None &&
+            request.requirements.authorizationPolicy is KeyUseAuthorizationPolicy.None &&
             cause is SignumKeyPolicyMismatchException
         ) {
             throw cause
@@ -118,23 +116,17 @@ public class IosPlatformKeyProvider : PlatformManagedKeyProvider {
         }
     }
 
-    private fun KeyUseAuthorizationPolicy.toSignumPolicy(
-        prompt: KeyUseAuthorizationPrompt = KeyUseAuthorizationPrompt(),
-    ): SignumKeyPolicy = when (this) {
-        KeyUseAuthorizationPolicy.None -> SignumKeyPolicy()
-        KeyUseAuthorizationPolicy.BiometricCurrentSet -> SignumKeyPolicy(
-            hardware = SignumHardwarePolicy.REQUIRED,
-            authentication = SignumAuthenticationPolicy.UserPresence(
-                biometric = true,
-                allowNewBiometrics = false,
-                deviceCredential = false,
-                timeoutSeconds = 0,
-                prompt = prompt.reason,
-                cancelText = prompt.cancelText,
-            ),
-        )
-    }
 }
+
+private fun KeyUseAuthorizationPolicy.supportedOnIos(): KeyUseAuthorizationSupport.Supported =
+    KeyUseAuthorizationSupport.Supported(
+        effectivePolicy = this,
+        reuseEnforcement = if (this is KeyUseAuthorizationPolicy.BiometricTimedReuse) {
+            KeyUseAuthorizationReuseEnforcement.ProviderProcess
+        } else {
+            null
+        },
+    )
 
 private val isSimulator: Boolean by lazy {
     NSProcessInfo.processInfo.environment.keys.any { it == "SIMULATOR_UDID" || it == "SIMULATOR_DEVICE_NAME" }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
@@ -117,9 +117,11 @@ Changing the configured default never changes an existing persisted key.
 Use `.biometricTimedReuse(timeoutSeconds:)` for a fixed, non-sliding 1–30 second
 reuse interval. It preserves strong-biometric-only signing and intentionally does
 not invalidate the key after new biometric enrollment. iOS preflight reports
-`.providerProcess` enforcement: the platform provider may end reusable
-authorization early, but does not extend it beyond the requested interval. The
-policy has no action, session, or batch scope.
+`.providerProcess` enforcement with `.providerConfigured` timeout verification:
+Signum receives the requested interval, but its pinned public API cannot
+independently expose the effective positive timeout after restoration. Timed
+reuse is recent provider authentication, not issuance, presentation, or other
+wallet-action consent, and is not guaranteed to be key-local.
 
 ## Local persistence
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
@@ -114,6 +114,13 @@ biometric authorization for every signature, and do not allow device-passcode
 fallback. The host app must declare `NSFaceIDUsageDescription` in its Info.plist.
 Changing the configured default never changes an existing persisted key.
 
+Use `.biometricTimedReuse(timeoutSeconds:)` for a fixed, non-sliding 1–30 second
+reuse interval. It preserves strong-biometric-only signing and intentionally does
+not invalidate the key after new biometric enrollment. iOS preflight reports
+`.providerProcess` enforcement: the platform provider may end reusable
+authorization early, but does not extend it beyond the requested interval. The
+policy has no action, session, or batch scope.
+
 ## Local persistence
 
 `WalletConfiguration()` uses managed persistence by default. The SDK opens an encrypted SQLDelight database through SQLCipher and manages the per-wallet database key internally in iOS Keychain. Apps using the normal Swift facade do not pass database key material.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
@@ -117,7 +117,7 @@ Changing the configured default never changes an existing persisted key.
 Use `.biometricTimedReuse(timeoutSeconds:)` for a fixed, non-sliding 1–30 second
 reuse interval. It preserves strong-biometric-only signing and intentionally does
 not invalidate the key after new biometric enrollment. iOS preflight reports
-`.providerProcess` enforcement with `.providerConfigured` timeout verification:
+`.providerProcess` enforcement with `.providerConfigurationOnly` timeout validation:
 Signum receives the requested interval, but its pinned public API cannot
 independently expose the effective positive timeout after restoration. Timed
 reuse is recent provider authentication, not issuance, presentation, or other

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
@@ -77,8 +77,8 @@ simulator cannot validate Secure Enclave or Face ID behavior.
 Use `.biometricTimedReuse(timeoutSeconds:)` for a fixed 1–30 second interval
 after successful strong-biometric authorization. The interval does not slide on
 signing and new biometric enrollment does not invalidate the key. Check the
-preflight result's `reuseEnforcement` and `timeoutVerification`: iOS reports
-provider-process enforcement with provider-configured timeout verification.
+preflight result's `reuseEnforcement` and `timeoutValidation`: iOS reports
+provider-process enforcement with provider-configuration-only validation.
 Signum receives the requested interval, but its pinned public API cannot
 independently expose the effective positive timeout after restoration. Timed
 reuse is recent provider authentication, not issuance, presentation, or other

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
@@ -77,9 +77,12 @@ simulator cannot validate Secure Enclave or Face ID behavior.
 Use `.biometricTimedReuse(timeoutSeconds:)` for a fixed 1–30 second interval
 after successful strong-biometric authorization. The interval does not slide on
 signing and new biometric enrollment does not invalidate the key. Check the
-preflight result's `reuseEnforcement`: iOS reports provider-process enforcement,
-which can expire earlier but never runs longer than the requested interval. This
-policy has no action, session, or batch scope.
+preflight result's `reuseEnforcement` and `timeoutVerification`: iOS reports
+provider-process enforcement with provider-configured timeout verification.
+Signum receives the requested interval, but its pinned public API cannot
+independently expose the effective positive timeout after restoration. Timed
+reuse is recent provider authentication, not issuance, presentation, or other
+wallet-action consent, and is not guaranteed to be key-local.
 
 Use the returned ``WalletBootstrapResult/did`` when a verifier flow needs an
 explicit wallet DID.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/GettingStarted.md
@@ -74,5 +74,12 @@ not change an existing key. The host app must also declare
 `NSFaceIDUsageDescription` in `Info.plist` before using this policy; the
 simulator cannot validate Secure Enclave or Face ID behavior.
 
+Use `.biometricTimedReuse(timeoutSeconds:)` for a fixed 1–30 second interval
+after successful strong-biometric authorization. The interval does not slide on
+signing and new biometric enrollment does not invalidate the key. Check the
+preflight result's `reuseEnforcement`: iOS reports provider-process enforcement,
+which can expire earlier but never runs longer than the requested interval. This
+policy has no action, session, or batch scope.
+
 Use the returned ``WalletBootstrapResult/did`` when a verifier flow needs an
 explicit wallet DID.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -75,17 +75,15 @@ final class KMPWalletCoreBridge: WalletCoreBridge, @unchecked Sendable {
             as: WalletBridgeKeyPreflight.self,
             operation: "key authorization preflight"
         )
-        switch (value.supported, value.effectivePolicy, value.reuseEnforcement, value.timeoutVerification, value.failure) {
-        case (true, let policy?, let reuseEnforcement?, let timeoutVerification?, nil):
-            guard policy.type == .biometricTimedReuse,
-                  (reuseEnforcement == .platformKeyStore && timeoutVerification == .platformVerified) ||
-                  (reuseEnforcement == .providerProcess && timeoutVerification == .providerConfigured) else {
+        switch (value.supported, value.effectivePolicy, value.reuseEnforcement, value.timeoutValidation, value.failure) {
+        case (true, let policy?, let reuseEnforcement?, let timeoutValidation?, nil):
+            guard policy.type == .biometricTimedReuse else {
                 throw WalletError.internalFailure("Invalid timed key authorization preflight result")
             }
             return .supported(
                 effectivePolicy: policy.toSwiftAuthorizationPolicy(),
                 reuseEnforcement: reuseEnforcement.toSwiftAuthorizationReuseEnforcement(),
-                timeoutVerification: timeoutVerification.toSwiftAuthorizationTimeoutVerification()
+                timeoutValidation: timeoutValidation.toSwiftAuthorizationTimeoutValidation()
             )
         case (true, let policy?, nil, nil, nil):
             guard policy.type != .biometricTimedReuse else {
@@ -94,7 +92,7 @@ final class KMPWalletCoreBridge: WalletCoreBridge, @unchecked Sendable {
             return .supported(
                 effectivePolicy: policy.toSwiftAuthorizationPolicy(),
                 reuseEnforcement: nil,
-                timeoutVerification: nil
+                timeoutValidation: nil
             )
         case (false, nil, nil, nil, let failure?): return .unsupported(failure.toSwiftAuthorizationUnsupportedReason())
         default: throw WalletError.internalFailure("Invalid key authorization preflight result")
@@ -772,11 +770,11 @@ private extension WalletBridgeKeyUseAuthorizationReuseEnforcement {
     }
 }
 
-private extension WalletBridgeKeyUseAuthorizationReuseTimeoutVerification {
-    func toSwiftAuthorizationTimeoutVerification() -> WalletKeyUseAuthorizationReuseTimeoutVerification {
+private extension WalletBridgeKeyUseAuthorizationReuseTimeoutValidation {
+    func toSwiftAuthorizationTimeoutValidation() -> WalletKeyUseAuthorizationReuseTimeoutValidation {
         switch self {
-        case .platformVerified: return .platformVerified
-        case .providerConfigured: return .providerConfigured
+        case .independentReadback: return .independentReadback
+        case .providerConfigurationOnly: return .providerConfigurationOnly
         }
     }
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -75,9 +75,13 @@ final class KMPWalletCoreBridge: WalletCoreBridge, @unchecked Sendable {
             as: WalletBridgeKeyPreflight.self,
             operation: "key authorization preflight"
         )
-        switch (value.supported, value.failure) {
-        case (true, nil): return .supported
-        case (false, let failure?): return .unsupported(failure.toSwiftAuthorizationUnsupportedReason())
+        switch (value.supported, value.effectivePolicy, value.reuseEnforcement, value.failure) {
+        case (true, let policy?, let reuseEnforcement, nil):
+            return .supported(
+                effectivePolicy: policy.toSwiftAuthorizationPolicy(),
+                reuseEnforcement: reuseEnforcement?.toSwiftAuthorizationReuseEnforcement()
+            )
+        case (false, nil, nil, let failure?): return .unsupported(failure.toSwiftAuthorizationUnsupportedReason())
         default: throw WalletError.internalFailure("Invalid key authorization preflight result")
         }
     }
@@ -708,12 +712,47 @@ private extension WalletKeyType {
 }
 
 private extension WalletKeyUseAuthorizationPolicy {
-    func toKMPAuthorizationPolicy() -> Waltid_openid4vc_wallet_persistence_mobileKeyUseAuthorizationPolicy {
+    func toKMPAuthorizationPolicy() -> WalletBridgeKeyUseAuthorizationPolicy {
         switch self {
         case .none:
-            return .none
+            return WalletBridgeKeyUseAuthorizationPolicy(
+                type: .none,
+                timeoutSeconds: nil
+            )
         case .biometricCurrentSet:
-            return .biometricCurrentSet
+            return WalletBridgeKeyUseAuthorizationPolicy(
+                type: .biometricCurrentSet,
+                timeoutSeconds: nil
+            )
+        case .biometricTimedReuse(let timeoutSeconds):
+            precondition((1...30).contains(timeoutSeconds), "Timed biometric reuse timeout must be between 1 and 30 seconds")
+            return WalletBridgeKeyUseAuthorizationPolicy(
+                type: .biometricTimedReuse,
+                timeoutSeconds: KotlinInt(int: Int32(timeoutSeconds))
+            )
+        }
+    }
+}
+
+private extension WalletBridgeKeyUseAuthorizationPolicy {
+    func toSwiftAuthorizationPolicy() -> WalletKeyUseAuthorizationPolicy {
+        switch type {
+        case .none: return .none
+        case .biometricCurrentSet: return .biometricCurrentSet
+        case .biometricTimedReuse:
+            guard let timeoutSeconds else {
+                preconditionFailure("Timed biometric reuse preflight omitted its timeout")
+            }
+            return .biometricTimedReuse(timeoutSeconds: Int(timeoutSeconds.intValue))
+        }
+    }
+}
+
+private extension WalletBridgeKeyUseAuthorizationReuseEnforcement {
+    func toSwiftAuthorizationReuseEnforcement() -> WalletKeyUseAuthorizationReuseEnforcement {
+        switch self {
+        case .platformKeyStore: return .platformKeyStore
+        case .providerProcess: return .providerProcess
         }
     }
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -75,13 +75,28 @@ final class KMPWalletCoreBridge: WalletCoreBridge, @unchecked Sendable {
             as: WalletBridgeKeyPreflight.self,
             operation: "key authorization preflight"
         )
-        switch (value.supported, value.effectivePolicy, value.reuseEnforcement, value.failure) {
-        case (true, let policy?, let reuseEnforcement, nil):
+        switch (value.supported, value.effectivePolicy, value.reuseEnforcement, value.timeoutVerification, value.failure) {
+        case (true, let policy?, let reuseEnforcement?, let timeoutVerification?, nil):
+            guard policy.type == .biometricTimedReuse,
+                  (reuseEnforcement == .platformKeyStore && timeoutVerification == .platformVerified) ||
+                  (reuseEnforcement == .providerProcess && timeoutVerification == .providerConfigured) else {
+                throw WalletError.internalFailure("Invalid timed key authorization preflight result")
+            }
             return .supported(
                 effectivePolicy: policy.toSwiftAuthorizationPolicy(),
-                reuseEnforcement: reuseEnforcement?.toSwiftAuthorizationReuseEnforcement()
+                reuseEnforcement: reuseEnforcement.toSwiftAuthorizationReuseEnforcement(),
+                timeoutVerification: timeoutVerification.toSwiftAuthorizationTimeoutVerification()
             )
-        case (false, nil, nil, let failure?): return .unsupported(failure.toSwiftAuthorizationUnsupportedReason())
+        case (true, let policy?, nil, nil, nil):
+            guard policy.type != .biometricTimedReuse else {
+                throw WalletError.internalFailure("Timed key authorization preflight lacks timeout metadata")
+            }
+            return .supported(
+                effectivePolicy: policy.toSwiftAuthorizationPolicy(),
+                reuseEnforcement: nil,
+                timeoutVerification: nil
+            )
+        case (false, nil, nil, nil, let failure?): return .unsupported(failure.toSwiftAuthorizationUnsupportedReason())
         default: throw WalletError.internalFailure("Invalid key authorization preflight result")
         }
     }
@@ -753,6 +768,15 @@ private extension WalletBridgeKeyUseAuthorizationReuseEnforcement {
         switch self {
         case .platformKeyStore: return .platformKeyStore
         case .providerProcess: return .providerProcess
+        }
+    }
+}
+
+private extension WalletBridgeKeyUseAuthorizationReuseTimeoutVerification {
+    func toSwiftAuthorizationTimeoutVerification() -> WalletKeyUseAuthorizationReuseTimeoutVerification {
+        switch self {
+        case .platformVerified: return .platformVerified
+        case .providerConfigured: return .providerConfigured
         }
     }
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Wallet.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Wallet.swift
@@ -65,7 +65,7 @@ public actor Wallet {
         )
     }
 
-    /// Checks whether an exact key-use authorization request can be enforced without creating a key.
+    /// Checks whether a key-use authorization request is supported without creating a key.
     ///
     /// - Parameters:
     ///   - keyType: Optional key type override. When omitted, the configured default is used.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -168,7 +168,7 @@ public enum WalletKeyUseAuthorizationPreflight: Equatable, Sendable {
     case supported(
         effectivePolicy: WalletKeyUseAuthorizationPolicy,
         reuseEnforcement: WalletKeyUseAuthorizationReuseEnforcement?,
-        timeoutVerification: WalletKeyUseAuthorizationReuseTimeoutVerification?
+        timeoutValidation: WalletKeyUseAuthorizationReuseTimeoutValidation?
     )
     /// The requested policy cannot currently be supported; the reason explains why.
     case unsupported(WalletKeyUseAuthorizationUnsupportedReason)
@@ -183,13 +183,13 @@ public enum WalletKeyUseAuthorizationReuseEnforcement: Equatable, Sendable {
     case providerProcess
 }
 
-/// Timeout-validation evidence reported when timed biometric reuse is supported.
-public enum WalletKeyUseAuthorizationReuseTimeoutVerification: Equatable, Sendable {
-    /// Android native KeyStore metadata exactly matches the requested interval.
-    case platformVerified
+/// Timeout-validation capability reported when timed biometric reuse is supported.
+public enum WalletKeyUseAuthorizationReuseTimeoutValidation: Equatable, Sendable {
+    /// Native metadata can be independently read back and compared after creation or restoration.
+    case independentReadback
 
-    /// Signum received the requested interval, but its effective timeout is not independently visible.
-    case providerConfigured
+    /// The provider receives the interval, but its effective timeout cannot be independently read back.
+    case providerConfigurationOnly
 }
 
 /// Trust configuration used to authenticate verifier Request Objects.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -107,8 +107,9 @@ public enum WalletKeyUseAuthorizationPolicy: Equatable, Sendable {
 
     ///
     /// Strong biometric authentication reusable for a fixed, non-sliding interval after authorization.
-    /// New biometric enrollment does not invalidate the key. Android's KeyStore enforces the interval;
-    /// iOS reports provider-process enforcement, which may end it earlier but never extend it.
+    /// Android verifies the native KeyStore interval. iOS configures the interval in Signum but cannot
+    /// independently inspect its effective positive timeout after restoration. This is recent platform
+    /// or provider authentication, not consent for issuance, presentation, or another wallet action.
     case biometricTimedReuse(timeoutSeconds: Int)
 }
 
@@ -151,7 +152,7 @@ public enum WalletKeyUseAuthorizationFailure: Equatable, Sendable {
     case invalidStoredKeyMetadata
 }
 
-/// Stable reasons an exact protected-key preflight cannot currently be supported.
+/// Stable reasons a protected-key preflight cannot currently be supported.
 public enum WalletKeyUseAuthorizationUnsupportedReason: Equatable, Sendable {
     /// The key type or usage set cannot satisfy the selected protected-key policy.
     case unsupportedCombination
@@ -161,14 +162,15 @@ public enum WalletKeyUseAuthorizationUnsupportedReason: Equatable, Sendable {
     case biometricNotEnrolled
 }
 
-/// Result of checking whether an exact protected-key request can be enforced.
+/// Result of checking whether a protected-key request is supported.
 public enum WalletKeyUseAuthorizationPreflight: Equatable, Sendable {
-    /// The exact requested protected-key policy can be enforced.
+    /// The requested protected-key policy can be created with reported timed-reuse metadata.
     case supported(
         effectivePolicy: WalletKeyUseAuthorizationPolicy,
-        reuseEnforcement: WalletKeyUseAuthorizationReuseEnforcement?
+        reuseEnforcement: WalletKeyUseAuthorizationReuseEnforcement?,
+        timeoutVerification: WalletKeyUseAuthorizationReuseTimeoutVerification?
     )
-    /// The exact requested policy cannot currently be enforced; the reason explains why.
+    /// The requested policy cannot currently be supported; the reason explains why.
     case unsupported(WalletKeyUseAuthorizationUnsupportedReason)
 }
 
@@ -179,6 +181,15 @@ public enum WalletKeyUseAuthorizationReuseEnforcement: Equatable, Sendable {
 
     /// The platform crypto provider reuses process-local authorization state.
     case providerProcess
+}
+
+/// Timeout-validation evidence reported when timed biometric reuse is supported.
+public enum WalletKeyUseAuthorizationReuseTimeoutVerification: Equatable, Sendable {
+    /// Android native KeyStore metadata exactly matches the requested interval.
+    case platformVerified
+
+    /// Signum received the requested interval, but its effective timeout is not independently visible.
+    case providerConfigured
 }
 
 /// Trust configuration used to authenticate verifier Request Objects.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/WalletModels.swift
@@ -104,6 +104,12 @@ public enum WalletKeyUseAuthorizationPolicy: Equatable, Sendable {
 
     /// Strong biometric authentication for every operation; new biometric enrollment invalidates the key.
     case biometricCurrentSet
+
+    ///
+    /// Strong biometric authentication reusable for a fixed, non-sliding interval after authorization.
+    /// New biometric enrollment does not invalidate the key. Android's KeyStore enforces the interval;
+    /// iOS reports provider-process enforcement, which may end it earlier but never extend it.
+    case biometricTimedReuse(timeoutSeconds: Int)
 }
 
 /// Prompt text supplied to the operating-system-owned authorization UI.
@@ -158,9 +164,21 @@ public enum WalletKeyUseAuthorizationUnsupportedReason: Equatable, Sendable {
 /// Result of checking whether an exact protected-key request can be enforced.
 public enum WalletKeyUseAuthorizationPreflight: Equatable, Sendable {
     /// The exact requested protected-key policy can be enforced.
-    case supported
+    case supported(
+        effectivePolicy: WalletKeyUseAuthorizationPolicy,
+        reuseEnforcement: WalletKeyUseAuthorizationReuseEnforcement?
+    )
     /// The exact requested policy cannot currently be enforced; the reason explains why.
     case unsupported(WalletKeyUseAuthorizationUnsupportedReason)
+}
+
+/// Enforcement boundary reported when timed biometric reuse is supported.
+public enum WalletKeyUseAuthorizationReuseEnforcement: Equatable, Sendable {
+    /// The native key store enforces the authorization validity interval.
+    case platformKeyStore
+
+    /// The platform crypto provider reuses process-local authorization state.
+    case providerProcess
 }
 
 /// Trust configuration used to authenticate verifier Request Objects.

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -137,12 +137,20 @@ final class WalletAPITests: XCTestCase {
         let policy = WalletKeyUseAuthorizationPolicy.biometricTimedReuse(timeoutSeconds: 10)
         let preflight = WalletKeyUseAuthorizationPreflight.supported(
             effectivePolicy: policy,
-            reuseEnforcement: .providerProcess
+            reuseEnforcement: .providerProcess,
+            timeoutVerification: .providerConfigured
         )
 
         acceptsSendable(policy)
         acceptsSendable(preflight)
-        XCTAssertEqual(preflight, .supported(effectivePolicy: policy, reuseEnforcement: .providerProcess))
+        XCTAssertEqual(
+            preflight,
+            .supported(
+                effectivePolicy: policy,
+                reuseEnforcement: .providerProcess,
+                timeoutVerification: .providerConfigured
+            )
+        )
     }
 
     func testPresentationPreviewModelsAreValueTypesAndEquatable() {
@@ -883,7 +891,8 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
         }
         return keyUseAuthorizationPreflightResult ?? .supported(
             effectivePolicy: policy,
-            reuseEnforcement: nil
+            reuseEnforcement: nil,
+            timeoutVerification: nil
         )
     }
 

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -133,6 +133,18 @@ final class WalletAPITests: XCTestCase {
 
     }
 
+    func testTimedKeyUseAuthorizationPolicyAndPreflightArePublicValueTypes() {
+        let policy = WalletKeyUseAuthorizationPolicy.biometricTimedReuse(timeoutSeconds: 10)
+        let preflight = WalletKeyUseAuthorizationPreflight.supported(
+            effectivePolicy: policy,
+            reuseEnforcement: .providerProcess
+        )
+
+        acceptsSendable(policy)
+        acceptsSendable(preflight)
+        XCTAssertEqual(preflight, .supported(effectivePolicy: policy, reuseEnforcement: .providerProcess))
+    }
+
     func testPresentationPreviewModelsAreValueTypesAndEquatable() {
         let preview = PresentationPreview(
             previewHandle: PresentationPreviewHandle(value: "presentation-preview-1"),
@@ -211,6 +223,16 @@ final class WalletAPITests: XCTestCase {
         _ = try await wallet.bootstrap(keyType: .rsa4096)
 
         XCTAssertEqual(bridge.bootstrapCalls.first?.keyType, .rsa4096)
+    }
+
+    func testBootstrapForwardsTimedKeyUseAuthorizationPolicy() async throws {
+        let bridge = FakeWalletCoreBridge()
+        let wallet = Wallet(configuration: .init(), bridge: bridge)
+        let policy = WalletKeyUseAuthorizationPolicy.biometricTimedReuse(timeoutSeconds: 10)
+
+        _ = try await wallet.bootstrap(keyUseAuthorizationPolicy: policy)
+
+        XCTAssertEqual(bridge.bootstrapCalls.first?.keyUseAuthorizationPolicy, policy)
     }
 
     func testIssuanceSessionOperationsForwardTypedInputs() async throws {
@@ -727,6 +749,7 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
     struct BootstrapCall {
         let keyType: WalletKeyType
         let didMethod: String
+        let keyUseAuthorizationPolicy: WalletKeyUseAuthorizationPolicy?
     }
 
     struct PresentCall {
@@ -766,6 +789,7 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
     var events: AsyncStream<WalletEvent>
     var error: WalletError?
     var bootstrapResult = WalletBootstrapResult(keyID: "key", did: "did:key:wallet")
+    var keyUseAuthorizationPreflightResult: WalletKeyUseAuthorizationPreflight?
     var issuanceSessionResult = IssuanceSession(
         id: "issuance-session-1",
         offer: IssuanceOfferPreview(
@@ -831,13 +855,36 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
         }
     }
 
-    func bootstrap(keyType: WalletKeyType, didMethod: String) async throws -> WalletBootstrapResult {
+    func bootstrap(
+        keyType: WalletKeyType,
+        didMethod: String,
+        keyUseAuthorizationPolicy: WalletKeyUseAuthorizationPolicy?
+    ) async throws -> WalletBootstrapResult {
         if let error {
             throw error
         }
 
-        bootstrapCalls.append(.init(keyType: keyType, didMethod: didMethod))
+        bootstrapCalls.append(
+            .init(
+                keyType: keyType,
+                didMethod: didMethod,
+                keyUseAuthorizationPolicy: keyUseAuthorizationPolicy
+            )
+        )
         return bootstrapResult
+    }
+
+    func keyUseAuthorizationPreflight(
+        keyType: WalletKeyType,
+        policy: WalletKeyUseAuthorizationPolicy
+    ) async throws -> WalletKeyUseAuthorizationPreflight {
+        if let error {
+            throw error
+        }
+        return keyUseAuthorizationPreflightResult ?? .supported(
+            effectivePolicy: policy,
+            reuseEnforcement: nil
+        )
     }
 
     func startIssuance(request: IssuanceRequest) async throws -> IssuanceSession {

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -138,7 +138,7 @@ final class WalletAPITests: XCTestCase {
         let preflight = WalletKeyUseAuthorizationPreflight.supported(
             effectivePolicy: policy,
             reuseEnforcement: .providerProcess,
-            timeoutVerification: .providerConfigured
+            timeoutValidation: .providerConfigurationOnly
         )
 
         acceptsSendable(policy)
@@ -148,7 +148,7 @@ final class WalletAPITests: XCTestCase {
             .supported(
                 effectivePolicy: policy,
                 reuseEnforcement: .providerProcess,
-                timeoutVerification: .providerConfigured
+                timeoutValidation: .providerConfigurationOnly
             )
         )
     }
@@ -889,10 +889,16 @@ private final class FakeWalletCoreBridge: WalletCoreBridge, @unchecked Sendable 
         if let error {
             throw error
         }
+        let timedMetadata: (WalletKeyUseAuthorizationReuseEnforcement?, WalletKeyUseAuthorizationReuseTimeoutValidation?)
+        if case .biometricTimedReuse = policy {
+            timedMetadata = (.providerProcess, .providerConfigurationOnly)
+        } else {
+            timedMetadata = (nil, nil)
+        }
         return keyUseAuthorizationPreflightResult ?? .supported(
             effectivePolicy: policy,
-            reuseEnforcement: nil,
-            timeoutVerification: nil
+            reuseEnforcement: timedMetadata.0,
+            timeoutValidation: timedMetadata.1
         )
     }
 


### PR DESCRIPTION
## Summary

This follow-up to [#1936](https://github.com/walt-id/waltid-identity/pull/1936) adds optional timed reuse of biometric authentication to the mobile wallet SDK. It implements [WAL-1209](https://linear.app/walt-new/issue/WAL-1209/specify-timed-key-use-authorization-reuse-semantics).

After a successful biometric check, eligible signing operations may reuse that authentication for a fixed interval of 1–30 seconds. The Compose Android, Compose iOS, and native iOS demo apps use a 10-second interval to avoid repeated prompts during operations such as credential issuance.

The SDK default remains `BiometricCurrentSet`, which authorizes every private-key operation separately. Applications must explicitly select `BiometricTimedReuse` to enable reuse.

## What Changed

### Public API and persistence

- Replaces the `KeyUseAuthorizationPolicy` enum with a serializable policy type containing `None`, `BiometricCurrentSet`, and `BiometricTimedReuse(timeoutSeconds)`.
- Persists the complete policy with each key and restores the same policy after a wallet reload.
- Exposes the timed policy and its platform capabilities through the Kotlin preflight API and the Swift facade.
- Updates tests, ABI snapshots, and SDK documentation for the new model.

### Platform behavior

| | Android | iOS |
| --- | --- | --- |
| Timeout enforcement | Android KeyStore (`PlatformKeyStore`) | Signum provider process (`ProviderProcess`) |
| Timeout validation | Reads native key metadata after creation or restoration (`IndependentReadback`) | Confirms the supported configuration sent to Signum; no independent readback (`ProviderConfigurationOnly`) |

On Android, signing continues without an interaction host while authentication is still valid. After the interval expires, a resumed `FragmentActivity` is required to show the biometric prompt. If no prompt host is available, the SDK reports `InteractionContextUnavailable`.

## Security Semantics

- Timed reuse is available only for hardware-backed P-256 signing keys.
- It requires strong biometrics and does not allow device-credential fallback.
- The interval is fixed and non-sliding. Another signing operation does not restart it.
- New biometric enrollment does not invalidate a key using the timed policy.
- Reused authentication authorizes key use only. It is not consent for credential issuance, presentation, or any other wallet action.
- Callers must not assume that reusable authentication state is isolated to a single key.

## Compatibility

This intentionally changes the Kotlin policy API introduced by #1936 from an enum to a sealed, serializable type. Existing defaults remain unchanged, and this PR does not add stored-key migrations or broader authorization scopes.

## Caveats and Follow-Ups

On iOS, the pinned Signum version does not expose a restored positive timeout, so the SDK reports `ProviderConfigurationOnly`. [a-sit-plus/signum#472](https://github.com/a-sit-plus/signum/issues/472) and [a-sit-plus/signum#473](https://github.com/a-sit-plus/signum/pull/473) add this readback. [WAL-1316](https://linear.app/walt-new/issue/WAL-1316/adopt-signum-ios-timeout-readback-and-remove-validation-workaround) will adopt the released API, validate restored policies directly, and remove the temporary timeout-validation types and fields. Enforcement remains in the Signum provider process.
