### PR TITLE
fix(ci): honor macOS opt-in labels and surface selector errors

### DIFF
--- a/.github/scripts/ci/decide-macos-lanes.sh
+++ b/.github/scripts/ci/decide-macos-lanes.sh
@@ -40,7 +40,7 @@ label_match() {
     --arg docs_label "$DOCS_LABEL" '
       . as $pr_labels
       | {
-          force_all: any($force_all[]; . as $label | ($pr_labels | index($label)) != null),
+          force_all: any($force_all[]; . as $force_label | ($pr_labels | index($force_label)) != null),
           docs: (($pr_labels | index($docs_label)) != null)
         }
       | if .force_all then "force_all"
@@ -89,7 +89,9 @@ case "$EVENT_NAME" in
       exit 0
     fi
 
-    case "$(label_match)" in
+    # Keep parsing outside the case expression so errexit propagates jq errors.
+    matched_labels="$(label_match)"
+    case "$matched_labels" in
       force_all)
         set_all_lanes true
         REASON="ci:macos or ci:mobile label"

--- a/.github/scripts/ci/test-macos-lane-predicates.sh
+++ b/.github/scripts/ci/test-macos-lane-predicates.sh
@@ -35,9 +35,55 @@ while IFS= read -r fixture; do
   fi
 done < <(jq -c '.fixtures[]' "$FIXTURES_FILE")
 
+# Exercise the real selector as well as the path predicates: label parsing must
+# not silently turn an opted-in draft into a successful all-lanes-skipped result.
+selection_dir="$(mktemp -d)"
+trap 'rm -rf "$selection_dir"' EXIT
+
+check_draft_selection() {
+  local name="$1" labels="$2" head_repo="$3" expected="$4"
+  local output="$selection_dir/output" log="$selection_dir/log" status=0
+  count=$((count + 1))
+  : > "$output"
+  env EVENT_NAME=pull_request PR_DRAFT=true PR_LABELS="$labels" \
+    PR_HEAD_REPO="$head_repo" GITHUB_REPOSITORY=walt-id/waltid-identity \
+    GITHUB_OUTPUT="$output" \
+    bash "$SCRIPT_DIR/decide-macos-lanes.sh" > "$log" 2>&1 || status=$?
+
+  local matches=true lane value
+  if [[ "$expected" == error ]]; then
+    [[ "$status" != 0 && ! -s "$output" ]] || matches=false
+  else
+    [[ "$status" == 0 ]] || matches=false
+    for lane in ios-simulator native compose enterprise sdk-docs; do
+      value=false
+      if [[ "$expected" == all || ("$expected" == docs && "$lane" == sdk-docs) ]]; then
+        value=true
+      fi
+      grep -qx "run-$lane=$value" "$output" || matches=false
+    done
+  fi
+  if [[ "$matches" == true ]]; then
+    echo "PASS: $name"
+  else
+    echo "FAIL: $name (exit=$status, expected=$expected)"
+    cat "$log" "$output"
+    failures=$((failures + 1))
+  fi
+}
+
+check_draft_selection 'ci:mobile enables every lane on a draft' '["ci:mobile"]' walt-id/waltid-identity all
+check_draft_selection 'ci:macos enables every lane on a draft' '["ci:macos"]' walt-id/waltid-identity all
+check_draft_selection 'force-all wins over docs-only selection' '["ci:sdk-docs","ci:mobile"]' walt-id/waltid-identity all
+check_draft_selection 'docs-only label enables only SDK docs on a draft' '["ci:sdk-docs"]' walt-id/waltid-identity docs
+check_draft_selection 'an unlabelled draft stays skipped' '[]' walt-id/waltid-identity none
+check_draft_selection 'an unrelated label does not opt a draft in' '["bug"]' walt-id/waltid-identity none
+check_draft_selection 'a fork cannot opt into privileged lanes' '["ci:mobile"]' contributor/fork none
+check_draft_selection 'invalid label JSON fails without publishing skip outputs' 'invalid-json' walt-id/waltid-identity error
+
 if ((failures > 0)); then
-  echo "macOS lane predicate fixtures: $failures/$count failed"
+  echo "macOS lane tests: $failures/$count failed"
   exit 1
 fi
 
-echo "macOS lane predicate fixtures: $count passed"
+echo "macOS lane tests: $count passed"


### PR DESCRIPTION
## Summary

Fixes macOS lane selection for PRs carrying `ci:mobile` or `ci:macos`. The previous query used a variable name rejected by jq 1.6, then swallowed the parser failure and reported a successful skip for labelled drafts. This caused iOS and SDK-docs lanes to be omitted, as shown in [the eligibility job](https://github.com/walt-id/waltid-identity/actions/runs/34123375898/job/101746307568).

## What Changed

- Uses a jq-compatible variable name when matching opt-in labels.
- Propagates label-parser failures instead of publishing all-lanes-skipped outputs.
- Extends the existing macOS predicate gate with real selector cases for draft opt-ins, docs-only selection, precedence, unlabelled drafts, fork restrictions and malformed input.

This is an independent fix to the workflow introduced in [#2132](https://github.com/walt-id/waltid-identity/pull/2132), targeting `main`. Existing lane-selection policy is preserved.
