### PR TITLE
fix(verifier2): load omitted clientId without Hoplite serialization ctor

### DIFF
--- a/docker-compose/verifier-api2/config/verifier-service.conf
+++ b/docker-compose/verifier-api2/config/verifier-service.conf
@@ -1,11 +1,13 @@
 # Omitted clientId is generated as redirect_uri:<response_uri> for unsigned sessions.
 # Signed requests still need an explicit clientId (for example x509_san_dns or decentralized_identifier).
 # clientId: "verifier2"
-#clientId: "x509_san_dns:verifier.example.com"
+# clientId: "x509_san_dns:verifier.example.com"
+
+clientId: "x509_hash:OPpTDyXlg6WRu2-Qn4rpQcA9uVqSrNExCS8kCYUe09A"
 
 clientMetadata: {
-#    client_name: "Verifier2"
-#    logo_uri: "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/4d493ccf-c893-4882-925f-fda3256c38f4/Walt.id_Logo_transparent.png"
+   client_name: "Verifier2"
+   logo_uri: "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/4d493ccf-c893-4882-925f-fda3256c38f4/Walt.id_Logo_transparent.png"
 }
 
 urlPrefix: "http://${SERVICE_HOST}:${VERIFIER_API2_PORT}/verification-session"

--- a/helm-charts/waltid/values.yaml
+++ b/helm-charts/waltid/values.yaml
@@ -82,7 +82,8 @@ verifier2:
   configMountPath: /waltid-verifier-api2/config
   configFiles:
     verifier-service.conf: |-
