### PR TITLE
[WAL-752] test(android): stabilize native DC API E2Es

### DIFF
--- a/.github/scripts/mobile-ci/configure-android-device-phase.sh
+++ b/.github/scripts/mobile-ci/configure-android-device-phase.sh
@@ -5,7 +5,6 @@ phase="${1:?Android device test phase is required}"
 emulator_api_level="34"
 emulator_profile=""
 emulator_avd_name=""
-emulator_test_options=""
 
 case "$phase" in
   wallet-mobile)
@@ -27,17 +26,19 @@ case "$phase" in
     emulator_target="default"
     ;;
   dc-api-compose)
-    # Dedicated Play Store lane for the GMS-gated Digital Credentials E2Es.
+    # Dedicated Google APIs lane for the GMS-gated Digital Credentials E2Es.
     dc_api_test_classes="id.walt.walletdemo.compose.android.DigitalCredentialSharingE2ETest,id.walt.walletdemo.compose.android.DigitalCredentialIssuanceE2ETest"
-    script="ANDROID_TEST_CLASS=$dc_api_test_classes ./waltid-identity/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh"
-    emulator_options="-no-window -gpu auto -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator"
-    emulator_test_options="$emulator_options -no-snapshot-save"
-    emulator_avd_name="dc-api-api37-pixel7-playstore"
+    script="ANDROID_TEST_CLASS=$dc_api_test_classes EXPECTED_ANDROID_TEST_CASE_COUNT=13 ./waltid-identity/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh"
+    # The cached artifact is the configured userdata disk, not a Quick Boot state. Always cold-boot
+    # it so the first process/ADB/GMS state is recreated for every job and never restored from a
+    # potentially poisoned host snapshot.
+    emulator_options="-no-snapshot -no-snapshot-save -no-window -gpu auto -noaudio -no-boot-anim -camera-back none -memory 4096 -feature GLDirectMem,HasSharedSlotsHostMemoryAllocator"
+    emulator_avd_name="dc-api-api37-pixel7-google-apis"
     report_paths="waltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/outputs/androidTest-results/**/*.xml"
     artifact_paths=$'waltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/reports/androidTests/**\nwaltid-identity/waltid-applications/waltid-wallet-demo-compose/androidApp/build/outputs/androidTest-results/**'
     emulator_api_level="37.0"
     emulator_profile="pixel_7"
-    emulator_target="playstore_ps16k"
+    emulator_target="google_apis"
     ;;
   enterprise-mobile)
     script="./waltid-identity/.github/scripts/mobile-ci/run-enterprise-android-mobile-tests.sh"
@@ -52,17 +53,12 @@ case "$phase" in
     ;;
 esac
 
-if [[ -z "$emulator_test_options" ]]; then
-  emulator_test_options="$emulator_options"
-fi
-
 {
   echo "script=$script"
   echo "emulator_api_level=$emulator_api_level"
   echo "emulator_profile=$emulator_profile"
   echo "emulator_avd_name=$emulator_avd_name"
   echo "emulator_options=$emulator_options"
-  echo "emulator_test_options=$emulator_test_options"
   echo "emulator_target=$emulator_target"
   echo "report_paths<<ANDROID_TEST_REPORT_PATHS"
   printf '%s\n' "$report_paths"

--- a/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh
+++ b/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh
@@ -4,10 +4,37 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$script_dir/prepare-android-dc-api-device.sh"
 
-echo "DC API AVD preparation: creating a known-good Play Store baseline for Quick Boot caching"
-prepare_android_dc_api_device false
-echo "DC API AVD preparation: rebooting once after GMS provisioning before snapshotting"
-adb_cmd reboot
-prepare_android_dc_api_device true
-assert_android_dc_api_device_unchanged
-echo "DC API AVD preparation: GMS and system UI health gates passed; the runner will persist the Quick Boot snapshot"
+DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS="${DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS:-60}"
+
+run_bounded_adb() {
+  local timeout_seconds="$1"
+  shift
+  local command=("$ADB_BIN")
+  if [[ -n "$ANDROID_SERIAL" ]]; then
+    command+=(-s "$ANDROID_SERIAL")
+  fi
+  timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" "${command[@]}" "$@"
+}
+
+echo "DC API AVD preparation: validating the factory image before configured-AVD caching"
+prepare_android_dc_api_device
+write_android_dc_api_baseline_manifest
+assert_android_dc_api_baseline_manifest
+echo "DC API AVD preparation: draining Android broadcast and application work before caching"
+if ! barrier_output="$(
+  run_bounded_adb "$DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS" \
+    shell am wait-for-broadcast-barrier \
+    --flush-broadcast-loopers \
+    --flush-application-threads
+)"; then
+  echo "::error::Android broadcast/application quiescence command failed" >&2
+  exit 1
+fi
+printf '%s\n' "$barrier_output"
+if [[ "$barrier_output" != *"Finished application barriers!"* ]]; then
+  echo "::error::Android application work did not reach the quiescence barrier" >&2
+  exit 1
+fi
+echo "DC API AVD preparation: flushing the guest filesystem"
+run_bounded_adb "$DC_API_CACHE_QUIESCENCE_TIMEOUT_SECONDS" shell sync
+echo "DC API AVD preparation: immutable manifest and guest durability gates passed"

--- a/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh
+++ b/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh
@@ -3,13 +3,21 @@ set -euo pipefail
 
 ADB_BIN="${ADB_BIN:-adb}"
 ANDROID_SERIAL="${ANDROID_SERIAL:-}"
