### PR TITLE
Accept non-#0 did:jwk kids during verification

### DIFF
--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolver.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolver.kt
@@ -115,13 +115,11 @@ class Crypto2JwtKeyResolver(
 
     private fun selectDidKey(keys: Set<Key>, did: String, kid: String?): Key {
         require(keys.isNotEmpty()) { "No verification keys resolved for DID: $did" }
+        if (did.startsWith("did:jwk:")) {
+            return selectDidJwkKey(keys, did, kid)
+        }
         if (kid == null) {
             require(keys.size == 1) { "JWT with multiple DID verification keys must include kid" }
-            return keys.single()
-        }
-        if (did.startsWith("did:jwk:")) {
-            require(keys.size == 1) { "did:jwk must resolve to exactly one verification key" }
-            require(kid == "$did#0") { "did:jwk kid must be '$did#0', but was '$kid'" }
             return keys.single()
         }
         if (keys.size == 1 && kid == did && did.startsWith("did:key:")) {
@@ -132,6 +130,26 @@ class Crypto2JwtKeyResolver(
         require(matches.size <= 1) { "Multiple DID verification keys match kid: $kid" }
         return matches.singleOrNull()
             ?: throw NoSuchElementException("No DID verification key matches kid: $kid")
+    }
+
+    /**
+     * did:jwk always publishes a single verification method `{did}#0`.
+     * Pre-2115 issuers wrote KMS-path or thumbprint fragments. Accept those as a
+     * compatibility fallback: the DID encodes exactly one key, so kid cannot select
+     * another key. Ignoring a non-`#0` kid is not spec-compliant DID URL matching;
+     * new issuance must still emit `{did}#0`.
+     */
+    private fun selectDidJwkKey(keys: Set<Key>, did: String, kid: String?): Key {
+        require(keys.size == 1) { "did:jwk must resolve to exactly one verification key" }
+        val methodKid = "$did#0"
+        if (kid != null && kid != methodKid) {
+            log.warn {
+                "did:jwk verification is ignoring non-spec kid '$kid' for '$did'; " +
+                    "the method verification method is '$methodKid'. " +
+                    "did:jwk documents contain exactly one key."
+            }
+        }
+        return keys.single()
     }
 
     private fun idCandidates(id: String): Set<String> =

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonMain/kotlin/id/walt/credentials/keyresolver/resolvers/DidKeyResolver.kt
@@ -20,6 +20,10 @@ object DidKeyResolver : BaseKeyResolver {
 
         if (keys.isEmpty()) throw Exception("No valid key found in DID document for $issuerId")
 
+        if (issuerId.startsWith("did:jwk:")) {
+            return selectDidJwkKey(keys, issuerId, kid)
+        }
+
         if (!kid.isNullOrBlank()) {
             val selfIdentifyingKid = kid == selfIdentifyingVerificationMethod(issuerId) ||
                 kid == issuerId && issuerId.startsWith("did:key:")
@@ -34,6 +38,28 @@ object DidKeyResolver : BaseKeyResolver {
             throw NoSuchElementException("No key with kid '$kid' found in DID document for $issuerId")
         }
 
+        return keys.first()
+    }
+
+    /**
+     * did:jwk always publishes a single verification method `{did}#0`.
+     * Pre-2115 issuers wrote KMS-path or thumbprint fragments. Accept those as a
+     * compatibility fallback: the DID encodes exactly one key, so kid cannot select
+     * another key. Ignoring a non-`#0` kid is not spec-compliant DID URL matching;
+     * new issuance must still emit `{did}#0`.
+     */
+    private fun selectDidJwkKey(keys: Set<Key>, did: String, kid: String?): Key {
+        if (keys.size != 1) {
+            throw Exception("did:jwk must resolve to exactly one verification key")
+        }
+        val methodKid = "$did#0"
+        if (!kid.isNullOrBlank() && kid != methodKid) {
+            log.warn {
+                "did:jwk verification is ignoring non-spec kid '$kid' for '$did'; " +
+                    "the method verification method is '$methodKid'. " +
+                    "did:jwk documents contain exactly one key."
+            }
+        }
         return keys.first()
     }
 
@@ -67,7 +93,6 @@ object DidKeyResolver : BaseKeyResolver {
 
     private fun selfIdentifyingVerificationMethod(did: String): String? = when {
         did.startsWith("did:key:") -> "$did#${did.removePrefix("did:key:")}"
-        did.startsWith("did:jwk:") -> "$did#0"
         else -> null
     }
 }

--- a/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonTest/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolverTest.kt
+++ b/waltid-libraries/credentials/waltid-credential-key-resolver/src/commonTest/kotlin/id/walt/credentials/keyresolver/Crypto2JwtKeyResolverTest.kt
@@ -83,23 +83,32 @@ class Crypto2JwtKeyResolverTest {
     }
 
     @Test
-    fun `did jwk resolution rejects kid that is the DID without fragment`() = runTest {
-        assertNull(
-            resolver("$DID_JWK#0").resolveFromJwt(
-                jwtHeader = buildJsonObject { put("kid", DID_JWK) },
-                jwtPayload = buildJsonObject { put("iss", DID_JWK) },
-            )
+    fun `did jwk resolution accepts kid that is the DID without fragment`() = runTest {
+        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
+            jwtHeader = buildJsonObject { put("kid", DID_JWK) },
+            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
         )
+
+        assertEquals(JwtKeyResolutionSource.DID, resolved?.source)
+        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
     }
 
     @Test
-    fun `did jwk resolution rejects kid that is not the method verification fragment`() = runTest {
-        assertNull(
-            resolver("$DID_JWK#0").resolveFromJwt(
-                jwtHeader = buildJsonObject { put("kid", "$DID_JWK#org.tenant.kms.key_issuer") },
-                jwtPayload = buildJsonObject { put("iss", DID_JWK) },
-            )
+    fun `did jwk resolution accepts kid that is not the method verification fragment`() = runTest {
+        val resolved = resolver("$DID_JWK#0").resolveFromJwt(
+            jwtHeader = buildJsonObject { put("kid", "$DID_JWK#org.tenant.kms.key_issuer") },
+            jwtPayload = buildJsonObject { put("iss", DID_JWK) },
         )
+
+        assertEquals(JwtKeyResolutionSource.DID, resolved?.source)
+        assertEquals(KeyId("$DID_JWK#0"), resolved?.key?.id)
+    }
+
+    @Test
+    fun `did jwk resolution rejects multiple verification keys`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            resolver("$DID_JWK#0", "$DID_JWK#1").resolveFromDid(DID_JWK, "$DID_JWK#0")
+        }
     }
 
     @Test

--- a/waltid-libraries/credentials/waltid-w3c-credentials/src/commonTest/kotlin/Crypto2W3cCredentialTest.kt
+++ b/waltid-libraries/credentials/waltid-w3c-credentials/src/commonTest/kotlin/Crypto2W3cCredentialTest.kt
@@ -177,7 +177,7 @@ class Crypto2W3cCredentialTest {
     }
 
     @Test
-    fun `did jwk credential signature resolves for method kid and rejects non-method kid`() = runTest {
+    fun `did jwk credential signature resolves for method kid and non-method kid`() = runTest {
         DidService.minimalInit()
         val key = key("org.tenant.kms.key_issuer")
         val didJwk = Crypto2DidJwkRegistrar().createByKey(key, DidJwkCreateOptions()).did
@@ -209,7 +209,7 @@ class Crypto2W3cCredentialTest {
                 put("typ", "dc+sd-jwt")
             },
         )
-        assertFalse(scheme.verifyCrypto2(nonMethodKid, setOf(JwsAlgorithm.ES256)).isSuccess)
+        assertTrue(scheme.verifyCrypto2(nonMethodKid, setOf(JwsAlgorithm.ES256)).isSuccess)
     }
 
     private suspend fun publicJwkThumbprint(key: Key) =


### PR DESCRIPTION
## Summary

Verifier2 can now resolve already-issued `did:jwk` credentials whose JWT `kid` is a KMS path, JWK thumbprint, or bare DID instead of `{did}#0`. `did:jwk` encodes exactly one public key, so a mismatched `kid` cannot select a different key; verification uses that single resolved key and warns that the match is not spec-compliant DID URL matching.

This is a follow-up to [walt-id/waltid-identity#2115](https://github.com/walt-id/waltid-identity/pull/2115) (WAL-1307). Issuance is unchanged and still always writes `{did}#0`. No enterprise Mongo migration or counterpart PR is required; Issuer2 and Verifier2 inherit this from the shared identity resolver.

## What Changed

### Verification
- `Crypto2JwtKeyResolver` accepts any `kid` when the issuer DID is `did:jwk` and exactly one verification key resolved.
- The same single-key fallback is applied in deprecated `DidKeyResolver`.
- A warn log is emitted when `kid` is present and is not `{did}#0`. Omitted `kid` and spec-compliant `{did}#0` stay quiet.

### Tests
- Bare-DID and KMS-path `did:jwk` kids now resolve and verify.
- Multi-key `did:jwk` documents are still rejected.
- `did:web` unmatched-kid rejection is unchanged.

## Architecture Notes

- Trust remains on `iss` plus signature verification against the single `did:jwk` key. RFC 7515 treats `kid` as a hint; the DID document still only publishes `#0`.
- The fallback is verify-only. New credentials continue to emit the method verification-method id.

## Caveats and Follow-Ups

- Ignoring a non-`#0` `kid` is not spec-compliant DID URL matching. The warn log and comments make that explicit so operators can find leftover pre-2115 issuers.
- Credential-status still has local kid builders that do not special-case `did:jwk`. Those lists now verify; aligning them with `Issuer.getKidHeader` so new lists emit `{did}#0` remains optional.

## Breaking

None. This restores verification of already-issued `did:jwk` credentials that 2115 began rejecting.