-      clientMetadata: {}
+      clientId: "x509_hash:OPpTDyXlg6WRu2-Qn4rpQcA9uVqSrNExCS8kCYUe09A"
+      clientMetadata: {client_name: "Verifier2",logo_uri: "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/4d493ccf-c893-4882-925f-fda3256c38f4/Walt.id_Logo_transparent.png"}
       urlPrefix: "https://{{ .Values.ingress.host }}/verification-session"
       urlHost: "openid4vp://authorize"
       key: {"type":"jwk","jwk":{"kty":"EC","d":"AEb4k1BeTR9xt2NxYZggdzkFLLUkhyyWvyUOq3qSiwA","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}}

--- a/waltid-services/waltid-verifier-api2/config/verifier-service.conf
+++ b/waltid-services/waltid-verifier-api2/config/verifier-service.conf
@@ -2,6 +2,7 @@
 # Signed requests still need an explicit clientId (for example x509_san_dns or decentralized_identifier).
 # clientId: "verifier2"
 #clientId: "x509_san_dns:verifier.example.com"
+clientId: "x509_hash:OPpTDyXlg6WRu2-Qn4rpQcA9uVqSrNExCS8kCYUe09A"
 
 clientMetadata: {
     # Base client name (default/fallback)

--- a/waltid-services/waltid-verifier-api2/k8s/deployment-dev.yaml
+++ b/waltid-services/waltid-verifier-api2/k8s/deployment-dev.yaml
@@ -7,7 +7,8 @@ data:
     webHost = "0.0.0.0"
     webPort = 3000
   verifier-service.conf: |
-    clientMetadata: {}
+    clientId: "x509_hash:OPpTDyXlg6WRu2-Qn4rpQcA9uVqSrNExCS8kCYUe09A"
+    clientMetadata: {client_name: "Verifier2",logo_uri: "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/4d493ccf-c893-4882-925f-fda3256c38f4/Walt.id_Logo_transparent.png"}
     urlPrefix: "https://verifier2.portal.test.waltid.cloud/verification-session"
     urlHost: "openid4vp://authorize"
     key: {"type":"jwk","jwk":{"kty":"EC","d":"AEb4k1BeTR9xt2NxYZggdzkFLLUkhyyWvyUOq3qSiwA","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}}

--- a/waltid-services/waltid-verifier-api2/k8s/deployment-prod.yaml
+++ b/waltid-services/waltid-verifier-api2/k8s/deployment-prod.yaml
@@ -7,7 +7,8 @@ data:
     webHost = "0.0.0.0"
     webPort = 3000
   verifier-service.conf: |
-    clientMetadata: {}
+    clientId: "x509_hash:OPpTDyXlg6WRu2-Qn4rpQcA9uVqSrNExCS8kCYUe09A"
+    clientMetadata: {client_name: "Verifier2",logo_uri: "https://images.squarespace-cdn.com/content/v1/609c0ddf94bcc0278a7cbdb4/4d493ccf-c893-4882-925f-fda3256c38f4/Walt.id_Logo_transparent.png"}
     urlPrefix: "https://verifier2.demo.walt.id/verification-session"
     urlHost: "openid4vp://authorize"
     key: {"type":"jwk","jwk":{"kty":"EC","d":"AEb4k1BeTR9xt2NxYZggdzkFLLUkhyyWvyUOq3qSiwA","crv":"P-256","kid":"_nd-T2YRYLSmuKkJZlRI641zrCIJLTpiHeqMwXuvdug","x":"G_TgBc0BkmMipiQ_6gkamIn3mmp7hcTrZuyrLTmknP0","y":"VkRMZdXYXSMff5AJLrnHiN0x5MV6u_8vrAcytGUe4z4"}}

--- a/waltid-services/waltid-verifier-api2/src/main/kotlin/id/walt/verifier2/OSSVerifier2ServiceConfig.kt
+++ b/waltid-services/waltid-verifier-api2/src/main/kotlin/id/walt/verifier2/OSSVerifier2ServiceConfig.kt
@@ -2,10 +2,8 @@ package id.walt.verifier2
 
 import id.walt.commons.config.WaltConfig
 import id.walt.verifier.openid.models.authorization.ClientMetadata
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
-@Serializable
 data class OSSVerifier2ServiceConfig(
     /** When omitted, unsigned cross-device sessions use `redirect_uri:<response_uri>`. Signed requests require an explicit value. */
     val clientId: String? = null,

--- a/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/OSSVerifier2Crypto2StartupTest.kt
+++ b/waltid-services/waltid-verifier-api2/src/test/kotlin/id/walt/verifier2/OSSVerifier2Crypto2StartupTest.kt
@@ -170,6 +170,23 @@ class OSSVerifier2Crypto2StartupTest {
     }
 
     @Test
+    fun `omitted clientId still loads when clientMetadata is present`() = runTest {
+        loadConfig(includeClientId = false, includeBundledOptionalFields = true)
+        OSSVerifier2Manager.initialize()
+
+        val loaded = ConfigManager.getConfig<OSSVerifier2ServiceConfig>()
+        assertEquals(null, loaded.clientId)
+
+        val session = OSSVerifier2Manager.createVerificationSession(
+            CrossDeviceFlowSetup(core = GeneralFlowConfig())
+        )
+        assertEquals(
+            "redirect_uri:http://localhost:7003/verification-session/${session.id}/response",
+            session.authorizationRequest.clientId,
+        )
+    }
+
+    @Test
     fun `blank per-session clientId falls back to configured service clientId`() = runTest {
         loadConfig()
         OSSVerifier2Manager.initialize()
@@ -185,12 +202,16 @@ class OSSVerifier2Crypto2StartupTest {
         storedKey: String? = null,
         legacyKey: String? = null,
         includeClientId: Boolean = true,
+        includeBundledOptionalFields: Boolean = false,
     ): Pair<Path, String> {
         val configFile = Files.createTempFile("verifier-service", ".conf")
         tempFiles.add(configFile)
         val tripleQuotes = "\"\"\""
         val content = buildString {
             if (includeClientId) appendLine("clientId = \"verifier2\"")
+            if (includeBundledOptionalFields) {
+                appendLine("clientMetadata: { client_name: \"Verifier2\" }")
+            }
             appendLine("urlPrefix = \"http://localhost:7003/verification-session\"")
             appendLine("urlHost = \"openid4vp://authorize\"")
             storedKey?.let { appendLine("requestSigningStoredKey = $tripleQuotes$it$tripleQuotes") }


### PR DESCRIPTION
Hoplite was matching kotlinx.serialization's synthetic constructor when clientId was absent, so startup failed instead of generating redirect_uri.