### PR TITLE
feat(android): accept historical OpenID4VCI DC API protocol aliases

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/README.md
+++ b/waltid-applications/waltid-wallet-demo-compose/README.md
@@ -91,7 +91,7 @@ implementation, and is unrelated to Credential Manager Digital Credentials issua
 Android builds register with Credential Manager for:
 
 - **Presentation (`GET_CREDENTIAL`)** — OpenID4VP unsigned and ISO 18013-7 Annex C, via `DigitalCredentialProviderActivity` (full-screen consent for now).
-- **Issuance (`CREATE_CREDENTIAL`)** — OpenID4VCI (`openid4vci-v1`), via `DigitalCredentialCreateActivity`.
+- **Issuance (`CREATE_CREDENTIAL`)** — OpenID4VCI (`openid4vci-v1` and historical aliases), via `DigitalCredentialCreateActivity`.
 
 Issuance uses a translucent create Activity and a Material bottom sheet for offer review (including transaction-code entry). Pre-authorized offers complete in that sheet. Authorization-code offers use the same external-browser + `openid://` path as the Receive tab; `DigitalCredentialCreateAuthHandoff` returns the callback to the still-running create Activity (or completes wallet-side issuance if that Activity was destroyed). The Credential Manager create-option picker remains system-owned; the sheet is wallet fulfillment UI after the user selects this wallet.
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/OPENID4VCI-MATCHER.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/OPENID4VCI-MATCHER.md
@@ -49,7 +49,13 @@ JSON offset, optional icon bytes, then UTF-8 JSON. The JSON registered by this S
     }
   ],
   "filter": { "Pass": {} },