-MIN_GMS_VERSION="${MIN_GMS_VERSION:-26.29.32}"
-GMS_READY_TIMEOUT_SECONDS="${GMS_READY_TIMEOUT_SECONDS:-300}"
-GMS_STABILITY_SECONDS="${GMS_STABILITY_SECONDS:-15}"
-GMS_POLL_SECONDS="${GMS_POLL_SECONDS:-2}"
-GMS_VALIDATION_TIMEOUT_SECONDS="${GMS_VALIDATION_TIMEOUT_SECONDS:-60}"
-LAUNCHER_READY_TIMEOUT_SECONDS="${LAUNCHER_READY_TIMEOUT_SECONDS:-30}"
-LAUNCHER_STABILITY_SECONDS="${LAUNCHER_STABILITY_SECONDS:-6}"
+ANDROID_HOME="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+DC_API_BASELINE_SCHEMA="${DC_API_BASELINE_SCHEMA:-3}"
+DC_API_EMULATOR_PACKAGE_REVISION="${DC_API_EMULATOR_PACKAGE_REVISION:-37.1.11}"
+DC_API_PLATFORM_TOOLS_REVISION="${DC_API_PLATFORM_TOOLS_REVISION:-37.0.1}"
+DC_API_SYSTEM_IMAGE_PACKAGE="${DC_API_SYSTEM_IMAGE_PACKAGE:-system-images;android-37.0;google_apis;x86_64}"
+DC_API_SYSTEM_IMAGE_REVISION="${DC_API_SYSTEM_IMAGE_REVISION:-6.5.11}"
+DC_API_AVD_NAME="${DC_API_AVD_NAME:-dc-api-api37-pixel7-google-apis}"
+DC_API_AVD_ROOT="${ANDROID_AVD_HOME:-${HOME}/.android/avd}"
+DC_API_AVD_DIR="$DC_API_AVD_ROOT/${DC_API_AVD_NAME}.avd"
+DC_API_BASELINE_MANIFEST="$DC_API_AVD_DIR/waltid-dc-api-baseline.manifest"
+MIN_GMS_VERSION="${MIN_GMS_VERSION:-24.31.0}"
+DC_API_READY_TIMEOUT_SECONDS="${DC_API_READY_TIMEOUT_SECONDS:-120}"
+DC_API_POLL_SECONDS="${DC_API_POLL_SECONDS:-2}"
+DC_API_LAUNCHER_READY_TIMEOUT_SECONDS="${DC_API_LAUNCHER_READY_TIMEOUT_SECONDS:-30}"
+DC_API_LAUNCHER_STABILITY_SECONDS="${DC_API_LAUNCHER_STABILITY_SECONDS:-6}"
 
 adb_cmd() {
   if [[ -n "$ANDROID_SERIAL" ]]; then
@@ -21,6 +29,72 @@ adb_cmd() {
 
 adb_shell() {
   adb_cmd shell "$@" | tr -d '\r'
+}
+
+package_revision() {
+  local package_xml="$1"
+  [[ -f "$package_xml" ]] || return 1
+  awk '
+    function value(text, tag, pattern, match_text) {
+      pattern = "<" tag ">[0-9]+</" tag ">"
+      if (!match(text, pattern)) return ""
+      match_text = substr(text, RSTART, RLENGTH)
+      gsub(/<[^>]+>/, "", match_text)
+      return match_text
+    }
+    {
+      text = $0
+      if (index(text, "<revision>") > 0) {
+        in_revision = 1
+        text = substr(text, index(text, "<revision>") + length("<revision>"))
+      }
+      if (!in_revision) next
+      major = major == "" ? value(text, "major") : major
+      minor = minor == "" ? value(text, "minor") : minor
+      micro = micro == "" ? value(text, "micro") : micro
+      if (index(text, "</revision>") > 0) {
+        if (major == "") exit 1
+        printf "%s", major
+        if (minor != "") printf ".%s", minor
+        if (micro != "") printf ".%s", micro
+        printf "\n"
+        exit
+      }
+    }
+  ' "$package_xml"
+}
+
+avd_config_file() {
+  if [[ -f "$DC_API_AVD_DIR/config.ini" ]]; then
+    printf '%s\n' "$DC_API_AVD_DIR/config.ini"
+    return 0
+  fi
+
+  [[ -d "$DC_API_AVD_ROOT" ]] || return 1
+  find "$DC_API_AVD_ROOT" -maxdepth 2 -type f \
+    -path "*/${DC_API_AVD_NAME}.avd/config.ini" -print -quit
+}
+
+avd_config_value() {
+  local key="$1"
+  local config_file
+  config_file="$(avd_config_file || true)"
+  [[ -n "$config_file" ]] || return 1
+  sed -n -E "s/^[[:space:]]*${key//./\\.}[[:space:]]*=[[:space:]]*(.*)$/\1/p" "$config_file" |
+    tail -n 1
+}
+
+avd_system_image_dir() {
+  local image_sysdir
+  image_sysdir="$(avd_config_value image.sysdir.1 || true)"
+  image_sysdir="${image_sysdir%/}"
+  [[ -n "$image_sysdir" ]] || return 1
+  printf '%s/%s\n' "$ANDROID_HOME/system-images" "${image_sysdir#system-images/}"
+}
+
+expected_avd_system_image_sysdir() {
+  local package_path="${DC_API_SYSTEM_IMAGE_PACKAGE#system-images;}"
+  printf 'system-images/%s/\n' "${package_path//;/\/}"
 }
 
 gms_details() {
@@ -35,24 +109,14 @@ gms_version_code() {
   gms_details | sed -n 's/.*versionCode=\([0-9]*\).*/\1/p' | head -n 1
 }
 
-gms_pid() {
-  adb_shell pidof com.google.android.gms 2>/dev/null |
-    tr '\n' ' ' |
-    xargs || true
-}
-
 version_at_least() {
-  local current_major current_minor current_patch
-  local minimum_major minimum_minor minimum_patch
+  local current_major current_minor current_patch minimum_major minimum_minor minimum_patch
   IFS=. read -r current_major current_minor current_patch <<< "$1"
   IFS=. read -r minimum_major minimum_minor minimum_patch <<< "$2"
 
-  [[ "${current_major:-}" =~ ^[0-9]+$ ]] || return 1
-  [[ "${current_minor:-}" =~ ^[0-9]+$ ]] || return 1
-  [[ "${current_patch:-}" =~ ^[0-9]+$ ]] || return 1
-  [[ "${minimum_major:-}" =~ ^[0-9]+$ ]] || return 1
-  [[ "${minimum_minor:-}" =~ ^[0-9]+$ ]] || return 1
-  [[ "${minimum_patch:-}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${current_major:-}" =~ ^[0-9]+$ && "${current_minor:-}" =~ ^[0-9]+$ &&
+    "${current_patch:-}" =~ ^[0-9]+$ && "${minimum_major:-}" =~ ^[0-9]+$ &&
+    "${minimum_minor:-}" =~ ^[0-9]+$ && "${minimum_patch:-}" =~ ^[0-9]+$ ]] || return 1
 
   if (( current_major != minimum_major )); then
     (( current_major > minimum_major ))
@@ -63,11 +127,131 @@ version_at_least() {
   fi
 }
 
-gms_version_identity() {
-  local version code
-  version="$(gms_version_name)"
-  code="$(gms_version_code)"
-  printf '%s|%s\n' "$version" "$code"
+wait_for_android_dc_api_device() {
+  local deadline=$((SECONDS + DC_API_READY_TIMEOUT_SECONDS))
+  local boot_completed version code
+
+  echo "DC API device readiness: waiting for boot, package manager, and Google Play services"
+  while (( SECONDS < deadline )); do
+    if ! adb_cmd get-state >/dev/null 2>&1; then
+      sleep "$DC_API_POLL_SECONDS"
+      continue
+    fi
+
+    boot_completed="$(adb_shell getprop sys.boot_completed 2>/dev/null || true)"
+    if [[ "$boot_completed" != "1" ]] || ! adb_shell pm list packages >/dev/null 2>&1; then
+      sleep "$DC_API_POLL_SECONDS"
+      continue
+    fi
+
+    version="$(gms_version_name)"
+    code="$(gms_version_code)"
+    if [[ -z "$version" || ! "$code" =~ ^[0-9]+$ ]]; then
+      sleep "$DC_API_POLL_SECONDS"
+      continue
+    fi
+    if ! version_at_least "$version" "$MIN_GMS_VERSION"; then
+      echo "::error::DC API device has Google Play services $version/$code; required >= $MIN_GMS_VERSION" >&2
+      return 1
+    fi
+
+    GMS_VERSION_BEFORE_TESTS="$version"
+    GMS_VERSION_CODE_BEFORE_TESTS="$code"
+    export GMS_VERSION_BEFORE_TESTS GMS_VERSION_CODE_BEFORE_TESTS
+    echo "DC API device readiness: GMS=$version versionCode=$code"
+    return 0
+  done
+
+  echo "::error::DC API device did not reach boot/package-manager/GMS readiness within ${DC_API_READY_TIMEOUT_SECONDS}s" >&2
+  log_android_dc_api_device_identity
+  return 1
+}
+
+android_dc_api_manifest_current_values() {
+  local emulator_revision platform_tools_revision image_revision image_sysdir
+  local data_partition device_profile device_api device_fingerprint device_page_size
+  local gms_version gms_code
+  emulator_revision="$(package_revision "$ANDROID_HOME/emulator/package.xml" || true)"
+  platform_tools_revision="$(package_revision "$ANDROID_HOME/platform-tools/package.xml" || true)"
+  image_revision="$(package_revision "$(avd_system_image_dir 2>/dev/null || true)/package.xml" || true)"
+  image_sysdir="$(avd_config_value image.sysdir.1 || true)"
+  data_partition="$(avd_config_value disk.dataPartition.size || true)"
+  device_profile="$(avd_config_value hw.device.name || true)"
+  device_api="$(adb_shell getprop ro.build.version.sdk 2>/dev/null || true)"
+  device_fingerprint="$(adb_shell getprop ro.build.fingerprint 2>/dev/null || true)"
+  device_page_size="$(adb_shell getconf PAGESIZE 2>/dev/null || true)"
+  gms_version="$(gms_version_name)"
+  gms_code="$(gms_version_code)"
+
+  if [[ "$emulator_revision" != "$DC_API_EMULATOR_PACKAGE_REVISION" ||
+    "$platform_tools_revision" != "$DC_API_PLATFORM_TOOLS_REVISION" ||
+    "$image_revision" != "$DC_API_SYSTEM_IMAGE_REVISION" ||
+    "$image_sysdir" != "$(expected_avd_system_image_sysdir)" ||
+    "$data_partition" != "6G" || "$device_profile" != "pixel_7" ||
+    "$device_api" != "37" || -z "$device_fingerprint" ||
+    ! "$device_page_size" =~ ^[0-9]+$ || ! "$gms_code" =~ ^[0-9]+$
+  ]]; then
+    echo "::error::DC API baseline identity is incomplete or outside the selected substrate" >&2
+    echo "host: emulator=$emulator_revision platformTools=$platform_tools_revision image=$image_revision" >&2
+    echo "avd: profile=$device_profile imageSysdir=$image_sysdir dataPartition=$data_partition" >&2
+    echo "device: api=$device_api fingerprint=${device_fingerprint:-<missing>} pageSize=${device_page_size:-<missing>}" >&2
+    echo "gms: version=${gms_version:-<missing>} code=${gms_code:-<missing>}" >&2
+    return 1
+  fi
+  if ! version_at_least "$gms_version" "$MIN_GMS_VERSION"; then
+    echo "::error::DC API baseline has GMS $gms_version/$gms_code; required >= $MIN_GMS_VERSION" >&2
+    return 1
+  fi
+
+  printf 'schema=%s\n' "$DC_API_BASELINE_SCHEMA"
+  printf 'avd_name=%s\n' "$DC_API_AVD_NAME"
+  printf 'emulator_package_revision=%s\n' "$emulator_revision"
+  printf 'platform_tools_package_revision=%s\n' "$platform_tools_revision"
+  printf 'system_image_package=%s\n' "$DC_API_SYSTEM_IMAGE_PACKAGE"
+  printf 'system_image_revision=%s\n' "$image_revision"
+  printf 'avd_image_sysdir=%s\n' "$image_sysdir"
+  printf 'avd_data_partition_size=%s\n' "$data_partition"
+  printf 'avd_device_profile=%s\n' "$device_profile"
+  printf 'device_api=%s\n' "$device_api"
+  printf 'device_fingerprint=%s\n' "$device_fingerprint"
+  printf 'device_page_size=%s\n' "$device_page_size"
+  printf 'gms_version=%s\n' "$gms_version"
+  printf 'gms_version_code=%s\n' "$gms_code"
+}
+
+write_android_dc_api_baseline_manifest() {
+  [[ -d "$DC_API_AVD_DIR" ]] || {
+    echo "::error::Cannot write DC API baseline; AVD directory is missing: $DC_API_AVD_DIR" >&2
+    return 1
+  }
+  local temporary_manifest="$DC_API_BASELINE_MANIFEST.tmp.$$"
+  android_dc_api_manifest_current_values > "$temporary_manifest"
+  mv "$temporary_manifest" "$DC_API_BASELINE_MANIFEST"
+  echo "DC API baseline manifest: wrote $DC_API_BASELINE_MANIFEST"
+  cat "$DC_API_BASELINE_MANIFEST"
+}
+
+assert_android_dc_api_baseline_manifest() {
+  [[ -f "$DC_API_BASELINE_MANIFEST" ]] || {
+    echo "::error::DC API baseline manifest is missing: $DC_API_BASELINE_MANIFEST" >&2
+    return 1
+  }
+
+  local expected current
+  expected="$(cat "$DC_API_BASELINE_MANIFEST")"
+  current="$(android_dc_api_manifest_current_values)"
+  if [[ "$expected" != "$current" ]]; then
+    echo "::error::Restored DC API AVD does not match its immutable baseline manifest" >&2
+    diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$current") || true
+    return 1
+  fi
+  echo "DC API baseline manifest: exact host/AVD/device/GMS identity match"
+}
+
+log_android_dc_api_device_identity() {
+  echo "DC API device: state=$(adb_cmd get-state 2>/dev/null || true) boot=$(adb_shell getprop sys.boot_completed 2>/dev/null || true)"
+  echo "DC API device: api=$(adb_shell getprop ro.build.version.sdk 2>/dev/null || true) fingerprint=$(adb_shell getprop ro.build.fingerprint 2>/dev/null || true)"
+  echo "DC API device: GMS=$(gms_version_name)/$(gms_version_code)"
 }
 
 current_foreground_package() {
@@ -84,302 +268,117 @@ home_activity() {
     tail -n 1
 }
 
-log_android_dc_api_device_identity() {
-  local sdk release build fingerprint avd emulator_version emulator_package_xml home foreground gms_state
-  sdk="$(adb_shell getprop ro.build.version.sdk || true)"
-  release="$(adb_shell getprop ro.build.version.release || true)"
-  build="$(adb_shell getprop ro.build.id || true)"
-  fingerprint="$(adb_shell getprop ro.build.fingerprint || true)"
-  avd="$(adb_cmd emu avd name 2>/dev/null | tr -d '\r' | head -n 1 || true)"
-  emulator_version="<unavailable>"
-  emulator_package_xml="${ANDROID_HOME:-}/emulator/package.xml"
-  if [[ -f "$emulator_package_xml" ]]; then
-    emulator_version="$(sed -n -E 's:.*<revision><major>([^<]+)</major><minor>([^<]+)</minor><micro>([^<]+)</micro></revision>.*:\1.\2.\3:p' "$emulator_package_xml" | head -n 1)"
-    if [[ -n "$emulator_version" ]]; then
-      emulator_version="package-revision=$emulator_version"
-    else
-      emulator_version="<unavailable>"
-    fi
+start_android_dc_api_home() {
+  local output
+  output="$(adb_shell am start -W \
+    -a android.intent.action.MAIN \
+    -c android.intent.category.HOME \
+    -f 0x10000000 2>&1 || true)"
+  if grep -q 'Status: ok' <<< "$output"; then
+    return 0
   fi
-  home="$(home_activity || true)"
-  foreground="$(current_foreground_package || true)"
-  gms_state="$(adb_shell cmd activity get-uid-state com.google.android.gms 2>/dev/null || true)"
-
-  echo "DC API device identity: serial=${ANDROID_SERIAL:-<default>} avd=${avd:-<unknown>}"
-  echo "DC API device identity: adbState=$(adb_cmd get-state 2>/dev/null || true) bootCompleted=$(adb_shell getprop sys.boot_completed || true)"
-  echo "DC API device identity: api=$sdk release=$release build=$build"
-  echo "DC API device identity: fingerprint=$fingerprint"
-  echo "DC API device identity: emulator=$emulator_version"
-  echo "DC API device identity: home=$home foreground=$foreground"
-  echo "DC API device identity: GMS version=$(gms_version_name || true) versionCode=$(gms_version_code || true) pid=$(gms_pid || true) uidState=$gms_state"
+  echo "DC API system UI health: HOME start did not report Status: ok" >&2
+  printf '%s\n' "$output" >&2
+  return 1
 }
 
 assert_android_dc_api_launcher_health() {
-  local failure_annotation="${1:-error}"
-  local deadline=$((SECONDS + LAUNCHER_READY_TIMEOUT_SECONDS))
+  local deadline=$((SECONDS + DC_API_LAUNCHER_READY_TIMEOUT_SECONDS))
   local healthy_for_seconds=0
   local resolved_activity=""
   local home_package=""
   local launcher_pid=""
   local foreground=""
-  local start_output=""
   local launcher_state=""
-  local launcher_started=false
+  local home_start_attempted=false
+  local recovery_attempted=false
 
   echo "DC API system UI health: waiting for stable HOME launcher"
   while (( SECONDS < deadline )); do
-    if [[ "$launcher_started" != "true" ]]; then
-      resolved_activity="$(home_activity || true)"
-      home_package="${resolved_activity%%/*}"
-      if [[ -z "$resolved_activity" || -z "$home_package" || "$home_package" == "$resolved_activity" ]]; then
-        healthy_for_seconds=0
-        echo "DC API system UI health: HOME activity not resolved yet"
-        sleep "$GMS_POLL_SECONDS"
-        continue
-      fi
-
-      start_output="$(adb_shell am start -W \
-        -a android.intent.action.MAIN \
-        -c android.intent.category.HOME \
-        -f 0x10000000 2>&1 || true)"
-      if ! grep -q 'Status: ok' <<< "$start_output"; then
-        healthy_for_seconds=0
-        echo "DC API system UI health: HOME start did not report Status: ok"
-        echo "$start_output"
-        sleep "$GMS_POLL_SECONDS"
-        continue
-      fi
-
-      launcher_started=true
-      echo "DC API system UI health: HOME start succeeded; observing launcher passively"
-      sleep "$GMS_POLL_SECONDS"
+    resolved_activity="$(home_activity || true)"
+    home_package="${resolved_activity%%/*}"
+    if [[ -z "$resolved_activity" || -z "$home_package" || "$home_package" == "$resolved_activity" ]]; then
+      healthy_for_seconds=0
+      sleep "$DC_API_POLL_SECONDS"
       continue
     fi
 
-    launcher_pid="$(adb_shell pidof "$home_package" || true)"
+    launcher_pid="$(adb_shell pidof "$home_package" 2>/dev/null || true)"
     foreground="$(current_foreground_package || true)"
     launcher_state="$(adb_shell dumpsys activity processes "$home_package" 2>/dev/null || true)"
-    if [[ -z "$launcher_pid" || "$foreground" != "$home_package" || -z "$launcher_state" ]]; then
+
+    if grep -Eqi '(^|[[:space:]])m?(notResponding|crashing)=true' <<< "$launcher_state"; then
       healthy_for_seconds=0
-      echo "DC API system UI health: waiting for launcher package=$home_package pid=${launcher_pid:-<missing>} foreground=${foreground:-<missing>} processState=$([[ -n "$launcher_state" ]] && echo present || echo missing)"
-      sleep "$GMS_POLL_SECONDS"
+      if [[ "$recovery_attempted" != "true" ]]; then
+        echo "DC API system UI health: launcher reports ANR/crash; restarting HOME once"
+        adb_shell am force-stop "$home_package" >/dev/null 2>&1 || true
+        start_android_dc_api_home || true
+        recovery_attempted=true
+        home_start_attempted=true
+      fi
+      sleep "$DC_API_POLL_SECONDS"
       continue
     fi
 
-    if grep -Eqi '(^|[[:space:]])m?notResponding=true|(^|[[:space:]])m?crashing=true' <<< "$launcher_state"; then
+    if [[ -n "$launcher_pid" && "$foreground" == "$home_package" && -n "$launcher_state" ]]; then
+      healthy_for_seconds=$((healthy_for_seconds + DC_API_POLL_SECONDS))
+      echo "DC API system UI health: package=$home_package pid=$launcher_pid foreground=$foreground healthyFor=${healthy_for_seconds}s"
+      if (( healthy_for_seconds >= DC_API_LAUNCHER_STABILITY_SECONDS )); then
+        return 0
+      fi
+    else
       healthy_for_seconds=0
-      echo "DC API system UI health: launcher process reports ANR/crash; waiting for recovery"
-      sleep "$GMS_POLL_SECONDS"
-      continue
+      if [[ "$home_start_attempted" != "true" ]]; then
+        echo "DC API system UI health: HOME is not ready; starting it once"
+        start_android_dc_api_home || true
+        home_start_attempted=true
+      fi
     fi
-
-    healthy_for_seconds=$((healthy_for_seconds + GMS_POLL_SECONDS))
-    echo "DC API system UI health: package=$home_package pid=$launcher_pid foreground=$foreground healthyFor=${healthy_for_seconds}s"
-    if (( healthy_for_seconds >= LAUNCHER_STABILITY_SECONDS )); then
-      return 0
-    fi
-    sleep "$GMS_POLL_SECONDS"
+    sleep "$DC_API_POLL_SECONDS"
   done
 
-  echo "::${failure_annotation}::DC API launcher did not remain healthy for ${LAUNCHER_STABILITY_SECONDS}s within ${LAUNCHER_READY_TIMEOUT_SECONDS}s" >&2
-  echo "resolvedHome=$resolved_activity"
-  echo "homePackage=$home_package"
-  echo "launcherPid=${launcher_pid:-<missing>}"
-  echo "foreground=${foreground:-<missing>}"
-  echo "launcher process state:"
-  printf '%s\n' "$launcher_state"
-  log_android_dc_api_device_identity
+  echo "::error::DC API launcher did not remain healthy for ${DC_API_LAUNCHER_STABILITY_SECONDS}s within ${DC_API_LAUNCHER_READY_TIMEOUT_SECONDS}s" >&2
+  echo "resolvedHome=${resolved_activity:-<missing>}" >&2
+  echo "launcherPid=${launcher_pid:-<missing>} foreground=${foreground:-<missing>}" >&2
+  printf '%s\n' "$launcher_state" >&2
+  log_android_dc_api_launcher_diagnostic
   return 1
 }
 
 log_android_dc_api_launcher_diagnostic() {
-  local resolved_activity home_package launcher_pid foreground launcher_state
-  resolved_activity="$(home_activity || true)"
-  home_package="${resolved_activity%%/*}"
-  launcher_pid=""
-  launcher_state=""
-  if [[ -n "$home_package" && "$home_package" != "$resolved_activity" ]]; then
-    launcher_pid="$(adb_shell pidof "$home_package" 2>/dev/null || true)"
-    launcher_state="$(adb_shell dumpsys activity processes "$home_package" 2>/dev/null || true)"
+  local home_activity home_package foreground state
+  home_activity="$(adb_shell cmd package resolve-activity --brief -a android.intent.action.MAIN -c android.intent.category.HOME 2>/dev/null | awk '/\// { print $NF }' | tail -n 1 || true)"
+  home_package="${home_activity%%/*}"
+  foreground="$(adb_shell dumpsys activity activities 2>/dev/null | sed -n -E 's/.*(mResumedActivity|topResumedActivity|ResumedActivity)[=:].* u0 ([^/[:space:]]+)\/.*/\2/p' | head -n 1 || true)"
+  state="$(adb_shell dumpsys activity processes "$home_package" 2>/dev/null || true)"
+  echo "DC API launcher diagnostic: activity=${home_activity:-<missing>} pid=$(adb_shell pidof "$home_package" 2>/dev/null || true) foreground=${foreground:-<missing>}"
+  if grep -Eqi '(^|[[:space:]])m?notResponding=true|(^|[[:space:]])m?crashing=true' <<< "$state"; then
+    echo "DC API launcher diagnostic: launcher reports ANR/crash"
   fi
-  foreground="$(current_foreground_package || true)"
-
-  echo "DC API postflight launcher diagnostic: resolvedHome=${resolved_activity:-<missing>} package=${home_package:-<missing>} pid=${launcher_pid:-<missing>} foreground=${foreground:-<missing>}"
-  echo "DC API postflight launcher process state:"
-  printf '%s\n' "${launcher_state:-<missing>}"
-}
-
-record_gms_baseline() {
-  local identity="$1"
-  local code="$2"
-  GMS_VERSION_BEFORE_TESTS="${identity%%|*}"
-  GMS_VERSION_CODE_BEFORE_TESTS="$code"
-  export GMS_VERSION_BEFORE_TESTS GMS_VERSION_CODE_BEFORE_TESTS
-  echo "DC API device preflight: Google Play services stabilized at $GMS_VERSION_BEFORE_TESTS (versionCode=$GMS_VERSION_CODE_BEFORE_TESTS)"
 }
 
 prepare_android_dc_api_device() {
-  local require_launcher_health="${1:-true}"
-  adb_cmd wait-for-device
-
-  local deadline=$((SECONDS + GMS_READY_TIMEOUT_SECONDS))
-  local last_logged_version=""
-  local stable_identity=""
-  local stable_for_seconds=0
-
-  echo "DC API device preflight: waiting for Android boot and package manager"
-  while (( SECONDS < deadline )); do
-    local boot_completed
-    boot_completed="$(adb_shell getprop sys.boot_completed 2>/dev/null || true)"
-    if [[ "$boot_completed" != "1" ]]; then
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-
-    if ! adb_shell pm list packages >/dev/null 2>&1; then
-      echo "DC API device preflight: package manager is not ready yet"
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-    if ! adb_shell pm path com.google.android.gms >/dev/null 2>&1; then
-      echo "DC API device preflight: package manager has no Google Play services yet"
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-
-    local version code
-    version="$(gms_version_name)"
-    code="$(gms_version_code)"
-    if [[ "$version" != "$last_logged_version" ]]; then
-      echo "DC API device preflight: Google Play services version=$version versionCode=$code"
-      last_logged_version="$version"
-    fi
-
-    if ! version_at_least "$version" "$MIN_GMS_VERSION"; then
-      echo "DC API device preflight: waiting for Google Play services >= $MIN_GMS_VERSION (found $version)"
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-
-    local identity
-    identity="$(gms_version_identity)"
-    if [[ "$identity" == *"|" ]]; then
-      stable_identity=""
-      stable_for_seconds=0
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-
-    if [[ "$identity" == "$stable_identity" ]]; then
-      stable_for_seconds=$((stable_for_seconds + GMS_POLL_SECONDS))
-    else
-      stable_identity="$identity"
-      stable_for_seconds=0
-    fi
-
-    echo "DC API device preflight: GMS identity=$identity stableFor=${stable_for_seconds}s"
-    if (( stable_for_seconds >= GMS_STABILITY_SECONDS )); then
-      record_gms_baseline "$identity" "$code"
-      log_android_dc_api_device_identity
-      if [[ "$require_launcher_health" == "true" ]]; then
-        assert_android_dc_api_launcher_health
-      fi
-      return 0
-    fi
-    sleep "$GMS_POLL_SECONDS"
-  done
-
-  local final_version final_code
-  final_version="$(gms_version_name || true)"
-  final_code="$(gms_version_code || true)"
-  echo "::error::DC API environment did not stabilize: GMS=$final_version versionCode=$final_code required>=$MIN_GMS_VERSION" >&2
-  return 1
+  wait_for_android_dc_api_device
+  android_dc_api_manifest_current_values >/dev/null
+  log_android_dc_api_device_identity
 }
 
 validate_android_dc_api_device() {
-  adb_cmd wait-for-device
-  adb_cmd get-state >/dev/null
-
-  local deadline=$((SECONDS + GMS_VALIDATION_TIMEOUT_SECONDS))
-  local stable_identity=""
-  local stable_for_seconds=0
-
-  echo "DC API device validation: validating restored Android/GMS baseline"
-  while (( SECONDS < deadline )); do
-    local boot_completed
-    boot_completed="$(adb_shell getprop sys.boot_completed 2>/dev/null || true)"
-    if [[ "$boot_completed" != "1" ]]; then
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-
-    if ! adb_shell pm list packages >/dev/null 2>&1; then
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-    if ! adb_shell pm path com.google.android.gms >/dev/null 2>&1; then
-      echo "::error::Restored DC API AVD has no Google Play services package" >&2
-      log_android_dc_api_device_identity
-      return 1
-    fi
-
-    local version code pid identity
-    version="$(gms_version_name)"
-    code="$(gms_version_code)"
-    pid="$(gms_pid)"
-    echo "DC API device validation: GMS version=$version versionCode=$code pid=${pid:-<missing>}"
-    if [[ -z "$version" || -z "$code" ]]; then
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-    if ! version_at_least "$version" "$MIN_GMS_VERSION"; then
-      echo "::error::Restored DC API AVD has GMS $version/$code, required >= $MIN_GMS_VERSION" >&2
-      log_android_dc_api_device_identity
-      return 1
-    fi
-    identity="$(gms_version_identity)"
-    if [[ "$identity" == *"|" ]]; then
-      stable_identity=""
-      stable_for_seconds=0
-      sleep "$GMS_POLL_SECONDS"
-      continue
-    fi
-    if [[ "$identity" == "$stable_identity" ]]; then
-      stable_for_seconds=$((stable_for_seconds + GMS_POLL_SECONDS))
-    else
-      stable_identity="$identity"
-      stable_for_seconds=0
-    fi
-    echo "DC API device validation: GMS identity=$identity stableFor=${stable_for_seconds}s"
-    if (( stable_for_seconds >= GMS_STABILITY_SECONDS )); then
-      record_gms_baseline "$identity" "$code"
-      log_android_dc_api_device_identity
-      assert_android_dc_api_launcher_health
-      return 0
-    fi
-    sleep "$GMS_POLL_SECONDS"
-  done
-
-  echo "::error::Restored DC API AVD did not reach a stable healthy baseline within ${GMS_VALIDATION_TIMEOUT_SECONDS}s" >&2
+  wait_for_android_dc_api_device
+  assert_android_dc_api_baseline_manifest
+  assert_android_dc_api_launcher_health
   log_android_dc_api_device_identity
-  return 1
 }
 
 assert_android_dc_api_device_unchanged() {
-  local after_version after_code after_pid
-  after_version="$(gms_version_name || true)"
-  after_code="$(gms_version_code || true)"
-  after_pid="$(gms_pid || true)"
-  echo "DC API device postflight: GMS version=$after_version versionCode=$after_code pid=${after_pid:-<missing>}"
-  echo "GMS_VERSION_BEFORE_TESTS=${GMS_VERSION_BEFORE_TESTS:-<unset>}"
-  echo "GMS_VERSION_CODE_BEFORE_TESTS=${GMS_VERSION_CODE_BEFORE_TESTS:-<unset>}"
-  echo "GMS_VERSION_AFTER_TESTS=$after_version"
-  echo "GMS_VERSION_CODE_AFTER_TESTS=$after_code"
-
+  local after_version after_code
+  after_version="$(gms_version_name)"
+  after_code="$(gms_version_code)"
+  echo "DC API device postflight: GMS=$after_version versionCode=$after_code"
   if [[ "${GMS_VERSION_BEFORE_TESTS:-}" != "$after_version" ||
     "${GMS_VERSION_CODE_BEFORE_TESTS:-}" != "$after_code"
   ]]; then
-    echo "::error::Google Play services changed during the DC API test suite: before=${GMS_VERSION_BEFORE_TESTS:-<unset>}/${GMS_VERSION_CODE_BEFORE_TESTS:-<unset>} after=$after_version/$after_code" >&2
+    echo "::error::Google Play services changed during the DC API suite: before=${GMS_VERSION_BEFORE_TESTS:-<unset>}/${GMS_VERSION_CODE_BEFORE_TESTS:-<unset>} after=$after_version/$after_code" >&2
     return 1
   fi
 }

--- a/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh
+++ b/.github/scripts/mobile-ci/run-android-dc-api-compose-tests.sh
@@ -5,8 +5,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 identity_dir="$(cd "$script_dir/../../.." && pwd -P)"
 source "$script_dir/prepare-android-dc-api-device.sh"
 
-# The AVD preparation job owns the bounded GMS update wait. Test jobs validate the
-# restored baseline and fail before Gradle if the cached device is stale or unhealthy.
+# The preparation job caches an unmodified factory-image AVD. Test jobs validate
+# that exact baseline and fail before Gradle if the restored device has drifted.
 validate_android_dc_api_device
 
 instrumentation_args=()
@@ -23,6 +23,36 @@ set +e
   --info
 test_status=$?
 set -e
+
+test_results_root="$identity_dir/waltid-applications/waltid-wallet-demo-compose/androidApp/build/outputs/androidTest-results"
+test_result_count=0
+test_case_count=0
+skipped_case_count=0
+if [[ -d "$test_results_root" ]]; then
+  test_result_count="$(find "$test_results_root" -type f -name '*.xml' -print | wc -l | tr -d ' ')"
+  if (( test_result_count > 0 )); then
+    test_case_count="$(find "$test_results_root" -type f -name '*.xml' -print0 |
+      xargs -0 grep -h -o '<testcase[[:space:]>]' 2>/dev/null |
+      wc -l | tr -d ' ' || true)"
+    skipped_case_count="$(find "$test_results_root" -type f -name '*.xml' -print0 |
+      xargs -0 grep -h -o '<skipped[[:space:]/>]' 2>/dev/null |
+      wc -l | tr -d ' ' || true)"
+  fi
+fi
+echo "DC API instrumentation result summary: xmlFiles=$test_result_count testCases=$test_case_count skipped=$skipped_case_count"
+if (( test_result_count == 0 || test_case_count == 0 )); then
+  echo "::error title=DC API instrumentation produced no test results::Gradle did not produce a non-empty Android instrumentation result set; classify this as device/setup infrastructure failure, not a passing/skipped test phase." >&2
+  test_status=1
+fi
+if (( skipped_case_count != 0 )); then
+  echo "::error title=DC API instrumentation skipped testcases::Found ${skipped_case_count} skipped testcase(s); a missing platform capability is a failed E2E precondition, not a green test phase." >&2
+  test_status=1
+fi
+if [[ -n "${EXPECTED_ANDROID_TEST_CASE_COUNT:-}" ]] &&
+  (( test_case_count != EXPECTED_ANDROID_TEST_CASE_COUNT )); then
+  echo "::error title=Unexpected DC API instrumentation test count::Expected ${EXPECTED_ANDROID_TEST_CASE_COUNT} testcases but found ${test_case_count}; fail closed so class-level assumptions, discovery regressions, or partial result sets cannot look green." >&2
+  test_status=1
+fi
 
 postflight_status=0
 assert_android_dc_api_device_unchanged || postflight_status=$?

--- a/.github/workflows/android-dc-api-tests.yml
+++ b/.github/workflows/android-dc-api-tests.yml
@@ -1,0 +1,25 @@
+name: Android DC API tests
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  android-dc-api-tests:
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci:mobile-dc-api') }}
+    uses: ./.github/workflows/android-device-tests.yml
+    secrets: inherit
+    with:
+      job_name_prefix: android-dc-api-tests
+      run_dc_api: true
+      dc_api_only: true

--- a/.github/workflows/android-device-tests.yml
+++ b/.github/workflows/android-device-tests.yml
@@ -2,6 +2,12 @@ name: Android device tests
 
 on:
   workflow_dispatch:
+    inputs:
+      run_dc_api:
+        description: 'Include the Digital Credentials API device-test phase.'
+        type: boolean
+        required: false
+        default: true
   workflow_call:
     inputs:
       job_name_prefix:
@@ -9,6 +15,16 @@ on:
         type: string
         required: false
         default: ''
+      run_dc_api:
+        description: 'Include the Digital Credentials API device-test phase.'
+        type: boolean
+        required: false
+        default: false
+      dc_api_only:
+        description: 'Run only the Digital Credentials API phase.'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   checks: write
@@ -20,12 +36,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # dc-api-compose is disabled: Play Store AVD GMS prep is flaky in CI
-        # (empty GMS versionCode vs required>=26.29.32). Re-enable when AVD prep is reliable.
-        phase: [wallet-mobile, compose-demo, enterprise-mobile]
+        phase: ${{ fromJSON(inputs.dc_api_only && '["dc-api-compose"]' || inputs.run_dc_api && '["wallet-mobile","compose-demo","dc-api-compose","enterprise-mobile"]' || '["wallet-mobile","compose-demo","enterprise-mobile"]') }}
     env:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
       MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      MIN_GMS_VERSION: '24.31.0'
+      DC_API_SYSTEM_IMAGE_PACKAGE: 'system-images;android-37.0;google_apis;x86_64'
+      DC_API_SYSTEM_IMAGE_REVISION: '6.5.11'
+      DC_API_AVD_NAME: 'dc-api-api37-pixel7-google-apis'
     steps:
       - name: Checkout all repos with ref fallback
         uses: walt-id/waltid-identity/.github/actions/checkout-repos@d123dc039bd55e193b3d54350791868fcfa6ac04
@@ -54,18 +72,21 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Restore warmed DC API AVD
+      - name: Restore configured DC API AVD
         if: matrix.phase == 'dc-api-compose'
         id: dc-api-avd-cache
         uses: actions/cache/restore@v4
         with:
-          # Keep the reusable baseline separate from the Gradle/test workspace. The key excludes
-          # commit and unrelated workflow changes; the schema, substrate, and preparation scripts
-          # make changes to the prepared-device contract explicit cache invalidation points.
+          # Cache the configured AVD disk plus the host ADB key pair that authorizes it. The restored
+          # userdata contains that key in its adbd authorization list; omitting the matching host key
+          # makes a cross-runner cache boot as `unauthorized`. This excludes the ADB daemon/device
+          # runtime state (`adb*.log`, sockets, server state) and no Quick Boot snapshot is reused.
           path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: dc-api-avd-v1-${{ runner.os }}-api37-x86_64-pixel7-playstore_ps16k-emulator-runner-2.38.0-${{ hashFiles('waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh') }}
+            ~/.android/avd/dc-api-api37-pixel7-google-apis.ini
+            ~/.android/avd/dc-api-api37-pixel7-google-apis.avd
+            ~/.android/adbkey
+            ~/.android/adbkey.pub
+          key: dc-api-avd-v6-minimal-${{ runner.os }}-api37-x86_64-pixel7-disk6g-emulator-37.1.11-platform-tools-37.0.1-system-image-6.5.11-${{ hashFiles('waltid-identity/.github/workflows/android-device-tests.yml', 'waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh') }}
 
       - name: Report DC API AVD cache state
         if: matrix.phase == 'dc-api-compose'
@@ -107,7 +128,7 @@ jobs:
         if: matrix.phase == 'enterprise-mobile'
         run: ./waltid-identity/.github/scripts/mobile-ci/prepare-enterprise-android-mobile-tests.sh
 
-      - name: Prepare warmed DC API AVD baseline
+      - name: Prepare configured DC API AVD baseline
         if: matrix.phase == 'dc-api-compose' && steps.dc-api-avd-cache.outputs.cache-hit != 'true'
         id: dc-api-avd-preparation
         uses: reactivecircus/android-emulator-runner@v2.38.0
@@ -119,18 +140,21 @@ jobs:
           profile: ${{ steps.android-device-phase.outputs.emulator_profile }}
           target: ${{ steps.android-device-phase.outputs.emulator_target }}
           emulator-boot-timeout: 600
+          disk-size: 6G
           emulator-options: ${{ steps.android-device-phase.outputs.emulator_options }}
           disable-animations: true
           script: ./waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh
 
-      - name: Save warmed DC API AVD baseline
+      - name: Save configured DC API AVD baseline
         if: matrix.phase == 'dc-api-compose' && steps.dc-api-avd-cache.outputs.cache-hit != 'true' && steps.dc-api-avd-preparation.outcome == 'success'
         uses: actions/cache/save@v4
         with:
           path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: dc-api-avd-v1-${{ runner.os }}-api37-x86_64-pixel7-playstore_ps16k-emulator-runner-2.38.0-${{ hashFiles('waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh') }}
+            ~/.android/avd/dc-api-api37-pixel7-google-apis.ini
+            ~/.android/avd/dc-api-api37-pixel7-google-apis.avd
+            ~/.android/adbkey
+            ~/.android/adbkey.pub
+          key: dc-api-avd-v6-minimal-${{ runner.os }}-api37-x86_64-pixel7-disk6g-emulator-37.1.11-platform-tools-37.0.1-system-image-6.5.11-${{ hashFiles('waltid-identity/.github/workflows/android-device-tests.yml', 'waltid-identity/.github/scripts/mobile-ci/configure-android-device-phase.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-device.sh', 'waltid-identity/.github/scripts/mobile-ci/prepare-android-dc-api-avd.sh') }}
 
       - name: Run Android device tests
         if: matrix.phase != 'dc-api-compose'
@@ -155,7 +179,8 @@ jobs:
           profile: ${{ steps.android-device-phase.outputs.emulator_profile }}
           target: ${{ steps.android-device-phase.outputs.emulator_target }}
           emulator-boot-timeout: 600
-          emulator-options: ${{ steps.android-device-phase.outputs.emulator_test_options }}
+          disk-size: 6G
+          emulator-options: ${{ steps.android-device-phase.outputs.emulator_options }}
           disable-animations: true
           script: ${{ steps.android-device-phase.outputs.script }}
 

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialIssuanceE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialIssuanceE2ETest.kt
@@ -32,14 +32,14 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.fail
-import org.junit.Assume.assumeTrue
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * OS-mediated Digital Credentials create E2E for OpenID4VCI pre-authorized offers.
  *
- * Requires Google Play services, so only the dedicated Play Store lane should run it.
+ * Requires Google Play services, so only the dedicated Google APIs lane should run it.
  *
  * Success is asserted from the issuer session and the wallet's own storage, not from the
  * `CreateDigitalCredentialResponse`. The provider acknowledgment is a fixed `{"data":{}}` payload
@@ -63,7 +63,7 @@ class DigitalCredentialIssuanceE2ETest {
      */
     @Test
     fun acceptsPortalShapedOfferThroughCreateCredential() = runBlocking {
-        val fixture = start() ?: return@runBlocking
+        val fixture = start()
         val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
         val portalOffer = createPortalShapedOffer(scenario)
 
@@ -79,12 +79,13 @@ class DigitalCredentialIssuanceE2ETest {
         clickByTag(fixture.device, "wallet.offerAcceptButton")
 
         DemoTestBackend.waitForIssuerIssuanceSuccess(portalOffer.offerId)
+        fixture.awaitCreateProviderCompletion()
         fixture.assertStoredCredentialIs(scenario)
     }
 
     @Test
     fun acceptsPreAuthorizedOfferThroughCreateCredential() = runBlocking {
-        val fixture = start() ?: return@runBlocking
+        val fixture = start()
         val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
         val offer = DemoTestBackend.createOffer(scenario, inlineOffer = true)
         val offerJson = requireNotNull(Uri.parse(offer.offerUrl).getQueryParameter("credential_offer")) {
@@ -112,12 +113,13 @@ class DigitalCredentialIssuanceE2ETest {
         clickByTag(fixture.device, "wallet.offerAcceptButton")
 
         DemoTestBackend.waitForIssuerIssuanceSuccess(offer.offerId)
+        fixture.awaitCreateProviderCompletion()
         fixture.assertStoredCredentialIs(scenario)
     }
 
     @Test
     fun acceptsPreAuthorizedOfferWithTransactionCodeThroughCreateCredential() = runBlocking {
-        val fixture = start() ?: return@runBlocking
+        val fixture = start()
         val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
         val offer = DemoTestBackend.createOffer(
             scenario,
@@ -155,6 +157,7 @@ class DigitalCredentialIssuanceE2ETest {
         clickByTag(fixture.device, "wallet.offerAcceptButton")
 
         DemoTestBackend.waitForIssuerIssuanceSuccess(offer.offerId)
+        fixture.awaitCreateProviderCompletion()
         fixture.assertStoredCredentialIs(scenario)
     }
 
@@ -298,10 +301,26 @@ class DigitalCredentialIssuanceE2ETest {
         val preexistingCardTags: Set<String>,
     )
 
-    private fun start(): Fixture? {
+    /**
+     * Issuer success can arrive before the provider finishes parsing and storing the credential.
+     * Relaunching with FLAG_ACTIVITY_CLEAR_TASK before this sheet closes destroys the provider
+     * Activity and cancels its issuance coroutine, turning a successful issuer response into an
+     * empty local store. Wait for the provider-owned review to disappear before relaunching.
+     */
+    private fun Fixture.awaitCreateProviderCompletion() {
+        val completed = device.wait(
+            Until.gone(By.res("wallet.offerReview")),
+            UI_ELEMENT_TIMEOUT,
+        )
+        if (!completed) {
+            fail("Wallet create provider did not finish after issuer success")
+        }
+    }
+
+    private fun start(): Fixture {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val context = instrumentation.targetContext
-        assumeTrue(
+        assertTrue(
             "Digital Credentials E2E requires an Android emulator with Google Play services",
             hasGooglePlayServices(context),
         )

--- a/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialSharingE2ETest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/androidApp/src/androidTest/java/id/walt/walletdemo/compose/android/DigitalCredentialSharingE2ETest.kt
@@ -37,9 +37,10 @@ import id.walt.wallet2.handlers.WalletIssuanceOutcome
 import id.walt.wallet2.mobile.MobileWallet
 import id.walt.wallet2.mobile.MobileWalletCredentialOffer
 import id.walt.wallet2.mobile.MobileWalletIssuanceRequest
-import id.walt.walletdemo.compose.logic.createAndroidDemoMobileWallet
 import id.walt.walletdemo.compose.logic.WalletDemoSigningProtection
 import id.walt.walletdemo.compose.logic.WalletDemoSigningProtectionMode
+import id.walt.walletdemo.compose.logic.createAndroidDemoMobileWallet
+import id.walt.walletdemo.compose.logic.createAndroidDemoSharingSettingsStore
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.CREDENTIAL_OPERATION_TIMEOUT
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.UI_ELEMENT_TIMEOUT
 import id.walt.walletdemo.compose.android.WalletComposeE2EHelper.assertClaimValueVisibleAfterScrolling
@@ -69,11 +70,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
-import org.junit.Assume.assumeTrue
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.security.MessageDigest
@@ -89,7 +88,7 @@ import java.security.MessageDigest
  * session could not be bound to this caller either: it requires a secure-context origin, while
  * Credential Manager asserts `android:apk-key-hash:...` for a native one.
  *
- * These require Google Play services, so only the dedicated Play Store lane runs them.
+ * These require Google Play services, so only the dedicated Google APIs lane runs them.
  */
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalDigitalCredentialApi::class)
@@ -101,8 +100,43 @@ class DigitalCredentialSharingE2ETest {
     fun prepareTest() {
         val fixture = fixture()
         assertCredentialManagerIdle(fixture)
+        createAndroidDemoSharingSettingsStore(fixture.context).setShowDcApiPresentationPreview(true)
         activeRequests.clear()
         runBlocking { assertSharedCredentialStateUnchanged() }
+    }
+
+    /**
+     * A small platform gate before the protocol assertions: registration has to be visible to the
+     * platform and a real Digital Credentials request has to open Google's selector. The remaining
+     * tests then exercise the same selector through issuance, matching, review, and submission.
+     */
+    @Test
+    fun credentialManagerPlatformSmoke() = runBlocking {
+        val fixture = fixture()
+        val registration = wallet.refreshDigitalCredentialRegistration()
+        assertTrue(
+            "Credential Manager registration was unavailable in the platform smoke: ${registration.reason}",
+            registration.available,
+        )
+        assertTrue(
+            "Credential Manager registered no credentials in the platform smoke",
+            registration.registeredEntryCount > 0,
+        )
+
+        val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
+        val session = DemoTestBackend.createDcApiVerifierSession(
+            scenario = scenario,
+            expectedOrigins = listOf(nativeAppOrigin(fixture.context)),
+        )
+        val request = fixture.startCredentialRequest(session.requestJson)
+        try {
+            assertNotNull(
+                "Credential Manager selector did not open for a real DC API request",
+                fixture.device.wait(Until.findObject(By.pkg(CREDENTIAL_SELECTOR_PACKAGE)), UI_ELEMENT_TIMEOUT),
+            )
+        } finally {
+            request.abandon()
+        }
     }
 
     @After
@@ -116,10 +150,39 @@ class DigitalCredentialSharingE2ETest {
         }
         activeRequests.clear()
         settleCredentialManagerInteraction(fixture)
+        createAndroidDemoSharingSettingsStore(fixture.context).setShowDcApiPresentationPreview(true)
         assertEquals(
             "Verifier request registry was not empty after test cleanup",
             0,
             DigitalCredentialTestVerifier.activeRequestCount(),
+        )
+    }
+
+    /** Disabling the wallet preview submits the picker's default selection without showing a sheet. */
+    @Test
+    fun sharesMdocWithoutWalletReviewWhenPreviewIsDisabled() = runBlocking {
+        val fixture = fixture()
+        val settings = createAndroidDemoSharingSettingsStore(fixture.context)
+        settings.setShowDcApiPresentationPreview(false)
+        assertFalse(settings.showDcApiPresentationPreview())
+
+        val scenario = DemoTestBackend.presentationScenarios.first { it.id == "iso-mdl" }
+        val session = DemoTestBackend.createDcApiVerifierSession(
+            scenario = scenario,
+            expectedOrigins = listOf(nativeAppOrigin(fixture.context)),
+        )
+
+        val credential = fixture.shareWithoutWalletReview(
+            request = fixture.startCredentialRequest(session.requestJson),
+            candidateText = MDL_DOC_TYPE,
+        )
+        assertFalse("Wallet review appeared while preview was disabled", fixture.walletReviewVisible())
+
+        assertVerifierAccepted(
+            sessionId = session.sessionId,
+            responseJson = credential.credentialJson,
+            presentedCredentialId = "mdl",
+            requiredPolicyIds = MDOC_REQUIRED_POLICIES,
         )
     }
 
@@ -257,7 +320,9 @@ class DigitalCredentialSharingE2ETest {
         val extraCredentialIds = mutableListOf<String>()
         try {
             extraCredentialIds += issueFromDemoIssuer(wallet, scaScenario)
-            extraCredentialIds += issueFromDemoIssuer(wallet, ageScenario)
+            val ageCredentialIds = issueFromDemoIssuer(wallet, ageScenario)
+            extraCredentialIds += ageCredentialIds
+            val ageCredentialId = ageCredentialIds.single()
             val registration = wallet.refreshDigitalCredentialRegistration()
             assertTrue("Temporary SCA/age registration was unavailable: ${registration.reason}", registration.available)
             assertEquals(4, registration.registeredEntryCount)
@@ -314,13 +379,29 @@ class DigitalCredentialSharingE2ETest {
                         message = "SCA payment currency missing from the wallet review",
                     )
                     // The review received both credentials, not just the one the prompt was built from.
-                    // The requested disclosure is asserted rather than the credential card, because a card
-                    // would also appear for a credential the platform offered without any claims selected.
+                    // Open the exact age credential and assert its requested disclosure: a card can also
+                    // appear when the platform offered a credential without selecting claims.
+                    clickByTag(
+                        device = device,
+                        tag = WalletDemoSharingReviewTestTags.credentialCard(
+                            queryId = AGE_CREDENTIAL_QUERY_ID,
+                            credentialId = ageCredentialId,
+                        ),
+                    )
+                    assertNotNull(
+                        "Age credential claims dialog did not open",
+                        waitForResource(
+                            device = device,
+                            tag = WalletDemoSharingReviewTestTags.ClaimsDialog,
+                            timeoutMs = UI_ELEMENT_TIMEOUT,
+                        ),
+                    )
                     assertTextContainingVisibleAfterScrolling(
                         device = device,
                         substring = AGE_DISCLOSURE_LABEL,
                         message = "Review did not receive the second credential",
                     )
+                    clickByTag(device, WalletDemoSharingReviewTestTags.ClaimsCloseButton)
                 },
             )
 
@@ -646,6 +727,45 @@ class DigitalCredentialSharingE2ETest {
         val response = withTimeout(CREDENTIAL_OPERATION_TIMEOUT) {
             request.await().getOrThrow()
         }
+        return requireNotNull(response.credential as? DigitalCredential) {
+            "Caller did not receive a digital credential: ${response.credential}"
+        }
+    }
+
+    /** Selects a Credential Manager candidate and requires completion without a wallet review. */
+    private suspend fun Fixture.shareWithoutWalletReview(
+        request: DigitalCredentialRequestHandle,
+        candidateText: String,
+    ): DigitalCredential {
+        val deadline = System.currentTimeMillis() + CREDENTIAL_OPERATION_TIMEOUT
+        var candidateSelected = false
+
+        while (!request.isComplete && System.currentTimeMillis() < deadline) {
+            assertFalse("Wallet review appeared while preview was disabled", walletReviewVisible())
+            if (!candidateSelected && device.findCredentialManagerText(candidateText) != null) {
+                assertTrue(
+                    "Could not click the '$candidateText' candidate",
+                    device.clickCredentialManagerCandidate(candidateText),
+                )
+                candidateSelected = true
+            } else if (device.findEnabledCredentialManagerContinue() != null) {
+                assertTrue(
+                    "Could not click Credential Manager's Continue button",
+                    device.clickCredentialManagerNode(::isCredentialManagerContinue),
+                )
+            }
+            delay(CLEANUP_POLL_MILLIS)
+        }
+
+        if (!request.isComplete) {
+            fail(
+                "Credential Manager did not complete without a wallet review.\n" +
+                    pickerDiagnostic(request, candidateText, candidateSelected),
+            )
+        }
+        assertFalse("Wallet review appeared while preview was disabled", walletReviewVisible())
+
+        val response = request.await().getOrThrow()
         return requireNotNull(response.credential as? DigitalCredential) {
             "Caller did not receive a digital credential: ${response.credential}"
         }
@@ -1120,7 +1240,7 @@ class DigitalCredentialSharingE2ETest {
         fun provisionCredentials() = runBlocking {
             val instrumentation = InstrumentationRegistry.getInstrumentation()
             val context = instrumentation.targetContext
-            assumeTrue(
+            assertTrue(
                 "Digital Credentials E2E requires an Android emulator with Google Play services",
                 hasGooglePlayServices(context),
             )

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoSharingReviewScreen.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoSharingReviewScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import id.walt.walletdemo.compose.logic.WalletDemoPresentationCredentialSelection
 import id.walt.walletdemo.compose.logic.WalletDemoSharingReview
 import id.walt.walletdemo.compose.logic.WalletDemoSharingSelection
 import id.walt.walletdemo.compose.logic.defaultCredentialSelection
@@ -217,6 +218,18 @@ object WalletDemoSharingReviewTestTags {
 
     /** Cancel button. */
     val CancelButton: String get() = WalletUiTestTags.PresentationCancelButton
+
+    /** Claims dialog opened from a compact credential card. */
+    val ClaimsDialog: String get() = WalletUiTestTags.PresentationClaimsDialog
+
+    /** Close button in the claims dialog. */
+    val ClaimsCloseButton: String get() = WalletUiTestTags.PresentationClaimsClose
+
+    /** Compact credential card for the given presentation option. */
+    fun credentialCard(queryId: String, credentialId: String): String =
+        WalletUiTestTags.credentialCard(
+            WalletDemoPresentationCredentialSelection(queryId = queryId, credentialId = credentialId).id,
+        )
 
     /** Requester section. */
     val RequesterSection: String get() = WalletUiTestTags.PresentationVerifierSection

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/SharingReviewSection.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/SharingReviewSection.kt
@@ -38,6 +38,7 @@ import id.walt.walletdemo.compose.logic.toCredentialDetails
 import id.walt.walletdemo.compose.logic.toRequestedDisclosureGroup
 import id.walt.walletdemo.compose.ui.SystemBackHandler
 import id.walt.walletdemo.compose.ui.WalletUiTestTags
+import id.walt.walletdemo.compose.ui.exportTestTagsForPlatformAutomation
 
 /**
  * The wallet's single presentation-review surface, shared by every transport that can ask for a
@@ -214,6 +215,7 @@ private fun SharingClaimsDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(max = 560.dp)
+                .exportTestTagsForPlatformAutomation()
                 .testTag(WalletUiTestTags.PresentationClaimsDialog),
         ) {
             Column(


### PR DESCRIPTION
## Summary

Re-enables the 11 native Android Digital Credentials API E2Es already present on `main`, adds two focused sharing cases for platform readiness and preview-disabled sharing, and reduces their CI substrate to the smallest setup that has been stable across fresh and restored runs.

- PRs run the lane only when `ci:mobile-dc-api` is added; `ci:mobile` continues to run the ordinary mobile phases without DC API.
- Pushes to `main` run the native DC API lane by default.
- Compared with `main`, this PR adds exactly two sharing E2Es and retains and stabilizes the existing eight sharing and three issuance tests, for a final suite of ten sharing plus three issuance cases.
- The browser/Portal2 experiment remains outside this PR.

## What changed

### CI substrate

- Use a pinned API 37 `google_apis` x86_64 image and its factory Google Play services; do not update GMS during a job.
- Cache only the configured AVD disk and its matching ADB key, never Quick Boot state.
- Record and validate an immutable host/AVD/device/GMS manifest around the cached baseline.
- Drain Android broadcast/application work and flush guest storage before saving a new baseline.
- Cold-boot restored devices and require a stable HOME launcher, with one recovery only when Android explicitly reports a launcher ANR or crash.
- Fail closed on missing XML, zero discovered tests, skipped cases, a count other than 13, or GMS identity drift.
- Do not retry product tests or route the label automatically from changed paths.

### Native DC API coverage

Compared with `main`, this PR adds two focused sharing tests:

- `credentialManagerPlatformSmoke` verifies that wallet registration reaches Credential Manager and that a real request opens Google's selector. This isolates a missing platform/GMS capability from protocol or wallet failures instead of letting the remaining tests fail ambiguously.
- `sharesMdocWithoutWalletReviewWhenPreviewIsDisabled` covers the persisted preview option now present on `main`. Existing settings tests prove the toggle is stored, but not that the platform-mediated production path skips the wallet sheet, submits the default selection, returns a real digital credential, and passes verifier2's required mdoc policies.

No issuance tests are newly added relative to `main`. The remaining eight sharing and three issuance tests are retained because they cover distinct clear, encrypted, unsupported-protocol, multi-alternative, transaction-data, multi-credential, cancellation, back-navigation, and issuance invariants.

- Assert verifier execution and success for the required mdoc, SD-JWT, and transaction-data policies rather than accepting a provider acknowledgement or a merely successful session.
- Keep the ordinary review path explicit in every other sharing test by resetting the persisted preview preference around each test.
- Adapt the combined SCA/age review assertion to the credential-card UI introduced by [#2144](https://github.com/walt-id/waltid-identity/pull/2144): open the exact age credential card and assert its requested disclosure in the claims dialog.
- Wait for native issuance provider completion and assert the newly stored credential and doctype for all three issuance shapes.

## CI behavior

| Event | Android phases |
|---|---|
| PR with `ci:mobile` only | Existing wallet, Compose demo, and Enterprise phases |
| PR with `ci:mobile-dc-api` | Native DC API phase |
| PR with both labels | Existing three phases plus native DC API |
| Push to `main` | Native DC API phase by default |
| Manual dispatch | Explicit option to include the DC API phase |

## Evidence

- The current rebased source passes the complete native suite locally: 10 sharing plus 3 issuance tests, 13 passed, 0 failed/errors/skipped. This includes both tests newly added relative to `main` and the review UI introduced by [#2144](https://github.com/walt-id/waltid-identity/pull/2144).
- The selected factory-image/cache substrate was qualified through independent fresh and restored scopes in the [PR caller](https://github.com/walt-id/waltid-identity/actions/runs/32359659951) and [dedicated lab branch](https://github.com/walt-id/waltid-identity/actions/runs/32359669707), followed by [one fresh PR run](https://github.com/walt-id/waltid-identity/actions/runs/32371729572) and [six consecutive restored-cache cold boots](https://github.com/walt-id/waltid-identity/actions/runs/32371744988). Those executions passed the then-current 12-test suite without skips or encrypted GMS registry corruption signatures.
- Current-head GitHub checks are the remaining review gate after this rebase.

## Scope and follow-up

All 13 native tests remain because each covers a distinct platform, protocol, consent, lifecycle, transaction-data, matcher, or issuance risk. The preview-disabled behavior uses the same production submission branch for OpenID4VP and Annex C, so one focused end-to-end mdoc case covers that decision without duplicating the suite by protocol.

Browser/Portal2 coverage remains separate. [#2064](https://github.com/walt-id/waltid-identity/pull/2064) was closed with its branch retained; its description documents the Chrome/browser issuance limitations that still prevent it from replacing the native lane.
