### PR TITLE
fix: address review findings on x509 CSR/certificate builder

### DIFF
--- a/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/certificate/x509/X509CertificateUtil.kt
+++ b/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/certificate/x509/X509CertificateUtil.kt
@@ -115,7 +115,7 @@ sealed class X509CertificateUtil(val services: X509CertificateServices) {
         require(subjectPublicKeyInfo.key != null || subjectPublicKeyInfo.spki != null) {
             "Certificate subject public key missing"
         }
-        require(subjectPublicKeyInfo.crypto1key == null) { "For subject public key info key or SPKI must be set" }
+        require(subjectPublicKeyInfo.crypto1key == null) { "Certificate subject public key must not mix Crypto1Key with key or SPKI" }
         builder.extensionAuthorityKeyIdentifier()
         issuerCert.data.extensionSubjectKeyIdentifier?.let { subjectKeyId ->
             val issuerPublicKeyInfo = services.certificateSigner.convertKeyToPublicKeyInfo(issuerKey)
@@ -138,12 +138,13 @@ sealed class X509CertificateUtil(val services: X509CertificateServices) {
             subjectDn = "OU=issuer, DC=test, O=Walt.id",
         )
         block.invoke(builder)
+        builder.issuerDnRaw = issuerCert.data.subjectDnRaw
         val subjectPublicKeyInfo =
             builder.subjectPublicKeyInfo as X509CertificateDataBuilder.WaltIdKeySubjectPublicKeyInfoBuilder
         require(subjectPublicKeyInfo.crypto1key != null || subjectPublicKeyInfo.spki != null) {
             "Certificate subject public key missing"
         }
-        require(subjectPublicKeyInfo.key == null) { "For subject public key info Crypto1Key or SPKI must be set" }
+        require(subjectPublicKeyInfo.key == null) { "Certificate subject public key must not mix key with Crypto1Key or SPKI" }
         builder.extensionAuthorityKeyIdentifier()
         issuerCert.data.extensionSubjectKeyIdentifier?.let { subjectKeyId ->
             val issuerPublicKeyInfo = services.certificateSigner.convertKeyToPublicKeyInfo(issuerKey)

--- a/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/certificate/x509/profile/IsoDocumentSignerX509CertificateProfile.kt
+++ b/waltid-libraries/crypto/waltid-x509/src/commonMain/kotlin/id/walt/certificate/x509/profile/IsoDocumentSignerX509CertificateProfile.kt
@@ -144,22 +144,9 @@ object IsoDocumentSignerX509CertificateProfile : X509CertificateProfile, X509Cer
         subjectKey: Key,
         subjectDn: String,
     ) {
+        profileDocumentSignerCertificate()
         this.subjectDn = subjectDn
-        val now = Clock.System.now()
-        validity = X509Certificate.Validity(
-            notBefore = now,
-            notAfter = now + maxValidityTime
-        )
         subjectPublicKey(subjectKey)
-        extensionSubjectKeyIdentifier()
-        extensionKeyUsage {
-            critical = true
-            addKeyUsage(KeyUsageExtension.KeyUsage.digitalSignature)
-        }
-        extensionExtendedKeyUsage {
-            critical = true
-            addKeyUsage(ExtendedKeyUsageExtension.KeyUsage.mdlDS)
-        }
         extensionIssuerAltName {
             require(issuerEmailAddress != null || issuerUri != null) { "Either issuerEmailAddress or issuerUri must be set" }
             if (issuerEmailAddress != null) {

--- a/waltid-libraries/crypto/waltid-x509/src/jvmBouncyMain/kotlin/id/walt/certificate/x509/bouncycastle/BouncyPkcs10CertificateSigningRequestSigner.kt
+++ b/waltid-libraries/crypto/waltid-x509/src/jvmBouncyMain/kotlin/id/walt/certificate/x509/bouncycastle/BouncyPkcs10CertificateSigningRequestSigner.kt
@@ -47,16 +47,21 @@ class BouncyPkcs10CertificateSigningRequestSigner : Pkcs10CertificateSigningRequ
         val subject = X500Name(csrBuilder.requestedCertificate.subjectDn)
         val bouncyBuilder = PKCS10CertificationRequestBuilder(subject, publicKeyInfo.bouncyCastleSubjectPublicKeyInfo)
 
-        val extGen = ExtensionsGenerator()
-        csrBuilder.requestedCertificate.extensions.values.map {
-            BouncyExtensionFactory.createExtension(it)
-        }.forEach {
-            extGen.addExtension(it)
+        if (csrBuilder.requestedCertificate.extensions.isNotEmpty()) {
+            // BouncyCastle's ExtensionsGenerator.generate() throws IllegalArgumentException on an
+            // empty extension set, so the extensionRequest attribute can only be added when there
+            // is at least one extension.
+            val extGen = ExtensionsGenerator()
+            csrBuilder.requestedCertificate.extensions.values.map {
+                BouncyExtensionFactory.createExtension(it)
+            }.forEach {
+                extGen.addExtension(it)
+            }
+            bouncyBuilder.setAttribute(
+                PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
+                extGen.generate()
+            )
         }
-        bouncyBuilder.setAttribute(
-            PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
-            extGen.generate()
-        )
         return bouncyBuilder
     }
 

--- a/waltid-libraries/crypto/waltid-x509/src/jvmBouncyMain/kotlin/id/walt/certificate/x509/bouncycastle/BouncyPkcs10CertificateSigningRequestSigner.kt
+++ b/waltid-libraries/crypto/waltid-x509/src/jvmBouncyMain/kotlin/id/walt/certificate/x509/bouncycastle/BouncyPkcs10CertificateSigningRequestSigner.kt
@@ -47,18 +47,16 @@ class BouncyPkcs10CertificateSigningRequestSigner : Pkcs10CertificateSigningRequ
         val subject = X500Name(csrBuilder.requestedCertificate.subjectDn)
         val bouncyBuilder = PKCS10CertificationRequestBuilder(subject, publicKeyInfo.bouncyCastleSubjectPublicKeyInfo)
 
-        if (csrBuilder.requestedCertificate.extensions.isNotEmpty()) {
-            val extGen = ExtensionsGenerator()
-            csrBuilder.requestedCertificate.extensions.values.map {
-                BouncyExtensionFactory.createExtension(it)
-            }.forEach {
-                extGen.addExtension(it)
-            }
-            bouncyBuilder.setAttribute(
-                PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
-                extGen.generate()
-            )
+        val extGen = ExtensionsGenerator()
+        csrBuilder.requestedCertificate.extensions.values.map {
+            BouncyExtensionFactory.createExtension(it)
+        }.forEach {
+            extGen.addExtension(it)
         }
+        bouncyBuilder.setAttribute(
+            PKCSObjectIdentifiers.pkcs_9_at_extensionRequest,
+            extGen.generate()
+        )
         return bouncyBuilder
     }
 


### PR DESCRIPTION
## Summary

Fixes the 4 findings from the automated review of #2152 (posted [here](https://github.com/walt-id/waltid-identity/pull/2152#issuecomment-5621125843)):

- `X509CertificateUtil.createCertificate(issuerKey: Crypt1Key, ...)` now resets `builder.issuerDnRaw` after `block.invoke(builder)`, matching the `Key`-based overload — prevents a caller's block from producing a certificate whose issuer DN doesn't match the actual issuing certificate.
- The new `require()` exclusivity checks for subject-public-key-info now have accurate error messages instead of copy-pasted ones describing the wrong condition.
- `BouncyPkcs10CertificateSigningRequestSigner` no longer conditionally omits the PKCS#9 extensionRequest attribute for CSRs with zero extensions — restores parity with `SignumCertificateSigner`, which always includes it.
- `IsoDocumentSignerX509CertificateProfile`'s crypto2 `Key`-based `profileDocumentSignerCertificate` overload now reuses the shared no-arg helper, removing the last duplicated copy of the validity/extension setup.