-  "preferred_protocols": ["openid4vci-v1"],
+  "preferred_protocols": [
+    "openid4vci-v1",
+    "openid4vci1.0",
+    "openid4vci-1.0",
+    "openid4vci1.1",
+    "openid4vci-1.1"
+  ],
   "package_info": {
     "name": "<host application label>",
     "icon": [4, "4 + icon length"]
@@ -62,10 +68,11 @@ packed blob. It follows AndroidX's auto-resolved package metadata; this provider
 privileged `self_declared_package_info` override.
 
 The non-empty `preferred_protocols` list is load-bearing. The upstream matcher gives exact preferred
-protocols precedence over its historical fallback list, so only `openid4vci-v1` is intentionally
-advertised and matched here. The binary still contains upstream fallback literals such as
-`openid4vci1.0`, but this registration never reaches that fallback. The Android provider separately
-accepts only `openid4vci-v1`; no historical aliases are part of this SDK's public/provider contract.
+protocols precedence over its historical fallback list, so this registration advertises the canonical
+`openid4vci-v1` identifier first, then the historical aliases still compiled into the matcher
+(`openid4vci1.0`, `openid4vci-1.0`, `openid4vci1.1`, `openid4vci-1.1`). The Android create provider
+accepts the same ordered set and echoes the selected protocol in the create acknowledgement. Bare
+`openid4vci` is not part of this contract.
 
 The `Pass` filter is deliberately broad. It lets this wallet be surfaced as a candidate for supported
 OpenID4VCI Digital Credentials API requests; the platform-neutral issuance engine remains responsible

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -86,7 +86,8 @@ val credentialIds = (outcome as? WalletIssuanceOutcome.Stored)?.credentialIds
 
 `MobileWalletCredentialOffer.Uri` is used for deep-link / QR offers.
 `MobileWalletCredentialOffer.InlineJson` is the Credential Offer object from an
-OpenID4VCI Digital Credentials create request (`openid4vci-v1`). On Android, use
+OpenID4VCI Digital Credentials create request (`openid4vci-v1`, plus historical
+aliases in `OPENID4VCI_CREATE_PROTOCOLS`). On Android, use
 `AndroidDigitalCredentialCreateProvider` to extract that request from Credential
 Manager and `AndroidDigitalCredentialRegistry.registerCreationOptions` to
 advertise issuance capability separately from presentation registry replacement.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -87,7 +87,7 @@ val credentialIds = (outcome as? WalletIssuanceOutcome.Stored)?.credentialIds
 `MobileWalletCredentialOffer.Uri` is used for deep-link / QR offers.
 `MobileWalletCredentialOffer.InlineJson` is the Credential Offer object from an
 OpenID4VCI Digital Credentials create request (`openid4vci-v1`, plus historical
-aliases in `OPENID4VCI_CREATE_PROTOCOLS`). On Android, use
+aliases). On Android, use
 `AndroidDigitalCredentialCreateProvider` to extract that request from Credential
 Manager and `AndroidDigitalCredentialRegistry.registerCreationOptions` to
 advertise issuance capability separately from presentation registry replacement.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -1792,9 +1792,6 @@ final object id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols { // 
         final fun <get-OPENID4VP_SIGNED>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VP_SIGNED.<get-OPENID4VP_SIGNED>|<get-OPENID4VP_SIGNED>(){}[0]
     final const val OPENID4VP_UNSIGNED // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VP_UNSIGNED|{}OPENID4VP_UNSIGNED[0]
         final fun <get-OPENID4VP_UNSIGNED>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VP_UNSIGNED.<get-OPENID4VP_UNSIGNED>|<get-OPENID4VP_UNSIGNED>(){}[0]
-
-    final val OPENID4VCI_CREATE_PROTOCOLS // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS|{}OPENID4VCI_CREATE_PROTOCOLS[0]
-        final fun <get-OPENID4VCI_CREATE_PROTOCOLS>(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS.<get-OPENID4VCI_CREATE_PROTOCOLS>|<get-OPENID4VCI_CREATE_PROTOCOLS>(){}[0]
 }
 
 final object id.walt.wallet2.mobile/UnavailableMobileWalletCredentialRegistry : id.walt.wallet2.mobile/MobileWalletCredentialRegistry { // id.walt.wallet2.mobile/UnavailableMobileWalletCredentialRegistry|null[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -1792,6 +1792,9 @@ final object id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols { // 
         final fun <get-OPENID4VP_SIGNED>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VP_SIGNED.<get-OPENID4VP_SIGNED>|<get-OPENID4VP_SIGNED>(){}[0]
     final const val OPENID4VP_UNSIGNED // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VP_UNSIGNED|{}OPENID4VP_UNSIGNED[0]
         final fun <get-OPENID4VP_UNSIGNED>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VP_UNSIGNED.<get-OPENID4VP_UNSIGNED>|<get-OPENID4VP_UNSIGNED>(){}[0]
+
+    final val OPENID4VCI_CREATE_PROTOCOLS // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS|{}OPENID4VCI_CREATE_PROTOCOLS[0]
+        final fun <get-OPENID4VCI_CREATE_PROTOCOLS>(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile/MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS.<get-OPENID4VCI_CREATE_PROTOCOLS>|<get-OPENID4VCI_CREATE_PROTOCOLS>(){}[0]
 }
 
 final object id.walt.wallet2.mobile/UnavailableMobileWalletCredentialRegistry : id.walt.wallet2.mobile/MobileWalletCredentialRegistry { // id.walt.wallet2.mobile/UnavailableMobileWalletCredentialRegistry|null[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProviderTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProviderTest.kt
@@ -50,8 +50,17 @@ class AndroidDigitalCredentialCreateProviderTest {
 
     @Test
     fun acceptsHistoricalOpenId4VciProtocolAliasesAndEchoesThem() {
-        val aliases = MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS
-            .filter { it != MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1 }
+        val expectedCreateProtocols = listOf(
+            MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1,
+            "openid4vci1.0",
+            "openid4vci-1.0",
+            "openid4vci1.1",
+            "openid4vci-1.1",
+        )
+        assertEquals(expectedCreateProtocols, OPENID4VCI_CREATE_PROTOCOLS)
+        val aliases = expectedCreateProtocols.filter {
+            it != MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1
+        }
         for (protocol in aliases) {
             val request = AndroidDigitalCredentialCreateProvider.resolveCreateRequest(
                 requestJson = """{"requests":[{"protocol":"$protocol","data":{"credential_issuer":"https://i.example","credential_configuration_ids":["c"]}}]}""",

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProviderTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProviderTest.kt
@@ -49,23 +49,42 @@ class AndroidDigitalCredentialCreateProviderTest {
     }
 
     @Test
-    fun rejectsHistoricalOpenId4VciProtocolAlias() {
-        assertFailsWith<IllegalArgumentException> {
-            AndroidDigitalCredentialCreateProvider.resolveCreateRequest(
-                requestJson = """{"requests":[{"protocol":"openid4vci1.0","data":{"credential_issuer":"https://i.example","credential_configuration_ids":["c"]}}]}""",
+    fun acceptsHistoricalOpenId4VciProtocolAliasesAndEchoesThem() {
+        val aliases = MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS
+            .filter { it != MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1 }
+        for (protocol in aliases) {
+            val request = AndroidDigitalCredentialCreateProvider.resolveCreateRequest(
+                requestJson = """{"requests":[{"protocol":"$protocol","data":{"credential_issuer":"https://i.example","credential_configuration_ids":["c"]}}]}""",
                 verifiedOrigin = "android:apk-key-hash:abc",
             )
+            assertEquals(protocol, request.protocol)
         }
     }
 
     @Test
-    fun rejectsUnsupportedOpenId4VciProtocolAlias() {
+    fun rejectsUnversionedOpenId4VciProtocolAlias() {
         assertFailsWith<IllegalArgumentException> {
             AndroidDigitalCredentialCreateProvider.resolveCreateRequest(
                 requestJson = """{"requests":[{"protocol":"openid4vci","data":{"credential_issuer":"https://i.example","credential_configuration_ids":["c"]}}]}""",
                 verifiedOrigin = "android:apk-key-hash:abc",
             )
         }
+    }
+
+    @Test
+    fun prefersCanonicalOpenId4VciV1OverHistoricalAlias() {
+        val request = AndroidDigitalCredentialCreateProvider.resolveCreateRequest(
+            requestJson = """
+                {"requests":[
+                  {"protocol":"openid4vci1.0","data":{"credential_issuer":"https://alias.example","credential_configuration_ids":["alias"]}},
+                  {"protocol":"openid4vci-v1","data":{"credential_issuer":"https://v1.example","credential_configuration_ids":["v1"]}}
+                ]}
+            """.trimIndent(),
+            verifiedOrigin = "https://issuer.example",
+        )
+        assertEquals(MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1, request.protocol)
+        val offer = Json.parseToJsonElement(request.offerJson).jsonObject
+        assertEquals("https://v1.example", offer["credential_issuer"]?.jsonPrimitive?.content)
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistryTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistryTest.kt
@@ -143,8 +143,16 @@ class AndroidDigitalCredentialRegistryTest {
             entry["explainer"]?.jsonObject?.get("default")?.jsonPrimitive?.content,
         )
         assertEquals(Json.parseToJsonElement("{\"Pass\":{}}"), json["filter"])
+        val expectedCreateProtocols = listOf(
+            MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1,
+            "openid4vci1.0",
+            "openid4vci-1.0",
+            "openid4vci1.1",
+            "openid4vci-1.1",
+        )
+        assertEquals(expectedCreateProtocols, OPENID4VCI_CREATE_PROTOCOLS)
         assertEquals(
-            MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS,
+            expectedCreateProtocols,
             json["preferred_protocols"]!!.jsonArray.map { it.jsonPrimitive.content },
         )
         assertEquals("walt.id Wallet", json["package_info"]!!.jsonObject["name"]?.jsonPrimitive?.content)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistryTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidHostTest/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistryTest.kt
@@ -144,7 +144,7 @@ class AndroidDigitalCredentialRegistryTest {
         )
         assertEquals(Json.parseToJsonElement("{\"Pass\":{}}"), json["filter"])
         assertEquals(
-            listOf("openid4vci-v1"),
+            MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS,
             json["preferred_protocols"]!!.jsonArray.map { it.jsonPrimitive.content },
         )
         assertEquals("walt.id Wallet", json["package_info"]!!.jsonObject["name"]?.jsonPrimitive?.content)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProvider.kt
@@ -33,8 +33,8 @@ public data class AndroidDigitalCredentialCreateProviderInput(
  *
  * Kept on the Android adapter boundary rather than the common mobile SDK surface.
  *
- * @property protocol Digital Credentials protocol identifier; this adapter only accepts
- * `openid4vci-v1`.
+ * @property protocol Digital Credentials protocol identifier selected from
+ * [MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS].
  * @property offerJson Credential Offer JSON object extracted from the selected protocol
  * alternative's `data` field.
  * @property verifiedOrigin Canonical caller origin derived from Credential Manager caller
@@ -75,8 +75,6 @@ public data class AndroidDigitalCredentialCreateResponse(
 /** Android framework boundary for official holder CREATE_CREDENTIAL request and response handling. */
 @OptIn(ExperimentalDigitalCredentialApi::class)
 public object AndroidDigitalCredentialCreateProvider {
-    private const val OPENID4VCI_PROTOCOL = MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1
-
     /**
      * Locates the OpenID4VCI create request and derives the origin from authenticated caller data.
      *
@@ -118,11 +116,11 @@ public object AndroidDigitalCredentialCreateProvider {
     }
 
     /**
-     * Resolves the first `openid4vci-v1` protocol alternative from a standard create-request envelope.
+     * Resolves the first preferred OpenID4VCI protocol alternative from a standard create-request envelope.
      *
-     * Only the Digital Credentials `requests` array shape is accepted. Unsupported alternatives are
-     * skipped so an issuer that also offers an unknown protocol still reaches this wallet when
-     * `openid4vci-v1` is present.
+     * Only the Digital Credentials `requests` array shape is accepted. Selection follows
+     * [MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS] order so a dual-protocol
+     * request prefers `openid4vci-v1`. Unsupported alternatives are skipped.
      */
     internal fun resolveCreateRequest(
         requestJson: String,
@@ -132,15 +130,21 @@ public object AndroidDigitalCredentialCreateProvider {
         val requests = requestObject["requests"] as? JsonArray
             ?: throw IllegalArgumentException("Digital credential create request must contain a requests array")
         require(requests.isNotEmpty()) { "At least one protocol request is required" }
-        val selected = requests.map { it.jsonObject }.firstOrNull { protocolRequest ->
-            protocolRequest["protocol"]?.jsonPrimitive?.content == OPENID4VCI_PROTOCOL
+        val protocolRequests = requests.map { it.jsonObject }
+        val selected = MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS.firstNotNullOfOrNull { protocol ->
+            protocolRequests.firstOrNull { protocolRequest ->
+                protocolRequest["protocol"]?.jsonPrimitive?.content == protocol
+            }
         } ?: throw IllegalArgumentException(
-            "No openid4vci-v1 Digital Credentials create protocol was offered",
+            "No OpenID4VCI Digital Credentials create protocol was offered",
         )
         val data = selected["data"] as? JsonObject
             ?: throw IllegalArgumentException("Digital credential create request data must be an object")
+        val protocol = requireNotNull(selected["protocol"]?.jsonPrimitive?.content) {
+            "Digital credential create request protocol must be a string"
+        }
         return AndroidDigitalCredentialCreateRequest(
-            protocol = OPENID4VCI_PROTOCOL,
+            protocol = protocol,
             offerJson = Json.encodeToString(JsonObject.serializer(), data),
             verifiedOrigin = verifiedOrigin,
         )

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProvider.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialCreateProvider.kt
@@ -33,8 +33,8 @@ public data class AndroidDigitalCredentialCreateProviderInput(
  *
  * Kept on the Android adapter boundary rather than the common mobile SDK surface.
  *
- * @property protocol Digital Credentials protocol identifier selected from
- * [MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS].
+ * @property protocol Digital Credentials protocol identifier selected from the advertised
+ * OpenID4VCI create protocols (`openid4vci-v1` first, then historical aliases).
  * @property offerJson Credential Offer JSON object extracted from the selected protocol
  * alternative's `data` field.
  * @property verifiedOrigin Canonical caller origin derived from Credential Manager caller
@@ -119,8 +119,8 @@ public object AndroidDigitalCredentialCreateProvider {
      * Resolves the first preferred OpenID4VCI protocol alternative from a standard create-request envelope.
      *
      * Only the Digital Credentials `requests` array shape is accepted. Selection follows
-     * [MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS] order so a dual-protocol
-     * request prefers `openid4vci-v1`. Unsupported alternatives are skipped.
+     * [OPENID4VCI_CREATE_PROTOCOLS] order so a dual-protocol request prefers `openid4vci-v1`.
+     * Unsupported alternatives are skipped.
      */
     internal fun resolveCreateRequest(
         requestJson: String,
@@ -131,7 +131,7 @@ public object AndroidDigitalCredentialCreateProvider {
             ?: throw IllegalArgumentException("Digital credential create request must contain a requests array")
         require(requests.isNotEmpty()) { "At least one protocol request is required" }
         val protocolRequests = requests.map { it.jsonObject }
-        val selected = MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS.firstNotNullOfOrNull { protocol ->
+        val selected = OPENID4VCI_CREATE_PROTOCOLS.firstNotNullOfOrNull { protocol ->
             protocolRequests.firstOrNull { protocolRequest ->
                 protocolRequest["protocol"]?.jsonPrimitive?.content == protocol
             }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistry.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistry.kt
@@ -269,7 +269,9 @@ public class AndroidDigitalCredentialRegistry(
                 putJsonObject("Pass") {}
             }
             putJsonArray("preferred_protocols") {
-                add(JsonPrimitive(MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1))
+                MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS.forEach { protocol ->
+                    add(JsonPrimitive(protocol))
+                }
             }
             putJsonObject("package_info") {
                 put("name", applicationName)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistry.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/AndroidDigitalCredentialRegistry.kt
@@ -269,7 +269,7 @@ public class AndroidDigitalCredentialRegistry(
                 putJsonObject("Pass") {}
             }
             putJsonArray("preferred_protocols") {
-                MobileWalletDigitalCredentialProtocols.OPENID4VCI_CREATE_PROTOCOLS.forEach { protocol ->
+                OPENID4VCI_CREATE_PROTOCOLS.forEach { protocol ->
                     add(JsonPrimitive(protocol))
                 }
             }

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/OpenId4VciCreateProtocols.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/androidMain/kotlin/id/walt/wallet2/mobile/OpenId4VciCreateProtocols.kt
@@ -1,0 +1,16 @@
+package id.walt.wallet2.mobile
+
+/**
+ * Ordered OpenID4VCI create-protocol identifiers advertised to Credential Manager.
+ *
+ * [MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1] is canonical and first. The remaining
+ * entries are historical aliases still sent by some issuer pages; they are accepted and echoed,
+ * not advertised as separate capabilities.
+ */
+internal val OPENID4VCI_CREATE_PROTOCOLS: List<String> = listOf(
+    MobileWalletDigitalCredentialProtocols.OPENID4VCI_V1,
+    "openid4vci1.0",
+    "openid4vci-1.0",
+    "openid4vci1.1",
+    "openid4vci-1.1",
+)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletDigitalCredentials.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletDigitalCredentials.kt
@@ -10,8 +10,23 @@ public object MobileWalletDigitalCredentialProtocols {
     public const val OPENID4VP_MULTISIGNED: String = "openid4vp-v1-multisigned"
     /** ISO 18013-7 Annex C mobile-document protocol identifier. */
     public const val ISO_MDOC_ANNEX_C: String = "org-iso-mdoc"
-    /** OpenID4VCI Digital Credentials issuance protocol identifier. */
+    /** Canonical OpenID4VCI Digital Credentials issuance protocol identifier. */
     public const val OPENID4VCI_V1: String = "openid4vci-v1"
+
+    /**
+     * Ordered OpenID4VCI create-protocol identifiers advertised to Credential Manager.
+     *
+     * [OPENID4VCI_V1] is canonical and first. The remaining entries are historical aliases still
+     * sent by some issuer pages; they are accepted and echoed, not advertised as separate
+     * capabilities.
+     */
+    public val OPENID4VCI_CREATE_PROTOCOLS: List<String> = listOf(
+        OPENID4VCI_V1,
+        "openid4vci1.0",
+        "openid4vci-1.0",
+        "openid4vci1.1",
+        "openid4vci-1.1",
+    )
 }
 
 /**

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletDigitalCredentials.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletDigitalCredentials.kt
@@ -12,21 +12,6 @@ public object MobileWalletDigitalCredentialProtocols {
     public const val ISO_MDOC_ANNEX_C: String = "org-iso-mdoc"
     /** Canonical OpenID4VCI Digital Credentials issuance protocol identifier. */
     public const val OPENID4VCI_V1: String = "openid4vci-v1"
-
-    /**
-     * Ordered OpenID4VCI create-protocol identifiers advertised to Credential Manager.
-     *
-     * [OPENID4VCI_V1] is canonical and first. The remaining entries are historical aliases still
-     * sent by some issuer pages; they are accepted and echoed, not advertised as separate
-     * capabilities.
-     */
-    public val OPENID4VCI_CREATE_PROTOCOLS: List<String> = listOf(
-        OPENID4VCI_V1,
-        "openid4vci1.0",
-        "openid4vci-1.0",
-        "openid4vci1.1",
-        "openid4vci-1.1",
-    )
 }
 
 /**


### PR DESCRIPTION
## Summary

Android Digital Credentials issuance previously advertised and accepted only `openid4vci-v1`. Relying parties that still send Chrome's historical protocol strings (`openid4vci1.0`, `openid4vci-1.0`, `openid4vci1.1`, `openid4vci-1.1`) never reached the wallet: Google's issuance matcher treats `preferred_protocols` as exclusive, and the create provider rejected the aliases even if a request arrived.

This PR registers those aliases in the matcher and accepts them in the create provider so Android wallets can complete OpenID4VCI Digital Credentials issuance when the browser/OS forwards a historical protocol string. Canonical `openid4vci-v1` remains first in the list and is still the capability-row key. Bare `openid4vci` stays rejected.

This overrules the `openid4vci-v1`-only provider contract that landed in [walt-id/waltid-identity#2101](https://github.com/walt-id/waltid-identity/pull/2101). The alias list is Android-internal; it is not public commonMain/KLIB API.

Linear: [WAL-1322](https://linear.app/walt-new/issue/WAL-1322/accept-historical-openid4vci-dc-api-protocol-aliases)

## What Changed

### Android protocol list
- Added ordered `OPENID4VCI_CREATE_PROTOCOLS` as an `internal` androidMain constant shared by matcher registration and request matching.
- Canonical `openid4vci-v1` stays first; historical aliases follow.
- Tests pin the required ordered literals independently so an empty production list cannot pass.

### Android matcher
- `encodeOpenId4VciCreationOptions` now writes the full alias list into `preferred_protocols`.
- Capability rows remain a single OpenID4VCI issuance entry keyed by `openid4vci-v1`.
- No WASM rebuild: the compiled matcher already iterates `preferred_protocols`.

### Android create provider
- `resolveCreateRequest` matches against the shared alias list in preferred-protocol order, so dual-protocol requests still select `openid4vci-v1`.
- The selected protocol string is preserved and echoed in the create ack instead of being rewritten to `openid4vci-v1`.

### Docs
- Matcher contract and wallet README text now describe the alias list and selection order without exposing a public Kotlin API.

## Architecture Notes

- Alias acceptance is a registration/provider concern, not a WASM change. Google's issuance matcher only considers protocols listed in `preferred_protocols`.
- Selection uses preferred-protocol order rather than the relying party's `requests` array order, so a mixed request that includes both `openid4vci-v1` and a historical alias still picks the canonical string.
- Portal2 and other first-party relying parties stay on `openid4vci-v1`; this only widens wallet compatibility for callers that still use historical identifiers.

## Caveats and Follow-Ups

- Chrome may still refuse `openid4vci1.0` via `DigitalCredential.userAgentAllowsProtocol` before Credential Manager. This change only helps when the browser/OS forwards that protocol string.
- Device Digital Credentials E2E for historical aliases is out of scope here.
- iOS Digital Credentials create matching is unchanged; this is an Android matcher/provider expansion.

## Breaking

- None. Additional protocol strings are accepted; existing `openid4vci-v1` behavior is preserved. No public KLIB/commonMain API was added.