### PR TITLE
fix(verifier2): emit credential_policy_results_available only once

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/handlers/vpresponse/Verifier2VPDirectPostHandler.kt
@@ -482,11 +482,9 @@ object Verifier2VPDirectPostHandler {
             // random response_code to the redirect URI. The wallet redirects the user browser to
             // this URI. The frontend then presents response_code + transaction-id to the Response
             // Endpoint to fetch the VP Token — only the browser that received the redirect can do this.
-            val responseCode = generateResponseCode()
-
-            // Store response_code on session so the frontend can validate it
-            updateSessionCallback(session, SessionEvent.credential_policy_results_available) {
-                this.responseCode = responseCode
+            // Assigned during credential_policy_results_available so this persist does not notify again.
+            val responseCode = requireNotNull(session.responseCode) {
+                "Success redirect is configured but response_code was not assigned"
             }
 
             val redirectUriWithCode = URLBuilder(optionalSuccessRedirectUrl)
@@ -547,7 +545,7 @@ object Verifier2VPDirectPostHandler {
      * Generates a fresh response_code per OID4VP 1.0 §1758.
      * Uses multiplatform UUID (backed by SecureRandom on JVM) for cryptographic randomness.
      */
-    private fun generateResponseCode(): String = Uuid.random().toHexString()
+    internal fun generateResponseCode(): String = Uuid.random().toHexString()
 
     fun parseVpToken(vpTokenString: String): ParsedVpToken = try {
         Json.Default.decodeFromString(vpTokenString)

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/commonMain/kotlin/id/walt/verifier2/verification2/PresentationVerificationEngine.kt
@@ -26,6 +26,7 @@ import id.walt.verifier2.data.SessionFailure
 import id.walt.verifier2.data.Verification2Session
 import id.walt.verifier2.handlers.vpresponse.ParsedVpToken
 import id.walt.verifier2.handlers.vpresponse.Verifier2SessionCredentialPolicyValidation
+import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler
 import id.walt.verifier2.handlers.vpresponse.Verifier2VPDirectPostHandler.PresentationRejectionException
 import id.walt.verifier2.verification.DcqlFulfillmentChecker
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -479,12 +480,16 @@ object PresentationVerificationEngine {
                 credentialPolicyResults.vcPolicies.filter { !it.success } +
                         credentialPolicyResults.specificVcPolicies.values.flatten().filter { !it.success }
 
+            if (verificationSessionPolicyResults.overallSuccess && session.redirects?.successRedirectUri != null) {
+                session.responseCode = Verifier2VPDirectPostHandler.generateResponseCode()
+            }
             session.updateSession(SessionEvent.credential_policy_results_available) {
                 this.policyResults = verificationSessionPolicyResults
                 this.status = when {
                     verificationSessionPolicyResults.overallSuccess -> Verification2Session.VerificationSessionStatus.SUCCESSFUL
                     else -> Verification2Session.VerificationSessionStatus.FAILED
                 }
+                this.responseCode = session.responseCode
                 if (!verificationSessionPolicyResults.overallSuccess) {
                     // Invariant: overallSuccess=false implies at least one credential policy failure
                     // in the same lists used to compute the overall result.

--- a/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/events/Verifier2WebhookRecorder.kt
+++ b/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/events/Verifier2WebhookRecorder.kt
@@ -59,18 +59,20 @@ class Verifier2WebhookRecorder : AutoCloseable {
     }
 
     fun assertReceivedInOrder(sessionId: String, expected: List<SessionEvent>, timeoutMillis: Long = 8_000) {
+        val expectedNames = expected.map { it.name }
         val deadline = System.currentTimeMillis() + timeoutMillis
-        var events = emptyList<KtorSessionUpdate>()
+        var events = emptyList<String>()
         while (System.currentTimeMillis() < deadline) {
-            events = receivedUpdates.filter { it.target == sessionId }
-            if (containsInOrder(events.map { it.event }, expected.map { it.name })) {
-                return
+            events = receivedUpdates.filter { it.target == sessionId }.map { it.event }
+            when {
+                events == expectedNames -> return
+                events.size > expectedNames.size -> break
+                events != expectedNames.take(events.size) -> break
             }
             Thread.sleep(50)
         }
         throw AssertionError(
-            "Session '$sessionId' did not emit expected callback events $expected. Received: " +
-                events.map { it.event }
+            "Session '$sessionId' did not emit exact callback events $expectedNames. Received: $events"
         )
     }
 
@@ -121,14 +123,5 @@ class Verifier2WebhookRecorder : AutoCloseable {
             SessionEvent.wallet_error_response_received,
         )
 
-        private fun containsInOrder(actual: List<String>, expected: List<String>): Boolean {
-            var index = 0
-            for (event in actual) {
-                if (index < expected.size && event == expected[index]) {
-                    index++
-                }
-            }
-            return index == expected.size
-        }
     }
 }

--- a/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/sdjwt/IETFSdJwtVcHappyPathVerifier2IntegrationTest.kt
+++ b/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/sdjwt/IETFSdJwtVcHappyPathVerifier2IntegrationTest.kt
@@ -44,6 +44,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.http.Url
 import io.ktor.server.application.Application
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -101,7 +102,10 @@ class IETFSdJwtVcHappyPathVerifier2IntegrationTest {
                 dcqlQuery = sdJwtVcDcqlQuery,
                 policies = sdjwtvcPolicies,
                 notifications = notifications,
-            )
+            ),
+            redirects = Verification2Session.VerificationSessionRedirects(
+                successRedirectUri = Url("https://example.com/success"),
+            ),
         )
 
     private val holderKeyFun = suspend {
@@ -257,7 +261,9 @@ class IETFSdJwtVcHappyPathVerifier2IntegrationTest {
                 val resp = presentationResult.getOrThrow()
                 println(resp)
                 assertTrue("Transmission did not succeed") { resp.transmissionSuccess == true }
-                assertTrue { resp.verifierResponse!!.jsonObject["status"]!!.jsonPrimitive.content == "received" }
+                val redirectUri = resp.verifierResponse!!.jsonObject["redirect_uri"]!!.jsonPrimitive.content
+                assertTrue(redirectUri.startsWith("https://example.com/success"))
+                assertTrue(redirectUri.contains("response_code="))
             }
 
             val info2 = testAndReturn("View presented session") {
@@ -278,6 +284,8 @@ class IETFSdJwtVcHappyPathVerifier2IntegrationTest {
                 assertTrue { info2.policyResults!!.overallSuccess }
                 assertEquals(1, info2.policyResults!!.vcPolicies.size)
                 assertEquals("my_pid", info2.policyResults!!.vcPolicies.single().queryId)
+                assertNotNull(info2.responseCode)
+                assertTrue(info2.responseCode!!.isNotBlank())
             }
 
             test("Emit successful verification callback events") {


### PR DESCRIPTION
## Summary

Stops verifier2 from sending `credential_policy_results_available` twice when a session has `successRedirectUri`. The second fire was only persisting `response_code` after policy results were already stored and notified.

Fixes [WAL-1337](https://linear.app/walt-new/issue/WAL-1337/support-duplicate-credential-policy-results-available-events-during).

Enterprise counterpart: [walt-id/waltid-identity-enterprise#638](https://github.com/walt-id/waltid-identity-enterprise/pull/638).

## What Changed

### Verification flow
- Assign and persist `response_code` on the existing policy-results session update when a success redirect is configured.
- The direct-post handler now reads that stored value instead of notifying again.

### Tests
- Callback assertions require the exact event list, not a subsequence.
- The SD-JWT happy path now uses a success redirect and checks that `response_code` is persisted and the webhook sequence still has one policy-results event.

## Architecture Notes

OSS session updates persist a copy of the session. The code sets `response_code` on the in-memory session first, then copies it into the persist block so both OSS and enterprise see the same value after verification.

## Caveats and Follow-Ups

- Enterprise counterpart covers the TRACE log wording and enterprise callback tests.
- Issuer2 enterprise webhook tests still only wait for named events. Tracked in [WAL-1340](https://linear.app/walt-new/issue/WAL-1340/tighten-issuer2-webhook-integration-tests-to-exact-event-order-and).

## Breaking

None. Webhook consumers that treated the duplicate as required will now receive one `credential_policy_results_available` event. That matches the documented session-event contract.