### PR TITLE
Feat/wal 1394 Quality of life changes

### DIFF
--- a/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/RequestContext.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonMain/kotlin/id/walt/openid4vp/clientidprefix/RequestContext.kt
@@ -40,19 +40,46 @@ data class ClientIdTrustConfiguration(
 
 /**
  * A sealed class representing all possible validation errors for clear, type-safe error handling.
+ *
+ * Every subtype is `@Serializable`, including the parameterless ones. kotlinx.serialization does not
+ * inherit the annotation from the sealed parent, so leaving them plain made
+ * `Json.encodeToString(ClientValidationResult.Failure(...))` throw for exactly the errors the X.509
+ * prefixes raise most often ([X509HashMismatch], [MissingX509TrustAnchors]).
  */
 @Serializable
 sealed class ClientIdError(val message: String) {
-    object MissingRequestObject : ClientIdError("Signed request object is required but was not provided.")
-    object InvalidSignature : ClientIdError("Request object signature validation failed.")
-    object DoesNotSupportSignature : ClientIdError("This client id prefix does not support signatures.")
-    object InvalidJws : ClientIdError("JWS cannot be parsed.")
-    object MissingX5cHeader : ClientIdError("Missing 'x5c' header in JWS.")
-    object EmptyX5cHeader : ClientIdError("Empty 'x5c' header in JWS.")
-    object MissingClientMetadata : ClientIdError("client_metadata parameter is required for this prefix but was not provided.")
-    object CannotExtractSanDnsNamesFromDer : ClientIdError("Could not extract SAN dNSNames from DER (leaf cert DER of x5c header).")
-    object X509HashMismatch : ClientIdError("The client_id hash does not match the hash of the provided certificate.")
-    object MissingX509TrustAnchors : ClientIdError("No X.509 trust anchors are configured.")
+    @Serializable
+    data object MissingRequestObject : ClientIdError("Signed request object is required but was not provided.")
+
+    @Serializable
+    data object InvalidSignature : ClientIdError("Request object signature validation failed.")
+
+    @Serializable
+    data object DoesNotSupportSignature : ClientIdError("This client id prefix does not support signatures.")
+
+    @Serializable
+    data object InvalidJws : ClientIdError("JWS cannot be parsed.")
+
+    @Serializable
+    data object MissingX5cHeader : ClientIdError("Missing 'x5c' header in JWS.")
+
+    @Serializable
+    data object EmptyX5cHeader : ClientIdError("Empty 'x5c' header in JWS.")
+
+    @Serializable
+    data object MissingClientMetadata :
+        ClientIdError("client_metadata parameter is required for this prefix but was not provided.")
+
+    @Serializable
+    data object CannotExtractSanDnsNamesFromDer :
+        ClientIdError("Could not extract SAN dNSNames from DER (leaf cert DER of x5c header).")
+
+    @Serializable
+    data object X509HashMismatch :
+        ClientIdError("The client_id hash does not match the hash of the provided certificate.")
+
+    @Serializable
+    data object MissingX509TrustAnchors : ClientIdError("No X.509 trust anchors are configured.")
 
     /**
      * The `redirect_uri`'s FQDN did not match an `x509_san_dns` Client Identifier.

--- a/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonTest/kotlin/id/walt/openid4vp/clientidprefix/ClientIdErrorSerializationTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-clientidprefix/src/commonTest/kotlin/id/walt/openid4vp/clientidprefix/ClientIdErrorSerializationTest.kt
@@ -1,0 +1,52 @@
+package id.walt.openid4vp.clientidprefix
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * [ClientValidationResult] is `@Serializable` so that a client-authentication failure can be reported
+ * over the wire. kotlinx.serialization does not inherit `@Serializable` from a sealed parent, so the
+ * parameterless [ClientIdError] subtypes used to lack a serializer and threw at runtime - for exactly
+ * the errors the X.509 prefixes raise most often.
+ */
+class ClientIdErrorSerializationTest {
+
+    private val errors = listOf(
+        ClientIdError.MissingRequestObject,
+        ClientIdError.InvalidSignature,
+        ClientIdError.DoesNotSupportSignature,
+        ClientIdError.InvalidJws,
+        ClientIdError.MissingX5cHeader,
+        ClientIdError.EmptyX5cHeader,
+        ClientIdError.MissingClientMetadata,
+        ClientIdError.CannotExtractSanDnsNamesFromDer,
+        ClientIdError.X509HashMismatch,
+        ClientIdError.MissingX509TrustAnchors,
+        ClientIdError.RedirectUriHostMismatch("verifier.example.com", "other.example.com"),
+        ClientIdError.DidResolutionFailed("not resolvable"),
+        ClientIdError.AttestationError("expired"),
+        ClientIdError.FederationError("no trust chain"),
+        ClientIdError.PreRegisteredClientNotFound("client-1"),
+        ClientIdError.UnsupportedPrefix("openid_federation"),
+        ClientIdError.InvalidMetadata("no verification keys"),
+        ClientIdError.SanDnsMismatch("verifier.example.com", listOf("other.example.com")),
+    )
+
+    @Test
+    fun `every ClientIdError round-trips through JSON`() {
+        errors.forEach { error ->
+            val encoded = Json.encodeToString(ClientIdError.serializer(), error)
+            assertEquals(error, Json.decodeFromString(ClientIdError.serializer(), encoded), "for $encoded")
+        }
+    }
+
+    @Test
+    fun `a failure result round-trips through JSON`() {
+        errors.forEach { error ->
+            val failure = ClientValidationResult.Failure(error)
+            val encoded = Json.encodeToString(ClientValidationResult.serializer(), failure)
+            assertEquals(failure, Json.decodeFromString(ClientValidationResult.serializer(), encoded), "for $encoded")
+        }
+    }
+}

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/build.gradle.kts
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/build.gradle.kts
@@ -50,6 +50,10 @@ kotlin {
 
         jvmMain.dependencies {
             implementation(project(":waltid-libraries:crypto:waltid-cose"))
+            // For the shared Client Identifier Prefix vocabulary and the canonical x509_hash
+            // derivation, so that producing a client_id here and verifying it wallet-side cannot
+            // drift apart. See X509Hash.hashOfCertificate.
+            implementation(project(":waltid-libraries:protocols:waltid-openid4vp-clientidprefix"))
         }
 
         commonTest.dependencies {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmMain/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreator.kt
@@ -25,6 +25,8 @@ import id.walt.mdoc.objects.deviceretrieval.DeviceRequest
 import id.walt.mdoc.objects.deviceretrieval.DeviceRequestInfo
 import id.walt.mdoc.objects.deviceretrieval.ReaderAuthenticationPayloads
 import id.walt.mdoc.objects.deviceretrieval.UseCase
+import id.walt.openid4vp.clientidprefix.ClientIdPrefix
+import id.walt.openid4vp.clientidprefix.prefixes.X509Hash
 import id.walt.policies2.vc.VCPolicyList
 import id.walt.policies2.vc.policies.CredentialSignaturePolicy
 import id.walt.policies2.vp.policies.*
@@ -55,12 +57,14 @@ import id.walt.crypto2.keys.Key as Crypto2Key
 /**
  * The OpenID4VP `redirect_uri` Client Identifier Prefix.
  *
- * Deliberately restated rather than shared with `ClientIdPrefix.REDIRECT_URI`: that enum lives in
- * `waltid-openid4vp-clientidprefix`, a wallet-side client-authentication module the verifier neither
- * depends on nor should. Adding a module dependency to share one string literal would be a worse
- * trade than repeating it here.
+ * Taken from the shared [ClientIdPrefix] vocabulary rather than restated. This module used to keep
+ * its own copy on the grounds that `waltid-openid4vp-clientidprefix` was wallet-only and a module
+ * dependency was too high a price for one string literal. That module also owns the canonical
+ * `x509_hash` derivation ([X509Hash.hashOfCertificate]), which the verifier needs in order to
+ * produce and validate its own `client_id`, so the dependency now carries real weight and the
+ * duplicate literal has no justification left.
  */
-private const val REDIRECT_URI_CLIENT_ID_PREFIX = "redirect_uri"
+private val REDIRECT_URI_CLIENT_ID_PREFIX = ClientIdPrefix.REDIRECT_URI.value
 
 object VerificationSessionCreator {
 
@@ -225,6 +229,7 @@ object VerificationSessionCreator {
             isAnnexC = isAnnexC,
             responseUri = responseUri,
         )
+        requireConsistentX509HashClientId(effectiveClientId, x5c)
 
         // Preserve OpenID4VP 1.0 algorithms while also advertising fully specified identifiers.
         val supportedJwsAlgorithms = JsonArray(
@@ -706,6 +711,30 @@ object VerificationSessionCreator {
                 "cross-device flows"
         }
         return "$REDIRECT_URI_CLIENT_ID_PREFIX:$destination"
+    }
+
+    /**
+     * OpenID4VP 1.0 §5.9.3: an `x509_hash` client identifier *is* the base64url-encoded SHA-256 hash
+     * of the DER encoding of the leaf certificate in `x5c`. The two are therefore not independent
+     * settings, and nothing downstream of session creation can catch them disagreeing: the request
+     * is signed and handed out happily, and the mismatch only surfaces inside the wallet as
+     * `X509HashMismatch`, with no trace on the verifier side. Rejecting it here turns a silent
+     * interop failure into a configuration error at the point the operator can act on it.
+     */
+    private fun requireConsistentX509HashClientId(clientId: String?, x5c: List<String>?) {
+        val prefix = "${ClientIdPrefix.X509_HASH.value}:"
+        val configuredHash = clientId?.takeIf { it.startsWith(prefix) }?.removePrefix(prefix) ?: return
+        val leafCertificate = requireNotNull(x5c?.firstOrNull()) {
+            "An $prefix client_id is derived from the leaf certificate, so x5c must be configured"
+        }
+        val leafDer = runCatching { Base64.decode(leafCertificate) }.getOrElse {
+            throw IllegalArgumentException("The x5c leaf certificate is not valid base64: ${it.message}", it)
+        }
+        val expectedHash = X509Hash.hashOfCertificate(leafDer)
+        require(configuredHash == expectedHash) {
+            "client_id '$clientId' does not match the configured certificate chain. " +
+                "The expected client_id for this x5c leaf is '$prefix$expectedHash'."
+        }
     }
 
     private sealed interface VerifierSigningKey {

--- a/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorX509HashTest.kt
+++ b/waltid-libraries/protocols/waltid-openid4vp-verifier/src/jvmTest/kotlin/id/walt/verifier2/handlers/sessioncreation/VerificationSessionCreatorX509HashTest.kt
@@ -1,0 +1,115 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package id.walt.verifier2.handlers.sessioncreation
+
+import id.walt.crypto.keys.KeyType
+import id.walt.crypto.keys.jwk.JWKKey
+import id.walt.dcql.models.CredentialFormat
+import id.walt.dcql.models.CredentialQuery
+import id.walt.dcql.models.DcqlQuery
+import id.walt.dcql.models.meta.JwtVcJsonMeta
+import id.walt.openid4vp.clientidprefix.prefixes.X509Hash
+import id.walt.verifier2.data.CrossDeviceFlowSetup
+import id.walt.verifier2.data.GeneralFlowConfig
+import kotlinx.coroutines.test.runTest
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * An `x509_hash` client identifier is not an independent setting: it *is* the base64url SHA-256 of the
+ * DER encoding of the `x5c` leaf. A mismatch is invisible to the verifier - the request signs and is
+ * served normally, and the wallet rejects it as `X509HashMismatch` - so it has to be caught at session
+ * creation.
+ */
+class VerificationSessionCreatorX509HashTest {
+
+    /** `verifier.example.com` self-signed P-256 leaf, the same certificate shipped in `verifier-service.conf`. */
+    private val leafCertificateBase64 =
+        "MIIBVzCB/aADAgECAggNKZAvUrtimzAKBggqhkjOPQQDAjAfMR0wGwYDVQQDDBR2ZXJpZmllci5leGFtcGxlLmNvbTAeFw0yNT" +
+            "EwMTQwNjI0MjBaFw0yNjEwMTQwNjI0MjBaMB8xHTAbBgNVBAMMFHZlcmlmaWVyLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0C" +
+            "AQYIKoZIzj0DAQcDQgAEG/TgBc0BkmMipiQ/6gkamIn3mmp7hcTrZuyrLTmknP1WRExl1dhdIx9/kAkuuceI3THkxXq7/y" +
+            "+sBzK0ZR7jPqMjMCEwHwYDVR0RBBgwFoIUdmVyaWZpZXIuZXhhbXBsZS5jb20wCgYIKoZIzj0EAwIDSQAwRgIhAOu0RGM6" +
+            "BjVQUepeLBogw+ZD3MQ9vFppbPIGMPjtn/qdAiEAttfdfyXHfzJ2tr+Pczyckzv3NlM43461cvP96sIzOQA="
+
+    /** Independently computed with `openssl x509 -outform DER | sha256sum`, then base64url-encoded. */
+    private val leafCertificateHash = "OPpTDyXlg6WRu2-Qn4rpQcA9uVqSrNExCS8kCYUe09A"
+
+    private val urlPrefix = "https://verifier.example.com/v1/org.tenant.verifier/verifier2-service-api"
+
+    private fun signedSetup() = CrossDeviceFlowSetup(
+        core = GeneralFlowConfig(
+            dcqlQuery = DcqlQuery(
+                credentials = listOf(
+                    CredentialQuery(
+                        id = "example_openbadge_jwt_vc",
+                        format = CredentialFormat.JWT_VC_JSON,
+                        meta = JwtVcJsonMeta(typeValues = listOf(listOf("OpenBadgeCredential"))),
+                    )
+                )
+            ),
+            signedRequest = true,
+        )
+    )
+
+    private suspend fun createSession(clientId: String?, x5c: List<String>?) =
+        VerificationSessionCreator.createVerificationSession(
+            setup = signedSetup(),
+            clientId = clientId,
+            urlPrefix = urlPrefix,
+            urlHost = "openid4vp://authorize",
+            key = JWKKey.generate(KeyType.secp256r1),
+            x5c = x5c,
+        )
+
+    @Test
+    fun `the derivation matches the independently computed hash`() {
+        assertEquals(leafCertificateHash, X509Hash.hashOfCertificate(Base64.decode(leafCertificateBase64)))
+    }
+
+    @Test
+    fun `a matching x509_hash client id is accepted`() = runTest {
+        val session = createSession("x509_hash:$leafCertificateHash", listOf(leafCertificateBase64))
+
+        assertEquals("x509_hash:$leafCertificateHash", session.authorizationRequest.clientId)
+        assertNotNull(session.signedAuthorizationRequestJwt)
+    }
+
+    @Test
+    fun `a mismatching x509_hash client id is rejected and names the expected value`() = runTest {
+        val wrongHash = "nPBr2E1pcPo5ga85kAngpdyzqK4EOLuG40lJSwL4Cdk"
+        val failure = assertFailsWith<IllegalArgumentException> {
+            createSession("x509_hash:$wrongHash", listOf(leafCertificateBase64))
+        }
+
+        assertTrue(failure.message!!.contains("x509_hash:$leafCertificateHash"), failure.message)
+    }
+
+    @Test
+    fun `an x509_hash client id without a certificate chain is rejected`() = runTest {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            createSession("x509_hash:$leafCertificateHash", x5c = null)
+        }
+
+        assertTrue(failure.message!!.contains("x5c must be configured"), failure.message)
+    }
+
+    @Test
+    fun `an x509_hash client id with a non-base64 certificate is rejected`() = runTest {
+        val failure = assertFailsWith<IllegalArgumentException> {
+            createSession("x509_hash:$leafCertificateHash", listOf("not base64!"))
+        }
+
+        assertTrue(failure.message!!.contains("not valid base64"), failure.message)
+    }
+
+    @Test
+    fun `other client id prefixes are unaffected`() = runTest {
+        val session = createSession("x509_san_dns:verifier.example.com", listOf(leafCertificateBase64))
+
+        assertEquals("x509_san_dns:verifier.example.com", session.authorizationRequest.clientId)
+    }
+}


### PR DESCRIPTION
https://github.com/walt-id/waltid-identity-enterprise/pull/662

- x509_hash/x5c consistency validation
- Serializable on ClientIdError
- keyReference in OpenAPI spec
- Verifier2 info section for HSM