### PR TITLE
[WAL-1381] fix(wallet): honor credential logo metadata

### DIFF
--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCardArt.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCardArt.kt
@@ -44,6 +44,8 @@ internal data class CredentialCardArtModel(
     val backgroundColor: String? = null,
     val backgroundImageUri: String? = null,
     val textColor: String? = null,
+    val logoUri: String? = null,
+    val logoAltText: String? = null,
 )
 
 internal fun CredentialCardDisplayData.toCardArt(): CredentialCardArtModel =
@@ -53,6 +55,8 @@ internal fun CredentialCardDisplayData.toCardArt(): CredentialCardArtModel =
         backgroundColor = backgroundColor,
         backgroundImageUri = backgroundImageUri,
         textColor = textColor,
+        logoUri = logoUri,
+        logoAltText = logoAltText,
     )
 
 internal fun WalletDemoMetadataDisplay.toCardArt(
@@ -65,7 +69,22 @@ internal fun WalletDemoMetadataDisplay.toCardArt(
         backgroundColor = backgroundColor,
         backgroundImageUri = backgroundImageUri,
         textColor = textColor,
+        logoUri = logoUri,
+        logoAltText = logoAltText,
     )
+
+internal sealed interface CredentialCardLogoSource {
+    data class Metadata(val uri: String) : CredentialCardLogoSource
+    data object BundledWalt : CredentialCardLogoSource
+}
+
+internal fun credentialCardLogoSource(uri: String?): CredentialCardLogoSource =
+    uri?.takeIf(::isHttpsUrl)
+        ?.let(CredentialCardLogoSource::Metadata)
+        ?: CredentialCardLogoSource.BundledWalt
+
+internal fun credentialCardLogoContentDescription(name: String, altText: String?): String =
+    altText?.trim()?.takeIf(String::isNotEmpty) ?: "$name logo"
 
 @Composable
 internal fun CredentialCardArt(
@@ -77,6 +96,7 @@ internal fun CredentialCardArt(
     val constructedColor = parseCssColor(art.backgroundColor) ?: DefaultWaltCardBlue
     val labelColor = parseCssColor(art.textColor) ?: Color.White
     val backgroundImageUri = art.backgroundImageUri?.takeIf(::isHttpsUrl)
+    val logoSource = credentialCardLogoSource(art.logoUri)
     var metadataArtState by remember(backgroundImageUri) {
         mutableStateOf(
             if (backgroundImageUri == null) {
@@ -133,13 +153,22 @@ internal fun CredentialCardArt(
         }
 
         if (showConstructedCardArtOverlay(metadataArtState)) {
-            DefaultWaltLogo(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(namePadding)
-                    .size(logoSize)
-                    .testTag(WalletUiTestTags.CredentialCardConstructedArt),
-            )
+            val logoModifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(namePadding)
+                .size(logoSize)
+                .testTag(WalletUiTestTags.CredentialCardConstructedArt)
+            when (logoSource) {
+                is CredentialCardLogoSource.Metadata -> SubcomposeAsyncImage(
+                    model = logoSource.uri,
+                    contentDescription = credentialCardLogoContentDescription(art.name, art.logoAltText),
+                    modifier = logoModifier,
+                    contentScale = ContentScale.Fit,
+                    loading = { DefaultWaltLogo(Modifier.fillMaxSize()) },
+                    error = { DefaultWaltLogo(Modifier.fillMaxSize()) },
+                )
+                CredentialCardLogoSource.BundledWalt -> DefaultWaltLogo(logoModifier)
+            }
             Text(
                 text = art.name,
                 color = labelColor,

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCardArt.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCardArt.kt
@@ -161,11 +161,19 @@ internal fun CredentialCardArt(
             when (logoSource) {
                 is CredentialCardLogoSource.Metadata -> SubcomposeAsyncImage(
                     model = logoSource.uri,
-                    contentDescription = credentialCardLogoContentDescription(art.name, art.logoAltText),
+                    contentDescription = null,
                     modifier = logoModifier,
                     contentScale = ContentScale.Fit,
-                    loading = { DefaultWaltLogo(Modifier.fillMaxSize()) },
-                    error = { DefaultWaltLogo(Modifier.fillMaxSize()) },
+                    success = { state ->
+                        Image(
+                            painter = state.painter,
+                            contentDescription = credentialCardLogoContentDescription(art.name, art.logoAltText),
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Fit,
+                        )
+                    },
+                    loading = {},
+                    error = {},
                 )
                 CredentialCardLogoSource.BundledWalt -> DefaultWaltLogo(logoModifier)
             }

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/ReviewMetadataComponents.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonMain/kotlin/id/walt/walletdemo/compose/ui/components/ReviewMetadataComponents.kt
@@ -1,5 +1,6 @@
 package id.walt.walletdemo.compose.ui.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -138,11 +139,19 @@ internal fun MetadataIdentityRow(
             if (logoUri != null) {
                 SubcomposeAsyncImage(
                     model = logoUri,
-                    contentDescription = display.logoAltText ?: "$name logo",
+                    contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
                     contentScale = ContentScale.Fit,
-                    loading = { MetadataLogoFallback(name) },
-                    error = { MetadataLogoFallback(name) },
+                    success = { state ->
+                        Image(
+                            painter = state.painter,
+                            contentDescription = display.logoAltText ?: "$name logo",
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Fit,
+                        )
+                    },
+                    loading = {},
+                    error = {},
                 )
             } else {
                 MetadataLogoFallback(name)

--- a/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonTest/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCardArtTest.kt
+++ b/waltid-applications/waltid-wallet-demo-compose/sharedUI/src/commonTest/kotlin/id/walt/walletdemo/compose/ui/components/CredentialCardArtTest.kt
@@ -1,6 +1,9 @@
 package id.walt.walletdemo.compose.ui.components
 
+import id.walt.walletdemo.compose.logic.CredentialCardDisplayData
+import id.walt.walletdemo.compose.logic.WalletDemoMetadataDisplay
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -16,5 +19,58 @@ class CredentialCardArtTest {
     fun constructedFallbackShowsWhenArtIsMissingOrRejected() {
         assertTrue(showConstructedCardArtOverlay(CredentialCardMetadataArtState.Absent))
         assertTrue(showConstructedCardArtOverlay(CredentialCardMetadataArtState.Rejected))
+    }
+
+    @Test
+    fun storedCredentialLogoIsPreservedInCardArt() {
+        val art = CredentialCardDisplayData(
+            id = "credential-id",
+            title = "Example credential",
+            credentialType = null,
+            format = "jwt_vc_json",
+            issuer = "Example issuer",
+            holderName = null,
+            validity = null,
+            portrait = null,
+            logoUri = "https://issuer.example/credential.png",
+            logoAltText = "Credential logo",
+        ).toCardArt()
+
+        assertEquals("https://issuer.example/credential.png", art.logoUri)
+        assertEquals("Credential logo", art.logoAltText)
+    }
+
+    @Test
+    fun offeredCredentialLogoIsPreservedInCardArt() {
+        val art = WalletDemoMetadataDisplay(
+            name = "Example credential",
+            logoUri = "https://issuer.example/credential.png",
+            logoAltText = "Credential logo",
+        ).toCardArt(id = "credential-configuration-id", fallbackName = "Fallback")
+
+        assertEquals("https://issuer.example/credential.png", art.logoUri)
+        assertEquals("Credential logo", art.logoAltText)
+    }
+
+    @Test
+    fun credentialLogoUsesHttpsMetadataAndOtherwiseFallsBack() {
+        assertEquals(
+            CredentialCardLogoSource.Metadata("https://issuer.example/credential.png"),
+            credentialCardLogoSource("https://issuer.example/credential.png"),
+        )
+        assertEquals(CredentialCardLogoSource.BundledWalt, credentialCardLogoSource("http://issuer.example/logo.png"))
+        assertEquals(CredentialCardLogoSource.BundledWalt, credentialCardLogoSource(null))
+    }
+
+    @Test
+    fun credentialLogoUsesTrimmedAltTextOrCredentialName() {
+        assertEquals(
+            "Credential logo",
+            credentialCardLogoContentDescription("Example credential", "  Credential logo  "),
+        )
+        assertEquals(
+            "Example credential logo",
+            credentialCardLogoContentDescription("Example credential", "  "),
+        )
     }
 }

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialCardArtOverlayTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialCardArtOverlayTests.swift
@@ -2,6 +2,15 @@ import WalletDemoSharingUI
 import XCTest
 
 final class CredentialCardArtOverlayTests: XCTestCase {
+    func testCredentialLogoUsesHTTPSMetadataAndOtherwiseFallsBack() throws {
+        XCTAssertEqual(
+            credentialCardLogoSource("https://issuer.example/credential.png"),
+            .metadata(try XCTUnwrap(URL(string: "https://issuer.example/credential.png")))
+        )
+        XCTAssertEqual(credentialCardLogoSource("http://issuer.example/logo.png"), .bundledWalt)
+        XCTAssertEqual(credentialCardLogoSource(nil), .bundledWalt)
+    }
+
     func testPendingMetadataArtDoesNotShowConstructedFallback() {
         XCTAssertFalse(
             showsConstructedCardArtOverlay(

--- a/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
+++ b/waltid-applications/waltid-wallet-demo-ios/iosApp/iosAppTests/CredentialDisplayNormalizerTests.swift
@@ -1031,6 +1031,7 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
 
         XCTAssertEqual(display?.name, "Personal ID")
         XCTAssertEqual(display?.logoURI, "https://issuer.example/pid.png")
+        XCTAssertEqual(display?.logoAltText, "PID logo")
         XCTAssertEqual(display?.backgroundColor, "#12107c")
         XCTAssertEqual(display?.backgroundImageURI, "https://issuer.example/pid-bg.png")
         XCTAssertEqual(display?.textColor, "#FFFFFF")
@@ -1053,7 +1054,7 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
               "credentialDisplay": [
                 {
                   "name": "Personal ID",
-                  "logo": { "uri": "https://issuer.example/pid.png" },
+                  "logo": { "uri": "https://issuer.example/pid.png", "alt_text": "PID logo" },
                   "background_color": "#12107c",
                   "text_color": "#FFFFFF"
                 }
@@ -1066,6 +1067,7 @@ final class CredentialDisplayNormalizerTests: XCTestCase {
         XCTAssertEqual(details.credentialDisplay?.name, "Personal ID")
         XCTAssertEqual(details.cardSummary.backgroundColor, "#12107c")
         XCTAssertEqual(details.cardSummary.logoURI, "https://issuer.example/pid.png")
+        XCTAssertEqual(details.cardSummary.logoAltText, "PID logo")
         XCTAssertEqual(details.cardSummary.title, "Personal ID")
     }
 

--- a/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/CredentialCardView.swift
+++ b/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/CredentialCardView.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 import UIKit
 import WalletSDK
@@ -64,7 +65,7 @@ public struct CredentialCardArtView: View {
                         .foregroundStyle(label)
                         .lineLimit(2)
                         .padding(padding)
-                    DefaultWaltLogo()
+                    credentialLogo()
                         .frame(width: logoSize, height: logoSize)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                         .padding(padding)
@@ -79,6 +80,34 @@ public struct CredentialCardArtView: View {
             loadedMetadataArt = await loadMetadataArt(from: summary.backgroundImageURI)
             metadataArtFailed = loadedMetadataArt == nil && httpsURL(summary.backgroundImageURI) != nil
         }
+    }
+
+    @ViewBuilder
+    private func credentialLogo() -> some View {
+        switch credentialCardLogoSource(summary.logoURI) {
+        case let .metadata(url):
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case let .success(image):
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .accessibilityLabel(credentialLogoAccessibilityLabel)
+                default:
+                    DefaultWaltLogo()
+                }
+            }
+        case .bundledWalt:
+            DefaultWaltLogo()
+        }
+    }
+
+    private var credentialLogoAccessibilityLabel: String {
+        if let label = summary.logoAltText?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !label.isEmpty {
+            return label
+        }
+        return "\(summary.title) logo"
     }
 }
 
@@ -214,6 +243,15 @@ private func bundledWaltLogo() -> UIImage? {
         return nil
     }
     return UIImage(contentsOfFile: url.path)
+}
+
+public enum CredentialCardLogoSource: Equatable {
+    case metadata(URL)
+    case bundledWalt
+}
+
+public func credentialCardLogoSource(_ value: String?) -> CredentialCardLogoSource {
+    httpsURL(value).map(CredentialCardLogoSource.metadata) ?? .bundledWalt
 }
 
 public func showsConstructedCardArtOverlay(

--- a/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/CredentialCardView.swift
+++ b/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/CredentialCardView.swift
@@ -93,8 +93,10 @@ public struct CredentialCardArtView: View {
                         .resizable()
                         .scaledToFit()
                         .accessibilityLabel(credentialLogoAccessibilityLabel)
-                default:
-                    DefaultWaltLogo()
+                case .empty, .failure:
+                    EmptyView()
+                @unknown default:
+                    EmptyView()
                 }
             }
         case .bundledWalt:

--- a/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/ReviewMetadataComponents.swift
+++ b/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/ReviewMetadataComponents.swift
@@ -172,12 +172,10 @@ public struct MetadataIdentityView: View {
                         switch phase {
                         case let .success(image):
                             image.resizable().scaledToFit()
-                        case .empty:
-                            ProgressView()
-                        case .failure:
-                            MetadataLogoFallback(name: name)
+                        case .empty, .failure:
+                            EmptyView()
                         @unknown default:
-                            MetadataLogoFallback(name: name)
+                            EmptyView()
                         }
                     }
                     .accessibilityLabel(display?.logoAltText ?? "\(name) logo")

--- a/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/ReviewMetadataComponents.swift
+++ b/waltid-applications/waltid-wallet-demo-shared-ios/Sources/WalletDemoSharingUI/Components/ReviewMetadataComponents.swift
@@ -171,14 +171,16 @@ public struct MetadataIdentityView: View {
                     AsyncImage(url: logoURL) { phase in
                         switch phase {
                         case let .success(image):
-                            image.resizable().scaledToFit()
+                            image
+                                .resizable()
+                                .scaledToFit()
+                                .accessibilityLabel(display?.logoAltText ?? "\(name) logo")
                         case .empty, .failure:
                             EmptyView()
                         @unknown default:
                             EmptyView()
                         }
                     }
-                    .accessibilityLabel(display?.logoAltText ?? "\(name) logo")
                 } else {
                     MetadataLogoFallback(name: name)
                 }


### PR DESCRIPTION
## Summary

Restores credential-logo metadata rendering on constructed credential cards across the Compose and native SwiftUI wallet demos. This fixes the regression where an available credential logo was replaced by the bundled walt.id mark.

Tracks [WAL-1381](https://linear.app/walt-new/issue/WAL-1381/honor-credential-logo-metadata-across-wallet-demos).

## What Changed

### Compose wallet demos

- Preserve logo URI and alternative text through both offer and stored-card projections.
- Render valid HTTPS credential logos in the shared Android, Compose iOS, and Web/Wasm card renderer, with the bundled mark used only when no valid credential logo is advertised.
- Render advertised credential and issuer logos only after a successful load; loading and failed remote images display no replacement.
- Keep accepted full-card background artwork unobstructed.

### Native iOS demo

- Apply the same remote-logo precedence, placement, success-only rendering, and accessibility behavior in the shared SwiftUI card and issuer renderers.
- Cover metadata selection and stored alternative-text propagation with regression tests.

## Screenshots

A generic issuer profile advertises distinct display metadata images: a blue `IS` issuer logo and an orange `CR` credential logo. These captures compare the `main` parent with the resulting UI on Android and both iOS demos. Issuer details remain collapsed, so no DID value is displayed.

|  | Compose Android | Compose iOS | Native iOS |
| --- | --- | --- | --- |
| Before - bundled card logo | <img width="240" alt="Before the fix on Compose Android: the issuer uses a blue IS logo while the credential card still uses the bundled walt.id logo" src="https://github.com/user-attachments/assets/736e3794-dbe8-4430-882c-602f995f47ae"> | <img width="240" alt="Before the fix on Compose iOS: the issuer uses a blue IS logo while the credential card still uses the bundled walt.id logo" src="https://github.com/user-attachments/assets/3d28cd14-a3bf-412f-b181-a93291c899c1"> | <img width="240" alt="Before the fix on native iOS: the issuer uses a blue IS logo while the credential card still uses the bundled walt.id logo" src="https://github.com/user-attachments/assets/ce05322c-ac9d-4975-99e0-1b5163206cbb"> |
| After - advertised card logo | <img width="240" alt="After the fix on Compose Android: the issuer keeps its blue IS logo while the credential card uses its separate orange CR logo" src="https://github.com/user-attachments/assets/2202bb50-f2fa-4e56-815c-a76f2f02a929"> | <img width="240" alt="After the fix on Compose iOS: the issuer keeps its blue IS logo while the credential card uses its separate orange CR logo" src="https://github.com/user-attachments/assets/d7d173cf-af04-4974-95f5-b7854429e4b5"> | <img width="240" alt="After the fix on native iOS: the issuer keeps its blue IS logo while the credential card uses its separate orange CR logo" src="https://github.com/user-attachments/assets/e183ed14-5bda-4db1-a94c-b435c081da31"> |

## Architecture Notes

- The Compose shared UI owns Android, Compose iOS, and Web/Wasm behavior; the shared SwiftUI package owns native iOS behavior.
- Display metadata remains untrusted: only HTTPS logo URLs are accepted. Credential cards use the bundled mark only when no valid logo is advertised; advertised remote logos show nothing while loading or after failure.
- Logo rendering is limited to constructed cards; accepted background images remain full-bleed.

## Caveats and Follow-Ups

- Issuer subtitle formatting and claim display metadata are unchanged.

## Breaking

- None.
