### PR TITLE
[WAL-1346] feat(wallet): configure proximity reader trust

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/composeResources/values/strings.xml
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/composeResources/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="proximity_open_app_settings">Open app settings</string>
     <string name="proximity_not_checked">Not checked</string>
     <string name="proximity_not_evaluated">Not evaluated</string>
+    <string name="proximity_unknown_authority">Unknown authority</string>
     <string name="proximity_preparing">Preparing a secure presentation…</string>
     <string name="proximity_presentation_complete">Presentation complete</string>
     <string name="proximity_presentation_complete_message">The approved credential data was sent to the reader.</string>

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoProximityScreen.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/mobileMain/kotlin/id/walt/walletdemo/compose/ui/WalletDemoProximityScreen.kt
@@ -904,6 +904,7 @@ private fun MobileWalletProximityReaderTrustState.displayName(): String = string
 private fun MobileWalletProximityReaderCertificatePathState.displayName(): String = stringResource(
     when (this) {
         MobileWalletProximityReaderCertificatePathState.NotEvaluated -> Res.string.proximity_not_evaluated
+        MobileWalletProximityReaderCertificatePathState.UnknownAuthority -> Res.string.proximity_unknown_authority
         MobileWalletProximityReaderCertificatePathState.Invalid -> Res.string.proximity_auth_invalid
         MobileWalletProximityReaderCertificatePathState.Valid -> Res.string.proximity_auth_valid
     }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/ProximityPresentationView.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosApp/Views/ProximityPresentationView.swift
@@ -715,6 +715,7 @@ private extension ProximityReaderCertificatePathState {
     var label: String {
         switch self {
         case .notEvaluated: String(localized: "Not evaluated")
+        case .unknownAuthority: String(localized: "Unknown authority")
         case .invalid: String(localized: "Invalid")
         case .valid: String(localized: "Valid")
         }

--- a/waltid-libraries/credentials/waltid-mdoc-proximity/src/commonMain/kotlin/id/walt/mdoc/proximity/Rical.kt
+++ b/waltid-libraries/credentials/waltid-mdoc-proximity/src/commonMain/kotlin/id/walt/mdoc/proximity/Rical.kt
@@ -192,15 +192,22 @@ fun interface RicalConstraintEvaluator {
     suspend fun accepts(constraints: List<RicalTrustConstraint>, reader: ReaderAuthenticationEvidence): Boolean
 }
 
-enum class RicalReaderPathState { NO_MATCH, INVALID, REVOKED, VALID }
+sealed interface RicalReaderPathResult {
+    data object NoMatch : RicalReaderPathResult
+    data object Invalid : RicalReaderPathResult
+    data object Revoked : RicalReaderPathResult
+    data class Valid(val authority: RicalCertificateInfo) : RicalReaderPathResult
+}
 
-/** Profile-owned RFC 5280/path/revocation validation against the complete active RICAL. */
+/**
+ * Profile-owned RFC 5280/path/revocation validation against the complete active RICAL.
+ * A valid result contains only the bottom-most matching authority whose constraints apply.
+ */
 fun interface RicalReaderPathValidator {
     suspend fun validate(
         reader: ReaderAuthenticationEvidence,
         rical: Rical,
-        matchingCertificateInfo: RicalCertificateInfo,
-    ): RicalReaderPathState
+    ): RicalReaderPathResult
 }
 
 data class RicalPolicy(
@@ -266,52 +273,86 @@ class RicalReaderTrustEvaluator(
     private val now: () -> Instant,
     private val pathValidator: RicalReaderPathValidator,
 ) : ReaderTrustEvaluator {
-    override suspend fun evaluate(evidence: ReaderAuthenticationEvidence): ReaderTrustDecision {
+    override suspend fun evaluate(evidence: ReaderAuthenticationEvidence): ReaderTrustDecision =
+        evaluateDetailed(evidence).decision
+
+    suspend fun evaluateDetailed(evidence: ReaderAuthenticationEvidence): RicalReaderTrustResult {
         val signed = when (val result = provider.current()) {
             is RicalProviderResult.Available -> result.signed
-            is RicalProviderResult.Unavailable -> return ReaderTrustDecision(
-                ReaderTrustState.VALID_BUT_UNTRUSTED,
-                "RICAL provider is unavailable: ${result.reason}",
+            is RicalProviderResult.Unavailable -> return RicalReaderTrustResult(
+                RicalEvaluationState.UNAVAILABLE,
+                ReaderTrustDecision(
+                    ReaderTrustState.VALID_BUT_UNTRUSTED,
+                    "RICAL provider is unavailable: ${result.reason}",
+                ),
             )
-            is RicalProviderResult.Conflict -> return ReaderTrustDecision(
-                ReaderTrustState.VALID_BUT_UNTRUSTED,
-                "RICAL provider has conflicting active data: ${result.reason}",
+            is RicalProviderResult.Conflict -> return RicalReaderTrustResult(
+                RicalEvaluationState.INVALID,
+                ReaderTrustDecision(
+                    ReaderTrustState.VALID_BUT_UNTRUSTED,
+                    "RICAL provider has conflicting active data: ${result.reason}",
+                ),
             )
         }
         val rical = signed.rical
         if (rical.provider != policy.providerId || rical.type !in policy.acceptedTypes) {
-            return ReaderTrustDecision(ReaderTrustState.VALID_BUT_UNTRUSTED, "RICAL provider or type is not permitted")
+            return invalid("RICAL provider or type is not permitted")
         }
         val current = now()
         if (rical.date > current || rical.notAfter?.let { current >= it } == true) {
-            return ReaderTrustDecision(ReaderTrustState.VALID_BUT_UNTRUSTED, "RICAL is not currently fresh")
+            return invalid("RICAL is not currently fresh")
         }
         if (!signatureValidator.validate(signed, policy.trustedProviderRootsDer)) {
-            return ReaderTrustDecision(ReaderTrustState.VALID_BUT_UNTRUSTED, "RICAL signature or provider path is invalid")
+            return invalid("RICAL signature or provider path is invalid")
         }
-        var authority: RicalCertificateInfo? = null
-        for (info in rical.certificateInfos) {
-            when (pathValidator.validate(evidence, rical, info)) {
-                RicalReaderPathState.NO_MATCH, RicalReaderPathState.INVALID -> Unit
-                RicalReaderPathState.REVOKED -> return ReaderTrustDecision(
+        val authority = when (val path = pathValidator.validate(evidence, rical)) {
+            RicalReaderPathResult.NoMatch -> return noMatchingAuthority()
+            RicalReaderPathResult.Invalid -> return invalid("Reader certificate path through the RICAL is invalid")
+            RicalReaderPathResult.Revoked -> return RicalReaderTrustResult(
+                RicalEvaluationState.MATCHED,
+                ReaderTrustDecision(
                     ReaderTrustState.REVOKED,
                     "Reader authentication certificate is revoked",
-                )
-                RicalReaderPathState.VALID -> if (constraintEvaluator.accepts(info.trustConstraints, evidence)) {
-                    authority = info
-                    break
-                }
-            }
+                ),
+            )
+            is RicalReaderPathResult.Valid -> path.authority.takeIf { it in rical.certificateInfos }
+                ?: return invalid("Reader path selected an authority outside the active RICAL")
         }
-        authority ?: return ReaderTrustDecision(
-            ReaderTrustState.VALID_BUT_UNTRUSTED,
-            "Reader does not satisfy a RICAL authority and its constraints",
-        )
-        return if (policy.establishReaderTrust) ReaderTrustDecision(ReaderTrustState.TRUSTED, displayName = authority.name)
-        else ReaderTrustDecision(
-            ReaderTrustState.VALID_BUT_UNTRUSTED,
-            "RICAL evidence is valid but the active policy does not establish reader trust",
-            authority.name,
+        if (!constraintEvaluator.accepts(authority.trustConstraints, evidence)) {
+            return noMatchingAuthority()
+        }
+        val decision = if (policy.establishReaderTrust) {
+            ReaderTrustDecision(ReaderTrustState.TRUSTED, displayName = authority.name)
+        } else {
+            ReaderTrustDecision(
+                ReaderTrustState.VALID_BUT_UNTRUSTED,
+                "RICAL evidence is valid but the active policy does not establish reader trust",
+                authority.name,
+            )
+        }
+        return RicalReaderTrustResult(
+            RicalEvaluationState.MATCHED,
+            decision,
         )
     }
+
+    private fun invalid(reason: String): RicalReaderTrustResult = RicalReaderTrustResult(
+        RicalEvaluationState.INVALID,
+        ReaderTrustDecision(ReaderTrustState.VALID_BUT_UNTRUSTED, reason),
+    )
+
+    private fun noMatchingAuthority(): RicalReaderTrustResult = RicalReaderTrustResult(
+        RicalEvaluationState.NO_MATCHING_AUTHORITY,
+        ReaderTrustDecision(
+            ReaderTrustState.VALID_BUT_UNTRUSTED,
+            "Reader does not satisfy a RICAL authority and its constraints",
+        ),
+    )
 }
+
+enum class RicalEvaluationState { UNAVAILABLE, INVALID, NO_MATCHING_AUTHORITY, MATCHED }
+
+data class RicalReaderTrustResult(
+    val state: RicalEvaluationState,
+    val decision: ReaderTrustDecision,
+)

--- a/waltid-libraries/credentials/waltid-mdoc-proximity/src/commonMain/kotlin/id/walt/mdoc/proximity/RicalX509Validation.kt
+++ b/waltid-libraries/credentials/waltid-mdoc-proximity/src/commonMain/kotlin/id/walt/mdoc/proximity/RicalX509Validation.kt
@@ -1,0 +1,128 @@
+package id.walt.mdoc.proximity
+
+import id.walt.certificate.x509.X509Certificate
+import id.walt.certificate.x509.X509CertificateUtil
+import id.walt.certificate.x509.extension.AuthorityKeyIdentifierExtension.Companion.extensionAuthorityKeyIdentifier
+import id.walt.certificate.x509.extension.SubjectKeyIdentifierExtension.Companion.extensionSubjectKeyIdentifier
+import id.walt.cose.Cose
+import id.walt.cose.verify
+import id.walt.x509.CertificateDer
+import id.walt.x509.validateMdocReaderAuthenticationCertificateChain
+import id.walt.x509.validateRicalSignerCertificateChain
+import id.walt.x509.validateRicalSignerCertificateProfile
+import kotlinx.coroutines.CancellationException
+import kotlinx.io.bytestring.ByteString
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/** Concrete RICAL COSE-signature, signer-profile, and explicit-provider-root validator. */
+class X509RicalSignatureValidator(
+    acceptedCertificatePolicyOids: Set<String>,
+    private val now: () -> Instant = { Clock.System.now() },
+) : RicalSignatureValidator {
+    private val acceptedCertificatePolicyOids = acceptedCertificatePolicyOids.toSet()
+
+    init {
+        require(this.acceptedCertificatePolicyOids.isNotEmpty())
+        require(this.acceptedCertificatePolicyOids.none(String::isBlank))
+    }
+
+    override suspend fun validate(
+        signed: SignedRical,
+        trustedProviderRootsDer: List<ImmutableBytes>,
+    ): Boolean = try {
+        val evaluatedAt = now()
+        val signerChain = signed.signerChainDer.map { CertificateDer(it.copy()) }
+        val roots = trustedProviderRootsDer.map { CertificateDer(it.copy()) }
+        val leaf = signerChain.first()
+        validateRicalSignerCertificateProfile(leaf, acceptedCertificatePolicyOids, evaluatedAt)
+        validateRicalSignerCertificateChain(leaf, signerChain.drop(1), roots, evaluatedAt)
+        val signer = X509CertificateUtil.parseCertificateDerEncoded(ByteString(leaf.bytes.toByteArray()))
+        signed.coseSign1.verify(
+            signer.restoreSubjectPublicKey(X509CertificateUtil.services.cryptoRuntime),
+            RICAL_SIGNATURE_ALGORITHMS,
+        )
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Throwable) {
+        false
+    }
+}
+
+/**
+ * Validates a reader path against the complete active RICAL and selects only its bottom-most
+ * matching CertificateInfo for constraint evaluation.
+ */
+class X509RicalReaderPathValidator(
+    private val now: () -> Instant = { Clock.System.now() },
+) : RicalReaderPathValidator {
+    override suspend fun validate(
+        reader: ReaderAuthenticationEvidence,
+        rical: Rical,
+    ): RicalReaderPathResult {
+        val evaluatedAt = now()
+        val readerChain = reader.certificateChainDer.map { CertificateDer(it.copy()) }
+        if (readerChain.isEmpty()) return RicalReaderPathResult.Invalid
+        val ricalCertificates = rical.certificateInfos.associateWith { CertificateDer(it.certificateDer.copy()) }
+        val parsedRicalCertificates = ricalCertificates.mapValues { (_, certificate) ->
+            X509CertificateUtil.parseCertificateDerEncoded(ByteString(certificate.bytes.toByteArray()))
+        }
+        val candidates = rical.certificateInfos.filter { info ->
+            runCatching {
+                validateMdocReaderAuthenticationCertificateChain(
+                    leaf = readerChain.first(),
+                    chain = readerChain.drop(1) + ricalCertificates.values,
+                    trustAnchors = listOf(ricalCertificates.getValue(info)),
+                    now = evaluatedAt,
+                )
+            }.isSuccess
+        }
+        val bottomMost = candidates.maxByOrNull { it.depthToRicalAnchor(parsedRicalCertificates) }
+            ?: return RicalReaderPathResult.NoMatch
+
+        val ricalRoots = rical.certificateInfos
+            .filter(RicalCertificateInfo::isTrustAnchor)
+            .map(ricalCertificates::getValue)
+        return if (runCatching {
+                validateMdocReaderAuthenticationCertificateChain(
+                    leaf = readerChain.first(),
+                    chain = readerChain.drop(1) + ricalCertificates.values,
+                    trustAnchors = ricalRoots,
+                    now = evaluatedAt,
+                )
+            }.isSuccess
+        ) {
+            RicalReaderPathResult.Valid(bottomMost)
+        } else {
+            RicalReaderPathResult.Invalid
+        }
+    }
+}
+
+private fun RicalCertificateInfo.depthToRicalAnchor(
+    all: Map<RicalCertificateInfo, X509Certificate>,
+): Int {
+    var current = this
+    var depth = 0
+    val visited = mutableSetOf<RicalCertificateInfo>()
+    while (visited.add(current) && !current.isTrustAnchor) {
+        val currentCertificate = all.getValue(current)
+        val authorityKeyIdentifier = currentCertificate.data.extensionAuthorityKeyIdentifier?.keyIdentifier
+            ?: break
+        current = all.entries.singleOrNull { (_, candidateCertificate) ->
+            candidateCertificate.data.subjectDnRaw == currentCertificate.data.issuerDnRaw &&
+                candidateCertificate.data.extensionSubjectKeyIdentifier?.keyIdentifier == authorityKeyIdentifier
+        }?.key ?: break
+        depth += 1
+    }
+    return depth
+}
+
+// DIS F.3.2 lists EdDSA at the COSE layer, while mandatory Table F.1 requires the
+// RICAL signer certificate to contain an EC public key. Keep parsing forward-compatible,
+// but only accept the algorithms that can satisfy the mandatory signer profile here.
+private val RICAL_SIGNATURE_ALGORITHMS = setOf(
+    Cose.Algorithm.ES256,
+    Cose.Algorithm.ES384,
+    Cose.Algorithm.ES512,
+)

--- a/waltid-libraries/credentials/waltid-mdoc-proximity/src/commonTest/kotlin/id/walt/mdoc/proximity/RicalTest.kt
+++ b/waltid-libraries/credentials/waltid-mdoc-proximity/src/commonTest/kotlin/id/walt/mdoc/proximity/RicalTest.kt
@@ -68,7 +68,7 @@ class RicalTest {
             signatureValidator = RicalSignatureValidator { _, _ -> true },
             constraintEvaluator = RicalConstraintEvaluator { _, _ -> true },
             now = { Instant.parse("2026-01-02T00:00:00Z") },
-            pathValidator = RicalReaderPathValidator { _, _, _ -> RicalReaderPathState.VALID },
+            pathValidator = RicalReaderPathValidator { _, _ -> RicalReaderPathResult.Valid(authority) },
         ).evaluate(evidence)
 
         assertEquals(ReaderTrustState.VALID_BUT_UNTRUSTED, evaluate(false).state)
@@ -91,7 +91,7 @@ class RicalTest {
         suspend fun evaluate(
             providerResult: RicalProviderResult = RicalProviderResult.Available(baseSigned),
             signatureValid: Boolean = true,
-            path: RicalReaderPathState = RicalReaderPathState.VALID,
+            path: RicalReaderPathResult = RicalReaderPathResult.Valid(authority),
             constraintsValid: Boolean = true,
             now: Instant = Instant.parse("2026-01-03T00:00:00Z"),
         ) = RicalReaderTrustEvaluator(
@@ -105,40 +105,47 @@ class RicalTest {
             signatureValidator = RicalSignatureValidator { _, _ -> signatureValid },
             constraintEvaluator = RicalConstraintEvaluator { _, _ -> constraintsValid },
             now = { now },
-            pathValidator = RicalReaderPathValidator { _, _, _ -> path },
-        ).evaluate(evidence)
+            pathValidator = RicalReaderPathValidator { _, _ -> path },
+        ).evaluateDetailed(evidence)
 
         assertEquals(
-            ReaderTrustState.VALID_BUT_UNTRUSTED,
+            RicalEvaluationState.UNAVAILABLE,
             evaluate(RicalProviderResult.Unavailable("offline")).state,
         )
         assertEquals(
-            ReaderTrustState.VALID_BUT_UNTRUSTED,
+            RicalEvaluationState.INVALID,
             evaluate(RicalProviderResult.Conflict("two current versions")).state,
         )
         assertEquals(
-            ReaderTrustState.VALID_BUT_UNTRUSTED,
+            RicalEvaluationState.INVALID,
             evaluate(RicalProviderResult.Available(signed(baseRical.copy(provider = "other")))).state,
         )
-        assertEquals(ReaderTrustState.VALID_BUT_UNTRUSTED, evaluate(signatureValid = false).state)
-        assertEquals(ReaderTrustState.VALID_BUT_UNTRUSTED, evaluate(path = RicalReaderPathState.INVALID).state)
-        assertEquals(ReaderTrustState.VALID_BUT_UNTRUSTED, evaluate(constraintsValid = false).state)
+        assertEquals(RicalEvaluationState.INVALID, evaluate(signatureValid = false).state)
+        assertEquals(RicalEvaluationState.INVALID, evaluate(path = RicalReaderPathResult.Invalid).state)
         assertEquals(
-            ReaderTrustState.VALID_BUT_UNTRUSTED,
+            RicalEvaluationState.INVALID,
+            evaluate(path = RicalReaderPathResult.Valid(authority.copy(name = "Not in active RICAL"))).state,
+        )
+        assertEquals(RicalEvaluationState.NO_MATCHING_AUTHORITY, evaluate(constraintsValid = false).state)
+        assertEquals(
+            RicalEvaluationState.INVALID,
             evaluate(now = Instant.parse("2026-02-01T00:00:00Z")).state,
         )
         assertEquals(
-            ReaderTrustState.VALID_BUT_UNTRUSTED,
+            RicalEvaluationState.INVALID,
             evaluate(
                 RicalProviderResult.Available(
                     signed(baseRical.copy(date = Instant.parse("2026-01-04T00:00:00Z"), nextUpdate = null))
                 )
             ).state,
         )
-        assertEquals(ReaderTrustState.REVOKED, evaluate(path = RicalReaderPathState.REVOKED).state)
+        val revoked = evaluate(path = RicalReaderPathResult.Revoked)
+        assertEquals(RicalEvaluationState.MATCHED, revoked.state)
+        assertEquals(ReaderTrustState.REVOKED, revoked.decision.state)
 
         val overdueUpdate = evaluate()
-        assertEquals(ReaderTrustState.TRUSTED, overdueUpdate.state)
+        assertEquals(RicalEvaluationState.MATCHED, overdueUpdate.state)
+        assertEquals(ReaderTrustState.TRUSTED, overdueUpdate.decision.state)
         assertTrue(baseRical.nextUpdate!! < Instant.parse("2026-01-03T00:00:00Z"))
     }
 

--- a/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/x509/IsoMdocReaderAuthenticationCertificate.kt
+++ b/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/x509/IsoMdocReaderAuthenticationCertificate.kt
@@ -1,0 +1,239 @@
+package id.walt.x509
+
+import id.walt.certificate.x509.X509Certificate
+import id.walt.certificate.x509.X509CertificateUtil
+import id.walt.certificate.x509.dn.DistinguishedName
+import id.walt.certificate.x509.extension.AuthorityKeyIdentifierExtension.Companion.extensionAuthorityKeyIdentifier
+import id.walt.certificate.x509.extension.CrlDistributionPointsExtension.Companion.extensionCrlDistributionPoints
+import id.walt.certificate.x509.extension.ExtendedKeyUsageExtension.Companion.extensionExtendedKeyUsage
+import id.walt.certificate.x509.extension.KeyUsageExtension
+import id.walt.certificate.x509.extension.KeyUsageExtension.Companion.extensionKeyUsage
+import id.walt.certificate.x509.extension.SubjectKeyIdentifierExtension.Companion.extensionSubjectKeyIdentifier
+import id.walt.certificate.x509.model.GeneralName
+import kotlinx.io.bytestring.ByteString
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/** Mandatory ISO/IEC 18013-5 reader-authentication extended-key-usage OID. */
+const val MdocReaderAuthenticationEkuOid: String = "1.0.18013.5.1.6"
+
+/** Recommended ISO/IEC 23220-4 reader-authentication extended-key-usage OID. */
+const val MdocReaderAuthentication23220EkuOid: String = "1.0.23220.4.1.6"
+
+/**
+ * Validates an mdoc reader-authentication leaf certificate against the ISO/IEC 18013-5 profile.
+ *
+ * This validates certificate contents only. Call [validateMdocReaderAuthenticationCertificateChain]
+ * to additionally establish an RFC 5280-style path to an explicit application trust anchor.
+ */
+@Throws(X509ValidationException::class)
+fun validateMdocReaderAuthenticationCertificateProfile(
+    certificate: CertificateDer,
+    now: Instant = Clock.System.now(),
+) {
+    val parsed = parseIsoCertificate(certificate, "reader certificate")
+    val data = parsed.data
+    val subjectPublicKey = data.subjectPublicKeyInfo
+
+    requireProfile(data.version == 3, "Reader certificate must be X.509 version 3")
+    validateIsoCertificateSerialNumber(data.serialNumberRaw, "Reader certificate")
+    requireProfile(
+        now >= data.validity.notBefore && now < data.validity.notAfter,
+        "Reader certificate is not currently valid",
+    )
+    requireProfile(
+        data.validity.notAfter - data.validity.notBefore <= MAX_READER_CERTIFICATE_VALIDITY,
+        "Reader certificate validity exceeds 1 187 days",
+    )
+    requireProfile(
+        parsed.signatureAlgorithmOid in ISO_ALLOWED_CERTIFICATE_SIGNATURE_ALGORITHM_OIDS,
+        "Reader certificate uses an unsupported certificate-signature algorithm",
+    )
+
+    val commonNames = DistinguishedName.ofString(data.subjectDn).rdnList
+        .flatten()
+        .filter { it.type.oid == COMMON_NAME_OID }
+        .map { it.value }
+    requireProfile(commonNames.size == 1 && commonNames.single().isNotBlank(), "Reader certificate requires one common name")
+
+    requireProfile(
+        subjectPublicKey.algorithmOid in ISO_ALLOWED_READER_SUBJECT_PUBLIC_KEY_ALGORITHM_OIDS,
+        "Reader certificate uses an unsupported subject-public-key algorithm",
+    )
+    if (subjectPublicKey.algorithmOid == EC_PUBLIC_KEY_OID) {
+        requireProfile(
+            subjectPublicKey.ellipticCurveOid in ISO_ALLOWED_ELLIPTIC_CURVE_OIDS,
+            "Reader certificate uses an unsupported elliptic curve",
+        )
+        requireProfile(
+            subjectPublicKey.keyValueRaw.size > 0 &&
+                subjectPublicKey.keyValueRaw[0] == UNCOMPRESSED_EC_POINT_PREFIX,
+            "Reader certificate EC public key must use uncompressed form",
+        )
+    } else {
+        requireProfile(subjectPublicKey.ellipticCurveOid == null, "Edwards-curve certificates must omit EC parameters")
+    }
+
+    val authorityKeyIdentifier = data.extensionAuthorityKeyIdentifier
+    requireProfile(
+        authorityKeyIdentifier != null &&
+            !authorityKeyIdentifier.critical &&
+            (authorityKeyIdentifier.keyIdentifier?.size ?: 0) > 0,
+        "Reader certificate requires an authority key identifier",
+    )
+    val subjectKeyIdentifier = data.extensionSubjectKeyIdentifier
+    requireProfile(
+        subjectKeyIdentifier != null &&
+            !subjectKeyIdentifier.critical &&
+            subjectKeyIdentifier.keyIdentifier == subjectPublicKey.keyId,
+        "Reader certificate requires the SHA-1 subject key identifier",
+    )
+
+    val keyUsage = data.extensionKeyUsage
+        ?: throw X509ValidationException("Reader certificate requires key usage")
+    requireProfile(keyUsage.critical, "Reader certificate key usage must be critical")
+    requireProfile(
+        keyUsage.keyPurposeIdList == setOf(KeyUsageExtension.KeyUsage.digitalSignature),
+        "Reader certificate key usage must contain only digitalSignature",
+    )
+
+    val extendedKeyUsage = data.extensionExtendedKeyUsage
+        ?: throw X509ValidationException("Reader certificate requires extended key usage")
+    requireProfile(extendedKeyUsage.critical, "Reader certificate extended key usage must be critical")
+    requireProfile(
+        MdocReaderAuthenticationEkuOid in extendedKeyUsage.keyPurposeIdList,
+        "Reader certificate extended key usage must contain $MdocReaderAuthenticationEkuOid",
+    )
+
+    val crlDistributionPoints = data.extensionCrlDistributionPoints
+        ?: throw X509ValidationException("Reader certificate requires CRL distribution points")
+    requireProfile(
+        !crlDistributionPoints.critical && crlDistributionPoints.distributionPoints.isNotEmpty(),
+        "Reader certificate requires a non-critical CRL distribution-points extension",
+    )
+    requireProfile(
+        crlDistributionPoints.distributionPoints.all { point ->
+            val fullNames = point.distributionPointFullName
+            point.reason == null &&
+                point.cRLIssuer == null &&
+                point.distributionPointNameRelativeToCrlIssuer == null &&
+                fullNames?.isNotEmpty() == true &&
+                fullNames.all { name ->
+                    name.type == GeneralName.NameType.uniformResourceIdentifier && name.value.isNotBlank()
+                }
+        },
+        "Reader certificate CRL distribution points must contain only full-name URIs",
+    )
+
+    val unsupportedCritical = data.extensions.values
+        .filter { it.critical }
+        .map { it.oid }
+        .filterNot { it == KEY_USAGE_OID || it == EXTENDED_KEY_USAGE_OID }
+    requireProfile(unsupportedCritical.isEmpty(), "Reader certificate contains an unsupported critical extension")
+}
+
+/**
+ * Validates a reader-authentication certificate and builds its path only to [trustAnchors].
+ * Certificates supplied by the reader are path-construction inputs and never implicit anchors.
+ */
+@Throws(X509ValidationException::class)
+fun validateMdocReaderAuthenticationCertificateChain(
+    leaf: CertificateDer,
+    chain: List<CertificateDer>,
+    trustAnchors: List<CertificateDer>,
+    now: Instant = Clock.System.now(),
+) {
+    requireProfile(trustAnchors.isNotEmpty(), "At least one explicit reader trust anchor is required")
+    requireProfile(leaf !in trustAnchors, "A reader end-entity certificate cannot be its own trust anchor")
+    validateMdocReaderAuthenticationCertificateProfile(leaf, now)
+
+    val parsedLeaf = parseIsoCertificate(leaf, "reader certificate")
+    val leafAuthorityKeyIdentifier = requireNotNull(
+        parsedLeaf.data.extensionAuthorityKeyIdentifier?.keyIdentifier
+    ) { "Reader certificate requires an authority key identifier" }
+    val possibleIssuers = (chain + trustAnchors)
+        .filterNot { it == leaf }
+        .map { parseIsoCertificate(it, "reader issuer certificate") }
+    requireProfile(
+        possibleIssuers.any {
+            it.data.subjectDnRaw == parsedLeaf.data.issuerDnRaw &&
+                it.data.extensionSubjectKeyIdentifier?.keyIdentifier == leafAuthorityKeyIdentifier
+        },
+        "Reader certificate issuer and authority key identifier do not exactly match an available CA",
+    )
+
+    validateCertificateChainWithExplicitTrust(
+        leaf = leaf,
+        chain = chain,
+        trustAnchors = trustAnchors,
+        enableTrustedChainRoot = false,
+        now = now,
+        additionalProcessedCriticalExtensionOids = setOf(EXTENDED_KEY_USAGE_OID),
+    )
+}
+
+/** Returns the common name from a reader certificate that has already passed profile validation. */
+@Throws(X509ValidationException::class)
+fun mdocReaderAuthenticationCommonName(certificate: CertificateDer): String {
+    val parsed = parseIsoCertificate(certificate, "reader certificate")
+    return DistinguishedName.ofString(parsed.data.subjectDn).rdnList
+        .flatten()
+        .single { it.type.oid == COMMON_NAME_OID }
+        .value
+}
+
+internal fun parseIsoCertificate(certificate: CertificateDer, description: String): X509Certificate = runCatching {
+    X509CertificateUtil.parseCertificateDerEncoded(certificate.bytes)
+}.getOrElse { cause ->
+    throw X509ValidationException("Invalid $description", cause)
+}
+
+internal fun validateIsoCertificateSerialNumber(serialNumber: ByteString, owner: String) {
+    requireProfile(serialNumber.size in 8..20, "$owner serial number must contain 63 to 159 bits")
+    requireProfile(serialNumber[0] >= 0, "$owner serial number must be positive")
+    val serialNumberBytes = serialNumber.toByteArray()
+    val firstNonZeroIndex = serialNumberBytes.indexOfFirst { it != 0.toByte() }
+    requireProfile(firstNonZeroIndex >= 0, "$owner serial number must be non-zero")
+    val mostSignificantByte = serialNumberBytes[firstNonZeroIndex].toInt() and 0xff
+    val bitLength = (serialNumberBytes.size - firstNonZeroIndex - 1) * 8 +
+        (Int.SIZE_BITS - mostSignificantByte.countLeadingZeroBits())
+    requireProfile(
+        bitLength >= 63,
+        "$owner serial number must contain at least 63 bits",
+    )
+}
+
+internal fun requireProfile(condition: Boolean, message: String) {
+    if (!condition) throw X509ValidationException(message)
+}
+
+internal val ISO_MAX_CERTIFICATE_VALIDITY = 1_187.days
+private val MAX_READER_CERTIFICATE_VALIDITY = ISO_MAX_CERTIFICATE_VALIDITY
+internal const val ISO_COMMON_NAME_OID = "2.5.4.3"
+private const val COMMON_NAME_OID = ISO_COMMON_NAME_OID
+internal const val ISO_EC_PUBLIC_KEY_OID = "1.2.840.10045.2.1"
+private const val EC_PUBLIC_KEY_OID = ISO_EC_PUBLIC_KEY_OID
+private const val KEY_USAGE_OID = "2.5.29.15"
+private const val EXTENDED_KEY_USAGE_OID = "2.5.29.37"
+internal const val ISO_UNCOMPRESSED_EC_POINT_PREFIX: Byte = 0x04
+private const val UNCOMPRESSED_EC_POINT_PREFIX = ISO_UNCOMPRESSED_EC_POINT_PREFIX
+internal val ISO_ALLOWED_CERTIFICATE_SIGNATURE_ALGORITHM_OIDS = setOf(
+    "1.2.840.10045.4.3.2",
+    "1.2.840.10045.4.3.3",
+    "1.2.840.10045.4.3.4",
+)
+private val ISO_ALLOWED_READER_SUBJECT_PUBLIC_KEY_ALGORITHM_OIDS = setOf(
+    EC_PUBLIC_KEY_OID,
+    "1.3.101.112",
+    "1.3.101.113",
+)
+internal val ISO_ALLOWED_ELLIPTIC_CURVE_OIDS = setOf(
+    "1.2.840.10045.3.1.7",
+    "1.3.132.0.34",
+    "1.3.132.0.35",
+    "1.3.36.3.3.2.8.1.1.7",
+    "1.3.36.3.3.2.8.1.1.9",
+    "1.3.36.3.3.2.8.1.1.11",
+    "1.3.36.3.3.2.8.1.1.13",
+)

--- a/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/x509/IsoRicalSignerCertificate.kt
+++ b/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/x509/IsoRicalSignerCertificate.kt
@@ -1,0 +1,188 @@
+package id.walt.x509
+
+import at.asitplus.signum.indispensable.asn1.Asn1Element
+import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import at.asitplus.signum.indispensable.asn1.encoding.parse
+import at.asitplus.signum.indispensable.asn1.readOid
+import at.asitplus.signum.indispensable.pki.X509Certificate as SignumX509Certificate
+import id.walt.certificate.x509.dn.DistinguishedName
+import id.walt.certificate.x509.extension.AuthorityKeyIdentifierExtension.Companion.extensionAuthorityKeyIdentifier
+import id.walt.certificate.x509.extension.CrlDistributionPointsExtension.Companion.extensionCrlDistributionPoints
+import id.walt.certificate.x509.extension.KeyUsageExtension
+import id.walt.certificate.x509.extension.KeyUsageExtension.Companion.extensionKeyUsage
+import id.walt.certificate.x509.extension.SubjectKeyIdentifierExtension.Companion.extensionSubjectKeyIdentifier
+import id.walt.certificate.x509.model.GeneralName
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Validates the ISO/IEC 18013-5 RICAL signer-certificate profile fields understood by waltid-x509.
+ *
+ * Certificate-path validation and the COSE signature remain separate checks. The application still
+ * decides whether the signer's certificate-policy OID represents an accepted RICAL governance policy.
+ */
+@Throws(X509ValidationException::class)
+fun validateRicalSignerCertificateProfile(
+    certificate: CertificateDer,
+    acceptedCertificatePolicyOids: Set<String>,
+    now: Instant = Clock.System.now(),
+) {
+    requireProfile(acceptedCertificatePolicyOids.isNotEmpty(), "Accepted RICAL certificate-policy OIDs are required")
+    requireProfile(acceptedCertificatePolicyOids.none(String::isBlank), "RICAL certificate-policy OIDs must not be blank")
+
+    val parsed = parseIsoCertificate(certificate, "RICAL signer certificate")
+    val data = parsed.data
+    val subjectPublicKey = data.subjectPublicKeyInfo
+
+    requireProfile(data.version == 3, "RICAL signer certificate must be X.509 version 3")
+    validateIsoCertificateSerialNumber(data.serialNumberRaw, "RICAL signer certificate")
+    requireProfile(
+        now >= data.validity.notBefore && now < data.validity.notAfter,
+        "RICAL signer certificate is not currently valid",
+    )
+    requireProfile(
+        data.validity.notAfter - data.validity.notBefore <= ISO_MAX_CERTIFICATE_VALIDITY,
+        "RICAL signer certificate validity exceeds 1 187 days",
+    )
+    requireProfile(
+        parsed.signatureAlgorithmOid in ISO_ALLOWED_CERTIFICATE_SIGNATURE_ALGORITHM_OIDS,
+        "RICAL signer certificate uses an unsupported certificate-signature algorithm",
+    )
+
+    val subject = DistinguishedName.ofString(data.subjectDn).rdnList.flatten()
+    requireSubjectValue(subject, COUNTRY_OID, "country")
+    requireSubjectValue(subject, ORGANIZATION_OID, "organization")
+    requireSubjectValue(subject, ISO_COMMON_NAME_OID, "common name")
+
+    requireProfile(
+        subjectPublicKey.algorithmOid == ISO_EC_PUBLIC_KEY_OID,
+        "RICAL signer certificate must use an elliptic-curve public key",
+    )
+    requireProfile(
+        subjectPublicKey.ellipticCurveOid in ISO_ALLOWED_ELLIPTIC_CURVE_OIDS,
+        "RICAL signer certificate uses an unsupported elliptic curve",
+    )
+    requireProfile(
+        subjectPublicKey.keyValueRaw.size > 0 &&
+            subjectPublicKey.keyValueRaw[0] == ISO_UNCOMPRESSED_EC_POINT_PREFIX,
+        "RICAL signer certificate EC public key must use uncompressed form",
+    )
+
+    val authorityKeyIdentifier = data.extensionAuthorityKeyIdentifier
+    requireProfile(
+        authorityKeyIdentifier != null &&
+            !authorityKeyIdentifier.critical &&
+            (authorityKeyIdentifier.keyIdentifier?.size ?: 0) > 0,
+        "RICAL signer certificate requires an authority key identifier",
+    )
+    val subjectKeyIdentifier = data.extensionSubjectKeyIdentifier
+    requireProfile(
+        subjectKeyIdentifier != null &&
+            !subjectKeyIdentifier.critical &&
+            subjectKeyIdentifier.keyIdentifier == subjectPublicKey.keyId,
+        "RICAL signer certificate requires the SHA-1 subject key identifier",
+    )
+
+    val keyUsage = data.extensionKeyUsage
+        ?: throw X509ValidationException("RICAL signer certificate requires key usage")
+    requireProfile(keyUsage.critical, "RICAL signer certificate key usage must be critical")
+    requireProfile(
+        keyUsage.keyPurposeIdList == setOf(KeyUsageExtension.KeyUsage.nonRepudiation),
+        "RICAL signer certificate key usage must contain only nonRepudiation",
+    )
+
+    val crlDistributionPoints = data.extensionCrlDistributionPoints
+        ?: throw X509ValidationException("RICAL signer certificate requires CRL distribution points")
+    requireProfile(
+        !crlDistributionPoints.critical && crlDistributionPoints.distributionPoints.isNotEmpty(),
+        "RICAL signer certificate requires non-critical CRL distribution points",
+    )
+    requireProfile(
+        crlDistributionPoints.distributionPoints.all { point ->
+            val fullNames = point.distributionPointFullName
+            point.reason == null &&
+                point.cRLIssuer == null &&
+                point.distributionPointNameRelativeToCrlIssuer == null &&
+                fullNames?.isNotEmpty() == true &&
+                fullNames.all { name ->
+                    name.type == GeneralName.NameType.uniformResourceIdentifier && name.value.isNotBlank()
+                }
+        },
+        "RICAL signer certificate CRL distribution points must contain only full-name URIs",
+    )
+
+    val certificatePolicies = data.extensions[CERTIFICATE_POLICIES_OID]
+        ?: throw X509ValidationException("RICAL signer certificate requires certificatePolicies")
+    requireProfile(!certificatePolicies.critical, "RICAL signer certificate policies must be non-critical")
+    requireProfile(
+        certificate.certificatePolicyOids().any(acceptedCertificatePolicyOids::contains),
+        "RICAL signer certificate does not contain an accepted certificate-policy OID",
+    )
+    data.extensions[AUTHORITY_INFORMATION_ACCESS_OID]?.let { extension ->
+        requireProfile(!extension.critical, "RICAL signer authority information access must be non-critical")
+    }
+
+    val unsupportedCritical = data.extensions.values
+        .filter { it.critical }
+        .map { it.oid }
+        .filterNot { it == KEY_USAGE_OID }
+    requireProfile(unsupportedCritical.isEmpty(), "RICAL signer certificate contains an unsupported critical extension")
+}
+
+/** Validates a RICAL signer path only to application-provisioned provider roots. */
+@Throws(X509ValidationException::class)
+fun validateRicalSignerCertificateChain(
+    leaf: CertificateDer,
+    chain: List<CertificateDer>,
+    trustAnchors: List<CertificateDer>,
+    now: Instant = Clock.System.now(),
+) {
+    requireProfile(trustAnchors.isNotEmpty(), "At least one explicit RICAL provider root is required")
+    requireProfile(
+        leaf !in trustAnchors && chain.none { it in trustAnchors },
+        "The RICAL protected x5chain must not carry its provider root",
+    )
+    validateCertificateChainWithExplicitTrust(
+        leaf = leaf,
+        chain = chain,
+        trustAnchors = trustAnchors,
+        enableTrustedChainRoot = false,
+        now = now,
+    )
+}
+
+private fun requireSubjectValue(
+    subject: List<id.walt.certificate.x509.dn.AttributeTypeAndValue>,
+    oid: String,
+    label: String,
+) {
+    requireProfile(
+        subject.count { it.type.oid == oid && it.value.isNotBlank() } == 1,
+        "RICAL signer certificate requires one $label",
+    )
+}
+
+private fun CertificateDer.certificatePolicyOids(): Set<String> {
+    val certificate = SignumX509Certificate.decodeFromByteArray(bytes.toByteArray())
+        ?: throw X509ValidationException("Invalid RICAL signer certificate")
+    val extension = certificate.tbsCertificate.extensions
+        ?.firstOrNull { it.oid == ObjectIdentifier(CERTIFICATE_POLICIES_OID) }
+        ?: return emptySet()
+    return runCatching {
+        Asn1Element.parse(extension.value.asOctetString().content)
+            .asSequence()
+            .children
+            .map { policyInformation ->
+                policyInformation.asSequence().children.first().asPrimitive().readOid().toString()
+            }
+            .toSet()
+    }.getOrElse { cause ->
+        throw X509ValidationException("Invalid RICAL signer certificatePolicies", cause)
+    }
+}
+
+private const val COUNTRY_OID = "2.5.4.6"
+private const val ORGANIZATION_OID = "2.5.4.10"
+private const val KEY_USAGE_OID = "2.5.29.15"
+private const val CERTIFICATE_POLICIES_OID = "2.5.29.32"
+private const val AUTHORITY_INFORMATION_ACCESS_OID = "1.3.6.1.5.5.7.1.1"

--- a/waltid-libraries/crypto/waltid-x509/src/commonTest/kotlin/id/walt/x509/IsoRicalSignerCertificateTest.kt
+++ b/waltid-libraries/crypto/waltid-x509/src/commonTest/kotlin/id/walt/x509/IsoRicalSignerCertificateTest.kt
@@ -1,0 +1,101 @@
+package id.walt.x509
+
+import kotlinx.io.bytestring.ByteString
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.time.Instant
+
+class IsoRicalSignerCertificateTest {
+    @Test
+    fun `ISO certificate serial numbers require a positive non-zero 63-bit value`() {
+        validateIsoCertificateSerialNumber(
+            ByteString(byteArrayOf(0x40, 0, 0, 0, 0, 0, 0, 0)),
+            "Test certificate",
+        )
+
+        listOf(
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0),
+            byteArrayOf(0, 0, 1, 0, 0, 0, 0, 0, 0),
+            byteArrayOf(0x80.toByte(), 0, 0, 0, 0, 0, 0, 0),
+        ).forEach { invalid ->
+            assertFailsWith<X509ValidationException> {
+                validateIsoCertificateSerialNumber(ByteString(invalid), "Test certificate")
+            }
+        }
+    }
+
+    @Test
+    fun `RICAL signer profile and path require accepted policy and explicit root`() {
+        validateRicalSignerCertificateProfile(
+            signer,
+            acceptedCertificatePolicyOids = setOf("1.2.3.4"),
+            now = Instant.parse("2026-09-01T00:00:00Z"),
+        )
+        validateRicalSignerCertificateChain(
+            leaf = signer,
+            chain = emptyList(),
+            trustAnchors = listOf(root),
+            now = Instant.parse("2026-09-01T00:00:00Z"),
+        )
+
+        assertFailsWith<X509ValidationException> {
+            validateRicalSignerCertificateProfile(
+                signer,
+                acceptedCertificatePolicyOids = setOf("1.2.3.5"),
+                now = Instant.parse("2026-09-01T00:00:00Z"),
+            )
+        }
+        assertFailsWith<X509ValidationException> {
+            validateRicalSignerCertificateChain(
+                leaf = signer,
+                chain = listOf(root),
+                trustAnchors = listOf(root),
+                now = Instant.parse("2026-09-01T00:00:00Z"),
+            )
+        }
+        assertFailsWith<X509ValidationException> {
+            validateRicalSignerCertificateChain(
+                leaf = root,
+                chain = emptyList(),
+                trustAnchors = listOf(root),
+                now = Instant.parse("2026-09-01T00:00:00Z"),
+            )
+        }
+    }
+
+    @Test
+    fun `expired RICAL signer is rejected`() {
+        assertFailsWith<X509ValidationException> {
+            validateRicalSignerCertificateProfile(
+                signer,
+                acceptedCertificatePolicyOids = setOf("1.2.3.4"),
+                now = Instant.parse("2026-10-01T00:00:00Z"),
+            )
+        }
+        assertFailsWith<X509ValidationException> {
+            validateRicalSignerCertificateProfile(
+                signer,
+                acceptedCertificatePolicyOids = setOf("1.2.3.4"),
+                now = Instant.parse("2026-09-29T20:42:06Z"),
+            )
+        }
+    }
+
+    private companion object {
+        @OptIn(ExperimentalEncodingApi::class)
+        val root = CertificateDer(
+            Base64.decode(
+                "MIIBjjCCATOgAwIBAgIIQAAAAAAAAAEwCgYIKoZIzj0EAwIwGjEYMBYGA1UEAwwPUklDQUwgVGVzdCBSb290MB4XDTI2MDgzMDIwNDIwNloXDTI3MDgzMDIwNDIwNlowGjEYMBYGA1UEAwwPUklDQUwgVGVzdCBSb290MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4Fc8ezWNtclkN8nWzjzYGxLUF0J6FO0r8pq5/YWiprJBGwTK0CIcesfDL+/pxMofjHC5p4TRlb4yuCg9XlIW46NjMGEwHwYDVR0jBBgwFoAU0wI39+8enyK9prUvHV4RWCaylxkwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFNMCN/fvHp8ivaa1Lx1eEVgmspcZMAoGCCqGSM49BAMCA0kAMEYCIQDYcsOwU11G+fme3xD2EgCgE45qXt3Rg8nhJY2IuA2+3QIhALVJKhK8NfsJMONZo8amHvX43b2PuSWhmB3DHufEOnE0"
+            )
+        )
+
+        @OptIn(ExperimentalEncodingApi::class)
+        val signer = CertificateDer(
+            Base64.decode(
+                "MIIB6zCCAZGgAwIBAgIIQAAAAAAAAAIwCgYIKoZIzj0EAwIwGjEYMBYGA1UEAwwPUklDQUwgVGVzdCBSb290MB4XDTI2MDgzMDIwNDIwNloXDTI2MDkyOTIwNDIwNlowSTELMAkGA1UEBhMCQVQxHjAcBgNVBAoMFXdhbHQuaWQgdGVzdCBmaXh0dXJlczEaMBgGA1UEAwwRUklDQUwgVGVzdCBTaWduZXIwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARtK4j0HidmssYZ3x9zeCEnQPrWct9tEeGqIrjLTJZomS7IbkM98UEC62dKFVWJi/AU+v7B2TamaU99V6Rem81No4GRMIGOMB0GA1UdDgQWBBSti6kphqKkS4k8rsZSMdVgQ2EhlzAfBgNVHSMEGDAWgBTTAjf37x6fIr2mtS8dXhFYJrKXGTAOBgNVHQ8BAf8EBAMCBkAwKgYDVR0fBCMwITAfoB2gG4YZaHR0cHM6Ly9yaWNhbC5leGFtcGxlL2NybDAQBgNVHSAECTAHMAUGAyoDBDAKBggqhkjOPQQDAgNIADBFAiEAkI4lWDQLobERLUoD9MjRf11cab4NLjcG8J1kZYwNxAYCIGGlfeY9tsoOj1GAfPJcd6QEB0LaySFQubeImAxEaARY"
+            )
+        )
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/README.md
@@ -174,6 +174,38 @@ Multiple reader-authentication statements retain their independent
 `authenticationIndex`, and holder-key authorization is reported per document
 request so mixed signature/MAC responses cannot be collapsed into one prompt.
 
+Reader authentication validity does not establish reader trust. To require a
+trusted reader, provision Reader CA certificates out of band and pass the shared
+evaluator explicitly:
+
+```kotlin
+val readerTrust = MobileWalletProximityConfiguredReaderTrustEvaluator(
+    MobileWalletProximityReaderTrustConfiguration(
+        trustAnchors = listOf(
+            MobileWalletProximityReaderTrustAnchor(
+                certificateDerBase64Url = readerCaDerBase64Url,
+                displayName = "Example reader authority",
+            )
+        ),
+        revocationPolicy = MobileWalletProximityReaderRevocationPolicy.Check(
+            applicationRevocationEvaluator
+        ),
+    )
+)
+val configuration = MobileWalletProximityConfiguration(
+    readerPolicy = MobileWalletProximityReaderPolicy.RequireTrusted,
+    readerTrustEvaluator = readerTrust,
+)
+```
+
+The SDK performs certificate profile, time, and explicit-anchor path validation,
+but performs no hidden network lookup and ships no reader trust list. A root sent
+by the reader is only path evidence; it is never trusted unless the application
+provisioned the same certificate. Optional RICAL providers use separate explicit
+provider roots, signer policy, revocation, and constraint boundaries. Demo apps
+can pass a named test anchor through the same configuration constructor, but
+test anchors must not become production defaults.
+
 Only one proximity session may be active per wallet. Always call `close()` when
 the journey leaves the screen; closing and cancellation are idempotent and every
 new session creates fresh engagement identifiers and ephemeral key material.

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/api/waltid-openid4vc-wallet-mobile.klib.api
@@ -424,6 +424,7 @@ final enum class id.walt.wallet2.mobile/MobileWalletProximityReaderAuthenticatio
 final enum class id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState : kotlin/Enum<id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState> { // id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState|null[0]
     enum entry Invalid // id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState.Invalid|null[0]
     enum entry NotEvaluated // id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState.NotEvaluated|null[0]
+    enum entry UnknownAuthority // id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState.UnknownAuthority|null[0]
     enum entry Valid // id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState.Valid|null[0]
 
     final val entries // id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState.entries|#static{}entries[0]
@@ -514,8 +515,24 @@ abstract fun interface id.walt.wallet2.mobile/MobileWalletProximityCredentialSta
     abstract suspend fun evaluate(id.walt.wallet2.mobile/MobileWalletProximityCredentialStatusInput): id.walt.wallet2.mobile/MobileWalletProximityCredentialStatus // id.walt.wallet2.mobile/MobileWalletProximityCredentialStatusEvaluator.evaluate|evaluate(id.walt.wallet2.mobile.MobileWalletProximityCredentialStatusInput){}[0]
 }
 
+abstract fun interface id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationEvaluator { // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationEvaluator|null[0]
+    abstract suspend fun evaluate(id.walt.wallet2.mobile/MobileWalletProximityReaderEvidence): id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationEvaluator.evaluate|evaluate(id.walt.wallet2.mobile.MobileWalletProximityReaderEvidence){}[0]
+}
+
 abstract fun interface id.walt.wallet2.mobile/MobileWalletProximityReaderTrustEvaluator { // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustEvaluator|null[0]
     abstract suspend fun evaluate(id.walt.wallet2.mobile/MobileWalletProximityReaderEvidence): id.walt.wallet2.mobile/MobileWalletProximityReaderTrustDecision // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustEvaluator.evaluate|evaluate(id.walt.wallet2.mobile.MobileWalletProximityReaderEvidence){}[0]
+}
+
+abstract fun interface id.walt.wallet2.mobile/MobileWalletProximityRicalConstraintEvaluator { // id.walt.wallet2.mobile/MobileWalletProximityRicalConstraintEvaluator|null[0]
+    abstract suspend fun accepts(kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint>, id.walt.wallet2.mobile/MobileWalletProximityReaderEvidence): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalConstraintEvaluator.accepts|accepts(kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityRicalTrustConstraint>;id.walt.wallet2.mobile.MobileWalletProximityReaderEvidence){}[0]
+}
+
+abstract fun interface id.walt.wallet2.mobile/MobileWalletProximityRicalProvider { // id.walt.wallet2.mobile/MobileWalletProximityRicalProvider|null[0]
+    abstract suspend fun current(): id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult // id.walt.wallet2.mobile/MobileWalletProximityRicalProvider.current|current(){}[0]
+}
+
+abstract fun interface id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationEvaluator { // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationEvaluator|null[0]
+    abstract suspend fun evaluate(id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence): id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationEvaluator.evaluate|evaluate(id.walt.wallet2.mobile.MobileWalletProximityRicalSignerEvidence){}[0]
 }
 
 abstract fun interface id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator { // id.walt.wallet2.mobile/MobileWalletReaderTrustEvaluator|null[0]
@@ -884,6 +901,40 @@ sealed interface id.walt.wallet2.mobile/MobileWalletProximityApplicationProfileR
     }
 }
 
+sealed interface id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult { // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult|null[0]
+    final class Indeterminate : id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult { // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate|null[0]
+        constructor <init>(kotlin/String) // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.<init>|<init>(kotlin.String){}[0]
+
+        final val reason // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.reason|{}reason[0]
+            final fun <get-reason>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.reason.<get-reason>|<get-reason>(){}[0]
+
+        final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Indeterminate.toString|toString(){}[0]
+    }
+
+    final class Revoked : id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult { // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked|null[0]
+        constructor <init>(kotlin/String? = ...) // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.<init>|<init>(kotlin.String?){}[0]
+
+        final val reason // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.reason|{}reason[0]
+            final fun <get-reason>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.reason.<get-reason>|<get-reason>(){}[0]
+
+        final fun component1(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.component1|component1(){}[0]
+        final fun copy(kotlin/String? = ...): id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.copy|copy(kotlin.String?){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Revoked.toString|toString(){}[0]
+    }
+
+    final object Good : id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult { // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Good|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Good.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Good.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityCertificateRevocationResult.Good.toString|toString(){}[0]
+    }
+}
+
 sealed interface id.walt.wallet2.mobile/MobileWalletProximityEngagement { // id.walt.wallet2.mobile/MobileWalletProximityEngagement|null[0]
     final class Qr : id.walt.wallet2.mobile/MobileWalletProximityEngagement { // id.walt.wallet2.mobile/MobileWalletProximityEngagement.Qr|null[0]
         constructor <init>(kotlin/String) // id.walt.wallet2.mobile/MobileWalletProximityEngagement.Qr.<init>|<init>(kotlin.String){}[0]
@@ -902,6 +953,89 @@ sealed interface id.walt.wallet2.mobile/MobileWalletProximityEngagement { // id.
         final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityEngagement.Nfc.equals|equals(kotlin.Any?){}[0]
         final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityEngagement.Nfc.hashCode|hashCode(){}[0]
         final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityEngagement.Nfc.toString|toString(){}[0]
+    }
+}
+
+sealed interface id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy { // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy|null[0]
+    final class Check : id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy { // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check|null[0]
+        constructor <init>(id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationEvaluator) // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.<init>|<init>(id.walt.wallet2.mobile.MobileWalletProximityReaderRevocationEvaluator){}[0]
+
+        final val evaluator // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.evaluator|{}evaluator[0]
+            final fun <get-evaluator>(): id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationEvaluator // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.evaluator.<get-evaluator>|<get-evaluator>(){}[0]
+
+        final fun component1(): id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationEvaluator // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.component1|component1(){}[0]
+        final fun copy(id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationEvaluator = ...): id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.copy|copy(id.walt.wallet2.mobile.MobileWalletProximityReaderRevocationEvaluator){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.Check.toString|toString(){}[0]
+    }
+
+    final object NotChecked : id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy { // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.NotChecked|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.NotChecked.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.NotChecked.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy.NotChecked.toString|toString(){}[0]
+    }
+}
+
+sealed interface id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult { // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult|null[0]
+    final class Available : id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult { // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available|null[0]
+        constructor <init>(kotlin/String) // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.<init>|<init>(kotlin.String){}[0]
+
+        final val signedRicalBase64Url // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.signedRicalBase64Url|{}signedRicalBase64Url[0]
+            final fun <get-signedRicalBase64Url>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.signedRicalBase64Url.<get-signedRicalBase64Url>|<get-signedRicalBase64Url>(){}[0]
+
+        final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Available.toString|toString(){}[0]
+    }
+
+    final class Conflict : id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult { // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict|null[0]
+        constructor <init>(kotlin/String) // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.<init>|<init>(kotlin.String){}[0]
+
+        final val reason // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.reason|{}reason[0]
+            final fun <get-reason>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.reason.<get-reason>|<get-reason>(){}[0]
+
+        final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Conflict.toString|toString(){}[0]
+    }
+
+    final class Unavailable : id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult { // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable|null[0]
+        constructor <init>(kotlin/String) // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.<init>|<init>(kotlin.String){}[0]
+
+        final val reason // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.reason|{}reason[0]
+            final fun <get-reason>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.reason.<get-reason>|<get-reason>(){}[0]
+
+        final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.component1|component1(){}[0]
+        final fun copy(kotlin/String = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.copy|copy(kotlin.String){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderResult.Unavailable.toString|toString(){}[0]
+    }
+}
+
+sealed interface id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy { // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy|null[0]
+    final class Check : id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy { // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check|null[0]
+        constructor <init>(id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationEvaluator) // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.<init>|<init>(id.walt.wallet2.mobile.MobileWalletProximityRicalSignerRevocationEvaluator){}[0]
+
+        final val evaluator // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.evaluator|{}evaluator[0]
+            final fun <get-evaluator>(): id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationEvaluator // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.evaluator.<get-evaluator>|<get-evaluator>(){}[0]
+
+        final fun component1(): id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationEvaluator // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.component1|component1(){}[0]
+        final fun copy(id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationEvaluator = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.copy|copy(id.walt.wallet2.mobile.MobileWalletProximityRicalSignerRevocationEvaluator){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.Check.toString|toString(){}[0]
+    }
+
+    final object NotChecked : id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy { // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.NotChecked|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.NotChecked.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.NotChecked.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy.NotChecked.toString|toString(){}[0]
     }
 }
 
@@ -2557,6 +2691,15 @@ final class id.walt.wallet2.mobile/MobileWalletProximityConfiguration { // id.wa
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityConfiguration.toString|toString(){}[0]
 }
 
+final class id.walt.wallet2.mobile/MobileWalletProximityConfiguredReaderTrustEvaluator : id.walt.wallet2.mobile/MobileWalletProximityReaderTrustEvaluator { // id.walt.wallet2.mobile/MobileWalletProximityConfiguredReaderTrustEvaluator|null[0]
+    constructor <init>(id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration) // id.walt.wallet2.mobile/MobileWalletProximityConfiguredReaderTrustEvaluator.<init>|<init>(id.walt.wallet2.mobile.MobileWalletProximityReaderTrustConfiguration){}[0]
+
+    final val configuration // id.walt.wallet2.mobile/MobileWalletProximityConfiguredReaderTrustEvaluator.configuration|{}configuration[0]
+        final fun <get-configuration>(): id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration // id.walt.wallet2.mobile/MobileWalletProximityConfiguredReaderTrustEvaluator.configuration.<get-configuration>|<get-configuration>(){}[0]
+
+    final suspend fun evaluate(id.walt.wallet2.mobile/MobileWalletProximityReaderEvidence): id.walt.wallet2.mobile/MobileWalletProximityReaderTrustDecision // id.walt.wallet2.mobile/MobileWalletProximityConfiguredReaderTrustEvaluator.evaluate|evaluate(id.walt.wallet2.mobile.MobileWalletProximityReaderEvidence){}[0]
+}
+
 final class id.walt.wallet2.mobile/MobileWalletProximityCredentialOption { // id.walt.wallet2.mobile/MobileWalletProximityCredentialOption|null[0]
     constructor <init>(kotlin/String, kotlin/String?, kotlin/String?, kotlin.time/Instant, id.walt.wallet2.mobile/MobileWalletProximityDeviceAuthenticationMethod, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRequestedElement>) // id.walt.wallet2.mobile/MobileWalletProximityCredentialOption.<init>|<init>(kotlin.String;kotlin.String?;kotlin.String?;kotlin.time.Instant;id.walt.wallet2.mobile.MobileWalletProximityDeviceAuthenticationMethod;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityRequestedElement>){}[0]
 
@@ -2824,6 +2967,41 @@ final class id.walt.wallet2.mobile/MobileWalletProximityReaderEvidence { // id.w
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReaderEvidence.toString|toString(){}[0]
 }
 
+final class id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor { // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor|null[0]
+    constructor <init>(kotlin/String, kotlin/String? = ...) // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.<init>|<init>(kotlin.String;kotlin.String?){}[0]
+
+    final val certificateDerBase64Url // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.certificateDerBase64Url|{}certificateDerBase64Url[0]
+        final fun <get-certificateDerBase64Url>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.certificateDerBase64Url.<get-certificateDerBase64Url>|<get-certificateDerBase64Url>(){}[0]
+    final val displayName // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.displayName|{}displayName[0]
+        final fun <get-displayName>(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.displayName.<get-displayName>|<get-displayName>(){}[0]
+
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String? = ...): id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.copy|copy(kotlin.String;kotlin.String?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration { // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration|null[0]
+    constructor <init>(kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration> = ..., id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy = ...) // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.<init>|<init>(kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityReaderTrustAnchor>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityRicalConfiguration>;id.walt.wallet2.mobile.MobileWalletProximityReaderRevocationPolicy){}[0]
+
+    final val revocationPolicy // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.revocationPolicy|{}revocationPolicy[0]
+        final fun <get-revocationPolicy>(): id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.revocationPolicy.<get-revocationPolicy>|<get-revocationPolicy>(){}[0]
+    final val ricalProviders // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.ricalProviders|{}ricalProviders[0]
+        final fun <get-ricalProviders>(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration> // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.ricalProviders.<get-ricalProviders>|<get-ricalProviders>(){}[0]
+    final val trustAnchors // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.trustAnchors|{}trustAnchors[0]
+        final fun <get-trustAnchors>(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor> // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.trustAnchors.<get-trustAnchors>|<get-trustAnchors>(){}[0]
+
+    final fun component1(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor> // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration> // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.component2|component2(){}[0]
+    final fun component3(): id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.component3|component3(){}[0]
+    final fun copy(kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityReaderTrustAnchor> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration> = ..., id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationPolicy = ...): id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.copy|copy(kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityReaderTrustAnchor>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityRicalConfiguration>;id.walt.wallet2.mobile.MobileWalletProximityReaderRevocationPolicy){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustConfiguration.toString|toString(){}[0]
+}
+
 final class id.walt.wallet2.mobile/MobileWalletProximityReaderTrustDecision { // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustDecision|null[0]
     constructor <init>(id.walt.wallet2.mobile/MobileWalletProximityReaderTrustState, id.walt.wallet2.mobile/MobileWalletProximityReaderCertificatePathState = ..., id.walt.wallet2.mobile/MobileWalletProximityReaderRevocationState = ..., id.walt.wallet2.mobile/MobileWalletProximityRicalState = ..., kotlin/String? = ..., kotlin/String? = ...) // id.walt.wallet2.mobile/MobileWalletProximityReaderTrustDecision.<init>|<init>(id.walt.wallet2.mobile.MobileWalletProximityReaderTrustState;id.walt.wallet2.mobile.MobileWalletProximityReaderCertificatePathState;id.walt.wallet2.mobile.MobileWalletProximityReaderRevocationState;id.walt.wallet2.mobile.MobileWalletProximityRicalState;kotlin.String?;kotlin.String?){}[0]
 
@@ -2897,6 +3075,82 @@ final class id.walt.wallet2.mobile/MobileWalletProximityReview { // id.walt.wall
     final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityReview.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityReview.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityReview.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration { // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/Set<kotlin/String>, kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor>, kotlin.collections/Set<kotlin/String>, id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy = ..., kotlin/Boolean = ..., id.walt.wallet2.mobile/MobileWalletProximityRicalProvider, id.walt.wallet2.mobile/MobileWalletProximityRicalConstraintEvaluator? = ...) // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.<init>|<init>(kotlin.String;kotlin.collections.Set<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityRicalProviderTrustAnchor>;kotlin.collections.Set<kotlin.String>;id.walt.wallet2.mobile.MobileWalletProximityRicalSignerRevocationPolicy;kotlin.Boolean;id.walt.wallet2.mobile.MobileWalletProximityRicalProvider;id.walt.wallet2.mobile.MobileWalletProximityRicalConstraintEvaluator?){}[0]
+
+    final val acceptedSignerCertificatePolicyOids // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.acceptedSignerCertificatePolicyOids|{}acceptedSignerCertificatePolicyOids[0]
+        final fun <get-acceptedSignerCertificatePolicyOids>(): kotlin.collections/Set<kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.acceptedSignerCertificatePolicyOids.<get-acceptedSignerCertificatePolicyOids>|<get-acceptedSignerCertificatePolicyOids>(){}[0]
+    final val acceptedTypes // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.acceptedTypes|{}acceptedTypes[0]
+        final fun <get-acceptedTypes>(): kotlin.collections/Set<kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.acceptedTypes.<get-acceptedTypes>|<get-acceptedTypes>(){}[0]
+    final val constraintEvaluator // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.constraintEvaluator|{}constraintEvaluator[0]
+        final fun <get-constraintEvaluator>(): id.walt.wallet2.mobile/MobileWalletProximityRicalConstraintEvaluator? // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.constraintEvaluator.<get-constraintEvaluator>|<get-constraintEvaluator>(){}[0]
+    final val establishReaderTrust // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.establishReaderTrust|{}establishReaderTrust[0]
+        final fun <get-establishReaderTrust>(): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.establishReaderTrust.<get-establishReaderTrust>|<get-establishReaderTrust>(){}[0]
+    final val provider // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.provider|{}provider[0]
+        final fun <get-provider>(): id.walt.wallet2.mobile/MobileWalletProximityRicalProvider // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.provider.<get-provider>|<get-provider>(){}[0]
+    final val providerId // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.providerId|{}providerId[0]
+        final fun <get-providerId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.providerId.<get-providerId>|<get-providerId>(){}[0]
+    final val providerTrustAnchors // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.providerTrustAnchors|{}providerTrustAnchors[0]
+        final fun <get-providerTrustAnchors>(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor> // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.providerTrustAnchors.<get-providerTrustAnchors>|<get-providerTrustAnchors>(){}[0]
+    final val signerRevocationPolicy // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.signerRevocationPolicy|{}signerRevocationPolicy[0]
+        final fun <get-signerRevocationPolicy>(): id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.signerRevocationPolicy.<get-signerRevocationPolicy>|<get-signerRevocationPolicy>(){}[0]
+
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Set<kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor> // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Set<kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component4|component4(){}[0]
+    final fun component5(): id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component5|component5(){}[0]
+    final fun component6(): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component6|component6(){}[0]
+    final fun component7(): id.walt.wallet2.mobile/MobileWalletProximityRicalProvider // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component7|component7(){}[0]
+    final fun component8(): id.walt.wallet2.mobile/MobileWalletProximityRicalConstraintEvaluator? // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.component8|component8(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/Set<kotlin/String> = ..., kotlin.collections/List<id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor> = ..., kotlin.collections/Set<kotlin/String> = ..., id.walt.wallet2.mobile/MobileWalletProximityRicalSignerRevocationPolicy = ..., kotlin/Boolean = ..., id.walt.wallet2.mobile/MobileWalletProximityRicalProvider = ..., id.walt.wallet2.mobile/MobileWalletProximityRicalConstraintEvaluator? = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.copy|copy(kotlin.String;kotlin.collections.Set<kotlin.String>;kotlin.collections.List<id.walt.wallet2.mobile.MobileWalletProximityRicalProviderTrustAnchor>;kotlin.collections.Set<kotlin.String>;id.walt.wallet2.mobile.MobileWalletProximityRicalSignerRevocationPolicy;kotlin.Boolean;id.walt.wallet2.mobile.MobileWalletProximityRicalProvider;id.walt.wallet2.mobile.MobileWalletProximityRicalConstraintEvaluator?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalConfiguration.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor { // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor|null[0]
+    constructor <init>(kotlin/String) // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.<init>|<init>(kotlin.String){}[0]
+
+    final val certificateDerBase64Url // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.certificateDerBase64Url|{}certificateDerBase64Url[0]
+        final fun <get-certificateDerBase64Url>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.certificateDerBase64Url.<get-certificateDerBase64Url>|<get-certificateDerBase64Url>(){}[0]
+
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.component1|component1(){}[0]
+    final fun copy(kotlin/String = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.copy|copy(kotlin.String){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalProviderTrustAnchor.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence { // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence|null[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>) // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+
+    final val certificateChainDerBase64Url // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.certificateChainDerBase64Url|{}certificateChainDerBase64Url[0]
+        final fun <get-certificateChainDerBase64Url>(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.certificateChainDerBase64Url.<get-certificateChainDerBase64Url>|<get-certificateChainDerBase64Url>(){}[0]
+    final val providerId // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.providerId|{}providerId[0]
+        final fun <get-providerId>(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.providerId.<get-providerId>|<get-providerId>(){}[0]
+
+    final fun component1(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<kotlin/String> = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.copy|copy(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalSignerEvidence.toString|toString(){}[0]
+}
+
+final class id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint { // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint|null[0]
+    constructor <init>(kotlin.collections/Map<kotlin/String, kotlin/String>) // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.<init>|<init>(kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+
+    final val valuesCborBase64Url // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.valuesCborBase64Url|{}valuesCborBase64Url[0]
+        final fun <get-valuesCborBase64Url>(): kotlin.collections/Map<kotlin/String, kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.valuesCborBase64Url.<get-valuesCborBase64Url>|<get-valuesCborBase64Url>(){}[0]
+
+    final fun component1(): kotlin.collections/Map<kotlin/String, kotlin/String> // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.component1|component1(){}[0]
+    final fun copy(kotlin.collections/Map<kotlin/String, kotlin/String> = ...): id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.copy|copy(kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // id.walt.wallet2.mobile/MobileWalletProximityRicalTrustConstraint.toString|toString(){}[0]
 }
 
 final class id.walt.wallet2.mobile/MobileWalletProximitySubmission { // id.walt.wallet2.mobile/MobileWalletProximitySubmission|null[0]

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletProximityModels.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletProximityModels.kt
@@ -292,6 +292,7 @@ public enum class MobileWalletProximityReaderTrustState {
 /** Result of validating the reader certificate path against explicitly configured trust material. */
 public enum class MobileWalletProximityReaderCertificatePathState {
     NotEvaluated,
+    UnknownAuthority,
     Invalid,
     Valid,
 }
@@ -364,27 +365,9 @@ public data class MobileWalletProximityReaderTrustDecision(
     public val reason: String? = null,
 ) {
     init {
-        require(state != MobileWalletProximityReaderTrustState.NotEvaluated) {
-            "A trust evaluator must return an evaluated trust state"
-        }
         require(displayName == null || displayName.isNotBlank())
         require(reason == null || reason.isNotBlank())
-        require(state != MobileWalletProximityReaderTrustState.Revoked ||
-            revocation == MobileWalletProximityReaderRevocationState.Revoked) {
-            "A revoked trust decision requires a revoked certificate result"
-        }
-        require(revocation != MobileWalletProximityReaderRevocationState.Revoked ||
-            state == MobileWalletProximityReaderTrustState.Revoked) {
-            "A revoked certificate result requires a revoked trust decision"
-        }
-        require(state != MobileWalletProximityReaderTrustState.Trusted ||
-            certificatePath == MobileWalletProximityReaderCertificatePathState.Valid) {
-            "A trusted reader requires a valid certificate path"
-        }
-        require(state != MobileWalletProximityReaderTrustState.Trusted ||
-            revocation != MobileWalletProximityReaderRevocationState.Indeterminate) {
-            "A reader with indeterminate revocation status cannot be trusted"
-        }
+        validateReaderTrustFacts(state, certificatePath, revocation, rical)
     }
 }
 
@@ -459,18 +442,58 @@ public data class MobileWalletProximityReaderAuthentication(
             rical == MobileWalletProximityRicalState.NotEvaluated) {
             "RICAL cannot be evaluated before reader authentication is valid"
         }
-        require(
-            trust != MobileWalletProximityReaderTrustState.Revoked ||
-                revocation == MobileWalletProximityReaderRevocationState.Revoked
-        )
-        require(
-            revocation != MobileWalletProximityReaderRevocationState.Revoked ||
-                trust == MobileWalletProximityReaderTrustState.Revoked
-        )
-        require(
-            trust != MobileWalletProximityReaderTrustState.Trusted ||
-                certificatePath == MobileWalletProximityReaderCertificatePathState.Valid
-        )
+        require(displayName == null || displayName.isNotBlank())
+        require(reason == null || reason.isNotBlank())
+        if (validity == MobileWalletProximityReaderAuthenticationValidity.Valid) {
+            validateReaderTrustFacts(trust, certificatePath, revocation, rical)
+        }
+    }
+}
+
+private fun validateReaderTrustFacts(
+    state: MobileWalletProximityReaderTrustState,
+    certificatePath: MobileWalletProximityReaderCertificatePathState,
+    revocation: MobileWalletProximityReaderRevocationState,
+    rical: MobileWalletProximityRicalState,
+) {
+    require(state != MobileWalletProximityReaderTrustState.NotEvaluated) {
+        "Valid reader authentication requires an evaluated trust state"
+    }
+    require(state != MobileWalletProximityReaderTrustState.Revoked ||
+        revocation == MobileWalletProximityReaderRevocationState.Revoked) {
+        "A revoked trust decision requires a revoked certificate result"
+    }
+    require(revocation != MobileWalletProximityReaderRevocationState.Revoked ||
+        state == MobileWalletProximityReaderTrustState.Revoked) {
+        "A revoked certificate result requires a revoked trust decision"
+    }
+    require(state != MobileWalletProximityReaderTrustState.Trusted ||
+        certificatePath == MobileWalletProximityReaderCertificatePathState.Valid) {
+        "A trusted reader requires a valid certificate path"
+    }
+    require(state != MobileWalletProximityReaderTrustState.Revoked ||
+        certificatePath == MobileWalletProximityReaderCertificatePathState.Valid) {
+        "A revoked reader requires a valid certificate path"
+    }
+    require(certificatePath != MobileWalletProximityReaderCertificatePathState.UnknownAuthority ||
+        state == MobileWalletProximityReaderTrustState.ValidButUntrusted) {
+        "An unknown reader authority must remain valid but untrusted"
+    }
+    require(certificatePath != MobileWalletProximityReaderCertificatePathState.Invalid ||
+        state == MobileWalletProximityReaderTrustState.ValidButUntrusted) {
+        "An invalid reader path must remain valid but untrusted"
+    }
+    require(certificatePath != MobileWalletProximityReaderCertificatePathState.Invalid ||
+        revocation == MobileWalletProximityReaderRevocationState.NotChecked) {
+        "Revocation cannot be evaluated for an invalid reader path"
+    }
+    require(state != MobileWalletProximityReaderTrustState.Trusted ||
+        revocation != MobileWalletProximityReaderRevocationState.Indeterminate) {
+        "A reader with indeterminate revocation status cannot be trusted"
+    }
+    require(rical != MobileWalletProximityRicalState.Matched ||
+        certificatePath == MobileWalletProximityReaderCertificatePathState.Valid) {
+        "A matching RICAL authority requires a valid reader path"
     }
 }
 

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletProximityReaderTrust.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletProximityReaderTrust.kt
@@ -51,16 +51,20 @@ public sealed interface MobileWalletProximityCertificateRevocationResult {
     public data object Good : MobileWalletProximityCertificateRevocationResult
 
     /** The configured source established that the certificate is revoked. */
-    public data class Revoked(public val reason: String? = null) :
-        MobileWalletProximityCertificateRevocationResult {
+    public data class Revoked(
+        /** Optional display-safe reason supplied by the configured revocation source. */
+        public val reason: String? = null,
+    ) : MobileWalletProximityCertificateRevocationResult {
         init {
             require(reason == null || reason.isNotBlank())
         }
     }
 
     /** The configured source could not establish current revocation status. */
-    public data class Indeterminate(public val reason: String) :
-        MobileWalletProximityCertificateRevocationResult {
+    public data class Indeterminate(
+        /** Display-safe reason why current revocation status could not be established. */
+        public val reason: String,
+    ) : MobileWalletProximityCertificateRevocationResult {
         init {
             require(reason.isNotBlank())
         }
@@ -82,12 +86,14 @@ public sealed interface MobileWalletProximityReaderRevocationPolicy {
 
     /** Require the supplied source to return a conclusive result before the reader can be trusted. */
     public data class Check(
+        /** Application-owned reader-certificate revocation source. */
         public val evaluator: MobileWalletProximityReaderRevocationEvaluator,
     ) : MobileWalletProximityReaderRevocationPolicy
 }
 
 /** Exact RICAL signer evidence passed to an application-owned revocation source. */
 public data class MobileWalletProximityRicalSignerEvidence(
+    /** Stable application-configured identifier for the RICAL provider. */
     public val providerId: String,
     /** DER certificates in leaf-first order, encoded as unpadded Base64URL. */
     public val certificateChainDerBase64Url: List<String>,
@@ -101,6 +107,7 @@ public data class MobileWalletProximityRicalSignerEvidence(
 
 /** Explicit application boundary for RICAL-signer OCSP, CRL, or another status source. */
 public fun interface MobileWalletProximityRicalSignerRevocationEvaluator {
+    /** Evaluates the verified signer chain for the selected RICAL provider. */
     public suspend fun evaluate(
         evidence: MobileWalletProximityRicalSignerEvidence,
     ): MobileWalletProximityCertificateRevocationResult
@@ -113,6 +120,7 @@ public sealed interface MobileWalletProximityRicalSignerRevocationPolicy {
 
     /** Require the supplied source to establish that the RICAL signer is not revoked. */
     public data class Check(
+        /** Application-owned RICAL-signer revocation source. */
         public val evaluator: MobileWalletProximityRicalSignerRevocationEvaluator,
     ) : MobileWalletProximityRicalSignerRevocationPolicy
 }
@@ -132,24 +140,30 @@ public data class MobileWalletProximityRicalProviderTrustAnchor(
 /** Exact active RICAL supplied by an application-owned provider boundary. */
 public sealed interface MobileWalletProximityRicalProviderResult {
     /** Untagged COSE_Sign1 bytes encoded as unpadded Base64URL. */
-    public data class Available(public val signedRicalBase64Url: String) :
-        MobileWalletProximityRicalProviderResult {
+    public data class Available(
+        /** Untagged COSE_Sign1 bytes encoded as unpadded Base64URL. */
+        public val signedRicalBase64Url: String,
+    ) : MobileWalletProximityRicalProviderResult {
         init {
             require(signedRicalBase64Url.isTrustBase64Url())
         }
     }
 
     /** No active list is available. */
-    public data class Unavailable(public val reason: String) :
-        MobileWalletProximityRicalProviderResult {
+    public data class Unavailable(
+        /** Display-safe reason why the provider has no active list. */
+        public val reason: String,
+    ) : MobileWalletProximityRicalProviderResult {
         init {
             require(reason.isNotBlank())
         }
     }
 
     /** The application detected conflicting active list state. */
-    public data class Conflict(public val reason: String) :
-        MobileWalletProximityRicalProviderResult {
+    public data class Conflict(
+        /** Display-safe description of the conflicting provider state. */
+        public val reason: String,
+    ) : MobileWalletProximityRicalProviderResult {
         init {
             require(reason.isNotBlank())
         }
@@ -158,11 +172,13 @@ public sealed interface MobileWalletProximityRicalProviderResult {
 
 /** Supplies the latest application-selected RICAL without an implicit SDK network request. */
 public fun interface MobileWalletProximityRicalProvider {
+    /** Returns the application's current provider result for this evaluation. */
     public suspend fun current(): MobileWalletProximityRicalProviderResult
 }
 
 /** One RICAL trust constraint, with each value CBOR-encoded as unpadded Base64URL. */
 public data class MobileWalletProximityRicalTrustConstraint(
+    /** Constraint name to its CBOR-encoded value, using unpadded Base64URL. */
     public val valuesCborBase64Url: Map<String, String>,
 ) {
     init {
@@ -183,13 +199,20 @@ public fun interface MobileWalletProximityRicalConstraintEvaluator {
 
 /** Immutable policy for one explicitly configured RICAL provider. */
 public data class MobileWalletProximityRicalConfiguration(
+    /** Stable application-configured provider identifier. */
     public val providerId: String,
+    /** RICAL type identifiers accepted from this provider. */
     public val acceptedTypes: Set<String>,
+    /** Explicit X.509 trust anchors accepted for this provider's signer. */
     public val providerTrustAnchors: List<MobileWalletProximityRicalProviderTrustAnchor>,
+    /** Certificate-policy OIDs accepted on this provider's signer certificate. */
     public val acceptedSignerCertificatePolicyOids: Set<String>,
+    /** Revocation behavior for this provider's verified signer certificate. */
     public val signerRevocationPolicy: MobileWalletProximityRicalSignerRevocationPolicy =
         MobileWalletProximityRicalSignerRevocationPolicy.NotChecked,
+    /** Whether an accepted matching authority may establish product reader trust. */
     public val establishReaderTrust: Boolean = false,
+    /** Application-owned source of the current signed RICAL. */
     public val provider: MobileWalletProximityRicalProvider,
     /** Null rejects any non-empty, ecosystem-specific constraint as unsupported. */
     public val constraintEvaluator: MobileWalletProximityRicalConstraintEvaluator? = null,
@@ -216,8 +239,11 @@ public data class MobileWalletProximityRicalConfiguration(
  * RICAL providers are evaluated in configured order; the first matching authority owns the result.
  */
 public data class MobileWalletProximityReaderTrustConfiguration(
+    /** Explicit application-provisioned Reader CA trust anchors. */
     public val trustAnchors: List<MobileWalletProximityReaderTrustAnchor> = emptyList(),
+    /** Ordered application-configured RICAL provider policies. */
     public val ricalProviders: List<MobileWalletProximityRicalConfiguration> = emptyList(),
+    /** Revocation behavior for a reader chain trusted by a direct Reader CA anchor. */
     public val revocationPolicy: MobileWalletProximityReaderRevocationPolicy =
         MobileWalletProximityReaderRevocationPolicy.NotChecked,
 ) {
@@ -236,6 +262,7 @@ public data class MobileWalletProximityReaderTrustConfiguration(
 
 /** Shared standards-profile, path, revocation, RICAL, and product-trust evaluator. */
 public class MobileWalletProximityConfiguredReaderTrustEvaluator internal constructor(
+    /** Immutable application-provisioned trust policy evaluated by this instance. */
     public val configuration: MobileWalletProximityReaderTrustConfiguration,
     private val now: () -> Instant,
 ) : MobileWalletProximityReaderTrustEvaluator {

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletProximityReaderTrust.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonMain/kotlin/id/walt/wallet2/mobile/MobileWalletProximityReaderTrust.kt
@@ -1,0 +1,551 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package id.walt.wallet2.mobile
+
+import id.walt.cose.coseCompliantCbor
+import id.walt.certificate.x509.X509CertificateUtil
+import id.walt.mdoc.proximity.ImmutableBytes
+import id.walt.mdoc.proximity.ReaderAuthenticationEvidence
+import id.walt.mdoc.proximity.ReaderTrustState
+import id.walt.mdoc.proximity.RicalConstraintEvaluator
+import id.walt.mdoc.proximity.RicalEvaluationState
+import id.walt.mdoc.proximity.RicalPolicy
+import id.walt.mdoc.proximity.RicalProvider
+import id.walt.mdoc.proximity.RicalProviderResult
+import id.walt.mdoc.proximity.RicalReaderTrustEvaluator
+import id.walt.mdoc.proximity.RicalSignatureValidator
+import id.walt.mdoc.proximity.RicalTrustConstraint
+import id.walt.mdoc.proximity.SignedRical
+import id.walt.mdoc.proximity.X509RicalReaderPathValidator
+import id.walt.mdoc.proximity.X509RicalSignatureValidator
+import id.walt.x509.CertificateDer
+import id.walt.x509.mdocReaderAuthenticationCommonName
+import id.walt.x509.validateMdocReaderAuthenticationCertificateChain
+import id.walt.x509.validateMdocReaderAuthenticationCertificateProfile
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.cbor.CborElement
+import kotlinx.serialization.encodeToByteArray
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/** Explicit application-provisioned Reader CA certificate and optional display label. */
+public data class MobileWalletProximityReaderTrustAnchor(
+    /** DER certificate encoded as unpadded Base64URL. */
+    public val certificateDerBase64Url: String,
+    /** Display-safe authority label. This label is evidence and never establishes trust by itself. */
+    public val displayName: String? = null,
+) {
+    init {
+        require(runCatching { certificateDerBase64Url.trustCertificateDer() }.isSuccess) {
+            "A reader trust anchor must be a DER X.509 certificate encoded as unpadded Base64URL"
+        }
+        require(displayName == null || displayName.isNotBlank())
+    }
+}
+
+/** Result returned by an application-owned certificate-revocation source. */
+public sealed interface MobileWalletProximityCertificateRevocationResult {
+    /** The configured source established that the certificate is not revoked. */
+    public data object Good : MobileWalletProximityCertificateRevocationResult
+
+    /** The configured source established that the certificate is revoked. */
+    public data class Revoked(public val reason: String? = null) :
+        MobileWalletProximityCertificateRevocationResult {
+        init {
+            require(reason == null || reason.isNotBlank())
+        }
+    }
+
+    /** The configured source could not establish current revocation status. */
+    public data class Indeterminate(public val reason: String) :
+        MobileWalletProximityCertificateRevocationResult {
+        init {
+            require(reason.isNotBlank())
+        }
+    }
+}
+
+/** Explicit application boundary for OCSP, CRL, or another reader-certificate status source. */
+public fun interface MobileWalletProximityReaderRevocationEvaluator {
+    /** Evaluates the exact verified reader evidence without an implicit SDK network request. */
+    public suspend fun evaluate(
+        evidence: MobileWalletProximityReaderEvidence,
+    ): MobileWalletProximityCertificateRevocationResult
+}
+
+/** Revocation behavior selected for reader trust. */
+public sealed interface MobileWalletProximityReaderRevocationPolicy {
+    /** Do not perform revocation lookup; the resulting trust fact remains `NotChecked`. */
+    public data object NotChecked : MobileWalletProximityReaderRevocationPolicy
+
+    /** Require the supplied source to return a conclusive result before the reader can be trusted. */
+    public data class Check(
+        public val evaluator: MobileWalletProximityReaderRevocationEvaluator,
+    ) : MobileWalletProximityReaderRevocationPolicy
+}
+
+/** Exact RICAL signer evidence passed to an application-owned revocation source. */
+public data class MobileWalletProximityRicalSignerEvidence(
+    public val providerId: String,
+    /** DER certificates in leaf-first order, encoded as unpadded Base64URL. */
+    public val certificateChainDerBase64Url: List<String>,
+) {
+    init {
+        require(providerId.isNotBlank())
+        require(certificateChainDerBase64Url.isNotEmpty())
+        require(certificateChainDerBase64Url.all(String::isTrustBase64Url))
+    }
+}
+
+/** Explicit application boundary for RICAL-signer OCSP, CRL, or another status source. */
+public fun interface MobileWalletProximityRicalSignerRevocationEvaluator {
+    public suspend fun evaluate(
+        evidence: MobileWalletProximityRicalSignerEvidence,
+    ): MobileWalletProximityCertificateRevocationResult
+}
+
+/** Revocation behavior selected for one RICAL provider's signer certificate. */
+public sealed interface MobileWalletProximityRicalSignerRevocationPolicy {
+    /** Do not perform a signer-revocation lookup. */
+    public data object NotChecked : MobileWalletProximityRicalSignerRevocationPolicy
+
+    /** Require the supplied source to establish that the RICAL signer is not revoked. */
+    public data class Check(
+        public val evaluator: MobileWalletProximityRicalSignerRevocationEvaluator,
+    ) : MobileWalletProximityRicalSignerRevocationPolicy
+}
+
+/** Explicit application-provisioned root for one RICAL provider. */
+public data class MobileWalletProximityRicalProviderTrustAnchor(
+    /** DER certificate encoded as unpadded Base64URL. */
+    public val certificateDerBase64Url: String,
+) {
+    init {
+        require(runCatching { certificateDerBase64Url.trustCertificateDer() }.isSuccess) {
+            "A RICAL provider trust anchor must be a DER X.509 certificate encoded as unpadded Base64URL"
+        }
+    }
+}
+
+/** Exact active RICAL supplied by an application-owned provider boundary. */
+public sealed interface MobileWalletProximityRicalProviderResult {
+    /** Untagged COSE_Sign1 bytes encoded as unpadded Base64URL. */
+    public data class Available(public val signedRicalBase64Url: String) :
+        MobileWalletProximityRicalProviderResult {
+        init {
+            require(signedRicalBase64Url.isTrustBase64Url())
+        }
+    }
+
+    /** No active list is available. */
+    public data class Unavailable(public val reason: String) :
+        MobileWalletProximityRicalProviderResult {
+        init {
+            require(reason.isNotBlank())
+        }
+    }
+
+    /** The application detected conflicting active list state. */
+    public data class Conflict(public val reason: String) :
+        MobileWalletProximityRicalProviderResult {
+        init {
+            require(reason.isNotBlank())
+        }
+    }
+}
+
+/** Supplies the latest application-selected RICAL without an implicit SDK network request. */
+public fun interface MobileWalletProximityRicalProvider {
+    public suspend fun current(): MobileWalletProximityRicalProviderResult
+}
+
+/** One RICAL trust constraint, with each value CBOR-encoded as unpadded Base64URL. */
+public data class MobileWalletProximityRicalTrustConstraint(
+    public val valuesCborBase64Url: Map<String, String>,
+) {
+    init {
+        require(valuesCborBase64Url.isNotEmpty())
+        require(valuesCborBase64Url.keys.none(String::isBlank))
+        require(valuesCborBase64Url.values.all(String::isTrustBase64Url))
+    }
+}
+
+/** Application-owned evaluator for ecosystem-specific RICAL trust-constraint semantics. */
+public fun interface MobileWalletProximityRicalConstraintEvaluator {
+    /** Returns true only when at least one complete constraint is understood and satisfied. */
+    public suspend fun accepts(
+        constraints: List<MobileWalletProximityRicalTrustConstraint>,
+        reader: MobileWalletProximityReaderEvidence,
+    ): Boolean
+}
+
+/** Immutable policy for one explicitly configured RICAL provider. */
+public data class MobileWalletProximityRicalConfiguration(
+    public val providerId: String,
+    public val acceptedTypes: Set<String>,
+    public val providerTrustAnchors: List<MobileWalletProximityRicalProviderTrustAnchor>,
+    public val acceptedSignerCertificatePolicyOids: Set<String>,
+    public val signerRevocationPolicy: MobileWalletProximityRicalSignerRevocationPolicy =
+        MobileWalletProximityRicalSignerRevocationPolicy.NotChecked,
+    public val establishReaderTrust: Boolean = false,
+    public val provider: MobileWalletProximityRicalProvider,
+    /** Null rejects any non-empty, ecosystem-specific constraint as unsupported. */
+    public val constraintEvaluator: MobileWalletProximityRicalConstraintEvaluator? = null,
+) {
+    init {
+        require(providerId.isNotBlank())
+        require(acceptedTypes.isNotEmpty() && acceptedTypes.none(String::isBlank))
+        require(providerTrustAnchors.isNotEmpty())
+        require(
+            providerTrustAnchors.distinctBy { it.certificateDerBase64Url }.size == providerTrustAnchors.size
+        ) { "RICAL provider trust anchors must be unique" }
+        require(
+            acceptedSignerCertificatePolicyOids.isNotEmpty() &&
+                acceptedSignerCertificatePolicyOids.none(String::isBlank)
+        ) { "Accepted RICAL signer certificate-policy OIDs are required" }
+    }
+}
+
+/**
+ * Immutable shared reader-trust policy.
+ *
+ * Direct Reader CA anchors and RICAL provider roots are always application-provisioned. Certificates
+ * carried by a reader or a RICAL are path inputs only and never become implicit SDK trust anchors.
+ * RICAL providers are evaluated in configured order; the first matching authority owns the result.
+ */
+public data class MobileWalletProximityReaderTrustConfiguration(
+    public val trustAnchors: List<MobileWalletProximityReaderTrustAnchor> = emptyList(),
+    public val ricalProviders: List<MobileWalletProximityRicalConfiguration> = emptyList(),
+    public val revocationPolicy: MobileWalletProximityReaderRevocationPolicy =
+        MobileWalletProximityReaderRevocationPolicy.NotChecked,
+) {
+    init {
+        require(trustAnchors.isNotEmpty() || ricalProviders.isNotEmpty()) {
+            "At least one explicit Reader CA anchor or RICAL provider is required"
+        }
+        require(trustAnchors.distinctBy { it.certificateDerBase64Url }.size == trustAnchors.size) {
+            "Reader CA trust anchors must be unique"
+        }
+        require(ricalProviders.distinctBy { it.providerId }.size == ricalProviders.size) {
+            "RICAL provider identifiers must be unique"
+        }
+    }
+}
+
+/** Shared standards-profile, path, revocation, RICAL, and product-trust evaluator. */
+public class MobileWalletProximityConfiguredReaderTrustEvaluator internal constructor(
+    public val configuration: MobileWalletProximityReaderTrustConfiguration,
+    private val now: () -> Instant,
+) : MobileWalletProximityReaderTrustEvaluator {
+    public constructor(
+        configuration: MobileWalletProximityReaderTrustConfiguration,
+    ) : this(configuration, { Clock.System.now() })
+
+    override suspend fun evaluate(
+        evidence: MobileWalletProximityReaderEvidence,
+    ): MobileWalletProximityReaderTrustDecision {
+        val evaluatedAt = now()
+        val chain = runCatching { evidence.certificateChainDerBase64Url.map(String::trustCertificateDer) }
+            .getOrElse { return invalidPathDecision() }
+        val leaf = chain.first()
+        val readerName = runCatching {
+            validateMdocReaderAuthenticationCertificateProfile(leaf, evaluatedAt)
+            mdocReaderAuthenticationCommonName(leaf)
+        }.getOrElse { return invalidPathDecision() }
+
+        configuration.trustAnchors.firstOrNull { anchor ->
+            runCatching {
+                validateMdocReaderAuthenticationCertificateChain(
+                    leaf = leaf,
+                    chain = chain.drop(1),
+                    trustAnchors = listOf(anchor.certificateDerBase64Url.trustCertificateDer()),
+                    now = evaluatedAt,
+                )
+            }.isSuccess
+        }?.let { anchor ->
+            return decisionForValidatedPath(
+                evidence = evidence,
+                displayName = anchor.displayName ?: readerName,
+                rical = MobileWalletProximityRicalState.NotEvaluated,
+                establishesTrust = true,
+            )
+        }
+
+        var fallback: RicalFallback? = null
+        for (rical in configuration.ricalProviders) {
+            val result = evaluateRical(rical, evidence, evaluatedAt)
+            result.matched?.let { matched ->
+                return when (matched) {
+                    is RicalMatch.Revoked -> MobileWalletProximityReaderTrustDecision(
+                        state = MobileWalletProximityReaderTrustState.Revoked,
+                        certificatePath = MobileWalletProximityReaderCertificatePathState.Valid,
+                        revocation = MobileWalletProximityReaderRevocationState.Revoked,
+                        rical = MobileWalletProximityRicalState.Matched,
+                        displayName = matched.displayName ?: readerName,
+                        reason = matched.reason ?: "Reader authentication certificate is revoked",
+                    )
+                    is RicalMatch.Valid -> decisionForValidatedPath(
+                        evidence = evidence,
+                        displayName = matched.displayName ?: readerName,
+                        rical = MobileWalletProximityRicalState.Matched,
+                        establishesTrust = matched.establishesTrust,
+                    )
+                }
+            }
+            fallback = fallback.prefer(result.fallback)
+        }
+
+        return MobileWalletProximityReaderTrustDecision(
+            state = MobileWalletProximityReaderTrustState.ValidButUntrusted,
+            certificatePath = MobileWalletProximityReaderCertificatePathState.UnknownAuthority,
+            rical = fallback?.state ?: MobileWalletProximityRicalState.NotEvaluated,
+            reason = fallback?.reason ?: "Reader authentication is valid, but its authority is not configured",
+        )
+    }
+
+    private suspend fun evaluateRical(
+        configuration: MobileWalletProximityRicalConfiguration,
+        evidence: MobileWalletProximityReaderEvidence,
+        evaluatedAt: Instant,
+    ): RicalAttempt {
+        val evaluator = RicalReaderTrustEvaluator(
+            provider = RicalProvider {
+                when (val result = configuration.provider.current()) {
+                    is MobileWalletProximityRicalProviderResult.Available -> RicalProviderResult.Available(
+                        SignedRical.decode(result.signedRicalBase64Url.decodeTrustBase64Url())
+                    )
+                    is MobileWalletProximityRicalProviderResult.Unavailable ->
+                        RicalProviderResult.Unavailable(result.reason)
+                    is MobileWalletProximityRicalProviderResult.Conflict ->
+                        RicalProviderResult.Conflict(result.reason)
+                }
+            },
+            policy = RicalPolicy(
+                providerId = configuration.providerId,
+                acceptedTypes = configuration.acceptedTypes,
+                trustedProviderRootsDer = configuration.providerTrustAnchors.map {
+                    ImmutableBytes.of(it.certificateDerBase64Url.decodeTrustBase64Url())
+                },
+                establishReaderTrust = configuration.establishReaderTrust,
+            ),
+            signatureValidator = configuration.signatureValidator(evaluatedAt),
+            constraintEvaluator = RicalConstraintEvaluator { constraints, _ ->
+                if (constraints.isEmpty()) true
+                else configuration.constraintEvaluator?.accepts(
+                    constraints.map(RicalTrustConstraint::toPublic),
+                    evidence,
+                ) == true
+            },
+            now = { evaluatedAt },
+            pathValidator = X509RicalReaderPathValidator { evaluatedAt },
+        )
+        val result = try {
+            evaluator.evaluateDetailed(evidence.toRicalEvidence())
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Throwable) {
+            return RicalAttempt(
+                fallback = RicalFallback(
+                    MobileWalletProximityRicalState.Invalid,
+                    "RICAL provider data is invalid",
+                )
+            )
+        }
+        return when (result.state) {
+            RicalEvaluationState.MATCHED -> RicalAttempt(
+                matched = if (result.decision.state == ReaderTrustState.REVOKED) {
+                    RicalMatch.Revoked(result.decision.displayName, result.decision.reason)
+                } else {
+                    RicalMatch.Valid(
+                        result.decision.displayName,
+                        result.decision.state == ReaderTrustState.TRUSTED,
+                    )
+                }
+            )
+            RicalEvaluationState.UNAVAILABLE -> RicalAttempt(
+                fallback = RicalFallback(
+                    MobileWalletProximityRicalState.Unavailable,
+                    result.decision.reason ?: "RICAL provider is unavailable",
+                )
+            )
+            RicalEvaluationState.INVALID -> RicalAttempt(
+                fallback = RicalFallback(
+                    MobileWalletProximityRicalState.Invalid,
+                    result.decision.reason ?: "RICAL provider data is invalid",
+                )
+            )
+            RicalEvaluationState.NO_MATCHING_AUTHORITY -> RicalAttempt(
+                fallback = RicalFallback(
+                    MobileWalletProximityRicalState.NoMatchingAuthority,
+                    result.decision.reason ?: "RICAL has no matching reader authority",
+                )
+            )
+        }
+    }
+
+    private fun MobileWalletProximityRicalConfiguration.signatureValidator(
+        evaluatedAt: Instant,
+    ): RicalSignatureValidator {
+        val x509 = X509RicalSignatureValidator(acceptedSignerCertificatePolicyOids) { evaluatedAt }
+        return RicalSignatureValidator { signed, roots ->
+            if (!x509.validate(signed, roots)) {
+                false
+            } else {
+                when (val policy = signerRevocationPolicy) {
+                    MobileWalletProximityRicalSignerRevocationPolicy.NotChecked -> true
+                    is MobileWalletProximityRicalSignerRevocationPolicy.Check -> try {
+                        policy.evaluator.evaluate(
+                            MobileWalletProximityRicalSignerEvidence(
+                                providerId = providerId,
+                                certificateChainDerBase64Url = signed.signerChainDer.map {
+                                    it.copy().encodeTrustBase64Url()
+                                },
+                            )
+                        ) == MobileWalletProximityCertificateRevocationResult.Good
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (_: Throwable) {
+                        false
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun decisionForValidatedPath(
+        evidence: MobileWalletProximityReaderEvidence,
+        displayName: String,
+        rical: MobileWalletProximityRicalState,
+        establishesTrust: Boolean,
+    ): MobileWalletProximityReaderTrustDecision = when (val revocation = evaluateRevocation(evidence)) {
+        is EvaluatedRevocation.Good -> MobileWalletProximityReaderTrustDecision(
+            state = if (establishesTrust) MobileWalletProximityReaderTrustState.Trusted
+                else MobileWalletProximityReaderTrustState.ValidButUntrusted,
+            certificatePath = MobileWalletProximityReaderCertificatePathState.Valid,
+            revocation = revocation.state,
+            rical = rical,
+            displayName = displayName,
+            reason = if (establishesTrust) null
+                else "RICAL evidence is valid but the active policy does not establish reader trust",
+        )
+        is EvaluatedRevocation.Revoked -> MobileWalletProximityReaderTrustDecision(
+            state = MobileWalletProximityReaderTrustState.Revoked,
+            certificatePath = MobileWalletProximityReaderCertificatePathState.Valid,
+            revocation = MobileWalletProximityReaderRevocationState.Revoked,
+            rical = rical,
+            displayName = displayName,
+            reason = revocation.reason ?: "Reader authentication certificate is revoked",
+        )
+        is EvaluatedRevocation.Indeterminate -> MobileWalletProximityReaderTrustDecision(
+            state = MobileWalletProximityReaderTrustState.ValidButUntrusted,
+            certificatePath = MobileWalletProximityReaderCertificatePathState.Valid,
+            revocation = MobileWalletProximityReaderRevocationState.Indeterminate,
+            rical = rical,
+            displayName = displayName,
+            reason = revocation.reason,
+        )
+    }
+
+    private suspend fun evaluateRevocation(
+        evidence: MobileWalletProximityReaderEvidence,
+    ): EvaluatedRevocation = when (val policy = configuration.revocationPolicy) {
+        MobileWalletProximityReaderRevocationPolicy.NotChecked ->
+            EvaluatedRevocation.Good(MobileWalletProximityReaderRevocationState.NotChecked)
+        is MobileWalletProximityReaderRevocationPolicy.Check -> try {
+            when (val result = policy.evaluator.evaluate(evidence)) {
+                MobileWalletProximityCertificateRevocationResult.Good ->
+                    EvaluatedRevocation.Good(MobileWalletProximityReaderRevocationState.Good)
+                is MobileWalletProximityCertificateRevocationResult.Revoked ->
+                    EvaluatedRevocation.Revoked(result.reason)
+                is MobileWalletProximityCertificateRevocationResult.Indeterminate ->
+                    EvaluatedRevocation.Indeterminate(result.reason)
+            }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Throwable) {
+            EvaluatedRevocation.Indeterminate("Reader certificate revocation status is unavailable")
+        }
+    }
+
+    private sealed interface EvaluatedRevocation {
+        data class Good(val state: MobileWalletProximityReaderRevocationState) : EvaluatedRevocation
+        data class Revoked(val reason: String?) : EvaluatedRevocation
+        data class Indeterminate(val reason: String) : EvaluatedRevocation
+    }
+
+    private sealed interface RicalMatch {
+        val displayName: String?
+
+        data class Valid(
+            override val displayName: String?,
+            val establishesTrust: Boolean,
+        ) : RicalMatch
+
+        data class Revoked(
+            override val displayName: String?,
+            val reason: String?,
+        ) : RicalMatch
+    }
+    private data class RicalFallback(val state: MobileWalletProximityRicalState, val reason: String)
+    private data class RicalAttempt(val matched: RicalMatch? = null, val fallback: RicalFallback? = null)
+
+    private fun RicalFallback?.prefer(candidate: RicalFallback?): RicalFallback? {
+        candidate ?: return this
+        this ?: return candidate
+        fun MobileWalletProximityRicalState.priority(): Int = when (this) {
+            MobileWalletProximityRicalState.Invalid -> 3
+            MobileWalletProximityRicalState.Unavailable -> 2
+            MobileWalletProximityRicalState.NoMatchingAuthority -> 1
+            MobileWalletProximityRicalState.NotEvaluated, MobileWalletProximityRicalState.Matched -> 0
+        }
+        return if (candidate.state.priority() > state.priority()) candidate else this
+    }
+
+    private fun invalidPathDecision(): MobileWalletProximityReaderTrustDecision =
+        MobileWalletProximityReaderTrustDecision(
+            state = MobileWalletProximityReaderTrustState.ValidButUntrusted,
+            certificatePath = MobileWalletProximityReaderCertificatePathState.Invalid,
+            reason = "Reader authentication certificate path or profile is invalid",
+        )
+}
+
+private fun MobileWalletProximityReaderEvidence.toRicalEvidence(): ReaderAuthenticationEvidence =
+    ReaderAuthenticationEvidence(
+        scope = when (scope) {
+            MobileWalletProximityReaderAuthenticationScope.Document ->
+                id.walt.mdoc.proximity.ReaderAuthenticationScope.DOCUMENT
+            MobileWalletProximityReaderAuthenticationScope.WholeRequest ->
+                id.walt.mdoc.proximity.ReaderAuthenticationScope.WHOLE_REQUEST
+        },
+        documentRequestIndex = documentRequestIndex,
+        authenticationIndex = authenticationIndex,
+        certificateChainDer = certificateChainDerBase64Url.map {
+            ImmutableBytes.of(it.decodeTrustBase64Url())
+        },
+    )
+
+private fun RicalTrustConstraint.toPublic(): MobileWalletProximityRicalTrustConstraint =
+    MobileWalletProximityRicalTrustConstraint(
+        valuesCborBase64Url = values.mapValues { (_, value) -> value.toTrustBase64Url() }
+    )
+
+private fun CborElement.toTrustBase64Url(): String =
+    coseCompliantCbor.encodeToByteArray(CborElement.serializer(), this).encodeTrustBase64Url()
+
+private fun String.trustCertificateDer(): CertificateDer = CertificateDer(decodeTrustBase64Url()).also {
+    X509CertificateUtil.parseCertificateDerEncoded(it.bytes)
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+private fun String.decodeTrustBase64Url(): ByteArray =
+    Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT).decode(this)
+
+@OptIn(ExperimentalEncodingApi::class)
+private fun ByteArray.encodeTrustBase64Url(): String =
+    Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT).encode(this)
+
+@OptIn(ExperimentalEncodingApi::class)
+private fun String.isTrustBase64Url(): Boolean =
+    isNotBlank() && !contains('=') && runCatching { decodeTrustBase64Url().isNotEmpty() }.getOrDefault(false)

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletProximityModelsTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletProximityModelsTest.kt
@@ -121,7 +121,26 @@ class MobileWalletProximityModelsTest {
                 revocation = MobileWalletProximityReaderRevocationState.Revoked,
             )
         }
-
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletProximityReaderTrustDecision(
+                state = MobileWalletProximityReaderTrustState.Trusted,
+                certificatePath = MobileWalletProximityReaderCertificatePathState.UnknownAuthority,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletProximityReaderTrustDecision(
+                state = MobileWalletProximityReaderTrustState.ValidButUntrusted,
+                certificatePath = MobileWalletProximityReaderCertificatePathState.Invalid,
+                revocation = MobileWalletProximityReaderRevocationState.Good,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletProximityReaderTrustDecision(
+                state = MobileWalletProximityReaderTrustState.ValidButUntrusted,
+                certificatePath = MobileWalletProximityReaderCertificatePathState.UnknownAuthority,
+                rical = MobileWalletProximityRicalState.Matched,
+            )
+        }
         val ricalEvidenceWithoutAutomaticTrust = MobileWalletProximityReaderTrustDecision(
             state = MobileWalletProximityReaderTrustState.ValidButUntrusted,
             certificatePath = MobileWalletProximityReaderCertificatePathState.Valid,
@@ -133,6 +152,25 @@ class MobileWalletProximityModelsTest {
             MobileWalletProximityReaderTrustState.ValidButUntrusted,
             ricalEvidenceWithoutAutomaticTrust.state,
         )
+
+        val directTrustWithUnavailableRical = MobileWalletProximityReaderTrustDecision(
+            state = MobileWalletProximityReaderTrustState.Trusted,
+            certificatePath = MobileWalletProximityReaderCertificatePathState.Valid,
+            revocation = MobileWalletProximityReaderRevocationState.Good,
+            rical = MobileWalletProximityRicalState.Unavailable,
+        )
+        assertEquals(MobileWalletProximityReaderTrustState.Trusted, directTrustWithUnavailableRical.state)
+
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletProximityReaderAuthentication(
+                scope = MobileWalletProximityReaderAuthenticationScope.WholeRequest,
+                documentRequestIndex = null,
+                validity = MobileWalletProximityReaderAuthenticationValidity.Valid,
+                trust = MobileWalletProximityReaderTrustState.Trusted,
+                certificatePath = MobileWalletProximityReaderCertificatePathState.Valid,
+                revocation = MobileWalletProximityReaderRevocationState.Indeterminate,
+            )
+        }
     }
 
     @Test

--- a/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletProximityReaderTrustTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vc-wallet-mobile/src/commonTest/kotlin/id/walt/wallet2/mobile/MobileWalletProximityReaderTrustTest.kt
@@ -1,0 +1,447 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package id.walt.wallet2.mobile
+
+import id.walt.certificate.x509.X509Certificate
+import id.walt.certificate.x509.X509CertificateUtil
+import id.walt.certificate.x509.extension.AuthorityKeyIdentifierExtension.Companion.extensionAuthorityKeyIdentifier
+import id.walt.certificate.x509.extension.BasicConstraintsExtension.Companion.extensionBasicConstraints
+import id.walt.certificate.x509.extension.CrlDistributionPointsExtension.Companion.extensionCrlDistributionPoints
+import id.walt.certificate.x509.extension.ExtendedKeyUsageExtension.Companion.extensionExtendedKeyUsage
+import id.walt.certificate.x509.extension.KeyUsageExtension
+import id.walt.certificate.x509.extension.KeyUsageExtension.Companion.extensionKeyUsage
+import id.walt.certificate.x509.extension.SubjectKeyIdentifierExtension.Companion.extensionSubjectKeyIdentifier
+import id.walt.crypto2.CryptoRuntime
+import id.walt.crypto2.algorithms.DigestAlgorithm
+import id.walt.crypto2.algorithms.EcdsaSignatureEncoding
+import id.walt.crypto2.algorithms.SignatureAlgorithm
+import id.walt.crypto2.keys.EcCurve
+import id.walt.crypto2.keys.Key
+import id.walt.crypto2.keys.KeyId
+import id.walt.crypto2.keys.KeySpec
+import id.walt.crypto2.keys.KeyUsage
+import id.walt.crypto2.providers.GenerateSoftwareKeyRequest
+import id.walt.crypto2.providers.cryptography.defaultSoftwareKeyProviders
+import id.walt.mdoc.proximity.ImmutableBytes
+import id.walt.mdoc.proximity.ReaderAuthenticationEvidence
+import id.walt.mdoc.proximity.ReaderAuthenticationScope
+import id.walt.mdoc.proximity.Rical
+import id.walt.mdoc.proximity.RicalCertificateInfo
+import id.walt.mdoc.proximity.RicalReaderPathResult
+import id.walt.mdoc.proximity.X509RicalReaderPathValidator
+import id.walt.x509.MdocReaderAuthenticationEkuOid
+import kotlinx.coroutines.test.runTest
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+class MobileWalletProximityReaderTrustTest {
+    @Test
+    fun `explicit anchor establishes trust without trusting a reader supplied root implicitly`() = runTest {
+        withCertificates { certificates ->
+            val trusted = evaluator(certificates.root).evaluate(certificates.evidence(includeRoot = false))
+            assertEquals(MobileWalletProximityReaderTrustState.Trusted, trusted.state)
+            assertEquals(MobileWalletProximityReaderCertificatePathState.Valid, trusted.certificatePath)
+            assertEquals(MobileWalletProximityReaderRevocationState.NotChecked, trusted.revocation)
+            assertEquals("Example reader", trusted.displayName)
+
+            val otherRoot = certificates.createRoot("Different reader root")
+            val unknown = evaluator(otherRoot).evaluate(certificates.evidence(includeRoot = true))
+            assertEquals(MobileWalletProximityReaderTrustState.ValidButUntrusted, unknown.state)
+            assertEquals(MobileWalletProximityReaderCertificatePathState.UnknownAuthority, unknown.certificatePath)
+            assertEquals(null, unknown.displayName)
+        }
+    }
+
+    @Test
+    fun `reader end entity cannot be configured as its own trust anchor`() = runTest {
+        withCertificates { certificates ->
+            val decision = evaluator(certificates.reader).evaluate(certificates.evidence())
+
+            assertEquals(MobileWalletProximityReaderTrustState.ValidButUntrusted, decision.state)
+            assertEquals(MobileWalletProximityReaderCertificatePathState.UnknownAuthority, decision.certificatePath)
+        }
+    }
+
+    @Test
+    fun `invalid reader certificate profile remains distinct from an unknown authority`() = runTest {
+        withCertificates(readerExtendedKeyUsage = null) { certificates ->
+            val decision = evaluator(certificates.root).evaluate(certificates.evidence())
+
+            assertEquals(MobileWalletProximityReaderTrustState.ValidButUntrusted, decision.state)
+            assertEquals(MobileWalletProximityReaderCertificatePathState.Invalid, decision.certificatePath)
+            assertEquals(MobileWalletProximityReaderRevocationState.NotChecked, decision.revocation)
+        }
+    }
+
+    @Test
+    fun `expired reader certificate fails profile validation before trust lookup`() = runTest {
+        withCertificates { certificates ->
+            val decision = evaluator(
+                certificates.root,
+                now = Clock.System.now() + 31.days,
+            ).evaluate(certificates.evidence())
+
+            assertEquals(MobileWalletProximityReaderTrustState.ValidButUntrusted, decision.state)
+            assertEquals(MobileWalletProximityReaderCertificatePathState.Invalid, decision.certificatePath)
+            assertEquals(MobileWalletProximityReaderRevocationState.NotChecked, decision.revocation)
+        }
+    }
+
+    @Test
+    fun `revoked and indeterminate status fail closed without collapsing path validity`() = runTest {
+        withCertificates { certificates ->
+            val revoked = evaluator(
+                certificates.root,
+                MobileWalletProximityCertificateRevocationResult.Revoked("Revoked by test source"),
+            ).evaluate(certificates.evidence())
+            assertEquals(MobileWalletProximityReaderTrustState.Revoked, revoked.state)
+            assertEquals(MobileWalletProximityReaderCertificatePathState.Valid, revoked.certificatePath)
+            assertEquals(MobileWalletProximityReaderRevocationState.Revoked, revoked.revocation)
+
+            val indeterminate = evaluator(
+                certificates.root,
+                MobileWalletProximityCertificateRevocationResult.Indeterminate("Status source is offline"),
+            ).evaluate(certificates.evidence())
+            assertEquals(MobileWalletProximityReaderTrustState.ValidButUntrusted, indeterminate.state)
+            assertEquals(MobileWalletProximityReaderCertificatePathState.Valid, indeterminate.certificatePath)
+            assertEquals(MobileWalletProximityReaderRevocationState.Indeterminate, indeterminate.revocation)
+        }
+    }
+
+    @Test
+    fun `revocation source exceptions are indeterminate and repeated evaluations are independent`() = runTest {
+        withCertificates { certificates ->
+            var calls = 0
+            val evaluator = MobileWalletProximityConfiguredReaderTrustEvaluator(
+                MobileWalletProximityReaderTrustConfiguration(
+                    trustAnchors = listOf(
+                        MobileWalletProximityReaderTrustAnchor(
+                            certificates.root.base64Url(),
+                            "Configured reader authority",
+                        )
+                    ),
+                    revocationPolicy = MobileWalletProximityReaderRevocationPolicy.Check(
+                        MobileWalletProximityReaderRevocationEvaluator {
+                            calls += 1
+                            if (calls == 1) error("status source offline")
+                            MobileWalletProximityCertificateRevocationResult.Good
+                        }
+                    ),
+                )
+            )
+
+            val first = evaluator.evaluate(certificates.evidence())
+            val second = evaluator.evaluate(certificates.evidence())
+
+            assertEquals(MobileWalletProximityReaderRevocationState.Indeterminate, first.revocation)
+            assertEquals(MobileWalletProximityReaderTrustState.ValidButUntrusted, first.state)
+            assertEquals(MobileWalletProximityReaderRevocationState.Good, second.revocation)
+            assertEquals(MobileWalletProximityReaderTrustState.Trusted, second.state)
+            assertEquals("Configured reader authority", second.displayName)
+            assertEquals(2, calls)
+        }
+    }
+
+    @Test
+    fun `RICAL provider availability and conflicts remain distinct trust facts`() = runTest {
+        withCertificates { certificates ->
+            suspend fun evaluate(result: MobileWalletProximityRicalProviderResult) =
+                MobileWalletProximityConfiguredReaderTrustEvaluator(
+                    MobileWalletProximityReaderTrustConfiguration(
+                        ricalProviders = listOf(
+                            MobileWalletProximityRicalConfiguration(
+                                providerId = "provider",
+                                acceptedTypes = setOf("org.iso.18013.5.1.reader_authentication"),
+                                providerTrustAnchors = listOf(
+                                    MobileWalletProximityRicalProviderTrustAnchor(certificates.root.base64Url())
+                                ),
+                                acceptedSignerCertificatePolicyOids = setOf("1.2.3.4"),
+                                provider = MobileWalletProximityRicalProvider { result },
+                            )
+                        )
+                    )
+                ).evaluate(certificates.evidence())
+
+            val unavailable = evaluate(MobileWalletProximityRicalProviderResult.Unavailable("offline"))
+            assertEquals(MobileWalletProximityReaderCertificatePathState.UnknownAuthority, unavailable.certificatePath)
+            assertEquals(MobileWalletProximityRicalState.Unavailable, unavailable.rical)
+
+            val conflict = evaluate(MobileWalletProximityRicalProviderResult.Conflict("two active lists"))
+            assertEquals(MobileWalletProximityReaderCertificatePathState.UnknownAuthority, conflict.certificatePath)
+            assertEquals(MobileWalletProximityRicalState.Invalid, conflict.rical)
+        }
+    }
+
+    @Test
+    fun `configured RICAL validates signer path policy status and reader authority`() = runTest {
+        var signerRevocationChecks = 0
+        val evidence = MobileWalletProximityReaderEvidence(
+            scope = MobileWalletProximityReaderAuthenticationScope.WholeRequest,
+            certificateChainDerBase64Url = listOf(RICAL_READER_LEAF),
+        )
+        val evaluator = ricalEvaluator {
+            signerRevocationChecks += 1
+            assertEquals("test-provider", it.providerId)
+            assertEquals(1, it.certificateChainDerBase64Url.size)
+            MobileWalletProximityCertificateRevocationResult.Good
+        }
+
+        val decision = evaluator.evaluate(evidence)
+
+        assertEquals(MobileWalletProximityReaderTrustState.Trusted, decision.state)
+        assertEquals(MobileWalletProximityReaderCertificatePathState.Valid, decision.certificatePath)
+        assertEquals(MobileWalletProximityReaderRevocationState.NotChecked, decision.revocation)
+        assertEquals(MobileWalletProximityRicalState.Matched, decision.rical)
+        assertEquals("Fixture reader authority", decision.displayName)
+        assertEquals(1, signerRevocationChecks)
+
+        val revokedSigner = ricalEvaluator {
+            MobileWalletProximityCertificateRevocationResult.Revoked("Signer revoked")
+        }.evaluate(evidence)
+        assertEquals(MobileWalletProximityReaderTrustState.ValidButUntrusted, revokedSigner.state)
+        assertEquals(MobileWalletProximityReaderCertificatePathState.UnknownAuthority, revokedSigner.certificatePath)
+        assertEquals(MobileWalletProximityRicalState.Invalid, revokedSigner.rical)
+    }
+
+    @Test
+    fun `RICAL path validation applies only the bottom-most matching authority`() = runTest {
+        val runtime = CryptoRuntime(defaultSoftwareKeyProviders())
+        try {
+            val rootKey = runtime.testKey("rical-reader-root")
+            val subCaKey = runtime.testKey("rical-reader-sub-ca")
+            val readerKey = runtime.testKey("rical-reader-leaf")
+            val root = createRoot(rootKey, "RICAL reader root")
+            val subCa = createCa(rootKey, root, subCaKey, "RICAL reader sub CA")
+            val reader = createReader(subCaKey, subCa, readerKey, MdocReaderAuthenticationEkuOid)
+            val rootInfo = root.ricalInfo(isTrustAnchor = true, name = "Root authority")
+            val subCaInfo = subCa.ricalInfo(isTrustAnchor = false, name = "Bottom authority")
+            val rical = Rical(
+                version = "1.0",
+                provider = "test-provider",
+                date = Clock.System.now() - 1.days,
+                certificateInfos = listOf(rootInfo, subCaInfo),
+                type = "org.iso.18013.5.1.reader_authentication",
+            )
+
+            val result = X509RicalReaderPathValidator().validate(
+                ReaderAuthenticationEvidence(
+                    scope = ReaderAuthenticationScope.WHOLE_REQUEST,
+                    certificateChainDer = listOf(reader, subCa).map {
+                        ImmutableBytes.of(it.encodedDer.toByteArray())
+                    },
+                ),
+                rical,
+            )
+
+            assertEquals(subCaInfo, assertIs<RicalReaderPathResult.Valid>(result).authority)
+        } finally {
+            runtime.close()
+        }
+    }
+
+    @Test
+    fun `configuration rejects empty and malformed anchors`() {
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletProximityReaderTrustConfiguration()
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MobileWalletProximityReaderTrustAnchor("not base64 url!")
+        }
+    }
+
+    @Test
+    fun `configuration rejects duplicate anchors`() = runTest {
+        withCertificates { certificates ->
+            val anchor = MobileWalletProximityReaderTrustAnchor(certificates.root.base64Url())
+
+            assertFailsWith<IllegalArgumentException> {
+                MobileWalletProximityReaderTrustConfiguration(
+                    trustAnchors = listOf(anchor, anchor)
+                )
+            }
+        }
+    }
+
+    private fun evaluator(
+        root: X509Certificate,
+        revocation: MobileWalletProximityCertificateRevocationResult? = null,
+        now: Instant = Clock.System.now(),
+    ): MobileWalletProximityConfiguredReaderTrustEvaluator = MobileWalletProximityConfiguredReaderTrustEvaluator(
+        MobileWalletProximityReaderTrustConfiguration(
+            trustAnchors = listOf(MobileWalletProximityReaderTrustAnchor(root.base64Url())),
+            revocationPolicy = revocation?.let { result ->
+                MobileWalletProximityReaderRevocationPolicy.Check(
+                    MobileWalletProximityReaderRevocationEvaluator { result }
+                )
+            } ?: MobileWalletProximityReaderRevocationPolicy.NotChecked,
+        ),
+        now = { now },
+    )
+
+    private fun ricalEvaluator(
+        signerRevocationEvaluator: MobileWalletProximityRicalSignerRevocationEvaluator,
+    ): MobileWalletProximityConfiguredReaderTrustEvaluator =
+        MobileWalletProximityConfiguredReaderTrustEvaluator(
+            configuration = MobileWalletProximityReaderTrustConfiguration(
+                ricalProviders = listOf(
+                    MobileWalletProximityRicalConfiguration(
+                        providerId = "test-provider",
+                        acceptedTypes = setOf("org.iso.18013.5.1.reader_authentication"),
+                        providerTrustAnchors = listOf(
+                            MobileWalletProximityRicalProviderTrustAnchor(RICAL_PROVIDER_ROOT)
+                        ),
+                        acceptedSignerCertificatePolicyOids = setOf("1.2.3.4"),
+                        signerRevocationPolicy = MobileWalletProximityRicalSignerRevocationPolicy.Check(
+                            signerRevocationEvaluator
+                        ),
+                        establishReaderTrust = true,
+                        provider = MobileWalletProximityRicalProvider {
+                            MobileWalletProximityRicalProviderResult.Available(SIGNED_RICAL)
+                        },
+                    )
+                )
+            ),
+            now = { Instant.parse("2026-09-02T00:00:00Z") },
+        )
+
+    private suspend fun <T> withCertificates(
+        readerExtendedKeyUsage: String? = MdocReaderAuthenticationEkuOid,
+        block: suspend (Certificates) -> T,
+    ): T {
+        val runtime = CryptoRuntime(defaultSoftwareKeyProviders())
+        return try {
+            val rootKey = runtime.testKey("reader-root")
+            val readerKey = runtime.testKey("reader-leaf")
+            val root = createRoot(rootKey, "Example reader root")
+            val reader = createReader(rootKey, root, readerKey, readerExtendedKeyUsage)
+            block(Certificates(runtime, root, reader))
+        } finally {
+            runtime.close()
+        }
+    }
+
+    private suspend fun CryptoRuntime.testKey(id: String): Key = generateSoftwareKey(
+        GenerateSoftwareKeyRequest(
+            id = KeyId(id),
+            spec = KeySpec.Ec(EcCurve.P256),
+            usages = setOf(KeyUsage.SIGN, KeyUsage.VERIFY),
+        )
+    )
+
+    private suspend fun createRoot(key: Key, commonName: String): X509Certificate =
+        X509CertificateUtil.createSelfSignedCertificate(key, certificateAlgorithm) {
+            subjectDn = "CN=$commonName"
+            extensionKeyUsage {
+                critical = true
+                addKeyUsage(KeyUsageExtension.KeyUsage.keyCertSign, KeyUsageExtension.KeyUsage.cRLSign)
+            }
+        }
+
+    private suspend fun createReader(
+        issuerKey: Key,
+        issuer: X509Certificate,
+        readerKey: Key,
+        extendedKeyUsage: String?,
+    ): X509Certificate = X509CertificateUtil.createCertificate(
+        issuerKey = issuerKey,
+        issuerCert = issuer,
+        signatureAlgorithm = certificateAlgorithm,
+    ) {
+        subjectDn = "CN=Example reader"
+        subjectPublicKey(readerKey)
+        extensionSubjectKeyIdentifier()
+        extensionKeyUsage {
+            critical = true
+            addKeyUsage(KeyUsageExtension.KeyUsage.digitalSignature)
+        }
+        extendedKeyUsage?.let { oid ->
+            extensionExtendedKeyUsage {
+                critical = true
+                addKeyUsage(oid)
+            }
+        }
+        extensionCrlDistributionPoints {
+            addUriDistributionPoint("https://reader.example/crl")
+        }
+    }
+
+    private suspend fun createCa(
+        issuerKey: Key,
+        issuer: X509Certificate,
+        subjectKey: Key,
+        commonName: String,
+    ): X509Certificate = X509CertificateUtil.createCertificate(
+        issuerKey = issuerKey,
+        issuerCert = issuer,
+        signatureAlgorithm = certificateAlgorithm,
+    ) {
+        subjectDn = "CN=$commonName"
+        subjectPublicKey(subjectKey)
+        extensionSubjectKeyIdentifier()
+        extensionBasicConstraints { cA = true }
+        extensionKeyUsage {
+            critical = true
+            addKeyUsage(KeyUsageExtension.KeyUsage.keyCertSign, KeyUsageExtension.KeyUsage.cRLSign)
+        }
+    }
+
+    private fun X509Certificate.ricalInfo(
+        isTrustAnchor: Boolean,
+        name: String,
+    ): RicalCertificateInfo = RicalCertificateInfo(
+        certificateDer = ImmutableBytes.of(encodedDer.toByteArray()),
+        serialNumber = ImmutableBytes.of(data.serialNumberRaw.toByteArray()),
+        subjectKeyIdentifier = ImmutableBytes.of(
+            requireNotNull(data.extensionSubjectKeyIdentifier).keyIdentifier.toByteArray()
+        ),
+        isTrustAnchor = isTrustAnchor,
+        authorityKeyIdentifier = data.extensionAuthorityKeyIdentifier?.keyIdentifier?.toByteArray()?.let {
+            ImmutableBytes.of(it)
+        },
+        name = name,
+    )
+
+    private inner class Certificates(
+        private val runtime: CryptoRuntime,
+        val root: X509Certificate,
+        val reader: X509Certificate,
+    ) {
+        fun evidence(includeRoot: Boolean = false): MobileWalletProximityReaderEvidence =
+            MobileWalletProximityReaderEvidence(
+                scope = MobileWalletProximityReaderAuthenticationScope.WholeRequest,
+                certificateChainDerBase64Url = buildList {
+                    add(reader.base64Url())
+                    if (includeRoot) add(root.base64Url())
+                },
+            )
+
+        suspend fun createRoot(commonName: String): X509Certificate =
+            this@MobileWalletProximityReaderTrustTest.createRoot(
+                runtime.testKey(commonName.replace(' ', '-')),
+                commonName,
+            )
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun X509Certificate.base64Url(): String =
+        Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT).encode(encodedDer.toByteArray())
+
+    private companion object {
+        val certificateAlgorithm = SignatureAlgorithm.Ecdsa(
+            DigestAlgorithm.SHA_256,
+            EcdsaSignatureEncoding.DER,
+        )
+
+        // Public-only test material. The corresponding private keys are intentionally not retained.
+        const val RICAL_PROVIDER_ROOT = "MIIBoDCCAUWgAwIBAgIIQAAAAAAAAAEwCgYIKoZIzj0EAwIwIzEhMB8GA1UEAwwYUklDQUwgUHJvdmlkZXIgVGVzdCBSb290MB4XDTI2MDgzMDIwNTgyMloXDTI3MDgzMDIwNTgyMlowIzEhMB8GA1UEAwwYUklDQUwgUHJvdmlkZXIgVGVzdCBSb290MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEdlAtVZ6AIUdT6Dz40ocIC1beZ4jBMkBCbIYT9aYANmpUIcfrbF7p0hxAMU_e3aFcOc0gE-3ctXDS_XYJ9pVw06NjMGEwDwYDVR0TAQH_BAUwAwEB_zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFOu5ldR964dGMxFoyzr-Wfg3SLBxMB8GA1UdIwQYMBaAFOu5ldR964dGMxFoyzr-Wfg3SLBxMAoGCCqGSM49BAMCA0kAMEYCIQDrTcqqxUk0W-nVpNdQXtIiuYkPO3fewH-jasVtnXEGuQIhAKc2LKRf3nZ93kCzVSErxvSiacBApOVD7o6F5yhBqUXC"
+        const val RICAL_READER_LEAF = "MIIBwjCCAWigAwIBAgIIQAAAAAAAAAQwCgYIKoZIzj0EAwIwGzEZMBcGA1UEAwwQUmVhZGVyIFRlc3QgUm9vdDAeFw0yNjA4MzAyMDU4MjJaFw0yNjA5MjkyMDU4MjJaMBkxFzAVBgNVBAMMDkZpeHR1cmUgUmVhZGVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0vfmnCwPggx1aO8shICyUA_M1mYt7CXaWNZyY4_uLQna7LISphQ7cjy2xoLCN9oT4Bqhewunrw7RKvH6_NVStKOBlzCBlDAdBgNVHQ4EFgQU-OVW6w6H38FtAa_Q1fKlUUn0qp4wHwYDVR0jBBgwFoAUhdjG_yjle9d7MBgoC9S57eK3_x8wDgYDVR0PAQH_BAQDAgeAMBUGA1UdJQEB_wQLMAkGByiBjF0FAQYwKwYDVR0fBCQwIjAgoB6gHIYaaHR0cHM6Ly9yZWFkZXIuZXhhbXBsZS9jcmwwCgYIKoZIzj0EAwIDSAAwRQIhAPQgGNKygRTaykDwA1SMy_yrm8y3xhIuoZnylecMEbtOAiAa_3jyEp3ZYuaXkDdegFYUySpSF_4JvCXEiVdvecyzDA"
+        const val SIGNED_RICAL = "hFkCAqIBJhghgVkB-TCCAfUwggGaoAMCAQICCEAAAAAAAAACMAoGCCqGSM49BAMCMCMxITAfBgNVBAMMGFJJQ0FMIFByb3ZpZGVyIFRlc3QgUm9vdDAeFw0yNjA4MzAyMDU4MjJaFw0yNjA5MjkyMDU4MjJaMEkxCzAJBgNVBAYTAkFUMR4wHAYDVQQKDBV3YWx0LmlkIHRlc3QgZml4dHVyZXMxGjAYBgNVBAMMEVJJQ0FMIFRlc3QgU2lnbmVyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpzO3bwxEx36dnpKkcMefEPyAldJM4kLPoP2eUTFi89Lr69Nfwh6ho_ANzdgcbRFMCBsp4S9UbSMB0hUeOozEDaOBkTCBjjAdBgNVHQ4EFgQUO_-jL0aDjkbcm6CgIHXWrUsbngUwHwYDVR0jBBgwFoAU67mV1H3rh0YzEWjLOv5Z-DdIsHEwDgYDVR0PAQH_BAQDAgZAMCoGA1UdHwQjMCEwH6AdoBuGGWh0dHBzOi8vcmljYWwuZXhhbXBsZS9jcmwwEAYDVR0gBAkwBzAFBgMqAwQwCgYIKoZIzj0EAwIDSQAwRgIhALZ_msangnrrXhHQdoVeHngvNkDTuUQF4twPPA5i-2XWAiEA1qWFVUwCpqpiQD7N5EvpQ4DTxi02m36JHMNdJvrxK-OgWQKepmd2ZXJzaW9uYzEuMGhwcm92aWRlcm10ZXN0LXByb3ZpZGVyZGRhdGXAdDIwMjYtMDktMDFUMDA6MDA6MDBaaG5vdEFmdGVywHQyMDI3LTAxLTAxVDAwOjAwOjAwWnBjZXJ0aWZpY2F0ZUluZm9zgaVrY2VydGlmaWNhdGVZAZIwggGOMIIBNaADAgECAghAAAAAAAAAAzAKBggqhkjOPQQDAjAbMRkwFwYDVQQDDBBSZWFkZXIgVGVzdCBSb290MB4XDTI2MDgzMDIwNTgyMloXDTI3MDgzMDIwNTgyMlowGzEZMBcGA1UEAwwQUmVhZGVyIFRlc3QgUm9vdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNYS1aGguJw1UW2bz_u4vhWK8NodDaUpB2QWq-aO9lLKtY9wrW3684IP-gcSALoEMNlFMlXLeOSS8rXHVIm1WTKjYzBhMA8GA1UdEwEB_wQFMAMBAf8wDgYDVR0PAQH_BAQDAgEGMB0GA1UdDgQWBBSF2Mb_KOV713swGCgL1Lnt4rf_HzAfBgNVHSMEGDAWgBSF2Mb_KOV713swGCgL1Lnt4rf_HzAKBggqhkjOPQQDAgNHADBEAiAPPd02BXTI7cCZxMxA8t9FZn4axqr2vI0v4Cg6mQswzwIgOm7mE-Y634y8cEkNSwCXy1DL6Od4D6HSmV5nswEqIYdsc2VyaWFsTnVtYmVywkhAAAAAAAAAA2Nza2lUAQIDBAUGBwgJCgsMDQ4PEBESExRtaXNUcnVzdEFuY2hvcvVkbmFtZXgYRml4dHVyZSByZWFkZXIgYXV0aG9yaXR5ZHR5cGV4J29yZy5pc28uMTgwMTMuNS4xLnJlYWRlcl9hdXRoZW50aWNhdGlvblhA5kQFmKh6ysjSmnvTqcE5vCffjsF_BlaAYXFMH8QIuoCZqrd2C0k0v7QsFjJpCS8T9zJpt92-lgOre5fkOVA2rg"
+    }
+}

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/README.md
@@ -157,6 +157,36 @@ Bluetooth, COSE, or platform objects. Call `close()` when the journey ends;
 closing is idempotent and every new session rotates engagement identifiers and
 ephemeral key material.
 
+Reader authentication validity does not establish reader trust. Provision
+Reader CA certificates out of band and inject the shared evaluator when the
+integration requires a trusted reader:
+
+```swift
+let readerTrust = ProximityConfiguredReaderTrustEvaluator(
+    configuration: ProximityReaderTrustConfiguration(
+        trustAnchors: [
+            ProximityReaderTrustAnchor(
+                certificateDER: readerCA,
+                displayName: "Example reader authority"
+            )
+        ],
+        revocationPolicy: .check(applicationRevocationEvaluator)
+    )
+)
+let configuration = ProximityPresentationConfiguration(
+    readerPolicy: .requireTrusted,
+    readerTrustEvaluator: readerTrust
+)
+```
+
+The SDK validates the certificate profile, time, and path only against explicit
+application anchors. It performs no hidden network lookup and ships no reader
+trust list. Certificates sent by the reader are path inputs, never implicit
+anchors. Optional RICAL providers have separate explicit provider roots, signer
+policy, revocation, and constraint boundaries. Demo apps can inject a named
+test anchor through the same configuration initializer without making it a
+production default.
+
 ## Protected keys
 
 New signing keys default to `.biometricCurrentSet`. Select `.none` explicitly

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/ProximityPresentation.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/ProximityPresentation.md
@@ -88,6 +88,39 @@ statement index. During protected-key work,
 ``ProximityHolderAuthorizationRequest`` per approved document so a mixed
 signature/MAC response cannot be collapsed into a global authorization method.
 
+### Configure reader trust
+
+Cryptographic reader-authentication validity does not establish application
+trust. Provision Reader CA certificates through an out-of-band application
+channel and inject ``ProximityConfiguredReaderTrustEvaluator`` when the wallet
+requires a trusted reader:
+
+```swift
+let readerTrust = ProximityConfiguredReaderTrustEvaluator(
+    configuration: ProximityReaderTrustConfiguration(
+        trustAnchors: [
+            ProximityReaderTrustAnchor(
+                certificateDER: readerCA,
+                displayName: "Example reader authority"
+            )
+        ],
+        revocationPolicy: .check(applicationRevocationEvaluator)
+    )
+)
+let configuration = ProximityPresentationConfiguration(
+    readerPolicy: .requireTrusted,
+    readerTrustEvaluator: readerTrust
+)
+```
+
+The shared evaluator validates the ISO certificate profile, time, and path only
+against explicit application anchors. It performs no hidden network request and
+ships no reader trust list. Certificates carried by the reader are path inputs,
+not implicit anchors. Optional RICAL configuration similarly requires explicit
+provider roots and application-owned signer-revocation and constraint policies.
+A demo can pass a named test anchor through this same initializer; do not ship
+test anchors as production defaults.
+
 ### Lifecycle
 
 Only one proximity session can be active per wallet. Cancellation is available

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/ProximityPresentation.md
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/Documentation.docc/ProximityPresentation.md
@@ -92,7 +92,7 @@ signature/MAC response cannot be collapsed into a global authorization method.
 
 Cryptographic reader-authentication validity does not establish application
 trust. Provision Reader CA certificates through an out-of-band application
-channel and inject ``ProximityConfiguredReaderTrustEvaluator`` when the wallet
+channel and inject `ProximityConfiguredReaderTrustEvaluator` when the wallet
 requires a trusted reader:
 
 ```swift

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/KMPWalletCoreBridge.swift
@@ -406,6 +406,10 @@ final class KMPWalletCoreBridge: WalletCoreBridge, @unchecked Sendable {
     }
 }
 
+private protocol KMPBackedProximityReaderTrustEvaluator {
+    var kmpReaderTrustEvaluator: any MobileWalletProximityReaderTrustEvaluator { get }
+}
+
 private extension ProximityPresentationConfiguration {
     func toKMPConfiguration() -> MobileWalletProximityConfiguration {
         MobileWalletProximityConfiguration(
@@ -416,8 +420,9 @@ private extension ProximityPresentationConfiguration {
             retrievalMethods: Set(retrievalMethods.map { $0.toKMPMethod() }),
             readerPolicy: readerPolicy.toKMPPolicy(),
             deviceAuthenticationPolicy: deviceAuthenticationPolicy.toKMPPolicy(),
-            readerTrustEvaluator: readerTrustEvaluator.map {
-                KMPProximityReaderTrustEvaluatorAdapter(evaluator: $0)
+            readerTrustEvaluator: readerTrustEvaluator.map { evaluator in
+                (evaluator as? any KMPBackedProximityReaderTrustEvaluator)?.kmpReaderTrustEvaluator ??
+                    KMPProximityReaderTrustEvaluatorAdapter(evaluator: evaluator)
             } ?? UnconfiguredMobileWalletProximityReaderTrustEvaluator.shared,
             credentialStatusEvaluator: credentialStatusEvaluator.map {
                 KMPProximityCredentialStatusEvaluatorAdapter(evaluator: $0)
@@ -426,6 +431,226 @@ private extension ProximityPresentationConfiguration {
                 profiles: applicationProfiles.map(KMPProximityApplicationProfileAdapter.init)
             ),
             maximumMessageBytes: Int32(maximumMessageBytes)
+        )
+    }
+}
+
+/// Swift-native facade for the shared ISO reader-certificate and RICAL trust evaluator.
+public final class ProximityConfiguredReaderTrustEvaluator:
+    ProximityReaderTrustEvaluator,
+    KMPBackedProximityReaderTrustEvaluator,
+    @unchecked Sendable {
+    private let evaluator: MobileWalletProximityConfiguredReaderTrustEvaluator
+
+    public init(configuration: ProximityReaderTrustConfiguration) {
+        evaluator = MobileWalletProximityConfiguredReaderTrustEvaluator(
+            configuration: configuration.toKMPConfiguration()
+        )
+    }
+
+    fileprivate var kmpReaderTrustEvaluator: any MobileWalletProximityReaderTrustEvaluator {
+        evaluator
+    }
+
+    public func evaluate(
+        _ evidence: ProximityReaderEvidence
+    ) async throws -> ProximityReaderTrustDecision {
+        try await evaluator.evaluate(evidence: evidence.toKMPEvidence()).toSwiftDecision()
+    }
+}
+
+private final class KMPProximityReaderRevocationEvaluatorAdapter:
+    MobileWalletProximityReaderRevocationEvaluator,
+    @unchecked Sendable {
+    private let evaluator: any ProximityReaderRevocationEvaluator
+
+    init(_ evaluator: any ProximityReaderRevocationEvaluator) {
+        self.evaluator = evaluator
+    }
+
+    func __evaluate(
+        evidence: MobileWalletProximityReaderEvidence
+    ) async throws -> any MobileWalletProximityCertificateRevocationResult {
+        switch try await evaluator.evaluate(evidence.toSwiftEvidence()).storage {
+        case .good:
+            return MobileWalletProximityCertificateRevocationResultGood.shared
+        case let .revoked(reason):
+            return MobileWalletProximityCertificateRevocationResultRevoked(reason: reason)
+        case let .indeterminate(reason):
+            return MobileWalletProximityCertificateRevocationResultIndeterminate(reason: reason)
+        }
+    }
+}
+
+private final class KMPProximityRICALSignerRevocationEvaluatorAdapter:
+    MobileWalletProximityRicalSignerRevocationEvaluator,
+    @unchecked Sendable {
+    private let evaluator: any ProximityRICALSignerRevocationEvaluator
+
+    init(_ evaluator: any ProximityRICALSignerRevocationEvaluator) {
+        self.evaluator = evaluator
+    }
+
+    func __evaluate(
+        evidence: MobileWalletProximityRicalSignerEvidence
+    ) async throws -> any MobileWalletProximityCertificateRevocationResult {
+        let result = try await evaluator.evaluate(
+            ProximityRICALSignerEvidence(
+                providerID: evidence.providerId,
+                certificateChainDER: try evidence.certificateChainDerBase64Url.map {
+                    try decodedBase64URL($0, context: "RICAL signer certificate evidence")
+                }
+            )
+        )
+        switch result.storage {
+        case .good:
+            return MobileWalletProximityCertificateRevocationResultGood.shared
+        case let .revoked(reason):
+            return MobileWalletProximityCertificateRevocationResultRevoked(reason: reason)
+        case let .indeterminate(reason):
+            return MobileWalletProximityCertificateRevocationResultIndeterminate(reason: reason)
+        }
+    }
+}
+
+private final class KMPProximityRICALProviderAdapter:
+    MobileWalletProximityRicalProvider,
+    @unchecked Sendable {
+    private let provider: any ProximityRICALProvider
+
+    init(_ provider: any ProximityRICALProvider) {
+        self.provider = provider
+    }
+
+    func __current() async throws -> any MobileWalletProximityRicalProviderResult {
+        switch try await provider.current().storage {
+        case let .available(signedRICAL):
+            return MobileWalletProximityRicalProviderResultAvailable(
+                signedRicalBase64Url: signedRICAL.base64URLEncodedString()
+            )
+        case let .unavailable(reason):
+            return MobileWalletProximityRicalProviderResultUnavailable(reason: reason)
+        case let .conflict(reason):
+            return MobileWalletProximityRicalProviderResultConflict(reason: reason)
+        }
+    }
+}
+
+private final class KMPProximityRICALConstraintEvaluatorAdapter:
+    MobileWalletProximityRicalConstraintEvaluator,
+    @unchecked Sendable {
+    private let evaluator: any ProximityRICALConstraintEvaluator
+
+    init(_ evaluator: any ProximityRICALConstraintEvaluator) {
+        self.evaluator = evaluator
+    }
+
+    func __accepts(
+        constraints: [MobileWalletProximityRicalTrustConstraint],
+        reader: MobileWalletProximityReaderEvidence
+    ) async throws -> KotlinBoolean {
+        let values = try constraints.map { constraint in
+            ProximityRICALTrustConstraint(
+                valuesCBOR: try constraint.valuesCborBase64Url.mapValues {
+                    try decodedBase64URL($0, context: "RICAL trust constraint")
+                }
+            )
+        }
+        return KotlinBoolean(bool: try await evaluator.accepts(values, reader: reader.toSwiftEvidence()))
+    }
+}
+
+private extension ProximityReaderTrustConfiguration {
+    func toKMPConfiguration() -> MobileWalletProximityReaderTrustConfiguration {
+        MobileWalletProximityReaderTrustConfiguration(
+            trustAnchors: trustAnchors.map {
+                MobileWalletProximityReaderTrustAnchor(
+                    certificateDerBase64Url: $0.certificateDER.base64URLEncodedString(),
+                    displayName: $0.displayName
+                )
+            },
+            ricalProviders: ricalProviders.map { configuration in
+                MobileWalletProximityRicalConfiguration(
+                    providerId: configuration.providerID,
+                    acceptedTypes: configuration.acceptedTypes,
+                    providerTrustAnchors: configuration.providerTrustAnchors.map {
+                        MobileWalletProximityRicalProviderTrustAnchor(
+                            certificateDerBase64Url: $0.certificateDER.base64URLEncodedString()
+                        )
+                    },
+                    acceptedSignerCertificatePolicyOids: configuration.acceptedSignerCertificatePolicyOIDs,
+                    signerRevocationPolicy: configuration.signerRevocationPolicy.toKMPPolicy(),
+                    establishReaderTrust: configuration.establishReaderTrust,
+                    provider: KMPProximityRICALProviderAdapter(configuration.provider),
+                    constraintEvaluator: configuration.constraintEvaluator.map {
+                        KMPProximityRICALConstraintEvaluatorAdapter($0)
+                    }
+                )
+            },
+            revocationPolicy: revocationPolicy.toKMPPolicy()
+        )
+    }
+}
+
+private extension ProximityRICALSignerRevocationPolicy {
+    func toKMPPolicy() -> any MobileWalletProximityRicalSignerRevocationPolicy {
+        switch self {
+        case .notChecked:
+            return MobileWalletProximityRicalSignerRevocationPolicyNotChecked.shared
+        case let .check(evaluator):
+            return MobileWalletProximityRicalSignerRevocationPolicyCheck(
+                evaluator: KMPProximityRICALSignerRevocationEvaluatorAdapter(evaluator)
+            )
+        }
+    }
+}
+
+private extension ProximityReaderRevocationPolicy {
+    func toKMPPolicy() -> any MobileWalletProximityReaderRevocationPolicy {
+        switch self {
+        case .notChecked:
+            return MobileWalletProximityReaderRevocationPolicyNotChecked.shared
+        case let .check(evaluator):
+            return MobileWalletProximityReaderRevocationPolicyCheck(
+                evaluator: KMPProximityReaderRevocationEvaluatorAdapter(evaluator)
+            )
+        }
+    }
+}
+
+private extension ProximityReaderEvidence {
+    func toKMPEvidence() -> MobileWalletProximityReaderEvidence {
+        MobileWalletProximityReaderEvidence(
+            scope: scope.toKMPScope(),
+            documentRequestIndex: documentRequestIndex.map { KotlinInt(int: Int32($0)) },
+            authenticationIndex: Int32(authenticationIndex),
+            certificateChainDerBase64Url: certificateChainDER.map { $0.base64URLEncodedString() }
+        )
+    }
+}
+
+private extension MobileWalletProximityReaderEvidence {
+    func toSwiftEvidence() throws -> ProximityReaderEvidence {
+        ProximityReaderEvidence(
+            scope: scope.toSwiftScope(),
+            documentRequestIndex: documentRequestIndex.map { Int($0.int32Value) },
+            authenticationIndex: Int(authenticationIndex),
+            certificateChainDER: try certificateChainDerBase64Url.map {
+                try decodedBase64URL($0, context: "reader certificate evidence")
+            }
+        )
+    }
+}
+
+private extension MobileWalletProximityReaderTrustDecision {
+    func toSwiftDecision() -> ProximityReaderTrustDecision {
+        ProximityReaderTrustDecision(
+            state: state.toSwiftTrust(),
+            certificatePath: certificatePath.toSwiftPath(),
+            revocation: revocation.toSwiftRevocation(),
+            rical: rical.toSwiftRICAL(),
+            displayName: displayName,
+            reason: reason
         )
     }
 }
@@ -442,20 +667,7 @@ private final class KMPProximityReaderTrustEvaluatorAdapter:
     func __evaluate(
         evidence: MobileWalletProximityReaderEvidence
     ) async throws -> MobileWalletProximityReaderTrustDecision {
-        let certificateChain = try swiftArray(evidence.certificateChainDerBase64Url, of: String.self).map {
-            guard let data = Data(base64URLEncoded: $0) else {
-                throw WalletError.internalFailure("Wallet core returned invalid reader certificate evidence")
-            }
-            return data
-        }
-        let decision = try await evaluator.evaluate(
-            ProximityReaderEvidence(
-                scope: evidence.scope.toSwiftScope(),
-                documentRequestIndex: evidence.documentRequestIndex.map { Int($0.int32Value) },
-                authenticationIndex: Int(evidence.authenticationIndex),
-                certificateChainDER: certificateChain
-            )
-        )
+        let decision = try await evaluator.evaluate(evidence.toSwiftEvidence())
         return MobileWalletProximityReaderTrustDecision(
             state: decision.state.toKMPState(),
             certificatePath: decision.certificatePath.toKMPState(),
@@ -1671,6 +1883,15 @@ private extension MobileWalletProximityReaderAuthenticationScope {
     }
 }
 
+private extension ProximityReaderAuthenticationScope {
+    func toKMPScope() -> MobileWalletProximityReaderAuthenticationScope {
+        switch self {
+        case .document: return .document
+        case .wholeRequest: return .wholeRequest
+        }
+    }
+}
+
 private extension ProximityReaderTrustState {
     func toKMPState() -> MobileWalletProximityReaderTrustState {
         switch self {
@@ -1686,6 +1907,7 @@ private extension ProximityReaderCertificatePathState {
     func toKMPState() -> MobileWalletProximityReaderCertificatePathState {
         switch self {
         case .notEvaluated: return .notEvaluated
+        case .unknownAuthority: return .unknownAuthority
         case .invalid: return .invalid
         case .valid: return .valid
         }
@@ -2053,6 +2275,7 @@ private extension MobileWalletProximityReaderCertificatePathState {
     func toSwiftPath() -> ProximityReaderCertificatePathState {
         switch self {
         case .notEvaluated: return .notEvaluated
+        case .unknownAuthority: return .unknownAuthority
         case .invalid: return .invalid
         case .valid: return .valid
         }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/ProximityPresentation.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/ProximityPresentation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 
 /// Versioned mdoc interoperability boundary selected for one proximity session.
 public enum ProximityPresentationProfile: String, Sendable, CaseIterable, Equatable {
@@ -102,6 +103,8 @@ public enum ProximityReaderTrustState: Sendable, Equatable {
 public enum ProximityReaderCertificatePathState: Sendable, Equatable {
     /// Certificate-path validation was not performed.
     case notEvaluated
+    /// The reader path is structurally valid, but no configured authority matches it.
+    case unknownAuthority
     /// The certificate path is invalid.
     case invalid
     /// The certificate path is valid.
@@ -209,7 +212,12 @@ public struct ProximityReaderTrustDecision: Sendable, Equatable {
         precondition(state != .revoked || revocation == .revoked)
         precondition(revocation != .revoked || state == .revoked)
         precondition(state != .trusted || certificatePath == .valid)
+        precondition(state != .revoked || certificatePath == .valid)
+        precondition(certificatePath != .unknownAuthority || state == .validButUntrusted)
+        precondition(certificatePath != .invalid || state == .validButUntrusted)
+        precondition(certificatePath != .invalid || revocation == .notChecked)
         precondition(state != .trusted || revocation != .indeterminate)
+        precondition(rical != .matched || certificatePath == .valid)
         precondition(displayName == nil || isProximityNonBlank(displayName!))
         precondition(reason == nil || isProximityNonBlank(reason!))
         self.state = state
@@ -227,6 +235,217 @@ public protocol ProximityReaderTrustEvaluator: Sendable {
     /// - Parameter evidence: Verified reader evidence for one authentication scope.
     /// - Returns: The application's coherent trust decision.
     func evaluate(_ evidence: ProximityReaderEvidence) async throws -> ProximityReaderTrustDecision
+}
+
+/// Explicit application-provisioned Reader CA certificate and optional display label.
+public struct ProximityReaderTrustAnchor: Sendable, Equatable {
+    /// DER-encoded Reader CA certificate.
+    public let certificateDER: Data
+    /// Display-safe authority label that does not establish trust by itself.
+    public let displayName: String?
+
+    public init(certificateDER: Data, displayName: String? = nil) {
+        precondition(isProximityX509Certificate(certificateDER))
+        precondition(displayName == nil || isProximityNonBlank(displayName!))
+        self.certificateDER = certificateDER
+        self.displayName = displayName
+    }
+}
+
+/// Immutable result from an application-owned certificate-status source.
+public struct ProximityCertificateRevocationResult: Sendable, Equatable {
+    enum Storage: Sendable, Equatable {
+        case good
+        case revoked(reason: String?)
+        case indeterminate(reason: String)
+    }
+
+    let storage: Storage
+
+    /// The configured source established that the certificate is not revoked.
+    public static let good = Self(storage: .good)
+
+    /// The configured source established that the certificate is revoked.
+    public static func revoked(reason: String? = nil) -> Self {
+        precondition(reason == nil || isProximityNonBlank(reason!))
+        return Self(storage: .revoked(reason: reason))
+    }
+
+    /// The configured source could not establish current revocation status.
+    public static func indeterminate(reason: String) -> Self {
+        precondition(isProximityNonBlank(reason))
+        return Self(storage: .indeterminate(reason: reason))
+    }
+}
+
+/// Application boundary for OCSP, CRL, or another reader-certificate status source.
+public protocol ProximityReaderRevocationEvaluator: Sendable {
+    func evaluate(_ evidence: ProximityReaderEvidence) async throws -> ProximityCertificateRevocationResult
+}
+
+/// Explicit revocation behavior selected for reader trust.
+public enum ProximityReaderRevocationPolicy: Sendable {
+    /// Do not perform revocation lookup; the resulting fact remains ``ProximityReaderRevocationState/notChecked``.
+    case notChecked
+    /// Require the supplied source to return a conclusive result before the reader can be trusted.
+    case check(any ProximityReaderRevocationEvaluator)
+}
+
+/// Exact RICAL signer evidence passed to an application-owned certificate-status source.
+public struct ProximityRICALSignerEvidence: Sendable, Equatable {
+    /// Stable identifier of the configured RICAL provider.
+    public let providerID: String
+    /// DER certificates in leaf-first order.
+    public let certificateChainDER: [Data]
+
+    public init(providerID: String, certificateChainDER: [Data]) {
+        precondition(isProximityNonBlank(providerID))
+        precondition(!certificateChainDER.isEmpty && certificateChainDER.allSatisfy { !$0.isEmpty })
+        self.providerID = providerID
+        self.certificateChainDER = certificateChainDER
+    }
+}
+
+/// Application boundary for RICAL-signer OCSP, CRL, or another status source.
+public protocol ProximityRICALSignerRevocationEvaluator: Sendable {
+    func evaluate(
+        _ evidence: ProximityRICALSignerEvidence
+    ) async throws -> ProximityCertificateRevocationResult
+}
+
+/// Explicit revocation behavior selected for one RICAL provider's signer certificate.
+public enum ProximityRICALSignerRevocationPolicy: Sendable {
+    /// Do not perform a signer-revocation lookup.
+    case notChecked
+    /// Require the supplied source to establish that the RICAL signer is not revoked.
+    case check(any ProximityRICALSignerRevocationEvaluator)
+}
+
+/// Explicit application-provisioned root for one RICAL provider.
+public struct ProximityRICALProviderTrustAnchor: Sendable, Equatable {
+    public let certificateDER: Data
+
+    public init(certificateDER: Data) {
+        precondition(isProximityX509Certificate(certificateDER))
+        self.certificateDER = certificateDER
+    }
+}
+
+/// Immutable active-RICAL result from an application-owned provider boundary.
+public struct ProximityRICALProviderResult: Sendable, Equatable {
+    enum Storage: Sendable, Equatable {
+        case available(signedRICAL: Data)
+        case unavailable(reason: String)
+        case conflict(reason: String)
+    }
+
+    let storage: Storage
+
+    /// Supplies exact untagged COSE_Sign1 bytes.
+    public static func available(signedRICAL: Data) -> Self {
+        precondition(!signedRICAL.isEmpty)
+        return Self(storage: .available(signedRICAL: signedRICAL))
+    }
+
+    /// No active list is available.
+    public static func unavailable(reason: String) -> Self {
+        precondition(isProximityNonBlank(reason))
+        return Self(storage: .unavailable(reason: reason))
+    }
+
+    /// The application detected conflicting active-list state.
+    public static func conflict(reason: String) -> Self {
+        precondition(isProximityNonBlank(reason))
+        return Self(storage: .conflict(reason: reason))
+    }
+}
+
+/// Supplies the latest application-selected RICAL without implicit SDK networking.
+public protocol ProximityRICALProvider: Sendable {
+    func current() async throws -> ProximityRICALProviderResult
+}
+
+/// One RICAL trust constraint. Values contain CBOR-encoded constraint data.
+public struct ProximityRICALTrustConstraint: Sendable, Equatable {
+    public let valuesCBOR: [String: Data]
+
+    public init(valuesCBOR: [String: Data]) {
+        precondition(!valuesCBOR.isEmpty)
+        precondition(valuesCBOR.allSatisfy { isProximityNonBlank($0.key) && !$0.value.isEmpty })
+        self.valuesCBOR = valuesCBOR
+    }
+}
+
+/// Application evaluator for ecosystem-specific RICAL trust-constraint semantics.
+public protocol ProximityRICALConstraintEvaluator: Sendable {
+    /// Returns true only when at least one complete constraint is understood and satisfied.
+    func accepts(
+        _ constraints: [ProximityRICALTrustConstraint],
+        reader: ProximityReaderEvidence
+    ) async throws -> Bool
+}
+
+/// Immutable policy for one explicitly configured RICAL provider.
+public struct ProximityRICALConfiguration: Sendable {
+    public let providerID: String
+    public let acceptedTypes: Set<String>
+    public let providerTrustAnchors: [ProximityRICALProviderTrustAnchor]
+    public let acceptedSignerCertificatePolicyOIDs: Set<String>
+    public let signerRevocationPolicy: ProximityRICALSignerRevocationPolicy
+    public let establishReaderTrust: Bool
+    public let provider: any ProximityRICALProvider
+    /// Nil rejects nonempty ecosystem-specific constraints as unsupported.
+    public let constraintEvaluator: (any ProximityRICALConstraintEvaluator)?
+
+    public init(
+        providerID: String,
+        acceptedTypes: Set<String>,
+        providerTrustAnchors: [ProximityRICALProviderTrustAnchor],
+        acceptedSignerCertificatePolicyOIDs: Set<String>,
+        signerRevocationPolicy: ProximityRICALSignerRevocationPolicy = .notChecked,
+        establishReaderTrust: Bool = false,
+        provider: any ProximityRICALProvider,
+        constraintEvaluator: (any ProximityRICALConstraintEvaluator)? = nil
+    ) {
+        precondition(isProximityNonBlank(providerID))
+        precondition(!acceptedTypes.isEmpty && acceptedTypes.allSatisfy(isProximityNonBlank))
+        precondition(
+            !providerTrustAnchors.isEmpty &&
+                Set(providerTrustAnchors.map(\.certificateDER)).count == providerTrustAnchors.count
+        )
+        precondition(
+            !acceptedSignerCertificatePolicyOIDs.isEmpty &&
+                acceptedSignerCertificatePolicyOIDs.allSatisfy(isProximityNonBlank)
+        )
+        self.providerID = providerID
+        self.acceptedTypes = acceptedTypes
+        self.providerTrustAnchors = providerTrustAnchors
+        self.acceptedSignerCertificatePolicyOIDs = acceptedSignerCertificatePolicyOIDs
+        self.signerRevocationPolicy = signerRevocationPolicy
+        self.establishReaderTrust = establishReaderTrust
+        self.provider = provider
+        self.constraintEvaluator = constraintEvaluator
+    }
+}
+
+/// Swift-native immutable configuration for the shared standards reader-trust evaluator.
+public struct ProximityReaderTrustConfiguration: Sendable {
+    public let trustAnchors: [ProximityReaderTrustAnchor]
+    public let ricalProviders: [ProximityRICALConfiguration]
+    public let revocationPolicy: ProximityReaderRevocationPolicy
+
+    public init(
+        trustAnchors: [ProximityReaderTrustAnchor] = [],
+        ricalProviders: [ProximityRICALConfiguration] = [],
+        revocationPolicy: ProximityReaderRevocationPolicy = .notChecked
+    ) {
+        precondition(!trustAnchors.isEmpty || !ricalProviders.isEmpty)
+        precondition(Set(trustAnchors.map(\.certificateDER)).count == trustAnchors.count)
+        precondition(Set(ricalProviders.map(\.providerID)).count == ricalProviders.count)
+        self.trustAnchors = trustAnchors
+        self.ricalProviders = ricalProviders
+        self.revocationPolicy = revocationPolicy
+    }
 }
 
 /// Application-owned status result for a candidate holder credential.
@@ -927,4 +1146,8 @@ public actor ProximityPresentationSession {
 
 private func isProximityNonBlank(_ value: String) -> Bool {
     !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+}
+
+private func isProximityX509Certificate(_ data: Data) -> Bool {
+    !data.isEmpty && SecCertificateCreateWithData(nil, data as CFData) != nil
 }

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/ProximityPresentation.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Sources/WalletSDK/ProximityPresentation.swift
@@ -244,6 +244,10 @@ public struct ProximityReaderTrustAnchor: Sendable, Equatable {
     /// Display-safe authority label that does not establish trust by itself.
     public let displayName: String?
 
+    /// Creates an explicitly application-provisioned Reader CA trust anchor.
+    /// - Parameters:
+    ///   - certificateDER: DER-encoded Reader CA certificate.
+    ///   - displayName: Optional display-safe authority label.
     public init(certificateDER: Data, displayName: String? = nil) {
         precondition(isProximityX509Certificate(certificateDER))
         precondition(displayName == nil || isProximityNonBlank(displayName!))
@@ -280,6 +284,9 @@ public struct ProximityCertificateRevocationResult: Sendable, Equatable {
 
 /// Application boundary for OCSP, CRL, or another reader-certificate status source.
 public protocol ProximityReaderRevocationEvaluator: Sendable {
+    /// Evaluates current revocation status for a verified reader chain.
+    /// - Parameter evidence: Verified reader evidence for one authentication scope.
+    /// - Returns: The configured source's immutable certificate-status result.
     func evaluate(_ evidence: ProximityReaderEvidence) async throws -> ProximityCertificateRevocationResult
 }
 
@@ -298,6 +305,10 @@ public struct ProximityRICALSignerEvidence: Sendable, Equatable {
     /// DER certificates in leaf-first order.
     public let certificateChainDER: [Data]
 
+    /// Creates exact signer evidence for one configured RICAL provider.
+    /// - Parameters:
+    ///   - providerID: Stable identifier of the configured provider.
+    ///   - certificateChainDER: Nonempty DER certificate chain in leaf-first order.
     public init(providerID: String, certificateChainDER: [Data]) {
         precondition(isProximityNonBlank(providerID))
         precondition(!certificateChainDER.isEmpty && certificateChainDER.allSatisfy { !$0.isEmpty })
@@ -308,6 +319,9 @@ public struct ProximityRICALSignerEvidence: Sendable, Equatable {
 
 /// Application boundary for RICAL-signer OCSP, CRL, or another status source.
 public protocol ProximityRICALSignerRevocationEvaluator: Sendable {
+    /// Evaluates current revocation status for a verified RICAL signer chain.
+    /// - Parameter evidence: Exact signer evidence for the selected provider.
+    /// - Returns: The configured source's immutable certificate-status result.
     func evaluate(
         _ evidence: ProximityRICALSignerEvidence
     ) async throws -> ProximityCertificateRevocationResult
@@ -323,8 +337,11 @@ public enum ProximityRICALSignerRevocationPolicy: Sendable {
 
 /// Explicit application-provisioned root for one RICAL provider.
 public struct ProximityRICALProviderTrustAnchor: Sendable, Equatable {
+    /// DER-encoded trust anchor for this RICAL provider's signer.
     public let certificateDER: Data
 
+    /// Creates an explicitly application-provisioned RICAL signer trust anchor.
+    /// - Parameter certificateDER: DER-encoded trust-anchor certificate.
     public init(certificateDER: Data) {
         precondition(isProximityX509Certificate(certificateDER))
         self.certificateDER = certificateDER
@@ -362,13 +379,18 @@ public struct ProximityRICALProviderResult: Sendable, Equatable {
 
 /// Supplies the latest application-selected RICAL without implicit SDK networking.
 public protocol ProximityRICALProvider: Sendable {
+    /// Returns the application's current active-list result for this provider.
+    /// - Returns: Exact signed RICAL bytes or a display-safe unavailable/conflict result.
     func current() async throws -> ProximityRICALProviderResult
 }
 
 /// One RICAL trust constraint. Values contain CBOR-encoded constraint data.
 public struct ProximityRICALTrustConstraint: Sendable, Equatable {
+    /// Constraint name to CBOR-encoded value.
     public let valuesCBOR: [String: Data]
 
+    /// Creates one nonempty ecosystem-specific RICAL trust constraint.
+    /// - Parameter valuesCBOR: Constraint names mapped to nonempty CBOR-encoded values.
     public init(valuesCBOR: [String: Data]) {
         precondition(!valuesCBOR.isEmpty)
         precondition(valuesCBOR.allSatisfy { isProximityNonBlank($0.key) && !$0.value.isEmpty })
@@ -379,6 +401,10 @@ public struct ProximityRICALTrustConstraint: Sendable, Equatable {
 /// Application evaluator for ecosystem-specific RICAL trust-constraint semantics.
 public protocol ProximityRICALConstraintEvaluator: Sendable {
     /// Returns true only when at least one complete constraint is understood and satisfied.
+    /// - Parameters:
+    ///   - constraints: Complete constraints carried by the matched RICAL authority.
+    ///   - reader: Verified reader evidence to which the constraints apply.
+    /// - Returns: Whether an understood complete constraint is satisfied.
     func accepts(
         _ constraints: [ProximityRICALTrustConstraint],
         reader: ProximityReaderEvidence
@@ -387,16 +413,33 @@ public protocol ProximityRICALConstraintEvaluator: Sendable {
 
 /// Immutable policy for one explicitly configured RICAL provider.
 public struct ProximityRICALConfiguration: Sendable {
+    /// Stable application-configured provider identifier.
     public let providerID: String
+    /// RICAL type identifiers accepted from this provider.
     public let acceptedTypes: Set<String>
+    /// Explicit X.509 trust anchors accepted for this provider's signer.
     public let providerTrustAnchors: [ProximityRICALProviderTrustAnchor]
+    /// Certificate-policy OIDs accepted on this provider's signer certificate.
     public let acceptedSignerCertificatePolicyOIDs: Set<String>
+    /// Revocation behavior for this provider's verified signer certificate.
     public let signerRevocationPolicy: ProximityRICALSignerRevocationPolicy
+    /// Whether an accepted matching authority may establish product reader trust.
     public let establishReaderTrust: Bool
+    /// Application-owned source of the current signed RICAL.
     public let provider: any ProximityRICALProvider
     /// Nil rejects nonempty ecosystem-specific constraints as unsupported.
     public let constraintEvaluator: (any ProximityRICALConstraintEvaluator)?
 
+    /// Creates immutable policy for one explicitly configured RICAL provider.
+    /// - Parameters:
+    ///   - providerID: Stable application-configured provider identifier.
+    ///   - acceptedTypes: Nonempty set of accepted RICAL type identifiers.
+    ///   - providerTrustAnchors: Nonempty set of explicit signer trust anchors.
+    ///   - acceptedSignerCertificatePolicyOIDs: Nonempty set of accepted signer policy OIDs.
+    ///   - signerRevocationPolicy: Revocation behavior for the verified signer certificate.
+    ///   - establishReaderTrust: Whether an accepted authority may establish product reader trust.
+    ///   - provider: Application-owned source of the current signed RICAL.
+    ///   - constraintEvaluator: Optional evaluator for ecosystem-specific trust constraints.
     public init(
         providerID: String,
         acceptedTypes: Set<String>,
@@ -430,10 +473,18 @@ public struct ProximityRICALConfiguration: Sendable {
 
 /// Swift-native immutable configuration for the shared standards reader-trust evaluator.
 public struct ProximityReaderTrustConfiguration: Sendable {
+    /// Explicit application-provisioned Reader CA trust anchors.
     public let trustAnchors: [ProximityReaderTrustAnchor]
+    /// Ordered application-configured RICAL provider policies.
     public let ricalProviders: [ProximityRICALConfiguration]
+    /// Revocation behavior for reader chains trusted by direct Reader CA anchors.
     public let revocationPolicy: ProximityReaderRevocationPolicy
 
+    /// Creates immutable application-owned reader-trust configuration.
+    /// - Parameters:
+    ///   - trustAnchors: Explicit Reader CA trust anchors.
+    ///   - ricalProviders: Ordered RICAL provider policies.
+    ///   - revocationPolicy: Revocation behavior for directly anchored reader chains.
     public init(
         trustAnchors: [ProximityReaderTrustAnchor] = [],
         ricalProviders: [ProximityRICALConfiguration] = [],

--- a/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
+++ b/waltid-libraries/protocols/waltid-wallet-sdk-ios/Tests/WalletSDKTests/WalletAPITests.swift
@@ -307,6 +307,42 @@ final class WalletAPITests: XCTestCase {
         XCTAssertNil(evidence.documentRequestIndex)
     }
 
+    #if canImport(WalletCore) && os(iOS)
+    func testConfiguredReaderTrustFacadeKeepsMalformedEvidenceUntrusted() async throws {
+        let trustAnchorBase64 = [
+            "MIIBjjCCATOgAwIBAgIIQAAAAAAAAAEwCgYIKoZIzj0EAwIwGjEYMBYGA1UEAwwP",
+            "UklDQUwgVGVzdCBSb290MB4XDTI2MDgzMDIwNDIwNloXDTI3MDgzMDIwNDIwNlow",
+            "GjEYMBYGA1UEAwwPUklDQUwgVGVzdCBSb290MFkwEwYHKoZIzj0CAQYIKoZIzj0D",
+            "AQcDQgAE4Fc8ezWNtclkN8nWzjzYGxLUF0J6FO0r8pq5/YWiprJBGwTK0CIcesf",
+            "DL+/pxMofjHC5p4TRlb4yuCg9XlIW46NjMGEwHwYDVR0jBBgwFoAU0wI39+8eny",
+            "K9prUvHV4RWCaylxkwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQ",
+            "YDVR0OBBYEFNMCN/fvHp8ivaa1Lx1eEVgmspcZMAoGCCqGSM49BAMCA0kAMEYCIQ",
+            "DYcsOwU11G+fme3xD2EgCgE45qXt3Rg8nhJY2IuA2+3QIhALVJKhK8NfsJMONZo",
+            "8amHvX43b2PuSWhmB3DHufEOnE0",
+        ].joined()
+        let trustAnchor = try XCTUnwrap(Data(base64Encoded: trustAnchorBase64))
+        let evaluator = ProximityConfiguredReaderTrustEvaluator(
+            configuration: ProximityReaderTrustConfiguration(
+                trustAnchors: [
+                    ProximityReaderTrustAnchor(certificateDER: trustAnchor)
+                ]
+            )
+        )
+
+        let decision = try await evaluator.evaluate(
+            ProximityReaderEvidence(
+                scope: .wholeRequest,
+                certificateChainDER: [Data([0x02])]
+            )
+        )
+
+        XCTAssertEqual(decision.state, .validButUntrusted)
+        XCTAssertEqual(decision.certificatePath, .invalid)
+        XCTAssertEqual(decision.revocation, .notChecked)
+        XCTAssertEqual(decision.rical, .notEvaluated)
+    }
+    #endif
+
     func testProximityHolderAuthorizationKeepsPerDocumentMethods() {
         let authorization = ProximityHolderAuthorization(
             exchange: 2,


### PR DESCRIPTION
## Summary

**Closed as superseded — do not merge standalone.** Its complete four-commit delta was transplanted into [#2160](https://github.com/walt-id/waltid-identity/pull/2160) with 4/4 exact patch-equivalence proof. The Settings/public-file-import work also lands only in #2160.

Completes the application-configurable holder-side reader-trust policy for [WAL-1346](https://linear.app/walt-new/issue/WAL-1346/expose-proximity-presentation-through-the-wallet-sdk-and-demo-apps). Applications can now supply explicit Reader CA anchors, revocation policy, and optional RICAL providers through one immutable Kotlin/Swift configuration; the SDK still ships no universal trust list and never promotes reader-supplied certificates to trust anchors.

This PR is stacked on the three-demo proximity journey in [walt-id/waltid-identity#2160](https://github.com/walt-id/waltid-identity/pull/2160). The governing architecture and trust boundary are documented in [walt-id/waltid-architecture#60](https://github.com/walt-id/waltid-architecture/pull/60).

## What Changed

### Shared X.509 and RICAL validation

- Adds reusable ISO mdoc reader-authentication and RICAL-signer certificate profile validation, including explicit-anchor path building and time/profile checks.
- Validates signed RICAL material against application-selected provider roots, types, signer policy, freshness, constraints, and revocation behavior without implicit network access or trust.
- Keeps list signature validity, signer path, reader path, revocation, constraints, and final product trust as separate evidence.

### Wallet SDK configuration

- Adds immutable Kotlin models for Reader CA anchors, reader revocation, RICAL providers, signer revocation, and ecosystem-specific constraint evaluation.
- Evaluates direct Reader CA and RICAL-derived trust through the existing shared reader-trust seam, with explicit trusted, unknown-authority, invalid, revoked, and indeterminate outcomes.
- Exposes the same semantics through Swift-native values and closures while keeping parsing and policy decisions in shared KMP code.

### Contract and UI alignment

- Extends the KLIB ABI, Kotlin/Swift documentation, and focused shared/Swift tests for legal construction, path/profile failures, revocation, RICAL conflicts/unavailability, and trust outcomes.
- Adds the display-safe unknown-authority result to both demo renderers; the demos remain deliberately unconfigured unless an application supplies test or production trust material.

## Architecture Notes

- Trust material and provider selection are application-owned. Reader-carried roots and intermediates are path inputs only.
- Revocation and RICAL retrieval are injected application boundaries; the SDK performs no hidden network requests.
- The immutable trust decision remains bound to the request preview, and platform UI code only renders the shared result.

## Caveats and Follow-Ups

- This PR provides the policy and configuration surface; it does not provision production Reader CA or RICAL material for integrators.
- External-reader interoperability and release qualification remain owned by [WAL-1349](https://linear.app/walt-new/issue/WAL-1349/qualify-proximity-presentation-for-interoperability-and-release).
- NFC transport and demo integration continue in the stacked [walt-id/waltid-identity#2165](https://github.com/walt-id/waltid-identity/pull/2165) and [walt-id/waltid-identity#2166](https://github.com/walt-id/waltid-identity/pull/2166).

## Breaking

No released API is broken. The mobile SDK is still unpublished, so the new trust configuration and exhaustive result state are introduced without migration aliases or compatibility shims.


